### PR TITLE
Notification and Access Request UI Bug Fixes

### DIFF
--- a/api/syncer.py
+++ b/api/syncer.py
@@ -576,8 +576,10 @@ def expiring_access_notifications_owner() -> None:
             owners = access_owners
 
         for owner in owners:
-            owner_expiring_groups_this[owner].users += users_per_group[group]
-            owner_expiring_groups_this[owner].groups.append(group)
+            non_owner_users = [user for user in users_per_group[group] if user.id != owner.id]
+            if len(non_owner_users) > 0:
+                owner_expiring_groups_this[owner].users += non_owner_users
+                owner_expiring_groups_this[owner].groups.append(group)
 
     one_week = date.today() + timedelta(weeks=1)
     two_weeks = one_week + timedelta(weeks=1)
@@ -613,8 +615,10 @@ def expiring_access_notifications_owner() -> None:
             owners = access_owners
 
         for owner in owners:
-            owner_expiring_groups_next[owner].users += users_per_group[group]
-            owner_expiring_groups_next[owner].groups.append(group)
+            non_owner_users = [user for user in users_per_group[group] if user.id != owner.id]
+            if len(non_owner_users) > 0:
+                owner_expiring_groups_next[owner].users += non_owner_users
+                owner_expiring_groups_next[owner].groups.append(group)
 
     for owner in owner_expiring_groups_this:
         # If the owner has members with access expiring both this week and next week, only send one message

--- a/src/pages/requests/Read.tsx
+++ b/src/pages/requests/Read.tsx
@@ -181,8 +181,11 @@ export default function ReadRequest() {
   const ownRequest = accessRequest.requester?.id == currentUser.id;
 
   const requestEndingAt = dayjs(accessRequest.request_ending_at);
+  // round the delta to adjust based on partial seconds
   const requestedUntilDelta =
-    accessRequest.request_ending_at == null ? null : requestEndingAt.diff(dayjs(accessRequest.created_at), 'second');
+    accessRequest.request_ending_at == null
+      ? null
+      : Math.round(requestEndingAt.diff(dayjs(accessRequest.created_at), 'second') / 100) * 100;
   const requestedUntil =
     requestedUntilDelta == null
       ? 'indefinite'


### PR DESCRIPTION
List of bugs addressed:

- Group owners were notified about their own expiring access as an owner notification instead of as just an individual expiring access notification (they cannot renew their own from the Expiring Access 'Owned by Me' page so this caused confusion)
- Access Request UI was interpreting some 'until' fields for requests as custom dates because of rounding errors with partial seconds (requestUntilDelta was calculated incorrectly for our expected level of granularity)