### PR TITLE
Reconfigure using the Okta Group Owners API to be opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ CLIENT_ORIGIN_URL=http://localhost:3000
 REACT_APP_API_SERVER_URL=http://localhost:6060
 ```
 
-Then run the following commands to set up your python virtual environment:
+Then run the following commands to set up your python virtual environment. Access can be run with Python 3.10 and above:
 
 ```
-python3.11 -m venv venv
+python3 -m venv venv
 . venv/bin/activate
 pip install -r requirements.txt
 ```
@@ -103,7 +103,7 @@ Invoke the tests using `tox -e test` and `tox -e lint` to run the linter
 
 ## Production Setup
 
-Create a `.env-production` file in the repo root with the following variables
+Create a `.env-production` file in the repo root with the following variables. Access supports running against PostgreSQL 14 and above.
 
 ```
 OKTA_DOMAIN=<YOUR_OKTA_DOMAIN> # For example, "mydomain.okta.com"

--- a/api/app.py
+++ b/api/app.py
@@ -124,7 +124,8 @@ def create_app(testing: Optional[bool]=False) -> Flask:
         force_https=False,
     )
 
-    okta.initialize(app.config["OKTA_DOMAIN"], app.config["OKTA_API_TOKEN"])
+    okta.initialize(app.config["OKTA_DOMAIN"], app.config["OKTA_API_TOKEN"],
+                    use_group_owners_api=app.config["OKTA_USE_GROUP_OWNERS_API"])
 
     @app.before_request
     def authenticate_request() -> Optional[ResponseReturnValue]:
@@ -166,7 +167,7 @@ def create_app(testing: Optional[bool]=False) -> Flask:
                 cloudsql_connection_name=app.config["CLOUDSQL_CONNECTION_NAME"],
                 db_user=app.config["DATABASE_USER"],
                 db_name=app.config["DATABASE_NAME"],
-                uses_public_ip=app.config["DATABASE_USES_PUBLIC_IP"] == "True",
+                uses_public_ip=app.config["DATABASE_USES_PUBLIC_IP"],
             )
         }
 

--- a/api/config.py
+++ b/api/config.py
@@ -8,6 +8,9 @@ CLIENT_ORIGIN_URL = os.getenv("CLIENT_ORIGIN_URL")
 
 OKTA_DOMAIN = os.getenv("OKTA_DOMAIN")
 OKTA_API_TOKEN = os.getenv("OKTA_API_TOKEN")
+# The Group Owners API is only available to Okta plans with IGA enabled
+# Disable by default, but allow opt-in to sync group owners to Okta if desired
+OKTA_USE_GROUP_OWNERS_API = os.getenv("OKTA_USE_GROUP_OWNERS_API", "False") == "True"
 CURRENT_OKTA_USER_EMAIL = os.getenv("CURRENT_OKTA_USER_EMAIL", "wumpus@discord.com")
 
 SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URI")
@@ -79,7 +82,7 @@ CLOUDSQL_CONNECTION_NAME = os.getenv("CLOUDSQL_CONNECTION_NAME", "")
 DATABASE_USER = os.getenv("DATABASE_USER", "root")
 DATABASE_PASSWORD = os.getenv("DATABASE_PASSWORD", "")
 DATABASE_NAME = os.getenv("DATABASE_NAME", "access")
-DATABASE_USES_PUBLIC_IP = os.getenv("DATABASE_USES_PUBLIC_IP", "False")
+DATABASE_USES_PUBLIC_IP = os.getenv("DATABASE_USES_PUBLIC_IP", "False") == "True"
 
 FLASK_SENTRY_DSN = os.getenv("FLASK_SENTRY_DSN")
 REACT_SENTRY_DSN = os.getenv("REACT_SENTRY_DSN")

--- a/api/manage.py
+++ b/api/manage.py
@@ -139,6 +139,7 @@ def _init_builtin_apps(admin_okta_user_email: str) -> None:
 @with_appcontext
 def sync(sync_groups_authoritatively: bool, sync_group_memberships_authoritatively: bool) -> None:
     from sentry_sdk import start_transaction
+    from flask import current_app
 
     from api.syncer import (
         expire_access_requests,
@@ -152,7 +153,8 @@ def sync(sync_groups_authoritatively: bool, sync_group_memberships_authoritative
         sync_users()
         sync_groups(act_as_authority=sync_groups_authoritatively)
         sync_group_memberships(act_as_authority=sync_group_memberships_authoritatively)
-        sync_group_ownerships(act_as_authority=sync_group_memberships_authoritatively)
+        if current_app.config["OKTA_USE_GROUP_OWNERS_API"]:
+            sync_group_ownerships(act_as_authority=sync_group_memberships_authoritatively)
         expire_access_requests()
 
 


### PR DESCRIPTION
As surfaced by @gabrielsroka, the Okta Group Owners API is only available on Okta organizations with IGA enabled. As this feature in Access is not necessary unless you're using Otka Group Owner in IGA, disable it by default, but allow it to be opt-in if desired.