### PR TITLE
Make the default time durations configurable on User Form Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,14 @@ The `.env.production` file is where you configure the application.
 
 **Check out `.env.psql.example` or `.env.production.example` for an example configuration file structure**.
 
+**Environment Default Overrides:**
+
+- `UNTIL_ID_TO_LABELS_OVERRIDE`: Allows overriding the default ID to labels mapping. **Example:** `'{"14400":"4 Hours","43200":"12 Hours","432000":"5 Days","1209600":"Two Weeks","2592000":"30 Days","7776000":"90 Days"}'`.
+- `UNTIL_JUST_NUMERIC_ID_TO_LABELS_OVERRIDE`: Allows overriding the default numeric ID to labels mapping. **Example:** `'{"14400":"4 Hours","43200":"12 Hours","432000":"5 Days","1209600":"Two Weeks","2592000":"30 Days","7776000":"90 Days"}'`.
+- `DEFAULT_ACCESS_TIME_OVERRIDE`: Allows overriding the default access time. **Example:** `43200` (in seconds).
+
+Defaults for these overrides can be found in the `src/env-overrides.tsx` file.
+
 **NOTE:**
 
 If you are using Cloudflare Access, ensure that you configure `CLOUDFLARE_TEAM_DOMAIN` and `CLOUDFLARE_APPLICATION_AUDIENCE`. `SECRET_KEY` and `OIDC_CLIENT_SECRETS` do not need to be set and can be removed from your env file.

--- a/src/env-overrides.tsx
+++ b/src/env-overrides.tsx
@@ -1,0 +1,41 @@
+// set a default set of values for UNTIL_ID_TO_LABELS that can be overridden in the environment
+const UNTIL_ID_TO_LABELS_DEFAULT: Record<string, string> = {
+  '43200': '12 Hours',
+  '432000': '5 Days',
+  '1209600': 'Two Weeks',
+  '2592000': '30 Days',
+  '7776000': '90 Days',
+  indefinite: 'Indefinite',
+  custom: 'Custom',
+} as const;
+
+// Uses process.env.UNTIL_ID_TO_LABELS_OVERRIDE if defined, otherwise uses default
+const UNTIL_ID_TO_LABELS_CONFIG: Record<string, string> = process.env.UNTIL_ID_TO_LABELS_OVERRIDE
+  ? JSON.parse(process.env.UNTIL_ID_TO_LABELS_OVERRIDE)
+  : UNTIL_ID_TO_LABELS_DEFAULT;
+
+export {UNTIL_ID_TO_LABELS_CONFIG};
+
+// set a default set of values for UNTIL_JUST_NUMERIC_ID_TO_LABELS that can be overridden in the environment
+const UNTIL_JUST_NUMERIC_ID_TO_LABELS_DEFAULT: Record<string, string> = {
+  '43200': '12 Hours',
+  '432000': '5 Days',
+  '1209600': 'Two Weeks',
+  '2592000': '30 Days',
+  '7776000': '90 Days',
+} as const;
+
+// Uses process.env.UNTIL_JUST_NUMERIC_ID_TO_LABELS_OVERRIDE if defined, otherwise uses default
+const UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG: Record<string, string> = process.env.UNTIL_JUST_NUMERIC_ID_TO_LABELS_OVERRIDE
+  ? JSON.parse(process.env.UNTIL_JUST_NUMERIC_ID_TO_LABELS_OVERRIDE)
+  : UNTIL_JUST_NUMERIC_ID_TO_LABELS_DEFAULT;
+
+export {UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG};
+
+// Set Default value for React form state that can be overriden
+const DEFAULT_ACCESS_TIME_DEFAULT = '1209600';
+
+// Parse and export DEFAULT_ACCESS_TIME_CONFIG
+export const DEFAULT_ACCESS_TIME_CONFIG: string = process.env.DEFAULT_ACCESS_TIME_OVERRIDE
+  ? process.env.DEFAULT_ACCESS_TIME_OVERRIDE
+  : DEFAULT_ACCESS_TIME_DEFAULT;

--- a/src/env-overrides.tsx
+++ b/src/env-overrides.tsx
@@ -9,9 +9,9 @@ const UNTIL_ID_TO_LABELS_DEFAULT: Record<string, string> = {
   custom: 'Custom',
 } as const;
 
