### PR TITLE
Notify requester and approvers via Slack on access request creation and completion

### DIFF
--- a/examples/plugins/notifications_slack/notifications.py
+++ b/examples/plugins/notifications_slack/notifications.py
@@ -178,7 +178,7 @@ def send_slack_channel_message(user: OktaUser, message: str) -> None:
         user_id = get_user_id_by_email(user.email)
 
         if user_id:
-            channel_message = f"<{user.email}> - {message}"
+            channel_message = f"{user.email} - {message}"
 
             def send_message() -> Dict[str, Any]:
                 response = client.chat_postMessage(

--- a/examples/plugins/notifications_slack/notifications.py
+++ b/examples/plugins/notifications_slack/notifications.py
@@ -173,6 +173,7 @@ def send_slack_channel_message(user: OktaUser, message: str) -> None:
 
     Args:
         message (str): The message content.
+        user (OktaUser): The user to relate the message to.
     """
     if alerts_channel:
         user_id = get_user_id_by_email(user.email)

--- a/examples/plugins/notifications_slack/notifications.py
+++ b/examples/plugins/notifications_slack/notifications.py
@@ -178,7 +178,7 @@ def send_slack_channel_message(user: OktaUser, message: str) -> None:
         user_id = get_user_id_by_email(user.email)
 
         if user_id:
-            channel_message = f"<{user_id}> - {message}"
+            channel_message = f"<{user.email}> - {message}"
 
             def send_message() -> Dict[str, Any]:
                 response = client.chat_postMessage(

--- a/examples/plugins/notifications_slack/notifications.py
+++ b/examples/plugins/notifications_slack/notifications.py
@@ -214,6 +214,10 @@ def access_request_created(
         send_slack_dm(approver, approver_message)
     logger.info(f"Approver message: {approver_message}")
 
+    # Send the message to the requester too
+    send_slack_dm(requester, approver_message)
+    logger.info("Requester received creation notification")
+
     # Post to the alerts channel
     send_slack_channel_message(approver_message)
 
@@ -247,6 +251,11 @@ def access_request_completed(
     if notify_requester:
         send_slack_dm(requester, requester_message)
     logger.info(f"Requester message: {requester_message}")
+
+    # Send the message to all approvers as well
+    for approver in approvers:
+        send_slack_dm(approver, requester_message)
+    logger.info("Approvers received completion notification")
 
     # Post to the alerts channel
     send_slack_channel_message(requester_message)

--- a/examples/plugins/notifications_slack/notifications.py
+++ b/examples/plugins/notifications_slack/notifications.py
@@ -233,7 +233,6 @@ def access_request_completed(
     group: OktaGroup,
     requester: OktaUser,
     approvers: List[OktaUser],
-    notify_requester: bool,
 ) -> None:
     """Notify the requester that their access request has been processed.
 
@@ -242,7 +241,6 @@ def access_request_completed(
         group (OktaGroup): The group for which access is requested.
         requester (OktaUser): The user requesting access.
         approvers (List[OktaUser]): The list of approvers.
-        notify_requester (bool): Whether to notify the requester.
     """
     access_request_url = get_base_url() + f"/requests/{access_request.id}"
     emoji = ":white_check_mark:" if access_request.status.lower() == "approved" else ":x:"
@@ -253,8 +251,7 @@ def access_request_completed(
     )
 
     # Send the message to the requester
-    if notify_requester:
-        send_slack_dm(requester, requester_message)
+    send_slack_dm(requester, requester_message)
     logger.info(f"Requester message: {requester_message}")
 
     # Send the message to all approvers (except the requester)

--- a/examples/plugins/notifications_slack/notifications.py
+++ b/examples/plugins/notifications_slack/notifications.py
@@ -178,7 +178,7 @@ def send_slack_channel_message(user: OktaUser, message: str) -> None:
         user_id = get_user_id_by_email(user.email)
 
         if user_id:
-            channel_message = f"<@{user_id}> - {message}"
+            channel_message = f"<{user_id}> - {message}"
 
             def send_message() -> Dict[str, Any]:
                 response = client.chat_postMessage(

--- a/examples/plugins/notifications_slack/notifications.py
+++ b/examples/plugins/notifications_slack/notifications.py
@@ -218,9 +218,10 @@ def access_request_created(
         send_slack_dm(approver, approver_message)
     logger.info(f"Approver message: {approver_message}")
 
-    # Send the message to the requester too
-    send_slack_dm(requester, approver_message)
-    logger.info("Requester received creation notification")
+    # Send the message to the requester only if they're not already an approver
+    if requester.id not in [approver.id for approver in approvers]:
+        send_slack_dm(requester, approver_message)
+        logger.info("Requester received creation notification")
 
     # Post to the alerts channel
     send_slack_channel_message(requester, approver_message)
@@ -256,9 +257,10 @@ def access_request_completed(
         send_slack_dm(requester, requester_message)
     logger.info(f"Requester message: {requester_message}")
 
-    # Send the message to all approvers as well
+    # Send the message to all approvers (except the requester)
     for approver in approvers:
-        send_slack_dm(approver, requester_message)
+        if approver.id != requester.id:  # Skip if approver is the requester
+            send_slack_dm(approver, requester_message)
     logger.info("Approvers received completion notification")
 
     # Post to the alerts channel


### PR DESCRIPTION
Small quality of life improvement for Slack notification plugin:  
* Send requestor message to the requestor as well
* Send all approvers a message when the request is completed, so they don't bother check if it's already completed
* Add email prefix to the alerts channel messages, so it's easier to relate which requests belong to which requestors