### PR TITLE
App owner group description bug

### DIFF
--- a/api/views/resources/app.py
+++ b/api/views/resources/app.py
@@ -149,6 +149,8 @@ class AppResource(MethodResource):
                         new_name_prefix,
                         app_group.name,
                     )
+                if app_group.is_owner:
+                    app_group.description = f"Owners of the {app.name} application"
                 if app_group.deleted_at is None:
                     okta.update_group(app_group.id, app_group.name, app_group.description)
 


### PR DESCRIPTION
Currently, the description of the app owners group is not changed when an app is renamed so it'll still say "Owners of the <old group name> application" and app owner group descriptions can't be modified in the Access UI. Fixes this for new name changes (not existing name mismatches)