### PR TITLE
TypeScript Improvements

### DIFF
--- a/src/helpers.tsx
+++ b/src/helpers.tsx
@@ -25,29 +25,16 @@ export function displayUserName(user: OktaUser | undefined) {
   return user.display_name != null ? user.display_name : user.first_name + ' ' + user.last_name;
 }
 
-// https://stackoverflow.com/a/8817461
-export function deepFind(obj: any, path: string) {
-  var paths = path.split('.'),
-    current = obj,
-    i;
-
-  for (i = 0; i < paths.length; ++i) {
-    if (current[paths[i]] == undefined) {
-      return undefined;
-    } else {
-      current = current[paths[i]];
-    }
-  }
-  return current;
-}
-
 // https://stackoverflow.com/a/34890276
-export function groupBy(xs: Array<any>, key: string) {
-  return xs.reduce(function (rv, x) {
-    const newKey = deepFind(x, key);
-    (rv[newKey] = rv[newKey] || []).push(x);
-    return rv;
-  }, {});
+export function groupBy<T>(xs: T[] | undefined, keyFn: (item: T) => string | undefined) {
+  return (xs ?? []).reduce(
+    (rv, x) => {
+      const newKey = keyFn(x) ?? '';
+      (rv[newKey] = rv[newKey] || []).push(x);
+      return rv;
+    },
+    {} as Record<string, T[]>,
+  );
 }
 
 export function getActiveTagsFromGroups(groups: PolymorphicGroup[]) {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -129,7 +129,7 @@ function AccordionMaker(props: AccordionMakerProps) {
         {sections[props.which][0]}
       </Typography>
       {Object.entries(guide[props.which]).map(([key, value]: [string, string]) => (
-        <Accordion key={key} expanded={expanded === key} onChange={handleChange(key)}>
+        <Accordion expanded={expanded === key} onChange={handleChange(key)}>
           <AccordionSummary
             expandIcon={<ExpandMoreIcon />}
             aria-controls={'panel-content' + key}
@@ -179,7 +179,7 @@ export default function Home() {
                 </Grid>
               </Grid>
               {Object.entries(sections).map(([key, [title, buttonTitle, icon]]) => (
-                <Grid key={key} item xs={12}>
+                <Grid item xs={12}>
                   <Button
                     variant="contained"
                     size="large"

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -129,7 +129,7 @@ function AccordionMaker(props: AccordionMakerProps) {
         {sections[props.which][0]}
       </Typography>
       {Object.entries(guide[props.which]).map(([key, value]: [string, string]) => (
-        <Accordion expanded={expanded === key} onChange={handleChange(key)}>
+        <Accordion key={key} expanded={expanded === key} onChange={handleChange(key)}>
           <AccordionSummary
             expandIcon={<ExpandMoreIcon />}
             aria-controls={'panel-content' + key}
@@ -179,7 +179,7 @@ export default function Home() {
                 </Grid>
               </Grid>
               {Object.entries(sections).map(([key, [title, buttonTitle, icon]]) => (
-                <Grid item xs={12}>
+                <Grid key={key} item xs={12}>
                   <Button
                     variant="contained"
                     size="large"

--- a/src/pages/apps/Read.tsx
+++ b/src/pages/apps/Read.tsx
@@ -43,10 +43,8 @@ function sortGroupMembers(
   return aEmail.localeCompare(bEmail);
 }
 
-function groupMemberships(
-  memberships: Array<OktaUserGroupMember> | undefined,
-): Map<string, Array<OktaUserGroupMember>> {
-  return groupBy(memberships ?? [], 'active_user.id');
+function groupMemberships(memberships: Array<OktaUserGroupMember> | undefined) {
+  return groupBy(memberships, (m) => m.active_user?.id);
 }
 
 export default function ReadApp() {

--- a/src/pages/groups/Read.tsx
+++ b/src/pages/groups/Read.tsx
@@ -148,23 +148,20 @@ export default function ReadGroup() {
     directRoleOwnerships.has(user.active_user!.id) ? null : allOwnerships.add(user);
   });
 
-  let ownerships: Map<string, Array<OktaUserGroupMember>> = groupBy(Array.from(allOwnerships), 'active_user.id');
+  let ownerships = groupBy(Array.from(allOwnerships), (m) => m.active_user?.id);
 
-  const memberships: Map<string, Array<OktaUserGroupMember>> = groupBy(
-    group.active_user_memberships ?? [],
-    'active_user.id',
-  );
+  const memberships = groupBy(group.active_user_memberships, (m) => m.active_user?.id);
 
-  let role_associated_group_owners = new Map<String, Array<RoleGroupMap>>();
-  let role_associated_group_members = new Map<String, Array<RoleGroupMap>>();
+  let role_associated_group_owners: Record<string, RoleGroupMap[]> = {};
+  let role_associated_group_members: Record<string, RoleGroupMap[]> = {};
   if (group.type == 'role_group') {
     role_associated_group_owners = groupBy(
-      (group as RoleGroup).active_role_associated_group_owner_mappings ?? [],
-      'active_group.id',
+      (group as RoleGroup).active_role_associated_group_owner_mappings,
+      (g) => g.active_group?.id,
     );
     role_associated_group_members = groupBy(
-      (group as RoleGroup).active_role_associated_group_member_mappings ?? [],
-      'active_group.id',
+      (group as RoleGroup).active_role_associated_group_member_mappings,
+      (g) => g.active_group?.id,
     );
   }
 

--- a/src/pages/requests/Read.tsx
+++ b/src/pages/requests/Read.tsx
@@ -255,10 +255,7 @@ export default function ReadRequest() {
     }));
   }
 
-  const ownerships: Map<string, Array<OktaUserGroupMember>> = groupBy(
-    group.active_user_ownerships ?? [],
-    'active_user.id',
-  );
+  const ownerships = groupBy(group.active_user_ownerships, (m) => m.active_user?.id);
 
   const {data: appData} = useGetAppById(
     {
@@ -276,7 +273,7 @@ export default function ReadRequest() {
   const appOwnershipsArray = (app.active_owner_app_groups ?? [])
     .map((appGroup) => appGroup.active_user_ownerships ?? [])
     .flat();
-  const appOwnerships: Map<string, Array<OktaUserGroupMember>> = groupBy(appOwnershipsArray, 'active_user.id');
+  const appOwnerships = groupBy(appOwnershipsArray, (m) => m.active_user?.id);
 
   const {data: accessAppData} = useGetAppById(
     {
@@ -295,9 +292,9 @@ export default function ReadRequest() {
 
   const accessApp = accessAppData ?? ({} as App);
 
-  const accessAppOwnerships: Map<string, Array<OktaUserGroupMember>> = groupBy(
+  const accessAppOwnerships = groupBy(
     (accessApp.active_owner_app_groups ?? []).map((appGroup) => appGroup.active_user_ownerships ?? []).flat(),
-    'active_user.id',
+    (m) => m.active_user?.id,
   );
 
   if (isError) {

--- a/src/pages/users/Read.tsx
+++ b/src/pages/users/Read.tsx
@@ -423,7 +423,7 @@ export default function ReadUser() {
   const user = data ?? ({} as OktaUser);
 
   const ownerships = groupBy(user.active_group_ownerships, (m) => m.active_user?.id);
-  const memberships = groupBy(user.active_group_memberships, (m) => m.active_user?.id);
+  const memberships = groupBy(user.active_group_memberships, (m) => m.active_group?.id);
 
   const showRemoveGroupFromRoleDialog = (removeGroup: PolymorphicGroup, fromRole: RoleGroup, owner: boolean) => {
     setRemoveGroupsFromRoleDialogParameters({

--- a/src/pages/users/Read.tsx
+++ b/src/pages/users/Read.tsx
@@ -111,7 +111,7 @@ function ReportingToCard({user}: ReportingToCardProps) {
 
 interface OwnerTableProps {
   user: OktaUser;
-  ownerships: Map<string, Array<OktaUserGroupMember>>;
+  ownerships: Record<string, OktaUserGroupMember[]>;
   onClickRemoveGroupFromRole: (removeGroup: PolymorphicGroup, fromRole: RoleGroup, owner: boolean) => void;
   onClickRemoveDirectAccess: (id: string, fromGroup: PolymorphicGroup, owner: boolean) => void;
 }
@@ -254,7 +254,7 @@ function OwnerTable({user, ownerships, onClickRemoveGroupFromRole, onClickRemove
 
 interface MemberTableProps {
   user: OktaUser;
-  memberships: Map<string, Array<OktaUserGroupMember>>;
+  memberships: Record<string, OktaUserGroupMember[]>;
   onClickRemoveGroupFromRole: (removeGroup: PolymorphicGroup, fromRole: RoleGroup, owner: boolean) => void;
   onClickRemoveDirectAccess: (id: string, fromGroup: PolymorphicGroup, owner: boolean) => void;
 }
@@ -422,14 +422,8 @@ export default function ReadUser() {
 
   const user = data ?? ({} as OktaUser);
 
-  const ownerships: Map<string, Array<OktaUserGroupMember>> = groupBy(
-    user.active_group_ownerships ?? [],
-    'active_group.id',
-  );
-  const memberships: Map<string, Array<OktaUserGroupMember>> = groupBy(
-    user.active_group_memberships ?? [],
-    'active_group.id',
-  );
+  const ownerships = groupBy(user.active_group_ownerships, (m) => m.active_user?.id);
+  const memberships = groupBy(user.active_group_memberships, (m) => m.active_user?.id);
 
   const showRemoveGroupFromRoleDialog = (removeGroup: PolymorphicGroup, fromRole: RoleGroup, owner: boolean) => {
     setRemoveGroupsFromRoleDialogParameters({

--- a/src/pages/users/Read.tsx
+++ b/src/pages/users/Read.tsx
@@ -422,7 +422,7 @@ export default function ReadUser() {
 
   const user = data ?? ({} as OktaUser);
 
-  const ownerships = groupBy(user.active_group_ownerships, (m) => m.active_user?.id);
+  const ownerships = groupBy(user.active_group_ownerships, (m) => m.active_group?.id);
   const memberships = groupBy(user.active_group_memberships, (m) => m.active_group?.id);
 
   const showRemoveGroupFromRoleDialog = (removeGroup: PolymorphicGroup, fromRole: RoleGroup, owner: boolean) => {


### PR DESCRIPTION
Converted `groupBy` helper to be strongly typed. This exposed some type errors where it was being used (result was assumed to be a `Map` but was actually just a `Record`). It now uses a typed accessor function to extract the key so the unsafe `deepFind` is not longer needed.