### PR TITLE
Add Docker Hub publishing to CI workflow

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -1,0 +1,36 @@
+name: Docker Hub Publish
+
+on:
+  push:
+    branches:
+     - main
+
+jobs:
+  docker-hub-publish:
+    name: Publish Docker image to Docker Hub
+    runs-on: ubuntu-22.04
+
+    permissions:
+      contents: "read"
+
+    steps:
+      - id: checkout
+        name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - id: docker-push-tagged
+        name: Tag Docker image and push to Docker Hub
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: |
+            discord/access:latest
+            discord/access:${{ github.sha }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   docker-release:
-    name: Docker release to Google Artifact Registry
+    name: Docker release to Google Artifact Registry and Docker Hub
     runs-on: ubuntu-22.04
 
     permissions:
@@ -37,13 +37,21 @@ jobs:
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - id: docker-push-tagged
-        name: Tag Docker image and push to Google Artifact Registry
+        name: Tag Docker image and push to Google Artifact Registry and Docker Hub
         uses: docker/build-push-action@v6
         with:
           push: true
           tags: |
             us-east1-docker.pkg.dev/discord-access-prd/access/access:latest
+            discord/access:latest
+            discord/access:${{ github.sha }}
           build-args: |
             SENTRY_RELEASE=${{ github.sha }}
             PUSH_SENTRY_RELEASE=true

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   docker-release:
-    name: Docker release to Google Artifact Registry and Docker Hub
+    name: Docker release to Google Artifact Registry
     runs-on: ubuntu-22.04
 
     permissions:
@@ -37,21 +37,13 @@ jobs:
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - id: docker-push-tagged
-        name: Tag Docker image and push to Google Artifact Registry and Docker Hub
+        name: Tag Docker image and push to Google Artifact Registry
         uses: docker/build-push-action@v6
         with:
           push: true
           tags: |
             us-east1-docker.pkg.dev/discord-access-prd/access/access:latest
-            discord/access:latest
-            discord/access:${{ github.sha }}
           build-args: |
             SENTRY_RELEASE=${{ github.sha }}
             PUSH_SENTRY_RELEASE=true


### PR DESCRIPTION
## Summary

Closes #338

This PR adds Docker Hub publishing alongside the existing Google Artifact Registry push in the Docker Image CI workflow.

## Changes

- Added a **Login to Docker Hub** step using `docker/login-action@v3` with `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets
- Added Docker Hub tags (`discord/access:latest` and `discord/access:${{ github.sha }}`) to the existing build-push step so the image is built once and pushed to both registries

## Required Setup

The following repository secrets need to be configured before this will work:

- `DOCKERHUB_USERNAME` — Docker Hub username
- `DOCKERHUB_TOKEN` — Docker Hub access token (create one at https://hub.docker.com/settings/security)

The Docker Hub repository `discord/access` should also be created beforehand.