### PR TITLE
Use a "centered" time icon for access requests

### DIFF
--- a/src/components/NavItems.tsx
+++ b/src/components/NavItems.tsx
@@ -13,7 +13,7 @@ import UserIcon from '@mui/icons-material/Person';
 import GroupIcon from '@mui/icons-material/People';
 import RoleIcon from '@mui/icons-material/Diversity3';
 import AppIcon from '@mui/icons-material/AppShortcut';
-import AccessRequestIcon from '@mui/icons-material/MoreTime';
+import AccessRequestIcon from './icons/MoreTime';
 import RequestFromMe from '@mui/icons-material/AssignmentInd';
 import RequestToMe from '@mui/icons-material/AssignmentReturn';
 import RequestAll from '@mui/icons-material/Assignment';

--- a/src/components/icons/MoreTime.tsx
+++ b/src/components/icons/MoreTime.tsx
@@ -1,0 +1,26 @@
+import {createSvgIcon} from '@mui/material';
+
+/** A version of the MUI `MoreTime` icon that's centered on the circle (instead of on the bounding box of all the elements) */
+const MoreTime = createSvgIcon(
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    enable-background="new 0 0 24 24"
+    height="24px"
+    viewBox="0 0 24 24"
+    width="24px"
+    fill="#e3e3e3">
+    <g>
+      <rect fill="none" height="24" width="24" />
+    </g>
+    <g>
+      <g>
+        <polygon points="15.7,15.9 16.5,14.7 12.5,12.3 12.5,7 11,7 11,13" />
+        <path d="m 18.92,11 c 0.05,0.33 0.08,0.66 0.08,1 0,3.9 -3.1,7 -7,7 -3.9,0 -7,-3.1 -7,-7 0,-3.9 3.1,-7 7,-7 0.7,0 1.37,0.1 2,0.29 V 3.23 C 13.36,3.08 12.69,3 12,3 7,3 3,7 3,12 c 0,5 4,9 9,9 5,0 9,-4 9,-9 0,-0.34 -0.02,-0.67 -0.06,-1 z" />
+        <polygon points="19,1 19,4 16,4 16,6 19,6 19,9 21,9 21,6 24,6 24,4 21,4 21,1" />
+      </g>
+    </g>
+  </svg>,
+  'MoreTime',
+);
+
+export default MoreTime;

--- a/src/pages/groups/BulkRenewal.tsx
+++ b/src/pages/groups/BulkRenewal.tsx
@@ -17,7 +17,7 @@ import Select from '@mui/material/Select';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 
-import AccessRequestIcon from '@mui/icons-material/MoreTime';
+import AccessRequestIcon from '../../components/icons/MoreTime';
 
 import {FormContainer, DatePickerElement, TextFieldElement} from 'react-hook-form-mui';
 

--- a/src/pages/requests/Create.tsx
+++ b/src/pages/requests/Create.tsx
@@ -12,7 +12,7 @@ import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
 import Divider from '@mui/material/Divider';
-import AccessRequestIcon from '@mui/icons-material/MoreTime';
+import AccessRequestIcon from '../../components/icons/MoreTime';
 import Alert from '@mui/material/Alert';
 import FormControl from '@mui/material/FormControl';
 import Grid from '@mui/material/Grid';

--- a/src/pages/requests/Read.tsx
+++ b/src/pages/requests/Read.tsx
@@ -10,7 +10,7 @@ import Button from '@mui/material/Button';
 import Avatar from '@mui/material/Avatar';
 import Typography from '@mui/material/Typography';
 import Divider from '@mui/material/Divider';
-import AccessRequestIcon from '@mui/icons-material/MoreTime';
+import AccessRequestIcon from '../../components/icons/MoreTime';
 import PendingIcon from '@mui/icons-material/HelpOutline';
 import ApprovedIcon from '@mui/icons-material/CheckCircleOutline';
 import RejectedIcon from '@mui/icons-material/HighlightOff';

--- a/src/pages/roles/BulkRenewal.tsx
+++ b/src/pages/roles/BulkRenewal.tsx
@@ -17,7 +17,7 @@ import Select from '@mui/material/Select';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 
-import AccessRequestIcon from '@mui/icons-material/MoreTime';
+import AccessRequestIcon from '../../components/icons/MoreTime';
 
 import {FormContainer, DatePickerElement, TextFieldElement} from 'react-hook-form-mui';
 


### PR DESCRIPTION
The people (or at least one of them) demand visual consistency.

![Screen Shot 2025-05-22 at 16 42 37](https://github.com/user-attachments/assets/a7967a80-7a87-4a74-ab61-2489cfbbe07a)
