### PR TITLE
Fix bug where all 'Ending' always listed as Never

### DIFF
--- a/src/pages/apps/components/AppsAccordionListGroup.tsx
+++ b/src/pages/apps/components/AppsAccordionListGroup.tsx
@@ -76,7 +76,7 @@ const GroupDetailList: React.FC<GroupDetailListProps> = React.memo(
                       </Link>
                     </TableCell>
                     <TableCell>
-                      <Ending memberships={member_list} />
+                      <Ending memberships={[member]} />
                     </TableCell>
                   </TableRow>
                 ))


### PR DESCRIPTION
'Ending' field for members/owners of an app group on app summary pages would always be listed as 'Never' even when access is finite. Fixed to display correct access

Before (mismatch):
<img width="718" height="191" alt="Screenshot 2025-12-08 at 5 24 24 PM" src="https://github.com/user-attachments/assets/c335aaa1-1fad-4bec-b9b2-4d76544e5ed0" />
<img width="1155" height="275" alt="Screenshot 2025-12-08 at 5 24 48 PM" src="https://github.com/user-attachments/assets/1638727e-ff67-4e90-8e26-aa63488ab267" />

After (correct):
<img width="1150" height="277" alt="Screenshot 2025-12-08 at 5 24 10 PM" src="https://github.com/user-attachments/assets/f8a4f28c-8627-4dfb-a04e-e73a09d492bd" />
