### PR TITLE
Create App with Role Owners

### DIFF
--- a/api/swagger.json
+++ b/api/swagger.json
@@ -225,6 +225,14 @@
           "minLength": 1,
           "type": "string"
         },
+        "initial_owner_role_ids": {
+          "items": {
+            "maxLength": 20,
+            "minLength": 20,
+            "type": "string"
+          },
+          "type": "array"
+        },
         "is_managed": {
           "readOnly": true,
           "type": "boolean"

--- a/api/views/schemas/core_schemas.py
+++ b/api/views/schemas/core_schemas.py
@@ -1161,6 +1161,7 @@ class AppSchema(SQLAlchemyAutoSchema):
     description = auto_field(validate=validate.Length(max=1024))
 
     initial_owner_id = fields.String(validate=validate.Length(min=1, max=255), load_only=True)
+    initial_owner_role_ids = fields.List(fields.String(validate=validate.Length(equal=20)), load_only=True)
     initial_additional_app_groups = fields.Nested(lambda: InitialAppGroupSchema, many=True, load_only=True)
 
     tags_to_add = fields.List(fields.String(validate=validate.Length(equal=20)), load_only=True)
@@ -1207,6 +1208,7 @@ class AppSchema(SQLAlchemyAutoSchema):
             "name",
             "description",
             "initial_owner_id",
+            "initial_owner_role_ids",
             "initial_additional_app_groups",
             "tags_to_add",
             "tags_to_remove",
@@ -1231,6 +1233,7 @@ class AppSchema(SQLAlchemyAutoSchema):
         )
         load_only = (
             "initial_owner_id",
+            "initial_owner_role_ids",
             "initial_additional_app_groups",
             "tags_to_add",
             "tags_to_remove",


### PR DESCRIPTION
Allow list of `initial_owner_role_ids` to be specified during App creation (a POST to the /api/app endpoint)