### PR TITLE
feat(conditional-access): changed this to work with tags as well as group names

### DIFF
--- a/examples/plugins/conditional_access/Readme.md
+++ b/examples/plugins/conditional_access/Readme.md
@@ -1,0 +1,31 @@
+# Conditional Access Plugin
+
+This plugin will allow you to automatically approve or deny access requests based on the group or tag membership of the group.
+
+## Installation
+
+Add the below to your Dockerfile to install the plugin. You can put it before the ENV section at the bottom of the file.
+```
+# Add the specific plugins and install conditional access plugin
+WORKDIR /app/plugins
+ADD ./examples/plugins/conditional_access ./conditional_access
+RUN pip install -r ./conditional_access/requirements.txt && pip install ./conditional_access
+
+# Reset working directory
+WORKDIR /app
+```
+
+Build and run your docker container as normal.
+
+
+## Configuration
+
+You can set the following environment variables to configure the plugin but note that neither are required by default. If you only want to use the specific tag `Auto-Approve` then no environment variables are required. You must however create the tag within the Access Application.
+
+- `AUTO_APPROVED_GROUP_NAMES`: A comma-separated list of group names that will be auto-approved.
+- `AUTO_APPROVED_TAG_NAMES`: A comma-separated list of tag names that will be auto-approved.
+
+
+## Usage
+
+The plugin will automatically approve access requests to the groups or tags specified in the environment variables by running a check on each access request that is processed. If neither the group name nor the tag name match, then a log line stating manual approval is required will be output.

--- a/examples/plugins/conditional_access/conditional_access.py
+++ b/examples/plugins/conditional_access/conditional_access.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import logging
+import os
 from typing import List, Optional
 
 import pluggy
@@ -11,6 +12,17 @@ from api.plugins import ConditionalAccessResponse
 request_hook_impl = pluggy.HookimplMarker("access_conditional_access")
 logger = logging.getLogger(__name__)
 
+# Constants for auto-approval conditions (not required if you only want to use the Auto-Approval TAG)
+# Example of how to set this in an environment variable in your .env.production file:
+# AUTO_APPROVED_GROUP_NAMES="Group1,Group2,Group3"
+AUTO_APPROVED_GROUP_NAMES = (
+    os.getenv("AUTO_APPROVED_GROUP_NAMES", "").split(",") if os.getenv("AUTO_APPROVED_GROUP_NAMES") else []
+)
+
+# Example of how to set this in an environment variable in your .env.production file:
+# AUTO_APPROVED_TAG_NAMES="Tag1,Tag2,Tag3"
+AUTO_APPROVED_TAG_NAMES = os.getenv("AUTO_APPROVED_TAG_NAMES", "Auto-Approve").split(",")
+
 
 @request_hook_impl
 def access_request_created(
@@ -18,11 +30,16 @@ def access_request_created(
 ) -> Optional[ConditionalAccessResponse]:
     """Auto-approve memberships to the Auto-Approved-Group group"""
 
-    if not access_request.request_ownership and group.name == "Auto-Approved-Group":
-        logger.info(f"Auto-approving access request {access_request.id} to group {group.name}")
-        return ConditionalAccessResponse(
-            approved=True, reason="Group membership auto-approved", ending_at=access_request.request_ending_at
-        )
+    if not access_request.request_ownership:
+        # Check either group name or tag for auto-approval
+        is_auto_approved_name = group.name in AUTO_APPROVED_GROUP_NAMES
+        is_auto_approved_tag = any(tag.name in AUTO_APPROVED_TAG_NAMES for tag in group_tags)
+
+        if is_auto_approved_name or is_auto_approved_tag:
+            logger.info(f"Auto-approving access request {access_request.id} to group {group.name}")
+            return ConditionalAccessResponse(
+                approved=True, reason="Group membership auto-approved", ending_at=access_request.request_ending_at
+            )
 
     logger.info(f"Access request {access_request.id} to group {group.name} requires manual approval")
 


### PR DESCRIPTION
The goal of this is to add the ability to use Tags as well as groups. I know people will customize this but I thought this might give them a better base if they don't have complex use cases.

1. Changed the code to rely on environment variable instead of hard coded group names.
2. Added ability to use a tag for auto-approvals.
3. By default, the tag `Auto-Approve` is used. This means you don't have to set any environment variables if you don't want.
4. Added a Readme.


Verified this works in my deployment. Please let me know if a test is required for plugins