### PR TITLE
Pin PG to version 16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - postgres
 
   postgres:
-    image: postgres:latest
+    image: postgres:16
     container_name: postgres
     env_file:
       - .env.psql


### PR DESCRIPTION
Pin PG to version 16 in docker-compose.yml?

I did clone of what's in latest and ran into the follow errir with `docker compose up --build`:
```
attaching to discord-access, postgres
postgres        | 
postgres        | PostgreSQL Database directory appears to contain a database; Skipping initialization
postgres        | 
postgres        | 2024-11-05 20:53:14.422 UTC [1] FATAL:  database files are incompatible with server
postgres        | 2024-11-05 20:53:14.422 UTC [1] DETAIL:  The data directory was initialized by PostgreSQL version 16, which is not compatible with this version 17.0 (Debian 17.0-1.pgdg120+1).
postgres exited with code 1
```
If I pin the postgres image to 16, it comes up fine and I was able to check out the new dark mode :) 
