### PR TITLE
Add `client-secrets.json` note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ The `.env.production` file is where you configure the application.
 
 If you are using Cloudflare Access, ensure that you configure `CLOUDFLARE_TEAM_DOMAIN` and `CLOUDFLARE_APPLICATION_AUDIENCE`. `SECRET_KEY` and `OIDC_CLIENT_SECRETS` do not need to be set and can be removed from your env file.
 
-Else, if you are using a generic OIDC identity provider (such as Okta), then you should configure `SECRET_KEY` and `OIDC_CLIENT_SECRETS`. `CLOUDFLARE_TEAM_DOMAIN` and `CLOUDFLARE_APPLICATION_AUDIENCE` do not need to be set and can be removed from your env file.
+Else, if you are using a generic OIDC identity provider (such as Okta), then you should configure `SECRET_KEY` and `OIDC_CLIENT_SECRETS`. `CLOUDFLARE_TEAM_DOMAIN` and `CLOUDFLARE_APPLICATION_AUDIENCE` do not need to be set and can be removed from your env file. Make sure to also mount your `client-secrets.json` file to the container if you don't have it inline.
 
 #### Database Setup
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     container_name: discord-access
     env_file:
       - .env.production
+    # volumes:
+    # - ./client_secrets.json:/app/client_secrets.json
     ports:
       - '3000:3000'
     restart: unless-stopped


### PR DESCRIPTION
Container cannot access `client-secrets.json` if the file isn't mounted inside when using OIDC configuration.