-// Uses process.env.UNTIL_ID_TO_LABELS_OVERRIDE if defined, otherwise uses default
-const UNTIL_ID_TO_LABELS_CONFIG: Record<string, string> = process.env.UNTIL_ID_TO_LABELS_OVERRIDE
-  ? JSON.parse(process.env.UNTIL_ID_TO_LABELS_OVERRIDE)
+// Uses process.env.REACT_APP_UNTIL_ID_TO_LABELS_OVERRIDE if defined, otherwise uses default
+const UNTIL_ID_TO_LABELS_CONFIG: Record<string, string> = process.env.REACT_APP_UNTIL_ID_TO_LABELS_OVERRIDE
+  ? JSON.parse(process.env.REACT_APP_UNTIL_ID_TO_LABELS_OVERRIDE)
   : UNTIL_ID_TO_LABELS_DEFAULT;
 
 export {UNTIL_ID_TO_LABELS_CONFIG};
@@ -25,9 +25,9 @@ const UNTIL_JUST_NUMERIC_ID_TO_LABELS_DEFAULT: Record<string, string> = {
   '7776000': '90 Days',
 } as const;
 
-// Uses process.env.UNTIL_JUST_NUMERIC_ID_TO_LABELS_OVERRIDE if defined, otherwise uses default
-const UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG: Record<string, string> = process.env.UNTIL_JUST_NUMERIC_ID_TO_LABELS_OVERRIDE
-  ? JSON.parse(process.env.UNTIL_JUST_NUMERIC_ID_TO_LABELS_OVERRIDE)
+// Uses process.env.REACT_APP_UNTIL_JUST_NUMERIC_ID_TO_LABELS_OVERRIDE if defined, otherwise uses default
+const UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG: Record<string, string> = process.env.REACT_APP_UNTIL_JUST_NUMERIC_ID_TO_LABELS_OVERRIDE
+  ? JSON.parse(process.env.REACT_APP_UNTIL_JUST_NUMERIC_ID_TO_LABELS_OVERRIDE)
   : UNTIL_JUST_NUMERIC_ID_TO_LABELS_DEFAULT;
 
 export {UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG};
@@ -36,6 +36,6 @@ export {UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG};
 const DEFAULT_ACCESS_TIME_DEFAULT = '1209600';
 
 // Parse and export DEFAULT_ACCESS_TIME_CONFIG
-export const DEFAULT_ACCESS_TIME_CONFIG: string = process.env.DEFAULT_ACCESS_TIME_OVERRIDE
-  ? process.env.DEFAULT_ACCESS_TIME_OVERRIDE
+export const DEFAULT_ACCESS_TIME_CONFIG: string = process.env.REACT_APP_DEFAULT_ACCESS_TIME_OVERRIDE
+  ? process.env.REACT_APP_DEFAULT_ACCESS_TIME_OVERRIDE
   : DEFAULT_ACCESS_TIME_DEFAULT;

--- a/src/pages/groups/AddRoles.tsx
+++ b/src/pages/groups/AddRoles.tsx
@@ -40,9 +40,12 @@ import {PolymorphicGroup, RoleGroup, RoleMember, OktaUser} from '../../api/apiSc
 import {canManageGroup, isAccessAdmin, isGroupOwner} from '../../authorization';
 import {minTagTime, ownerCantAddSelf, requiredReason} from '../../helpers';
 import {useCurrentUser} from '../../authentication';
-import {UNTIL_ID_TO_LABELS_CONFIG} from '../../env-overrides';
-import {UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG} from '../../env-overrides';
-import {DEFAULT_ACCESS_TIME_CONFIG} from '../../env-overrides';
+
+import {
+  UNTIL_ID_TO_LABELS_CONFIG,
+  UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG,
+  DEFAULT_ACCESS_TIME_CONFIG
+} from '../../env-overrides';
 
 dayjs.extend(IsSameOrBefore);
 

--- a/src/pages/groups/AddRoles.tsx
+++ b/src/pages/groups/AddRoles.tsx
@@ -40,6 +40,9 @@ import {PolymorphicGroup, RoleGroup, RoleMember, OktaUser} from '../../api/apiSc
 import {canManageGroup, isAccessAdmin, isGroupOwner} from '../../authorization';
 import {minTagTime, ownerCantAddSelf, requiredReason} from '../../helpers';
 import {useCurrentUser} from '../../authentication';
