### PR TITLE
Fix bug causing 403 responses when plugin data is not set

### DIFF
--- a/api/views/resources/app.py
+++ b/api/views/resources/app.py
@@ -101,7 +101,7 @@ class AppResource(MethodResource):
         # privilege escalation in the managed apps.
         if (
             app_changes.app_group_lifecycle_plugin != app.app_group_lifecycle_plugin
-            or app_changes.plugin_data != app.plugin_data
+            or (app_changes.plugin_data or {}) != app.plugin_data
         ) and not AuthorizationHelpers.is_access_admin():
             abort(
                 403,

--- a/api/views/resources/group.py
+++ b/api/views/resources/group.py
@@ -122,7 +122,7 @@ class GroupResource(MethodResource):
 
         # Enforce stricter authorization for plugin configuration changes to prevent
         # privilege escalation in the managed apps.
-        if group_changes.plugin_data != group.plugin_data and not (
+        if (group_changes.plugin_data or {}) != group.plugin_data and not (
             AuthorizationHelpers.is_access_admin()
             or (type(group) is AppGroup and AuthorizationHelpers.is_app_owner_group_owner(app_group=group))
         ):


### PR DESCRIPTION
Fixes an authZ bug introduced in https://github.com/discord/access/pull/351, arising when the changes to an app or group did not include any plugin data (`None`). This was causing some group/app owners to inappropriately get 403 responses when modifying other group/app metadata.