### PR TITLE
Make blocked roles more clear

### DIFF
--- a/src/pages/roles/AddGroups.tsx
+++ b/src/pages/roles/AddGroups.tsx
@@ -230,7 +230,9 @@ function AddGroupsDialog(props: AddGroupsDialogProps) {
           </Typography>
           <Typography variant="subtitle1" color="text.accent">
             {disallowedGroups.length != 0 && !isAccessAdmin(currentUser)
-              ? 'Some groups may not be added due to group tag constraints.'
+              ? // this case will never be hit as-is since admins are exempt from owner add constraints
+                // leaving in in case we change the visibility of this dialog in the future
+                'Some groups may not be added due to group tag constraints.'
               : null}
           </Typography>
           {requestError != '' ? <Alert severity="error">{requestError}</Alert> : null}

--- a/src/pages/roles/BulkRenewal.tsx
+++ b/src/pages/roles/BulkRenewal.tsx
@@ -478,7 +478,7 @@ function BulkRenewalDialog(props: BulkRenewalDialogProps) {
           </Typography>
           <Typography variant="subtitle1" color="text.accent">
             {display_owner_add_constraint
-              ? 'Due to group constraints, some roles may not be renewed since you are both a member of the role and an owner of the group. Please reach out to another group owner to renew the role membership to the group.'
+              ? 'Due to group tag constraints, some roles may not be renewed since you are both a member of the role and an owner of the group. Please reach out to another group owner to renew the role membership to the group or create a role request if you own the role.'
               : null}
           </Typography>
           <Typography variant="body2" color="text.secondary" sx={{mb: 2}}>


### PR DESCRIPTION
Updated messaging around roles that cannot be added to a group due to tag constraints. In the 'Add roles' to group dialog, changed filtering out blocked roles to displaying them but making them unselectable with a message

<img width="1425" height="876" alt="Screenshot 2025-07-11 at 3 45 25 PM" src="https://github.com/user-attachments/assets/80de5db9-efc6-4efd-8b89-2adadde7a7c1" />
