### PR TITLE
Fix tag removal authorization bug in app groups

### DIFF
--- a/api/views/resources/group.py
+++ b/api/views/resources/group.py
@@ -118,7 +118,7 @@ class GroupResource(MethodResource):
             )
 
         json_data = request.get_json()
-        if "tags_to_remove" in json_data:
+        if "tags_to_remove" in json_data and type(group) is not AppGroup:
             if len(json_data["tags_to_remove"]) > 0 and not AuthorizationHelpers.is_access_admin():
                 abort(
                     403,


### PR DESCRIPTION
There is a small authorization logic bug in `GroupResources` PUT method, which prevents removing `Tags` for app owner.

This patch fixes logic that only Access admin can remove app group `Tags`, even that app owner can add new `Tags` to owned app groups.
