### PR TITLE
Add name pronunciation and pronouns to profile if they exist

### DIFF
--- a/src/pages/users/Read.tsx
+++ b/src/pages/users/Read.tsx
@@ -67,7 +67,7 @@ function ProfileToCard({user}: ProfileToCardProps) {
         </Typography>
         <List>
           {Object.entries(user.profile)
-            .filter(([_, v]) => v != null)
+            .filter(([u, v]) => v != null && u != 'Pronouns' && u != 'Name Pronunciation')
             .map(([key, value]: [string, string]) => (
               <ListItem key={key} sx={{padding: 0}}>
                 <ListItemText primary={key} secondary={value} />
@@ -437,6 +437,11 @@ export default function ReadUser() {
                   </Typography>
                   <Typography variant="h5" textAlign="center">
                     {user.email?.toLowerCase()}
+                  </Typography>
+                  <Typography>
+                    {user.profile?.Pronouns}
+                    {user.profile?.Pronouns && user.profile?.['Name Pronunciation'] && <> • </>}
+                    {user.profile?.['Name Pronunciation']}
                   </Typography>
                 </Stack>
                 <Divider />


### PR DESCRIPTION
If Pronouns and Name Pronunciation are included in USER_DISPLAY_CUSTOM_ATTRIBUTES, display them on user profile title cards


<img width="1186" height="501" alt="Screenshot 2025-10-22 at 6 00 58 PM" src="https://github.com/user-attachments/assets/c04f11f1-fb97-47ea-a05f-f9a945651606" />
