### PR TITLE
Show expiration date on chip hover

### DIFF
--- a/src/components/MembershipChip.tsx
+++ b/src/components/MembershipChip.tsx
@@ -3,9 +3,10 @@ import {useNavigate} from 'react-router-dom';
 import {useCurrentUser} from '../authentication';
 import {canManageGroup, isGroupOwner} from '../authorization';
 import Chip from '@mui/material/Chip';
+import Tooltip from '@mui/material/Tooltip';
 
 export interface MembershipChipProps {
-  user: OktaUserGroupMember;
+  okta_user_group_member: OktaUserGroupMember;
   group: PolymorphicGroup;
   removeRoleGroup: (roleGroup: RoleGroup) => void;
   removeDirectAccessAsUser: () => void;
@@ -13,7 +14,7 @@ export interface MembershipChipProps {
 }
 
 export default function MembershipChip({
-  user,
+  okta_user_group_member,
   group,
   removeRoleGroup,
   removeDirectAccessAsUser,
@@ -21,39 +22,47 @@ export default function MembershipChip({
 }: MembershipChipProps) {
   const navigate = useNavigate();
   const currentUser = useCurrentUser();
-  const activeRoleGroup = user.active_role_group_mapping?.active_role_group;
+  const activeRoleGroup = okta_user_group_member.active_role_group_mapping?.active_role_group;
+  const ending_date = okta_user_group_member.ended_at ?? 'Never';
   const canManageUserRoleGroup = activeRoleGroup?.id ? isGroupOwner(currentUser, activeRoleGroup.id) : false;
   const canManageThisGroup = group.is_managed && canManageGroup(currentUser, group);
-  const canManageThisUser = group.is_managed && currentUser.id === user.active_user?.id;
+  const canManageThisUser = group.is_managed && currentUser.id === okta_user_group_member.active_user?.id;
+
+  const moveTooltip = {modifiers: [{name: 'offset', options: {offset: [0, -10]}}]};
+
   return activeRoleGroup ? (
-    <Chip
-      label={activeRoleGroup.name}
-      variant="outlined"
-      color="primary"
-      onClick={() => navigate(`/roles/${activeRoleGroup.name}`)}
-      onDelete={
-        canManageThisGroup || canManageUserRoleGroup
-          ? () => {
-              removeRoleGroup(activeRoleGroup);
-            }
-          : undefined
-      }
-    />
-  ) : (
-    <Chip
-      label="Direct"
-      color="primary"
-      onDelete={
-        canManageThisUser
-          ? () => {
-              removeDirectAccessAsUser();
-            }
-          : canManageThisGroup
+    <Tooltip title={ending_date} placement="right" PopperProps={moveTooltip}>
+      <Chip
+        label={activeRoleGroup.name}
+        variant="outlined"
+        color="primary"
+        onClick={() => navigate(`/roles/${activeRoleGroup.name}`)}
+        onDelete={
+          canManageThisGroup || canManageUserRoleGroup
             ? () => {
-                removeDirectAccessAsGroupManager();
+                removeRoleGroup(activeRoleGroup);
               }
             : undefined
-      }
-    />
+        }
+      />
+    </Tooltip>
+  ) : (
+    <Tooltip title={ending_date} placement="right" PopperProps={moveTooltip}>
+      <Chip
+        label="Direct"
+        color="primary"
+        onDelete={
+          canManageThisUser
+            ? () => {
+                removeDirectAccessAsUser();
+              }
+            : canManageThisGroup
+              ? () => {
+                  removeDirectAccessAsGroupManager();
+                }
+              : undefined
+        }
+      />
+    </Tooltip>
   );
 }

--- a/src/pages/groups/Read.tsx
+++ b/src/pages/groups/Read.tsx
@@ -586,7 +586,7 @@ export default function ReadGroup() {
                                   directRoleOwnerships.has(user.active_user!.id) ? (
                                     <MembershipChip
                                       key={`${user.active_user?.id}${user.active_role_group_mapping?.active_role_group?.id}`}
-                                      user={user}
+                                      okta_user_group_member={user}
                                       group={group}
                                       removeRoleGroup={(roleGroup) => {
                                         removeGroupFromRole(group, roleGroup, true);
@@ -741,7 +741,7 @@ export default function ReadGroup() {
                                 {users.sort(sortOktaUserGroupMembers).map((user) => (
                                   <MembershipChip
                                     key={`${user.active_user?.id}${user.active_role_group_mapping?.active_role_group?.id}`}
-                                    user={user}
+                                    okta_user_group_member={user}
                                     group={group}
                                     removeRoleGroup={(roleGroup) => {
                                       removeGroupFromRole(group, roleGroup, false);

--- a/src/pages/users/Read.tsx
+++ b/src/pages/users/Read.tsx
@@ -198,7 +198,7 @@ function OwnerTable({user, ownerships, onClickRemoveGroupFromRole, onClickRemove
                         group.active_group ? (
                           <MembershipChip
                             key={group.active_role_group_mapping?.active_role_group?.name ?? ''}
-                            user={group}
+                            okta_user_group_member={group}
                             group={group.active_group}
                             removeRoleGroup={(roleGroup) => {
                               onClickRemoveGroupFromRole(group.active_group!, roleGroup, true);
@@ -321,7 +321,7 @@ function MemberTable({user, memberships, onClickRemoveGroupFromRole, onClickRemo
                         group.active_group ? (
                           <MembershipChip
                             key={group.active_role_group_mapping?.active_role_group?.name ?? ''}
-                            user={group}
+                            okta_user_group_member={group}
                             group={group.active_group}
                             removeRoleGroup={(roleGroup) => {
                               onClickRemoveGroupFromRole(group.active_group!, roleGroup, false);


### PR DESCRIPTION
If a user has direct access and access via one or more roles, it can be unclear if one is granting longer access than the other since the 'Ending' column just shows the max. Added labels on hover to show expiration dates associated with each membership/ownership. Left the date format the same as on other pages (eg. the Access Request list page) to be consistent

![Screenshot 2025-06-03 at 11 58 36 AM](https://github.com/user-attachments/assets/91e10be7-37ae-421a-a4a7-145bc38df291)
