### PR TITLE
Pull the membership `Chip` logic into a component

### DIFF
--- a/src/components/MembershipChip.tsx
+++ b/src/components/MembershipChip.tsx
@@ -1,0 +1,59 @@
+import {OktaUserGroupMember, PolymorphicGroup, RoleGroup} from '../api/apiSchemas';
+import {useNavigate} from 'react-router-dom';
+import {useCurrentUser} from '../authentication';
+import {canManageGroup, isGroupOwner} from '../authorization';
+import Chip from '@mui/material/Chip';
+
+export interface MembershipChipProps {
+  user: OktaUserGroupMember;
+  group: PolymorphicGroup;
+  removeRoleGroup: (roleGroup: RoleGroup) => void;
+  removeDirectAccessAsUser: () => void;
+  removeDirectAccessAsGroupManager: () => void;
+}
+
+export default function MembershipChip({
+  user,
+  group,
+  removeRoleGroup,
+  removeDirectAccessAsUser,
+  removeDirectAccessAsGroupManager,
+}: MembershipChipProps) {
+  const navigate = useNavigate();
+  const currentUser = useCurrentUser();
+  const activeRoleGroup = user.active_role_group_mapping?.active_role_group;
+  const canManageUserRoleGroup = activeRoleGroup?.id ? isGroupOwner(currentUser, activeRoleGroup.id) : false;
+  const canManageThisGroup = group.is_managed && canManageGroup(currentUser, group);
+  const canManageThisUser = group.is_managed && currentUser.id === user.active_user?.id;
+  return activeRoleGroup ? (
+    <Chip
+      label={activeRoleGroup.name}
+      variant="outlined"
+      color="primary"
+      onClick={() => navigate(`/roles/${activeRoleGroup.name}`)}
+      onDelete={
+        canManageThisGroup || canManageUserRoleGroup
+          ? () => {
+              removeRoleGroup(activeRoleGroup);
+            }
+          : undefined
+      }
+    />
+  ) : (
+    <Chip
+      label="Direct"
+      color="primary"
+      onDelete={
+        canManageThisUser
+          ? () => {
+              removeDirectAccessAsUser();
+            }
+          : canManageThisGroup
+            ? () => {
+                removeDirectAccessAsGroupManager();
+              }
+            : undefined
+      }
+    />
+  );
+}

--- a/src/pages/groups/Read.tsx
+++ b/src/pages/groups/Read.tsx
@@ -54,6 +54,7 @@ import {canManageGroup} from '../../authorization';
 import {Diversity3 as RoleIcon} from '@mui/icons-material';
 import AppLinkButton from './AppLinkButton';
 import AvatarButton from '../../components/AvatarButton';
+import MembershipChip from '../../components/MembershipChip';
 
 function sortGroupMembers(
   [aUserId, aUsers]: [string, Array<OktaUserGroupMember>],
@@ -580,42 +581,20 @@ export default function ReadGroup() {
                                   />
                                 ) : null}
                                 {users.sort(sortOktaUserGroupMembers).map((user) =>
-                                  user.active_role_group_mapping == null &&
                                   directRoleOwnerships.has(user.active_user!.id) ? (
-                                    <Chip
-                                      key={'owners' + userId}
-                                      label="Direct"
-                                      color="primary"
-                                      onDelete={
-                                        group.is_managed && (groupOwner || currentUser.id == userId)
-                                          ? () => {
-                                              currentUser.id == userId
-                                                ? removeOwnDirectAccess(userId, group, true)
-                                                : removeDirectUserFromGroup(userId ?? '', true);
-                                            }
-                                          : undefined
-                                      }
-                                    />
-                                  ) : user.active_role_group_mapping != null &&
-                                    directRoleOwnerships.has(user.active_user!.id) ? (
-                                    <Chip
-                                      key={'owners' + userId + user.active_role_group_mapping?.active_role_group?.id}
-                                      label={user.active_role_group_mapping?.active_role_group?.name}
-                                      variant="outlined"
-                                      color="primary"
-                                      onClick={() =>
-                                        navigate(`/roles/${user.active_role_group_mapping?.active_role_group?.name}`)
-                                      }
-                                      onDelete={
-                                        groupOwner
-                                          ? () =>
-                                              removeGroupFromRole(
-                                                group,
-                                                user.active_role_group_mapping?.active_role_group ?? ({} as RoleGroup),
-                                                true,
-                                              )
-                                          : undefined
-                                      }
+                                    <MembershipChip
+                                      key={`${user.active_user?.id}${user.active_role_group_mapping?.active_role_group?.id}`}
+                                      user={user}
+                                      group={group}
+                                      removeRoleGroup={(roleGroup) => {
+                                        removeGroupFromRole(group, roleGroup, true);
+                                      }}
+                                      removeDirectAccessAsUser={() => {
+                                        removeOwnDirectAccess(userId, group, true);
+                                      }}
+                                      removeDirectAccessAsGroupManager={() => {
+                                        removeDirectUserFromGroup(userId, true);
+                                      }}
                                     />
                                   ) : null,
                                 )}
