### PR TITLE
Show disabled role request button when the user owns no roles

### DIFF
--- a/src/pages/role_requests/Create.tsx
+++ b/src/pages/role_requests/Create.tsx
@@ -54,6 +54,7 @@ import {minTagTime, minTagTimeGroups} from '../../helpers';
 dayjs.extend(IsSameOrBefore);
 
 interface CreateRequestButtonProps {
+  enabled: boolean;
   setOpen(open: boolean): any;
   role?: RoleGroup;
   group?: PolymorphicGroup;
@@ -63,7 +64,11 @@ interface CreateRequestButtonProps {
 
 function CreateRequestButton(props: CreateRequestButtonProps) {
   return (
-    <Button variant="contained" onClick={() => props.setOpen(true)} endIcon={<RoleRequestIcon />}>
+    <Button
+      variant="contained"
+      onClick={() => props.setOpen(true)}
+      endIcon={<RoleRequestIcon />}
+      disabled={!props.enabled}>
       {props.group == null
         ? 'Create Request'
         : props.renew
@@ -490,6 +495,7 @@ function CreateRequestDialog(props: CreateRequestDialogProps) {
 }
 
 interface CreateRequestProps {
+  enabled: boolean;
   currentUser: OktaUser;
   role?: RoleGroup;
   group?: PolymorphicGroup;
@@ -511,6 +517,7 @@ export default function CreateRequest(props: CreateRequestProps) {
   return (
     <>
       <CreateRequestButton
+        enabled={props.enabled}
         setOpen={setOpen}
         role={props.role}
         group={props.group}

--- a/src/pages/role_requests/Create.tsx
+++ b/src/pages/role_requests/Create.tsx
@@ -50,6 +50,7 @@ import {
 import {useCurrentUser} from '../../authentication';
 import {canManageGroup} from '../../authorization';
 import {minTagTime, minTagTimeGroups} from '../../helpers';
+import {Tooltip} from '@mui/material';
 
 dayjs.extend(IsSameOrBefore);
 
@@ -64,19 +65,28 @@ interface CreateRequestButtonProps {
 
 function CreateRequestButton(props: CreateRequestButtonProps) {
   return (
-    <Button
-      variant="contained"
-      onClick={() => props.setOpen(true)}
-      endIcon={<RoleRequestIcon />}
-      disabled={!props.enabled}>
-      {props.group == null
-        ? 'Create Request'
-        : props.renew
-          ? 'Renew'
-          : props.owner
-            ? 'Request Ownership'
-            : 'Request Membership'}
-    </Button>
+    <Tooltip
+      title={
+        props.enabled
+          ? 'Request access on behalf of a role you own.'
+          : 'You do not own any roles for which to request access.'
+      }>
+      <span>
+        <Button
+          variant="contained"
+          onClick={() => props.setOpen(true)}
+          endIcon={<RoleRequestIcon />}
+          disabled={!props.enabled}>
+          {props.group == null
+            ? 'Create Request'
+            : props.renew
+              ? 'Renew'
+              : props.owner
+                ? 'Request Ownership'
+                : 'Request Membership'}
+        </Button>
+      </span>
+    </Tooltip>
   );
 }
 

--- a/src/pages/role_requests/List.tsx
+++ b/src/pages/role_requests/List.tsx
@@ -40,7 +40,7 @@ function userOwnsRoles(user: OktaUserGroupMember[]): boolean {
 
 export default function ListRoleRequests() {
   const currentUser = useCurrentUser();
-  const showCreateRequest = userOwnsRoles(currentUser.active_group_ownerships ?? []);
+  const enableCreateRequest = userOwnsRoles(currentUser.active_group_ownerships ?? []);
 
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -138,7 +138,7 @@ export default function ListRoleRequests() {
   return (
     <TableContainer component={Paper}>
       <TableTopBar title="Role Requests">
-        {showCreateRequest && <CreateRoleRequest currentUser={currentUser}></CreateRoleRequest>}
+        <CreateRoleRequest currentUser={currentUser} enabled={enableCreateRequest}></CreateRoleRequest>
         <TableTopBarAutocomplete
           options={searchRows.map(
             (row) =>


### PR DESCRIPTION
Small transparency change to always include the role requests button, but to disable it and provide a helptext explanation when the user owns no roles.

The two states:

![image](https://github.com/user-attachments/assets/de371d57-7a11-4596-8bf2-912fbbc72d67)

![image](https://github.com/user-attachments/assets/9306740f-75ee-477a-8242-d275bafe8b8d)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210335812409828