### PR TITLE
Filter 'expiring in a week' individual notifications

### DIFF
--- a/api/syncer.py
+++ b/api/syncer.py
@@ -458,6 +458,12 @@ def expiring_access_notifications_user() -> None:
         .all()
     )
 
+    db_memberships_expiring_next_week = [
+        member
+        for member in db_memberships_expiring_next_week
+        if (member.user_id, member.group_id) not in user_id_group_id_roles
+    ]
+
     grouped_next_week: dict[OktaUser, list[OktaGroup]] = {}
     for membership in db_memberships_expiring_next_week:
         grouped_next_week.setdefault(membership.active_user, []).append(membership.active_group)

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -458,6 +458,7 @@ def expiring_access_notifications_user() -> None:
         .all()
     )
 
+    # remove OktaUserGroupMembers from the list where there's a role that grants the same access
     db_memberships_expiring_next_week = [
         member
         for member in db_memberships_expiring_next_week


### PR DESCRIPTION
Currently, expiring access notifications for individuals come in two forms. Access expiring tomorrow and access expiring in a week. A while ago we added filtering for the 'expiring tomorrow' notifications to give preference to access via a role (users aren't notified about expiring individual access if they have the same access via a role) but did not add the same filtering logic to 'expiring in a week' notifications. This PR corrects that oversight.