@@ -757,44 +736,22 @@ export default function ReadGroup() {
                                   flexWrap: 'wrap',
                                   rowGap: '.5rem',
                                 }}>
-                                {users.sort(sortOktaUserGroupMembers).map((user) =>
-                                  user.active_role_group_mapping == null ? (
-                                    <Chip
-                                      key={'members' + userId}
-                                      label="Direct"
-                                      color="primary"
-                                      onDelete={
-                                        group.is_managed && (groupOwner || currentUser.id == userId)
-                                          ? () => {
-                                              currentUser.id == userId
-                                                ? removeOwnDirectAccess(userId, group, false)
-                                                : removeDirectUserFromGroup(userId ?? '', false);
-                                            }
-                                          : undefined
-                                      }
-                                    />
-                                  ) : (
-                                    <Chip
-                                      key={'members' + userId + user.active_role_group_mapping?.active_role_group?.id}
-                                      label={user.active_role_group_mapping?.active_role_group?.name}
-                                      variant="outlined"
-                                      color="primary"
-                                      onClick={() =>
-                                        navigate(`/roles/${user.active_role_group_mapping?.active_role_group?.name}`)
-                                      }
-                                      onDelete={
-                                        groupOwner
-                                          ? () =>
-                                              removeGroupFromRole(
-                                                group,
-                                                user.active_role_group_mapping?.active_role_group ?? ({} as RoleGroup),
-                                                false,
-                                              )
-                                          : undefined
-                                      }
-                                    />
-                                  ),
-                                )}
+                                {users.sort(sortOktaUserGroupMembers).map((user) => (
+                                  <MembershipChip
+                                    key={`${user.active_user?.id}${user.active_role_group_mapping?.active_role_group?.id}`}
+                                    user={user}
+                                    group={group}
+                                    removeRoleGroup={(roleGroup) => {
+                                      removeGroupFromRole(group, roleGroup, false);
+                                    }}
+                                    removeDirectAccessAsUser={() => {
+                                      removeOwnDirectAccess(userId, group, false);
+                                    }}
+                                    removeDirectAccessAsGroupManager={() => {
+                                      removeDirectUserFromGroup(userId, false);
+                                    }}
+                                  />
+                                ))}
                               </Stack>
                             </TableCell>
                           ) : (

--- a/src/pages/users/Read.tsx
+++ b/src/pages/users/Read.tsx
@@ -38,6 +38,7 @@ import RemoveGroupsDialog, {RemoveGroupsDialogParameters} from '../roles/RemoveG
 import RemoveOwnDirectAccessDialog, {RemoveOwnDirectAccessDialogParameters} from '../groups/RemoveOwnDirectAccess';
 import {groupBy, displayUserName, displayGroupType} from '../../helpers';
 import {canManageGroup, isGroupOwner} from '../../authorization';
+import MembershipChip from '../../components/MembershipChip';
 
 function sortUserGroups(
   [aGroupId, aGroups]: [string, Array<OktaUserGroupMember>],
@@ -193,48 +194,22 @@ function OwnerTable({user, ownerships, onClickRemoveGroupFromRole, onClickRemove
                         rowGap: '.5rem',
                       }}>
                       {groups.map((group) =>
-                        group.active_role_group_mapping == null ? (
-                          <Chip
-                            key="direct"
-                            label="Direct"
-                            color="primary"
-                            onDelete={
-                              group.active_group?.is_managed &&
-                              (currentUser.id === user.id || canManageGroup(currentUser, group.active_group))
-                                ? () => {
-                                    currentUser.id == user.id
-                                      ? onClickRemoveDirectAccess(
-                                          user.id,
-                                          group.active_group ?? ({} as PolymorphicGroup),
-                                          true,
-                                        )
-                                      : removeUserFromGroup(group.active_group?.id ?? '');
-                                  }
-                                : undefined
-                            }
+                        group.active_group ? (
+                          <MembershipChip
+                            key={group.active_role_group_mapping?.active_role_group?.name ?? ''}
+                            user={group}
+                            group={group.active_group}
+                            removeRoleGroup={(roleGroup) => {
+                              onClickRemoveGroupFromRole(group.active_group!, roleGroup, true);
+                            }}
+                            removeDirectAccessAsUser={() => {
+                              onClickRemoveDirectAccess(user.id, group.active_group!, true);
+                            }}
+                            removeDirectAccessAsGroupManager={() => {
+                              removeUserFromGroup(group.active_group!.id ?? '');
+                            }}
                           />
-                        ) : (
-                          <Chip
-                            key={group.active_role_group_mapping?.active_role_group?.name}
-                            label={group.active_role_group_mapping?.active_role_group?.name}
-                            variant="outlined"
-                            color="primary"
-                            onClick={() =>
-                              navigate(`/roles/${group.active_role_group_mapping?.active_role_group?.name}`)
-                            }
-                            onDelete={
-                              canManageGroup(currentUser, group.active_group) ||
-                              isGroupOwner(currentUser, group.active_role_group_mapping.active_role_group?.id ?? '')
-                                ? () =>
-                                    onClickRemoveGroupFromRole(
-                                      group.active_group ?? ({} as PolymorphicGroup),
-                                      group.active_role_group_mapping?.active_role_group ?? ({} as RoleGroup),
-                                      true,
-                                    )
-                                : undefined
-                            }
-                          />
-                        ),
+                        ) : null,
                       )}
                     </Stack>
                   </TableCell>
@@ -342,48 +317,22 @@ function MemberTable({user, memberships, onClickRemoveGroupFromRole, onClickRemo
                         rowGap: '.5rem',
                       }}>
                       {groups.map((group) =>
-                        group.active_role_group_mapping == null ? (
-                          <Chip
-                            key="direct"
-                            label="Direct"
-                            color="primary"
-                            onDelete={
-                              group.active_group?.is_managed &&
-                              (currentUser.id === user.id || canManageGroup(currentUser, group.active_group))
-                                ? () => {
-                                    currentUser.id == user.id
-                                      ? onClickRemoveDirectAccess(
-                                          user.id,
-                                          group.active_group ?? ({} as PolymorphicGroup),
-                                          false,
-                                        )
-                                      : removeUserFromGroup(group.active_group?.id ?? '');
-                                  }
-                                : undefined
-                            }
+                        group.active_group ? (
+                          <MembershipChip
+                            key={group.active_role_group_mapping?.active_role_group?.name ?? ''}
+                            user={group}
+                            group={group.active_group}
+                            removeRoleGroup={(roleGroup) => {
+                              onClickRemoveGroupFromRole(group.active_group!, roleGroup, false);
+                            }}
+                            removeDirectAccessAsUser={() => {
+                              onClickRemoveDirectAccess(user.id, group.active_group!, false);
+                            }}
+                            removeDirectAccessAsGroupManager={() => {
+                              removeUserFromGroup(group.active_group!.id ?? '');
+                            }}
                           />
-                        ) : (
-                          <Chip
-                            key={group.active_role_group_mapping?.active_role_group?.name}
-                            label={group.active_role_group_mapping?.active_role_group?.name}
-                            variant="outlined"
-                            color="primary"
-                            onClick={() =>
-                              navigate(`/roles/${group.active_role_group_mapping?.active_role_group?.name}`)
-                            }
-                            onDelete={
-                              canManageGroup(currentUser, group.active_group) ||
-                              isGroupOwner(currentUser, group.active_role_group_mapping.active_role_group?.id ?? '')
-                                ? () =>
-                                    onClickRemoveGroupFromRole(
-                                      group.active_group ?? ({} as PolymorphicGroup),
-                                      group.active_role_group_mapping?.active_role_group ?? ({} as RoleGroup),
-                                      false,
-                                    )
-                                : undefined
-                            }
-                          />
-                        ),
+                        ) : null,
                       )}
                     </Stack>
                   </TableCell>


### PR DESCRIPTION
Deeply nesting the logic for membership management inside the JSX templates made it hard to understand the meaning behind the conditionals. This change explicitly names those conditionals and reduces their duplication across the codebase.