### PR TITLE
Add allow_discord_access custom Okta Group profile attribute check

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -13,6 +13,9 @@ OKTA_API_TOKEN = os.getenv("OKTA_API_TOKEN")
 OKTA_USE_GROUP_OWNERS_API = os.getenv("OKTA_USE_GROUP_OWNERS_API", "False") == "True"
 CURRENT_OKTA_USER_EMAIL = os.getenv("CURRENT_OKTA_USER_EMAIL", "wumpus@discord.com")
 
+# Optional env var to set a custom Okta Group Profile attribute for Access management inclusion/exclusion
+OKTA_GROUP_PROFILE_CUSTOM_ATTR = os.getenv("OKTA_GROUP_PROFILE_CUSTOM_ATTR")
+
 SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URI")
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 SQLALCHEMY_ECHO = ENV == "development"  # or ENV == "test"

--- a/api/services/okta_service.py
+++ b/api/services/okta_service.py
@@ -535,4 +535,16 @@ class Group:
 
 
 def is_managed_group(group: Group, group_ids_with_group_rules: dict[str, list[OktaGroupRuleType]]) -> bool:
+    # Check if 'allow_discord_access' attribute exists as a custom Okta Group Profile attribute and retrieve its value
+    allow_discord_access = getattr(group.profile, "allow_discord_access", None)
+
+    # If 'allow_discord_access' is explicitly set to False, the group should not be managed
+    if allow_discord_access is False:
+        return False
+
+    # If 'allow_discord_access' is True and the group type is OKTA_GROUP, it can be managed even if it has group rules
+    if allow_discord_access is True and group.type == "OKTA_GROUP":
+        return True
+
+    # By default, the group should be of type OKTA_GROUP and should not have any group rules to be managed
     return (group.type == "OKTA_GROUP") and (group.id not in group_ids_with_group_rules)

--- a/api/services/okta_service.py
+++ b/api/services/okta_service.py
@@ -14,6 +14,7 @@ from okta.models.user import User as OktaUserType
 from okta.models.user_schema import UserSchema as OktaUserSchemaType
 from okta.request_executor import RequestExecutor as OktaRequestExecutor
 
+from api.config import OKTA_GROUP_PROFILE_CUSTOM_ATTR
 from api.models import OktaGroup, OktaUser
 
 REQUEST_MAX_RETRIES = 3
@@ -535,16 +536,17 @@ class Group:
 
 
 def is_managed_group(group: Group, group_ids_with_group_rules: dict[str, list[OktaGroupRuleType]]) -> bool:
-    # Check if 'allow_discord_access' attribute exists as a custom Okta Group Profile attribute and retrieve its value
-    allow_discord_access = getattr(group.profile, "allow_discord_access", None)
+    # Check if OKTA_GROUP_PROFILE_CUSTOM_ATTR attribute exists as a custom Okta Group Profile attribute and retrieve its value
+    if OKTA_GROUP_PROFILE_CUSTOM_ATTR:
+        custom_manage_attr = getattr(group.profile, f"{OKTA_GROUP_PROFILE_CUSTOM_ATTR}", None)
 
-    # If 'allow_discord_access' is explicitly set to False, the group should not be managed
-    if allow_discord_access is False:
-        return False
+        # If OKTA_GROUP_PROFILE_CUSTOM_ATTR is explicitly set to False, the group should not be managed
+        if custom_manage_attr is False:
+            return False
 
-    # If 'allow_discord_access' is True and the group type is OKTA_GROUP, it can be managed even if it has group rules
-    if allow_discord_access is True and group.type == "OKTA_GROUP":
-        return True
+        # If OKTA_GROUP_PROFILE_CUSTOM_ATTR is True and the group type is OKTA_GROUP, it can be managed even if it has group rules
+        if custom_manage_attr is True and group.type == "OKTA_GROUP":
+            return True
 
     # By default, the group should be of type OKTA_GROUP and should not have any group rules to be managed
     return (group.type == "OKTA_GROUP") and (group.id not in group_ids_with_group_rules)

--- a/api/services/okta_service.py
+++ b/api/services/okta_service.py
@@ -535,10 +535,14 @@ class Group:
         return okta_group
 
 
