### PR TITLE
Require at least one entity when adding to a group

### DIFF
--- a/src/pages/groups/AddRoles.tsx
+++ b/src/pages/groups/AddRoles.tsx
@@ -375,7 +375,7 @@ function AddRolesDialog(props: AddRolesDialogProps) {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => props.setOpen(false)}>Cancel</Button>
-          <Button type="submit" disabled={submitting}>
+          <Button type="submit" disabled={submitting || roles.length === 0}>
             {submitting ? <CircularProgress size={24} /> : 'Add'}
           </Button>
         </DialogActions>

--- a/src/pages/groups/AddUsers.tsx
+++ b/src/pages/groups/AddUsers.tsx
@@ -378,7 +378,7 @@ function AddUsersDialog(props: AddUsersDialogProps) {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => props.setOpen(false)}>Cancel</Button>
-          <Button type="submit" disabled={submitting}>
+          <Button type="submit" disabled={submitting || users.length === 0}>
             {submitting ? <CircularProgress size={24} /> : 'Add'}
           </Button>
         </DialogActions>


### PR DESCRIPTION
Fixes a bug where the 'Add' button is clickable when there have been no entities selected, which for users does nothing and for roles causes the modal to get stuck in a submitting state indefinitely.

![bug](https://github.com/discord/access/assets/1375517/d92fecfb-0914-48d7-960a-b517522932c5)
