### PR TITLE
Group Audit Color Bug

### DIFF
--- a/src/pages/groups/Audit.tsx
+++ b/src/pages/groups/Audit.tsx
@@ -256,10 +256,10 @@ export default function AuditGroup() {
             <TableRow
               key={row.id}
               sx={{
-                backgroundColor: ({palette}) =>
-                  Object.values(row.ended_at == null || dayjs().isBefore(dayjs(row.ended_at)))
-                    ? palette.highlight.success.main
-                    : palette.highlight.danger.main,
+                bgcolor: ({palette: {highlight}}) =>
+                  row.ended_at == null || dayjs().isBefore(dayjs(row.ended_at))
+                    ? highlight.success.main
+                    : highlight.danger.main,
               }}>
               <TableCell>
                 {(row.user?.deleted_at ?? null) != null ? (


### PR DESCRIPTION
Expired access was shown as green instead of red on group audit pages. Fixed this so it's now back to being red
