### PR TITLE
docs: fix API endpoint in README.md to prevent 404 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Finally, you can run the server:
 flask run
 ```
 
-Go to [http://localhost:6060/api/users/](http://localhost:6060/api/users/) to view the API.
+Go to [http://localhost:6060/api/users](http://localhost:6060/api/users) to view the API.
 
 ### Node
 


### PR DESCRIPTION
The API endpoint in the README included an extra trailing slash ('/') which caused a 404 error. Updated the endpoint to remove the slash and ensure the URL works correctly.