+import {UNTIL_ID_TO_LABELS_CONFIG} from '../../env-overrides';
+import {UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG} from '../../env-overrides';
+import {DEFAULT_ACCESS_TIME_CONFIG} from '../../env-overrides';
 
 dayjs.extend(IsSameOrBefore);
 
@@ -78,23 +81,9 @@ const GROUP_TYPE_ID_TO_LABELS: Record<string, string> = {
 
 const RFC822_FORMAT = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
 
-const UNTIL_ID_TO_LABELS: Record<string, string> = {
-  '43200': '12 Hours',
-  '432000': '5 Days',
-  '1209600': 'Two Weeks',
-  '2592000': '30 Days',
-  '7776000': '90 Days',
-  indefinite: 'Indefinite',
-  custom: 'Custom',
-} as const;
+const UNTIL_ID_TO_LABELS = UNTIL_ID_TO_LABELS_CONFIG;
 
-const UNTIL_JUST_NUMERIC_ID_TO_LABELS: Record<string, string> = {
-  '43200': '12 Hours',
-  '432000': '5 Days',
-  '1209600': 'Two Weeks',
-  '2592000': '30 Days',
-  '7776000': '90 Days',
-} as const;
+const UNTIL_JUST_NUMERIC_ID_TO_LABELS = UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG;
 
 const UNTIL_OPTIONS = Object.entries(UNTIL_ID_TO_LABELS).map(([id, label], index) => ({id: id, label: label}));
 
@@ -110,7 +99,7 @@ function AddRolesDialog(props: AddRolesDialogProps) {
         return out;
       }, new Array<string>()) ?? [];
 
-  const [until, setUntil] = React.useState('1209600');
+  const [until, setUntil] = React.useState(DEFAULT_ACCESS_TIME_CONFIG);
   const [roleSearchInput, setRoleSearchInput] = React.useState('');
   const [roles, setRoles] = React.useState<Array<RoleGroup>>([]);
   const [requestError, setRequestError] = React.useState('');
