### PR TITLE
Fix datetime offset comparison error

### DIFF
--- a/api/models/tag.py
+++ b/api/models/tag.py
@@ -40,4 +40,4 @@ def coalesce_ended_at(
         if initial_ended_at is None:
             return constraint_ended_at
         else:
-            return min(constraint_ended_at, initial_ended_at)
+            return min(constraint_ended_at, initial_ended_at.replace(tzinfo=UTC))

--- a/api/operations/modify_group_users.py
+++ b/api/operations/modify_group_users.py
@@ -497,7 +497,8 @@ class ModifyGroupUsers:
                             associated_users_ended_at = role_associated_group_map.ended_at
                         else:
                             associated_users_ended_at = (
-                                min(self.members_added_ended_at, role_associated_group_map.ended_at.replace(tzinfo=UTC))
+                                min(self.members_added_ended_at.replace(tzinfo=UTC),
+                                    role_associated_group_map.ended_at.replace(tzinfo=UTC))
                             )
 
                         access_to_add = OktaUserGroupMember(

--- a/api/operations/modify_role_groups.py
+++ b/api/operations/modify_role_groups.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Dict, Optional
 
 from flask import current_app, has_request_context, request
@@ -342,7 +342,8 @@ class ModifyRoleGroups:
                         associated_users_ended_at = role_associated_group_map.ended_at
                     else:
                         associated_users_ended_at = (
-                            min(member.ended_at, role_associated_group_map.ended_at)
+                            min(member.ended_at.replace(tzinfo=UTC),
+                                role_associated_group_map.ended_at.replace(tzinfo=UTC))
                         )
 
                     membership_to_add = OktaUserGroupMember(
@@ -380,7 +381,8 @@ class ModifyRoleGroups:
                         associated_users_ended_at = role_associated_group_map.ended_at
                     else:
                         associated_users_ended_at = (
-                            min(member.ended_at, role_associated_group_map.ended_at)
+                            min(member.ended_at.replace(tzinfo=UTC),
+                                role_associated_group_map.ended_at.replace(tzinfo=UTC))
                         )
                     ownership_to_add = OktaUserGroupMember(
                         user_id=member.user_id,


### PR DESCRIPTION
Fixes error described in #36 
```
  File "access/api/models/tag.py", line 43, in coalesce_ended_at
    return min(constraint_ended_at, initial_ended_at)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: can't compare offset-naive and offset-aware datetimes
```

See more info at https://stackoverflow.com/a/15307743