-def is_managed_group(group: Group, group_ids_with_group_rules: dict[str, list[OktaGroupRuleType]]) -> bool:
+def is_managed_group(
+    group: Group,
+    group_ids_with_group_rules: dict[str, list[OktaGroupRuleType]],
+    custom_attr: Optional[str] = OKTA_GROUP_PROFILE_CUSTOM_ATTR,
+) -> bool:
     # Check if OKTA_GROUP_PROFILE_CUSTOM_ATTR attribute exists as a custom Okta Group Profile attribute and retrieve its value
-    if OKTA_GROUP_PROFILE_CUSTOM_ATTR:
-        custom_manage_attr = getattr(group.profile, f"{OKTA_GROUP_PROFILE_CUSTOM_ATTR}", None)
+    if custom_attr:
+        custom_manage_attr = getattr(group.profile, custom_attr, None)
 
         # If OKTA_GROUP_PROFILE_CUSTOM_ATTR is explicitly set to False, the group should not be managed
         if custom_manage_attr is False:

--- a/tests/test_okta_service.py
+++ b/tests/test_okta_service.py
@@ -23,5 +23,4 @@ def test_is_managed_group_with_allow_discord_access_false(set_okta_group_profile
     group_ids_with_group_rules = {}  # Empty dictionary for group rules
     result = is_managed_group(group, group_ids_with_group_rules)
 
-    print(f"Result of is_managed_group: {result}")  # Debug output
     assert result is False  # Assert that the result is False

--- a/tests/test_okta_service.py
+++ b/tests/test_okta_service.py
@@ -1,55 +1,27 @@
-from typing import Dict, Generator, List
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
-from okta.models.group_rule import GroupRule as OktaGroupRuleType
 
 from api.services.okta_service import is_managed_group
 
 
+# Fixture to set the environment variable for the test
 @pytest.fixture
-def okta_group_profile_custom_attr() -> Generator[None, None, None]:
-    with patch.dict("os.environ", {"OKTA_GROUP_PROFILE_CUSTOM_ATTR": "allow_discord_access"}):
+def set_okta_group_profile_custom_attr_env_var():
+    with patch("api.config.OKTA_GROUP_PROFILE_CUSTOM_ATTR", "allow_discord_access"):
         yield
 
 
-def test_is_managed_group_without_allow_discord_access(okta_group_profile_custom_attr: None) -> None:
-    group: Mock = Mock()
-    group.profile = Mock()
-    setattr(group.profile, "allow_discord_access", False)
+def test_is_managed_group_with_allow_discord_access_false(set_okta_group_profile_custom_attr_env_var):
+    # Create a mock of the Group class with all necessary properties
+    group = MagicMock()
+    group.profile = MagicMock()
+    group.profile.allow_discord_access = False  # Set the attribute to False
     group.type = "OKTA_GROUP"
-    group.id = "mock_group_id"
+    group.id = "123456789"  # Example group ID
 
-    group_ids_with_group_rules: Dict[str, List[OktaGroupRuleType]] = {}
-
+    group_ids_with_group_rules = {}  # Empty dictionary for group rules
     result = is_managed_group(group, group_ids_with_group_rules)
 
-    assert result is False
-
-
-def test_is_managed_group_with_allow_discord_access(okta_group_profile_custom_attr: None) -> None:
-    group: Mock = Mock()
-    group.profile = Mock()
-    setattr(group.profile, "allow_discord_access", True)
-    group.type = "OKTA_GROUP"
-    group.id = "mock_group_id"
-
-    group_ids_with_group_rules: Dict[str, List[OktaGroupRuleType]] = {"mock_group_id": [Mock(spec=OktaGroupRuleType)]}
-
-    result = is_managed_group(group, group_ids_with_group_rules)
-
-    assert result is True
-
-
-def test_is_managed_group_with_allow_discord_access_undefined(okta_group_profile_custom_attr: None) -> None:
-    group: Mock = Mock()
-    group.profile = Mock()
-    setattr(group.profile, "allow_discord_access", None)
-    group.type = "OKTA_GROUP"
-    group.id = "mock_group_id"
-
-    group_ids_with_group_rules: Dict[str, List[OktaGroupRuleType]] = {}
-
-    result = is_managed_group(group, group_ids_with_group_rules)
-
-    assert result is True
+    print(f"Result of is_managed_group: {result}")  # Debug output
+    assert result is False  # Assert that the result is False

--- a/tests/test_okta_service.py
+++ b/tests/test_okta_service.py
@@ -1,26 +1,60 @@
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from api.services.okta_service import is_managed_group
 
 
-# Fixture to set the environment variable for the test
-@pytest.fixture
-def set_okta_group_profile_custom_attr_env_var():
+def test_is_managed_group_with_allow_discord_access_false():
+    """Test that is_managed_group returns False when allow_discord_access is False."""
     with patch("api.config.OKTA_GROUP_PROFILE_CUSTOM_ATTR", "allow_discord_access"):
-        yield
+        from api.config import OKTA_GROUP_PROFILE_CUSTOM_ATTR
+
+        # Create a mock of the Group class
+        group = MagicMock()
+        group.profile = MagicMock()
+        group.profile.allow_discord_access = False  # Set the profile attribute to False
+        group.type = "OKTA_GROUP"
+        group.id = "123456789"  # Example group ID
+
+        group_ids_with_group_rules = {}  # Empty dictionary for group rules
+
+        # Call the function and assert the expected result
+        result = is_managed_group(group, group_ids_with_group_rules, OKTA_GROUP_PROFILE_CUSTOM_ATTR)
+        assert result is False
 
 
-def test_is_managed_group_with_allow_discord_access_false(set_okta_group_profile_custom_attr_env_var):
-    # Create a mock of the Group class with all necessary properties
-    group = MagicMock()
-    group.profile = MagicMock()
-    group.profile.allow_discord_access = False  # Set the attribute to False
-    group.type = "OKTA_GROUP"
-    group.id = "123456789"  # Example group ID
+def test_is_managed_group_with_allow_discord_access_true():
+    """Test that is_managed_group returns True when allow_discord_access is True."""
+    with patch("api.config.OKTA_GROUP_PROFILE_CUSTOM_ATTR", "allow_discord_access"):
+        from api.config import OKTA_GROUP_PROFILE_CUSTOM_ATTR
 
-    group_ids_with_group_rules = {}  # Empty dictionary for group rules
-    result = is_managed_group(group, group_ids_with_group_rules)
+        # Create a mock of the Group class
+        group = MagicMock()
+        group.profile = MagicMock()
+        group.profile.allow_discord_access = True  # Set the profile attribute to True
+        group.type = "OKTA_GROUP"
+        group.id = "123456789"  # Example group ID
 
-    assert result is False  # Assert that the result is False
+        group_ids_with_group_rules = {}  # Empty dictionary for group rules
+
+        # Call the function and assert the expected result
+        result = is_managed_group(group, group_ids_with_group_rules, OKTA_GROUP_PROFILE_CUSTOM_ATTR)
+        assert result is True
+
+
+def test_is_managed_group_with_allow_discord_access_undefined():
+    """Test that is_managed_group returns True when the custom attribute is undefined."""
+    with patch("api.config.OKTA_GROUP_PROFILE_CUSTOM_ATTR", None):
+        from api.config import OKTA_GROUP_PROFILE_CUSTOM_ATTR
+
+        # Create a mock of the Group class
+        group = MagicMock()
+        group.profile = MagicMock()
+        group.profile.allow_discord_access = False  # Set the profile attribute to False
+        group.type = "OKTA_GROUP"
+        group.id = "123456789"  # Example group ID
+
+        group_ids_with_group_rules = {}  # Empty dictionary for group rules
+
+        # Call the function and assert the expected result
+        result = is_managed_group(group, group_ids_with_group_rules, OKTA_GROUP_PROFILE_CUSTOM_ATTR)
+        assert result is True

--- a/tests/test_okta_service.py
+++ b/tests/test_okta_service.py
@@ -1,9 +1,11 @@
 from unittest.mock import MagicMock, patch
 
+from okta.models.group_rule import GroupRule as OktaGroupRuleType
+
 from api.services.okta_service import is_managed_group
 
 
-def test_is_managed_group_with_allow_discord_access_false():
+def test_is_managed_group_with_allow_discord_access_false() -> None:
     """Test that is_managed_group returns False when allow_discord_access is False."""
     with patch("api.config.OKTA_GROUP_PROFILE_CUSTOM_ATTR", "allow_discord_access"):
         from api.config import OKTA_GROUP_PROFILE_CUSTOM_ATTR
@@ -15,14 +17,14 @@ def test_is_managed_group_with_allow_discord_access_false():
         group.type = "OKTA_GROUP"
         group.id = "123456789"  # Example group ID
 
-        group_ids_with_group_rules = {}  # Empty dictionary for group rules
+        group_ids_with_group_rules: dict[str, list[OktaGroupRuleType]] = {}  # Empty dictionary for group rules
 
         # Call the function and assert the expected result
         result = is_managed_group(group, group_ids_with_group_rules, OKTA_GROUP_PROFILE_CUSTOM_ATTR)
         assert result is False
 
 
-def test_is_managed_group_with_allow_discord_access_true():
+def test_is_managed_group_with_allow_discord_access_true() -> None:
     """Test that is_managed_group returns True when allow_discord_access is True."""
     with patch("api.config.OKTA_GROUP_PROFILE_CUSTOM_ATTR", "allow_discord_access"):
         from api.config import OKTA_GROUP_PROFILE_CUSTOM_ATTR
@@ -34,14 +36,14 @@ def test_is_managed_group_with_allow_discord_access_true():
         group.type = "OKTA_GROUP"
         group.id = "123456789"  # Example group ID
 
-        group_ids_with_group_rules = {}  # Empty dictionary for group rules
+        group_ids_with_group_rules: dict[str, list[OktaGroupRuleType]] = {}  # Empty dictionary for group rules
 
         # Call the function and assert the expected result
         result = is_managed_group(group, group_ids_with_group_rules, OKTA_GROUP_PROFILE_CUSTOM_ATTR)
         assert result is True
 
 
-def test_is_managed_group_with_allow_discord_access_undefined():
+def test_is_managed_group_with_allow_discord_access_undefined() -> None:
     """Test that is_managed_group returns True when the custom attribute is undefined."""
     with patch("api.config.OKTA_GROUP_PROFILE_CUSTOM_ATTR", None):
         from api.config import OKTA_GROUP_PROFILE_CUSTOM_ATTR
@@ -53,7 +55,7 @@ def test_is_managed_group_with_allow_discord_access_undefined():
         group.type = "OKTA_GROUP"
         group.id = "123456789"  # Example group ID
 
-        group_ids_with_group_rules = {}  # Empty dictionary for group rules
+        group_ids_with_group_rules: dict[str, list[OktaGroupRuleType]] = {}  # Empty dictionary for group rules
 
         # Call the function and assert the expected result
         result = is_managed_group(group, group_ids_with_group_rules, OKTA_GROUP_PROFILE_CUSTOM_ATTR)

--- a/tests/test_okta_service.py
+++ b/tests/test_okta_service.py
@@ -1,46 +1,54 @@
-from unittest.mock import Mock
+from typing import Dict, Generator, List
+from unittest.mock import Mock, patch
+
+import pytest
+from okta.models.group_rule import GroupRule as OktaGroupRuleType
 
 from api.services.okta_service import is_managed_group
 
 
-def test_is_managed_group_without_allow_discord_access() -> None:
-    # Create a mock group with allow_discord_access attribute set to False
-    group = Mock()
-    group.profile.allow_discord_access = False
+@pytest.fixture
+def okta_group_profile_custom_attr() -> Generator[None, None, None]:
+    with patch.dict("os.environ", {"OKTA_GROUP_PROFILE_CUSTOM_ATTR": "allow_discord_access"}):
+        yield
+
+
+def test_is_managed_group_without_allow_discord_access(okta_group_profile_custom_attr: None) -> None:
+    group: Mock = Mock()
+    group.profile = Mock()
+    setattr(group.profile, "allow_discord_access", False)
     group.type = "OKTA_GROUP"
     group.id = "mock_group_id"
 
-    # Mock group_ids_with_group_rules
-    group_ids_with_group_rules: dict[str, list] = {}
+    group_ids_with_group_rules: Dict[str, List[OktaGroupRuleType]] = {}
 
     result = is_managed_group(group, group_ids_with_group_rules)
 
-    # Assert the result
     assert result is False
 
 
-def test_is_managed_group_with_allow_discord_access() -> None:
-    # Create a mock group with allow_discord_access attribute set to True
-    group = Mock()
-    group.profile.allow_discord_access = True
+def test_is_managed_group_with_allow_discord_access(okta_group_profile_custom_attr: None) -> None:
+    group: Mock = Mock()
+    group.profile = Mock()
+    setattr(group.profile, "allow_discord_access", True)
     group.type = "OKTA_GROUP"
     group.id = "mock_group_id"
 
-    group_ids_with_group_rules: dict[str, list] = {}
+    group_ids_with_group_rules: Dict[str, List[OktaGroupRuleType]] = {"mock_group_id": [Mock(spec=OktaGroupRuleType)]}
 
     result = is_managed_group(group, group_ids_with_group_rules)
 
     assert result is True
 
 
-def test_is_managed_group_with_allow_discord_access_undefined() -> None:
-    # Create a mock group with allow_discord_access attribute not set
-    group = Mock()
-    group.profile.allow_discord_access = None
+def test_is_managed_group_with_allow_discord_access_undefined(okta_group_profile_custom_attr: None) -> None:
+    group: Mock = Mock()
+    group.profile = Mock()
+    setattr(group.profile, "allow_discord_access", None)
     group.type = "OKTA_GROUP"
     group.id = "mock_group_id"
 
-    group_ids_with_group_rules: dict[str, list] = {}
+    group_ids_with_group_rules: Dict[str, List[OktaGroupRuleType]] = {}
 
     result = is_managed_group(group, group_ids_with_group_rules)
 

--- a/tests/test_okta_service.py
+++ b/tests/test_okta_service.py
@@ -1,0 +1,47 @@
+from unittest.mock import Mock
+
+from api.services.okta_service import is_managed_group
+
+
+def test_is_managed_group_without_allow_discord_access() -> None:
+    # Create a mock group with allow_discord_access attribute set to False
+    group = Mock()
+    group.profile.allow_discord_access = False
+    group.type = "OKTA_GROUP"
+    group.id = "mock_group_id"
+
+    # Mock group_ids_with_group_rules
+    group_ids_with_group_rules: dict[str, list] = {}
+
+    result = is_managed_group(group, group_ids_with_group_rules)
+
+    # Assert the result
+    assert result is False
+
+
+def test_is_managed_group_with_allow_discord_access() -> None:
+    # Create a mock group with allow_discord_access attribute set to True
+    group = Mock()
+    group.profile.allow_discord_access = True
+    group.type = "OKTA_GROUP"
+    group.id = "mock_group_id"
+
+    group_ids_with_group_rules: dict[str, list] = {}
+
+    result = is_managed_group(group, group_ids_with_group_rules)
+
+    assert result is True
+
+
+def test_is_managed_group_with_allow_discord_access_undefined() -> None:
+    # Create a mock group with allow_discord_access attribute not set
+    group = Mock()
+    group.profile.allow_discord_access = None
+    group.type = "OKTA_GROUP"
+    group.id = "mock_group_id"
+
+    group_ids_with_group_rules: dict[str, list] = {}
+
+    result = is_managed_group(group, group_ids_with_group_rules)
+
+    assert result is True


### PR DESCRIPTION
Add `OKTA_GROUP_PROFILE_CUSTOM_ATTR` to may specify an Okta Group Custom Profile attribute used to override `is_managed_group` logic.

For the purposes of the tests and this comment, I've set `OKTA_GROUP_PROFILE_CUSTOM_ATTR` to `allow_discord_access`.  However, it is arbitrary and optional.  We'll use this ENV VAR value with regard to the following logic in this comment:

Verify the `allow_discord_access` custom Okta Group profile attribute to determine if Discord Access can manage the group: if true, management is enabled; if false, it is not.

**Why:**
* We have some Okta Groups that we want viewable in Discord Access, but do not want them to be manageable by it.
* We have some Okta Groups with a couple small Group Rules that we still want managed by Discord Access; membership rules won't step on each other between the existing Okta Group rules and Discord Access Access Requests

To support this, we're proposing a simple check under `is_managed_group` that looks for `allow_discord_access` in a Custom Okta Group profile attribute.
- if allow_discord_access is Undefined on the Okta Group, it'll default to the current logic in is_managed_group
- if allow_discord_access is True, return True - Discord Access can manage it (even if there are Group Rules)
- if allow_discord_access is False, return False - Discord Access cannot manage it - works to exclude any Okta Groups we don't want Discord Access to manage ever.