@@ -132,7 +121,7 @@ function AddRolesDialog(props: AddRolesDialogProps) {
   const disallowOwnerAdd = isGroupOwner(currentUser, props.group.id!) && ownerCantAddSelf(activeGroupTags, props.owner);
 
   let labels = null;
-  let timeLimitUntil = null;
+  let timeLimitUntil: string | null = null;
   if (!(timeLimit == null)) {
     const filteredUntil = Object.keys(UNTIL_JUST_NUMERIC_ID_TO_LABELS)
       .filter((key) => Number(key) <= timeLimit!)
@@ -144,7 +133,8 @@ function AddRolesDialog(props: AddRolesDialogProps) {
         {} as Record<string, string>,
       );
 
-    timeLimitUntil = timeLimit >= 1209600 ? '1209600' : Object.keys(filteredUntil).at(-1)!;
+    const timeLimitUntil =
+      timeLimit >= parseInt(DEFAULT_ACCESS_TIME_CONFIG) ? DEFAULT_ACCESS_TIME_CONFIG : Object.keys(filteredUntil).at(-1)!;
 
     labels = Object.entries(Object.assign({}, filteredUntil, {custom: 'Custom'})).map(([id, label], index) => ({
       id: id,
@@ -242,7 +232,7 @@ function AddRolesDialog(props: AddRolesDialogProps) {
   return (
     <Dialog open fullWidth onClose={() => props.setOpen(false)}>
       <FormContainer<AddRolesForm>
-        defaultValues={timeLimit ? {until: timeLimitUntil!} : {until: '1209600'}}
+        defaultValues={timeLimit ? {until: timeLimitUntil!} : {until: DEFAULT_ACCESS_TIME_CONFIG.toString()}}
         onSuccess={(formData) => submit(formData)}>
         <DialogTitle>Add {addRolesText}</DialogTitle>
         <DialogContent>

--- a/src/pages/groups/AddUsers.tsx
+++ b/src/pages/groups/AddUsers.tsx
@@ -48,6 +48,10 @@ import {
   requiredReasonGroups,
 } from '../../helpers';
 
+import {UNTIL_ID_TO_LABELS_CONFIG} from '../../env-overrides';
+import {UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG} from '../../env-overrides';
+import {DEFAULT_ACCESS_TIME_CONFIG} from '../../env-overrides';
+
 dayjs.extend(IsSameOrBefore);
 
 interface AddUsersButtonProps {
@@ -78,30 +82,16 @@ interface AddUsersForm {
 
 const RFC822_FORMAT = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
 
-const UNTIL_ID_TO_LABELS: Record<string, string> = {
-  '43200': '12 Hours',
-  '432000': '5 Days',
-  '1209600': 'Two Weeks',
-  '2592000': '30 Days',
-  '7776000': '90 Days',
-  indefinite: 'Indefinite',
-  custom: 'Custom',
-} as const;
+const UNTIL_ID_TO_LABELS = UNTIL_ID_TO_LABELS_CONFIG;
 
-const UNTIL_JUST_NUMERIC_ID_TO_LABELS: Record<string, string> = {
-  '43200': '12 Hours',
-  '432000': '5 Days',
-  '1209600': 'Two Weeks',
-  '2592000': '30 Days',
-  '7776000': '90 Days',
-} as const;
+const UNTIL_JUST_NUMERIC_ID_TO_LABELS = UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG;
 
 const UNTIL_OPTIONS = Object.entries(UNTIL_ID_TO_LABELS).map(([id, label], index) => ({id: id, label: label}));
 
 function AddUsersDialog(props: AddUsersDialogProps) {
   const navigate = useNavigate();
 
-  const [until, setUntil] = React.useState('1209600');
+  const [until, setUntil] = React.useState(DEFAULT_ACCESS_TIME_CONFIG);
   const [userSearchInput, setUserSearchInput] = React.useState('');
   const [users, setUsers] = React.useState<Array<OktaUser>>([]);
   const [requestError, setRequestError] = React.useState('');
@@ -150,7 +140,7 @@ function AddUsersDialog(props: AddUsersDialogProps) {
   }
 
   let labels = null;
-  let timeLimitUntil = null;
+  let timeLimitUntil: string | null = null;
   if (!(timeLimit == null)) {
     const filteredUntil = Object.keys(UNTIL_JUST_NUMERIC_ID_TO_LABELS)
       .filter((key) => Number(key) <= timeLimit!)
@@ -162,7 +152,8 @@ function AddUsersDialog(props: AddUsersDialogProps) {
         {} as Record<string, string>,
       );
 
-    timeLimitUntil = timeLimit >= 1209600 ? '1209600' : Object.keys(filteredUntil).at(-1)!;
+    const timeLimitUntil =
+      timeLimit >= parseInt(DEFAULT_ACCESS_TIME_CONFIG) ? DEFAULT_ACCESS_TIME_CONFIG : Object.keys(filteredUntil).at(-1)!;
 
     labels = Object.entries(Object.assign({}, filteredUntil, {custom: 'Custom'})).map(([id, label], index) => ({
       id: id,
@@ -244,7 +235,7 @@ function AddUsersDialog(props: AddUsersDialogProps) {
   return (
     <Dialog open fullWidth onClose={() => props.setOpen(false)}>
       <FormContainer<AddUsersForm>
-        defaultValues={timeLimit ? {until: timeLimitUntil!} : {until: '1209600'}}
+        defaultValues={timeLimit ? {until: timeLimitUntil!} : {until: DEFAULT_ACCESS_TIME_CONFIG.toString()}}
         onSuccess={(formData) => submit(formData)}>
         <DialogTitle>Add {addUsersText}</DialogTitle>
         <DialogContent>

--- a/src/pages/groups/AddUsers.tsx
+++ b/src/pages/groups/AddUsers.tsx
@@ -48,9 +48,11 @@ import {
   requiredReasonGroups,
 } from '../../helpers';
 
-import {UNTIL_ID_TO_LABELS_CONFIG} from '../../env-overrides';
-import {UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG} from '../../env-overrides';
-import {DEFAULT_ACCESS_TIME_CONFIG} from '../../env-overrides';
+import {
+  UNTIL_ID_TO_LABELS_CONFIG,
+  UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG,
+  DEFAULT_ACCESS_TIME_CONFIG
+} from '../../env-overrides';
 
 dayjs.extend(IsSameOrBefore);
 

--- a/src/pages/groups/BulkRenewal.tsx
+++ b/src/pages/groups/BulkRenewal.tsx
@@ -31,9 +31,11 @@ import {usePutGroupMembersById, PutGroupMembersByIdError, PutGroupMembersByIdVar
 import {GroupMember, OktaUserGroupMember, PolymorphicGroup, RoleGroupMap, RoleGroup} from '../../api/apiSchemas';
 import BulkRenewalDataGrid from '../../components/BulkRenewalDataGrid';
 
-import {UNTIL_ID_TO_LABELS_CONFIG} from '../../env-overrides';
-import {UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG} from '../../env-overrides';
-import {DEFAULT_ACCESS_TIME_CONFIG} from '../../env-overrides';
+import {
+  UNTIL_ID_TO_LABELS_CONFIG,
+  UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG,
+  DEFAULT_ACCESS_TIME_CONFIG
+} from '../../env-overrides';
 
 interface Data {
   id: number;

--- a/src/pages/groups/BulkRenewal.tsx
+++ b/src/pages/groups/BulkRenewal.tsx
@@ -31,6 +31,10 @@ import {usePutGroupMembersById, PutGroupMembersByIdError, PutGroupMembersByIdVar
 import {GroupMember, OktaUserGroupMember, PolymorphicGroup, RoleGroupMap, RoleGroup} from '../../api/apiSchemas';
 import BulkRenewalDataGrid from '../../components/BulkRenewalDataGrid';
 
+import {UNTIL_ID_TO_LABELS_CONFIG} from '../../env-overrides';
+import {UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG} from '../../env-overrides';
+import {DEFAULT_ACCESS_TIME_CONFIG} from '../../env-overrides';
+
 interface Data {
   id: number;
   userName: string;
@@ -68,23 +72,9 @@ interface CreateRequestForm {
   reason?: string;
 }
 
-const UNTIL_ID_TO_LABELS: Record<string, string> = {
-  '43200': '12 Hours',
-  '432000': '5 Days',
-  '1209600': 'Two Weeks',
-  '2592000': '30 Days',
-  '7776000': '90 Days',
-  indefinite: 'Indefinite',
-  custom: 'Custom',
-} as const;
+const UNTIL_ID_TO_LABELS = UNTIL_ID_TO_LABELS_CONFIG;
 
-const UNTIL_JUST_NUMERIC_ID_TO_LABELS: Record<string, string> = {
-  '43200': '12 Hours',
-  '432000': '5 Days',
-  '1209600': 'Two Weeks',
-  '2592000': '30 Days',
-  '7776000': '90 Days',
-} as const;
+const UNTIL_JUST_NUMERIC_ID_TO_LABELS = UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG
 
 const UNTIL_OPTIONS = Object.entries(UNTIL_ID_TO_LABELS).map(([id, label], index) => ({id: id, label: label}));
 
@@ -113,7 +103,7 @@ function BulkRenewalDialog(props: BulkRenewalDialogProps) {
   const [selected, setSelected] = React.useState<OktaUserGroupMember[]>(() =>
     props.select != undefined ? props.rows.filter((r) => r.id == props.select) : [],
   );
-  const [until, setUntil] = React.useState('1209600');
+  const [until, setUntil] = React.useState(DEFAULT_ACCESS_TIME_CONFIG);
 
   const [selectionModel, setSelectionModel] = React.useState<GridRowSelectionModel>(() =>
     props.rows.filter((r) => r.id == props.select).map((r) => r.id),

--- a/src/pages/requests/Create.tsx
+++ b/src/pages/requests/Create.tsx
@@ -43,9 +43,11 @@ import {
 import {canManageGroup} from '../../authorization';
 import {minTagTime, minTagTimeGroups} from '../../helpers';
 
-import {UNTIL_ID_TO_LABELS_CONFIG} from '../../env-overrides';
-import {UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG} from '../../env-overrides';
-import {DEFAULT_ACCESS_TIME_CONFIG} from '../../env-overrides';
+import {
+  UNTIL_ID_TO_LABELS_CONFIG,
+  UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG,
+  DEFAULT_ACCESS_TIME_CONFIG
+} from '../../env-overrides';
 
 dayjs.extend(IsSameOrBefore);
 

--- a/src/pages/requests/Create.tsx
+++ b/src/pages/requests/Create.tsx
@@ -43,6 +43,10 @@ import {
 import {canManageGroup} from '../../authorization';
 import {minTagTime, minTagTimeGroups} from '../../helpers';
 
+import {UNTIL_ID_TO_LABELS_CONFIG} from '../../env-overrides';
+import {UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG} from '../../env-overrides';
+import {DEFAULT_ACCESS_TIME_CONFIG} from '../../env-overrides';
+
 dayjs.extend(IsSameOrBefore);
 
 interface CreateRequestButtonProps {
@@ -168,23 +172,9 @@ const GROUP_TYPE_ID_TO_LABELS: Record<string, string> = {
 
 const RFC822_FORMAT = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
 
-const UNTIL_ID_TO_LABELS: Record<string, string> = {
-  '43200': '12 Hours',
-  '432000': '5 Days',
-  '1209600': 'Two Weeks',
-  '2592000': '30 Days',
-  '7776000': '90 Days',
-  indefinite: 'Indefinite',
-  custom: 'Custom',
-} as const;
+const UNTIL_ID_TO_LABELS = UNTIL_ID_TO_LABELS_CONFIG;
 
-const UNTIL_JUST_NUMERIC_ID_TO_LABELS: Record<string, string> = {
-  '43200': '12 Hours',
-  '432000': '5 Days',
-  '1209600': 'Two Weeks',
-  '2592000': '30 Days',
-  '7776000': '90 Days',
-} as const;
+const UNTIL_JUST_NUMERIC_ID_TO_LABELS = UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG;
 
 const UNTIL_OPTIONS = Object.entries(UNTIL_ID_TO_LABELS).map(([id, label], index) => ({id: id, label: label}));
 
@@ -232,7 +222,7 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
 
   const untilLabels: [string, Array<Record<string, string>>] = timeLimit
     ? filterUntilLabels(timeLimit)
-    : ['1209600', UNTIL_OPTIONS];
+    : [DEFAULT_ACCESS_TIME_CONFIG, UNTIL_OPTIONS];
   const [until, setUntil] = React.useState(untilLabels[0]);
   const [labels, setLabels] = React.useState<Array<Record<string, string>>>(untilLabels[1]);
 
@@ -320,7 +310,7 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
     <FormContainer<CreateRequestForm>
       defaultValues={{
         group: props.group,
-        until: '1209600',
+        until: DEFAULT_ACCESS_TIME_CONFIG,
         ownerOrMember: props.owner != null ? (props.owner ? 'owner' : 'member') : undefined,
       }}
       onSuccess={(formData) => submit(formData)}>

--- a/src/pages/requests/Read.tsx
+++ b/src/pages/requests/Read.tsx
@@ -73,6 +73,9 @@ import {
 import NotFound from '../NotFound';
 import Loading from '../../components/Loading';
 
+import {UNTIL_ID_TO_LABELS_CONFIG} from '../../env-overrides';
+import {UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG} from '../../env-overrides';
+
 dayjs.extend(RelativeTime);
 dayjs.extend(IsSameOrBefore);
 
@@ -99,23 +102,9 @@ const GROUP_TYPE_ID_TO_LABELS: Record<string, string> = {
 
 const RFC822_FORMAT = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
 
-const UNTIL_ID_TO_LABELS: Record<string, string> = {
-  '43200': '12 Hours',
-  '432000': '5 Days',
-  '1209600': 'Two Weeks',
-  '2592000': '30 Days',
-  '7776000': '90 Days',
-  indefinite: 'Indefinite',
-  custom: 'Custom',
-} as const;
+const UNTIL_ID_TO_LABELS = UNTIL_ID_TO_LABELS_CONFIG;
 
-const UNTIL_JUST_NUMERIC_ID_TO_LABELS: Record<string, string> = {
-  '43200': '12 Hours',
-  '432000': '5 Days',
-  '1209600': 'Two Weeks',
-  '2592000': '30 Days',
-  '7776000': '90 Days',
-} as const;
+const UNTIL_JUST_NUMERIC_ID_TO_LABELS = UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG;
 
 const UNTIL_OPTIONS = Object.entries(UNTIL_ID_TO_LABELS).map(([id, label], index) => ({id: id, label: label}));
 

--- a/src/pages/requests/Read.tsx
+++ b/src/pages/requests/Read.tsx
@@ -73,8 +73,10 @@ import {
 import NotFound from '../NotFound';
 import Loading from '../../components/Loading';
 
-import {UNTIL_ID_TO_LABELS_CONFIG} from '../../env-overrides';
-import {UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG} from '../../env-overrides';
+import {
+  UNTIL_ID_TO_LABELS_CONFIG,
+  UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG,
+} from '../../env-overrides';
 
 dayjs.extend(RelativeTime);
 dayjs.extend(IsSameOrBefore);

--- a/src/pages/roles/AddGroups.tsx
+++ b/src/pages/roles/AddGroups.tsx
@@ -44,9 +44,11 @@ import {minTagTimeGroups, requiredReasonGroups, ownerCantAddSelf} from '../../he
 import {useCurrentUser} from '../../authentication';
 import {group} from 'console';
 
-import {UNTIL_ID_TO_LABELS_CONFIG} from '../../env-overrides';
-import {UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG} from '../../env-overrides';
-import {DEFAULT_ACCESS_TIME_CONFIG} from '../../env-overrides';
+import {
+  UNTIL_ID_TO_LABELS_CONFIG,
+  UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG,
+  DEFAULT_ACCESS_TIME_CONFIG
+} from '../../env-overrides';
 
 dayjs.extend(IsSameOrBefore);
 

--- a/src/pages/roles/AddGroups.tsx
+++ b/src/pages/roles/AddGroups.tsx
@@ -44,6 +44,10 @@ import {minTagTimeGroups, requiredReasonGroups, ownerCantAddSelf} from '../../he
 import {useCurrentUser} from '../../authentication';
 import {group} from 'console';
 
+import {UNTIL_ID_TO_LABELS_CONFIG} from '../../env-overrides';
+import {UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG} from '../../env-overrides';
+import {DEFAULT_ACCESS_TIME_CONFIG} from '../../env-overrides';
+
 dayjs.extend(IsSameOrBefore);
 
 interface AddGroupsButtonProps {
@@ -79,23 +83,9 @@ const GROUP_TYPE_ID_TO_LABELS: Record<string, string> = {
 
 const RFC822_FORMAT = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
 
-const UNTIL_ID_TO_LABELS: Record<string, string> = {
-  '43200': '12 Hours',
-  '432000': '5 Days',
-  '1209600': 'Two Weeks',
-  '2592000': '30 Days',
-  '7776000': '90 Days',
-  indefinite: 'Indefinite',
-  custom: 'Custom',
-} as const;
+const UNTIL_ID_TO_LABELS = UNTIL_ID_TO_LABELS_CONFIG;
 
-const UNTIL_JUST_NUMERIC_ID_TO_LABELS: Record<string, string> = {
-  '43200': '12 Hours',
-  '432000': '5 Days',
-  '1209600': 'Two Weeks',
-  '2592000': '30 Days',
-  '7776000': '90 Days',
-} as const;
+const UNTIL_JUST_NUMERIC_ID_TO_LABELS = UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG;
 
 const UNTIL_OPTIONS = Object.entries(UNTIL_ID_TO_LABELS).map(([id, label], index) => ({id: id, label: label}));
 
@@ -121,7 +111,7 @@ function AddGroupsDialog(props: AddGroupsDialogProps) {
     props.group.active_user_memberships?.map((membership) => membership.active_user!.id).includes(currentUser.id) ??
     false;
 
-  const [until, setUntil] = React.useState('1209600');
+  const [until, setUntil] = React.useState(DEFAULT_ACCESS_TIME_CONFIG);
   const [groupSearchInput, setGroupSearchInput] = React.useState('');
   const [groups, setGroups] = React.useState<Array<OktaGroup | AppGroup>>([]);
   const [requestError, setRequestError] = React.useState('');

--- a/src/pages/roles/BulkRenewal.tsx
+++ b/src/pages/roles/BulkRenewal.tsx
@@ -34,9 +34,11 @@ import {RoleMember, RoleGroupMap, OktaGroup, AppGroup} from '../../api/apiSchema
 import {isAccessAdmin} from '../../authorization';
 import BulkRenewalDataGrid from '../../components/BulkRenewalDataGrid';
 
-import {UNTIL_ID_TO_LABELS_CONFIG} from '../../env-overrides';
-import {UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG} from '../../env-overrides';
-import {DEFAULT_ACCESS_TIME_CONFIG} from '../../env-overrides';
+import {
+  UNTIL_ID_TO_LABELS_CONFIG,
+  UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG,
+  DEFAULT_ACCESS_TIME_CONFIG
+} from '../../env-overrides';
 
 interface Data {
   id: number;

--- a/src/pages/roles/BulkRenewal.tsx
+++ b/src/pages/roles/BulkRenewal.tsx
@@ -34,6 +34,10 @@ import {RoleMember, RoleGroupMap, OktaGroup, AppGroup} from '../../api/apiSchema
 import {isAccessAdmin} from '../../authorization';
 import BulkRenewalDataGrid from '../../components/BulkRenewalDataGrid';
 
+import {UNTIL_ID_TO_LABELS_CONFIG} from '../../env-overrides';
+import {UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG} from '../../env-overrides';
+import {DEFAULT_ACCESS_TIME_CONFIG} from '../../env-overrides';
+
 interface Data {
   id: number;
   groupName: string | undefined;
@@ -71,23 +75,9 @@ interface CreateRequestForm {
   reason?: string;
 }
 
-const UNTIL_ID_TO_LABELS: Record<string, string> = {
-  '43200': '12 Hours',
-  '432000': '5 Days',
-  '1209600': 'Two Weeks',
-  '2592000': '30 Days',
-  '7776000': '90 Days',
-  indefinite: 'Indefinite',
-  custom: 'Custom',
-} as const;
+const UNTIL_ID_TO_LABELS = UNTIL_ID_TO_LABELS_CONFIG;
 
-const UNTIL_JUST_NUMERIC_ID_TO_LABELS: Record<string, string> = {
-  '43200': '12 Hours',
-  '432000': '5 Days',
-  '1209600': 'Two Weeks',
-  '2592000': '30 Days',
-  '7776000': '90 Days',
-} as const;
+const UNTIL_JUST_NUMERIC_ID_TO_LABELS = UNTIL_JUST_NUMERIC_ID_TO_LABELS_CONFIG;
 
 const UNTIL_OPTIONS = Object.entries(UNTIL_ID_TO_LABELS).map(([id, label], index) => ({id: id, label: label}));
 
@@ -116,7 +106,7 @@ function BulkRenewalDialog(props: BulkRenewalDialogProps) {
   const [labels, setLabels] = React.useState<Array<Record<string, string>>>(UNTIL_OPTIONS);
   const [timeLimit, setTimeLimit] = React.useState<number | null>(null);
   const [requiredReason, setRequiredReason] = React.useState<boolean>(false);
-  const [until, setUntil] = React.useState('1209600');
+  const [until, setUntil] = React.useState(DEFAULT_ACCESS_TIME_CONFIG);
 
   const [paginationModel, setPaginationModel] = React.useState({
     pageSize: 10,


### PR DESCRIPTION
We'd like customize the selectable time durations--including having a different default duration--when creating an Access Request.

Updated README with new REACT_APP Environment Vars introduced:
```
**Environment Default Overrides:**

- `UNTIL_ID_TO_LABELS_OVERRIDE`: Allows overriding the default ID to labels mapping. **Example:** `'{"14400":"4 Hours","43200":"12 Hours","432000":"5 Days","1209600":"Two Weeks","2592000":"30 Days","7776000":"90 Days"}'`.
- `UNTIL_JUST_NUMERIC_ID_TO_LABELS_OVERRIDE`: Allows overriding the default numeric ID to labels mapping. **Example:** `'{"14400":"4 Hours","43200":"12 Hours","432000":"5 Days","1209600":"Two Weeks","2592000":"30 Days","7776000":"90 Days"}'`.
- `DEFAULT_ACCESS_TIME_OVERRIDE`: Allows overriding the default access time. **Example:** `43200` (in seconds).

Defaults for these overrides can be found in the `src/env-overrides.tsx` file.
```

Credit to @Jui1337 who worked on the initial logic for this during her Internship on our team, but didn't manage to get this upstream yet.

I believe we've respected the current settings by setting them as the defaults in `src/env-overrides.tsx`.  

Let me know if you'd like any changes / if this can be accepted upstream.

