### PR TITLE
Fix bug where wrong variable used for app group owners length

### DIFF
--- a/src/pages/requests/Read.tsx
+++ b/src/pages/requests/Read.tsx
@@ -810,7 +810,7 @@ export default function ReadRequest() {
                                           alignItems: 'right',
                                         }}>
                                         <Divider sx={{mx: 2}} orientation="vertical" flexItem />
-                                        Total Owners: {Object.keys(ownerships).length}
+                                        Total Owners: {Object.keys(appOwnerships).length}
                                       </Box>
                                     </TableCell>
                                   </TableRow>


### PR DESCRIPTION
For access requests to an app group, the 'Total Owners' for an app in the approvers lists was mistakenly calculated using the app group owners instead of the app owners. Changed to use the correct variable.