### PR TITLE
Note Python 3.11 dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ CLIENT_ORIGIN_URL=http://localhost:3000
 REACT_APP_API_SERVER_URL=http://localhost:6060
 ```
 
-Next, run the following commands to set up your python virtual environment. Access can be run with Python 3.10 and above:
+Next, run the following commands to set up your python virtual environment. Access can be run with Python 3.11 and above:
 
 ```
 python3 -m venv venv


### PR DESCRIPTION
Access requires at least Python 3.11 to use `StrEnum`:
```
(venv) ➜  access git:(main) flask db upgrade
Error: While importing 'api.app', an ImportError was raised:

Traceback (most recent call last):
  File "/home/discord/workspaces/access/venv/lib/python3.10/site-packages/flask/cli.py", line 245, in locate_app
    __import__(module_name)
  File "/home/discord/workspaces/access/api/app.py", line 19, in <module>
    from api.authentication import AuthenticationHelpers, CloudflareAuthenticationHelpers
  File "/home/discord/workspaces/access/api/authentication.py", line 14, in <module>
    from api.models import OktaUser
  File "/home/discord/workspaces/access/api/models/__init__.py", line 1, in <module>
    from api.models.core_models import (
  File "/home/discord/workspaces/access/api/models/core_models.py", line 2, in <module>
    from enum import StrEnum
ImportError: cannot import name 'StrEnum' from 'enum' (/usr/lib/python3.10/enum.py)
```