### PR TITLE
Access request and expiring access bugs

### DIFF
--- a/src/pages/requests/Create.tsx
+++ b/src/pages/requests/Create.tsx
@@ -188,17 +188,49 @@ const UNTIL_JUST_NUMERIC_ID_TO_LABELS: Record<string, string> = {
 
 const UNTIL_OPTIONS = Object.entries(UNTIL_ID_TO_LABELS).map(([id, label], index) => ({id: id, label: label}));
 
+function filterUntilLabels(timeLimit: number): [string, Array<Record<string, string>>] {
+  const filteredUntil = Object.keys(UNTIL_JUST_NUMERIC_ID_TO_LABELS)
+    .filter((key) => Number(key) <= timeLimit!)
+    .reduce(
+      (obj, key) => {
+        obj[key] = UNTIL_JUST_NUMERIC_ID_TO_LABELS[key];
+        return obj;
+      },
+      {} as Record<string, string>,
+    );
+
+  const filteredLabeles = Object.entries(Object.assign({}, filteredUntil, {custom: 'Custom'})).map(
+    ([id, label], index) => ({
+      id: id,
+      label: label,
+    }),
+  );
+
+  return [Object.keys(filteredUntil).at(-1)!, filteredLabeles];
+}
+
 function CreateRequestContainer(props: CreateRequestContainerProps) {
   const navigate = useNavigate();
 
-  const [until, setUntil] = React.useState('1209600');
+  const [timeLimit, setTimeLimit] = React.useState<number | null>(
+    props.group
+      ? minTagTime(
+          props.group.active_group_tags ? props.group.active_group_tags.map((tagMap) => tagMap.active_tag!) : [],
+          props.owner ?? false,
+        )
+      : null,
+  );
   const [groupSearchInput, setGroupSearchInput] = React.useState(props.group?.name ?? '');
   const [requestError, setRequestError] = React.useState('');
   const [submitting, setSubmitting] = React.useState(false);
-  const [labels, setLabels] = React.useState<Array<Record<string, string>>>(UNTIL_OPTIONS);
-  const [timeLimit, setTimeLimit] = React.useState<number | null>(null);
   const [selectedGroup, setSelectedGroup] = React.useState<PolymorphicGroup | null>(props.group ?? null);
   const [owner, setOwner] = React.useState<boolean>(props.owner ?? false);
+
+  const untilLabels: [string, Array<Record<string, string>>] = timeLimit
+    ? filterUntilLabels(timeLimit)
+    : ['1209600', UNTIL_OPTIONS];
+  const [until, setUntil] = React.useState(untilLabels[0]);
+  const [labels, setLabels] = React.useState<Array<Record<string, string>>>(untilLabels[1]);
 
   const complete = (
     completedRequest: AccessRequest | undefined,
@@ -246,24 +278,10 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
     setTimeLimit(time);
 
     if (!(time == null)) {
-      const filteredUntil = Object.keys(UNTIL_JUST_NUMERIC_ID_TO_LABELS)
-        .filter((key) => Number(key) <= time!)
-        .reduce(
-          (obj, key) => {
-            obj[key] = UNTIL_JUST_NUMERIC_ID_TO_LABELS[key];
-            return obj;
-          },
-          {} as Record<string, string>,
-        );
+      const [filteredUntil, filteredLabels] = filterUntilLabels(time);
 
-      setUntil(Object.keys(filteredUntil).at(-1)!);
-
-      setLabels(
-        Object.entries(Object.assign({}, filteredUntil, {custom: 'Custom'})).map(([id, label], index) => ({
-          id: id,
-          label: label,
-        })),
-      );
+      setUntil(filteredUntil);
+      setLabels(filteredLabels);
     } else {
       setLabels(UNTIL_OPTIONS);
     }

--- a/src/pages/requests/Create.tsx
+++ b/src/pages/requests/Create.tsx
@@ -212,6 +212,10 @@ function filterUntilLabels(timeLimit: number): [string, Array<Record<string, str
 function CreateRequestContainer(props: CreateRequestContainerProps) {
   const navigate = useNavigate();
 
+  // If a group is already selected by default and it has constraints limiting ownership or membership time,
+  // find the shortest time (max allowed access time) and set that as the time limit. This value is used to
+  // filter until drop-down labels, display a message about the constraint, and set a max date on the custom
+  // until calendar.
   const [timeLimit, setTimeLimit] = React.useState<number | null>(
     props.group
       ? minTagTime(

--- a/src/pages/roles/BulkRenewal.tsx
+++ b/src/pages/roles/BulkRenewal.tsx
@@ -157,15 +157,8 @@ function BulkRenewalDialog(props: BulkRenewalDialogProps) {
   const [labels, setLabels] = React.useState<Array<Record<string, string>>>(UNTIL_OPTIONS);
   const [timeLimit, setTimeLimit] = React.useState<number | null>(null);
   const [requiredReason, setRequiredReason] = React.useState<boolean>(false);
-
-  const [selected, setSelected] = React.useState<RoleGroupMap[]>(() =>
-    props.select != undefined ? props.rows.filter((r) => r.id == props.select) : [],
-  );
   const [until, setUntil] = React.useState('1209600');
 
-  const [selectionModel, setSelectionModel] = React.useState<GridRowSelectionModel>(() =>
-    props.rows.filter((r) => r.id == props.select).map((r) => r.id!),
-  );
   const [paginationModel, setPaginationModel] = React.useState({
     pageSize: 10,
     page: props.select != undefined ? Math.ceil((props.rows.map((e) => e.id).indexOf(props.select) + 1) / 10) - 1 : 0,
@@ -195,6 +188,33 @@ function BulkRenewalDialog(props: BulkRenewalDialogProps) {
     ownerCantAddSelfGroups([curr.group!], false) ? out.add(curr.group!.name) : null;
     return out;
   }, new Set<string>());
+
+  const [selected, setSelected] = React.useState<RoleGroupMap[]>(() =>
+    props.select != undefined
+      ? props.rows.filter(
+          (r) =>
+            r.id == props.select &&
+            !(
+              role_memberships.has(r.role_group!.name) &&
+              ((groups_cant_add_self_owner.has(r.group!.name) && r.is_owner!) ||
+                (groups_cant_add_self_member.has(r.group!.name) && !r.is_owner))
+            ),
+        )
+      : [],
+  );
+  const [selectionModel, setSelectionModel] = React.useState<GridRowSelectionModel>(() =>
+    props.rows
+      .filter(
+        (r) =>
+          r.id == props.select &&
+          !(
+            role_memberships.has(r.role_group!.name) &&
+            ((groups_cant_add_self_owner.has(r.group!.name) && r.is_owner!) ||
+              (groups_cant_add_self_member.has(r.group!.name) && !r.is_owner))
+          ),
+      )
+      .map((r) => r.id!),
+  );
 
   const display_owner_add_constraint =
     !isAccessAdmin(currentUser) &&

--- a/src/pages/roles/BulkRenewal.tsx
+++ b/src/pages/roles/BulkRenewal.tsx
@@ -189,6 +189,9 @@ function BulkRenewalDialog(props: BulkRenewalDialogProps) {
     return out;
   }, new Set<string>());
 
+  // If user is renewing a specific role, set it as selected by default *only* if the group tag constraints allow them
+  // to renew it. (Eg. if there is the owner can't add themselves' constraint, make sure they aren't in the role before
+  // selecting the row by default)
   const [selected, setSelected] = React.useState<RoleGroupMap[]>(() =>
     props.select != undefined
       ? props.rows.filter(


### PR DESCRIPTION
Bug fixes:

- If you created a access request from a group's page, it would not apply time limit constraints (they would still be applied when the access request was approved/rejected so no biggie but still good to fix from a UX perspective)
  - Corrected to filter the until drop down and warn that there's a time limit constraint

- If you tried to renew a role's membership/ownership to a group you own that had the 'owners can't add themselves' constraint applied but used the row's 'Renew' button on the Expiring Access page instead of the 'Bulk Renewal' button, it would allow you to select the row but then throw an error when you tried to submit.
  - Corrected to not automatically select rows you shouldn't be able to renew