### PR TITLE
Preserve custom attributes on Discord Access Okta Group UI updates 

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -29,6 +29,7 @@ class GroupProfileFactory(factory.Factory[GroupProfile]):
         {
             "name": factory.Faker("pystr"),
             "description": factory.Faker("pystr"),
+            "allow_discord_access": None,  # Default to None for the custom attribute
         }
     )
 


### PR DESCRIPTION
On our Okta tenant we use Custom Attributes for the Okta Group profile.  When updating Okta groups from the UI, we noticed that the Custom Attributes are getting wiped out.  

Updated `update_group` to pull the current Okta Group profile data, merge in the updates, and use that new payload for the `okta_client.update_group` call.  

Added new test for it.

Passes tests and in my local testing against a Okta Preview tenant, it appears to be working as desired.