### PR TITLE
[fix] update user avatars to have adequate contrast across themes

### DIFF
--- a/src/pages/users/UserAvatar.tsx
+++ b/src/pages/users/UserAvatar.tsx
@@ -1,9 +1,14 @@
+import {PaletteMode, useTheme} from '@mui/material';
 import Avatar from '@mui/material/Avatar';
 import Typography from '@mui/material/Typography';
 
-function stringToColor(string: string) {
+function stringToColor(string: string, mode: PaletteMode) {
   const hue = string.split('').reduce((acc, curr) => curr.charCodeAt(0) + acc, 0) % 360;
-  return `hsl(${hue}, 65%, 65%)`;
+  if (mode === 'dark') {
+    return `hsl(${hue}, 65%, 70%)`;
+  } else {
+    return `hsl(${hue}, 65%, 55%)`;
+  }
 }
 
 interface UserAvatarProps {
@@ -13,13 +18,16 @@ interface UserAvatarProps {
 }
 
 export default function UserAvatar(props: UserAvatarProps) {
+  const {
+    palette: {mode},
+  } = useTheme();
   const splitName = props.name.split(' ');
 
   return (
     <Avatar
       alt={props.name}
       sx={{
-        bgcolor: stringToColor(props.name),
+        bgcolor: stringToColor(props.name, mode),
         width: props.size ?? 24,
         height: props.size ?? 24,
       }}

--- a/src/pages/users/UserAvatar.tsx
+++ b/src/pages/users/UserAvatar.tsx
@@ -2,23 +2,8 @@ import Avatar from '@mui/material/Avatar';
 import Typography from '@mui/material/Typography';
 
 function stringToColor(string: string) {
-  let hash = 0;
-  let i;
-
-  /* eslint-disable no-bitwise */
-  for (i = 0; i < string.length; i += 1) {
-    hash = string.charCodeAt(i) + ((hash << 5) - hash);
-  }
-
-  let color = '#';
-
-  for (i = 0; i < 3; i += 1) {
-    const value = (hash >> (i * 8)) & 0xff;
-    color += `00${value.toString(16)}`.slice(-2);
-  }
-  /* eslint-enable no-bitwise */
-
-  return color;
+  const hue = string.split('').reduce((acc, curr) => curr.charCodeAt(0) + acc, 0) % 360;
+  return `hsl(${hue}, 65%, 65%)`;
 }
 
 interface UserAvatarProps {


### PR DESCRIPTION
| Before |  After (light) | Before (dark) | After (dark) |
| --- | --- | --- | --- |
|![Screenshot 2024-10-30 at 13 37 27](https://github.com/user-attachments/assets/a70fe85c-7d59-45df-b127-7966f6645572)|![Screenshot 2024-10-30 at 13 52 32](https://github.com/user-attachments/assets/b13330b9-b416-4e6c-a8be-854aaf418136)|![Screenshot 2024-10-30 at 13 54 20](https://github.com/user-attachments/assets/79eda7bd-cd92-4d3b-b29c-a6fc5d9f7050)|![Screenshot 2024-10-30 at 13 52 28](https://github.com/user-attachments/assets/e67f0516-3a30-4ec2-9fe7-2a3de0237c90)|
