### PR TITLE
Fix ended at bug

### DIFF
--- a/src/components/Ending.tsx
+++ b/src/components/Ending.tsx
@@ -11,7 +11,7 @@ function selectLastTime(
 ): OktaUserGroupMember | RoleGroupMap {
   if (a.ended_at == null) return a;
   if (b.ended_at == null) return b;
-  if (a.ended_at > b.ended_at) {
+  if (dayjs(a.ended_at).isAfter(dayjs(b.ended_at))) {
     return a;
   } else {
     return b;


### PR DESCRIPTION
If someone had access to a group via multiple adds (multiple roles or direct and via role) and one of them was expiring in less than 24 hours, the 'Ending' comparison would not work correctly. This would cause the UI to display that access was ending in x hours instead of the longer add.

This PR changes the string comparison to a date comparison to correct this.  