### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Else, if you are using a generic OIDC identity provider (such as Okta), then you
 
 #### Database Setup
 
-After `docker-compose up --build`, you can run the following commands to setup the database:
+After `docker compose up --build`, you can run the following commands to setup the database:
 
 Create the database in the postgres container:
 ```


### PR DESCRIPTION
`docker-compose` is deprecated it is recommended to use `docker compose` instead see https://docs.docker.com/compose/migrate/.