### PR TITLE
Fix Okta retry timeout crashing group sync

### DIFF
--- a/api/services/okta_service.py
+++ b/api/services/okta_service.py
@@ -58,11 +58,11 @@ class OktaService:
             try:
                 result = await asyncio.wait_for(func(*args, **kwargs), timeout=REQUEST_TIMEOUT)
             except asyncio.TimeoutError as e:
-                logger.warning("Timeout on Okta request. Retrying...")
                 if attempt == REQUEST_MAX_RETRIES:
                     raise Exception(
                         f"Okta request timed out after {1 + REQUEST_MAX_RETRIES} attempts"
                     ) from e
+                logger.warning("Timeout on Okta request. Retrying...")
                 await asyncio.sleep(RETRY_BACKOFF_FACTOR * (2**attempt))
                 continue
 

--- a/api/services/okta_service.py
+++ b/api/services/okta_service.py
@@ -59,7 +59,12 @@ class OktaService:
                 result = await asyncio.wait_for(func(*args, **kwargs), timeout=REQUEST_TIMEOUT)
             except asyncio.TimeoutError as e:
                 logger.warning("Timeout on Okta request. Retrying...")
-                result = (None, e)
+                if attempt == REQUEST_MAX_RETRIES:
+                    raise Exception(
+                        f"Okta request timed out after {1 + REQUEST_MAX_RETRIES} attempts"
+                    ) from e
+                await asyncio.sleep(RETRY_BACKOFF_FACTOR * (2**attempt))
+                continue
 
             if len(result) == 2:
                 response, error = result

--- a/api/services/okta_service.py
+++ b/api/services/okta_service.py
@@ -59,9 +59,7 @@ class OktaService:
                 result = await asyncio.wait_for(func(*args, **kwargs), timeout=REQUEST_TIMEOUT)
             except asyncio.TimeoutError as e:
                 if attempt == REQUEST_MAX_RETRIES:
-                    raise Exception(
-                        f"Okta request timed out after {1 + REQUEST_MAX_RETRIES} attempts"
-                    ) from e
+                    raise Exception(f"Okta request timed out after {1 + REQUEST_MAX_RETRIES} attempts") from e
                 logger.warning("Timeout on Okta request. Retrying...")
                 await asyncio.sleep(RETRY_BACKOFF_FACTOR * (2**attempt))
                 continue

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -184,76 +184,81 @@ def sync_group_memberships(act_as_authority: bool) -> None:
     group_ids_with_group_rules = okta.list_groups_with_active_rules()
 
     for group in groups:
-        is_managed = is_managed_group(group, group_ids_with_group_rules)
+        try:
+            is_managed = is_managed_group(group, group_ids_with_group_rules)
 
-        act_authoritatively = act_as_authority and is_managed
+            act_authoritatively = act_as_authority and is_managed
 
-        logger.info(f"Syncing group {group.id}. act_authoritatively: {act_authoritatively}")
+            logger.info(f"Syncing group {group.id}. act_authoritatively: {act_authoritatively}")
 
-        members = okta.list_users_for_group(group.id)
+            members = okta.list_users_for_group(group.id)
 
-        logger.info(f"Fetched users list for group {group.id}")
+            logger.info(f"Fetched users list for group {group.id}")
 
-        db_all_group_members = {
-            row.id: row.user_id
-            for row in db.session.query(
-                OktaUserGroupMember.user_id,
-                OktaUserGroupMember.id,
-            ).filter(
-                OktaUserGroupMember.group_id == group.id,
-                OktaUserGroupMember.is_owner.is_(False),
-                db.or_(
-                    OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > db.func.now(),
-                ),
-            )
-        }
+            db_all_group_members = {
+                row.id: row.user_id
+                for row in db.session.query(
+                    OktaUserGroupMember.user_id,
+                    OktaUserGroupMember.id,
+                ).filter(
+                    OktaUserGroupMember.group_id == group.id,
+                    OktaUserGroupMember.is_owner.is_(False),
+                    db.or_(
+                        OktaUserGroupMember.ended_at.is_(None),
+                        OktaUserGroupMember.ended_at > db.func.now(),
+                    ),
+                )
+            }
 
-        for member in members:
-            # User is a member in okta but not in the DB
-            if member.id not in db_all_group_members.values():
-                logger.info(f"User {member.id} is not in the group in our DB.")
+            for member in members:
+                # User is a member in okta but not in the DB
+                if member.id not in db_all_group_members.values():
+                    logger.info(f"User {member.id} is not in the group in our DB.")
 
-                if act_authoritatively:
-                    okta.remove_user_from_group(group.id, member.id)
+                    if act_authoritatively:
+                        okta.remove_user_from_group(group.id, member.id)
+                    else:
+                        reason = (
+                            "User in Okta group but not in Access group."
+                            if is_managed
+                            else "User added via Okta group rule."
+                        )
+                        ModifyGroupUsers(
+                            group=group.id,
+                            members_to_add=[member.id],
+                            created_reason=reason,
+                        ).execute()
+
+                # User is a member in okta and an entry exists in our DB
                 else:
-                    reason = (
-                        "User in Okta group but not in Access group."
-                        if is_managed
-                        else "User added via Okta group rule."
-                    )
-                    ModifyGroupUsers(
-                        group=group.id,
-                        members_to_add=[member.id],
-                        created_reason=reason,
-                    ).execute()
+                    db_all_group_members = {k: v for k, v in db_all_group_members.items() if v != member.id}
 
-            # User is a member in okta and an entry exists in our DB
-            else:
-                db_all_group_members = {k: v for k, v in db_all_group_members.items() if v != member.id}
+            logger.info("Members in Okta synced to DB.")
 
-        logger.info("Members in Okta synced to DB.")
+            # All remaining values are memberships that are marked active in our DB
+            # But are not valid memberships in okta
+            if db_all_group_members:
+                logger.info(
+                    f"Users were marked as members in the DB but not in okta. Updating. User IDs: {db_all_group_members}"
+                )
 
-        # All remaining values are memberships that are marked active in our DB
-        # But are not valid memberships in okta
-        if db_all_group_members:
-            logger.info(
-                f"Users were marked as members in the DB but not in okta. Updating. User IDs: {db_all_group_members}"
-            )
+                distinct_member_ids = set(db_all_group_members.values())
+                if act_authoritatively:
+                    # Create in okta
+                    for member_id in distinct_member_ids:
+                        okta.add_user_to_group(group.id, member_id)
+                else:
+                    # Remove the direct group memberships to this group in our DB
+                    # This will not affect group memberships that are via other group roles
+                    ModifyGroupUsers(group=group.id, members_to_remove=list(distinct_member_ids)).execute()
 
-            distinct_member_ids = set(db_all_group_members.values())
-            if act_authoritatively:
-                # Create in okta
-                for member_id in distinct_member_ids:
-                    okta.add_user_to_group(group.id, member_id)
-            else:
-                # Remove the direct group memberships to this group in our DB
-                # This will not affect group memberships that are via other group roles
-                ModifyGroupUsers(group=group.id, members_to_remove=list(distinct_member_ids)).execute()
+            logger.info("Members in DB synced to Okta.")
 
-        logger.info("Members in DB synced to Okta.")
-
-        db.session.commit()
+            db.session.commit()
+        except Exception:
+            logger.exception(f"Failed to sync memberships for group {group.id}, skipping.")
+            db.session.rollback()
+            continue
 
     logger.info("Membership sync finished.")
 
@@ -265,99 +270,104 @@ def sync_group_ownerships(act_as_authority: bool) -> None:
     group_ids_with_group_rules = okta.list_groups_with_active_rules()
 
     for group in groups:
-        is_managed = is_managed_group(group, group_ids_with_group_rules)
+        try:
+            is_managed = is_managed_group(group, group_ids_with_group_rules)
 
-        act_authoritatively = act_as_authority and is_managed
+            act_authoritatively = act_as_authority and is_managed
 
-        logger.info(f"Syncing group {group.id}. act_authoritatively: {act_authoritatively}")
+            logger.info(f"Syncing group {group.id}. act_authoritatively: {act_authoritatively}")
 
-        owners = okta.list_owners_for_group(group.id)
+            owners = okta.list_owners_for_group(group.id)
 
-        db_all_group_owners = {
-            row.id: row.user_id
-            for row in db.session.query(
-                OktaUserGroupMember.user_id,
-                OktaUserGroupMember.id,
-            ).filter(
-                OktaUserGroupMember.group_id == group.id,
-                OktaUserGroupMember.is_owner.is_(True),
-                db.or_(
-                    OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > db.func.now(),
-                ),
-            )
-        }
-
-        # If the group ownership is managed by Access and there are no owners for it
-        # check to see if it's an AppGroup and if so, add the app owners as owners in Okta
-        if act_authoritatively and len(db_all_group_owners) == 0:
-            app_group = (
-                AppGroup.query.options(
-                    joinedload(AppGroup.app).options(selectinload(App.active_owner_app_groups)),
+            db_all_group_owners = {
+                row.id: row.user_id
+                for row in db.session.query(
+                    OktaUserGroupMember.user_id,
+                    OktaUserGroupMember.id,
+                ).filter(
+                    OktaUserGroupMember.group_id == group.id,
+                    OktaUserGroupMember.is_owner.is_(True),
+                    db.or_(
+                        OktaUserGroupMember.ended_at.is_(None),
+                        OktaUserGroupMember.ended_at > db.func.now(),
+                    ),
                 )
-                .filter(AppGroup.deleted_at.is_(None))
-                .filter(AppGroup.id == group.id)
-                .first()
-            )
+            }
 
-            if app_group is not None and not app_group.is_owner:
-                app_owner_group_ids = [g.id for g in app_group.app.active_owner_app_groups]
-                db_all_group_owners = {
-                    row.id: row.user_id
-                    for row in db.session.query(
-                        OktaUserGroupMember.user_id,
-                        OktaUserGroupMember.id,
-                    ).filter(
-                        OktaUserGroupMember.group_id.in_(app_owner_group_ids),
-                        OktaUserGroupMember.is_owner.is_(True),
-                        db.or_(
-                            OktaUserGroupMember.ended_at.is_(None),
-                            OktaUserGroupMember.ended_at > db.func.now(),
-                        ),
+            # If the group ownership is managed by Access and there are no owners for it
+            # check to see if it's an AppGroup and if so, add the app owners as owners in Okta
+            if act_authoritatively and len(db_all_group_owners) == 0:
+                app_group = (
+                    AppGroup.query.options(
+                        joinedload(AppGroup.app).options(selectinload(App.active_owner_app_groups)),
                     )
-                }
+                    .filter(AppGroup.deleted_at.is_(None))
+                    .filter(AppGroup.id == group.id)
+                    .first()
+                )
 
-        for owner in owners:
-            # User is a owner in okta but not in the DB
-            if owner.id not in db_all_group_owners.values():
-                logger.info(f"User {owner.id} is not in the group in our DB.")
+                if app_group is not None and not app_group.is_owner:
+                    app_owner_group_ids = [g.id for g in app_group.app.active_owner_app_groups]
+                    db_all_group_owners = {
+                        row.id: row.user_id
+                        for row in db.session.query(
+                            OktaUserGroupMember.user_id,
+                            OktaUserGroupMember.id,
+                        ).filter(
+                            OktaUserGroupMember.group_id.in_(app_owner_group_ids),
+                            OktaUserGroupMember.is_owner.is_(True),
+                            db.or_(
+                                OktaUserGroupMember.ended_at.is_(None),
+                                OktaUserGroupMember.ended_at > db.func.now(),
+                            ),
+                        )
+                    }
 
-                if act_authoritatively:
-                    okta.remove_owner_from_group(group.id, owner.id)
+            for owner in owners:
+                # User is a owner in okta but not in the DB
+                if owner.id not in db_all_group_owners.values():
+                    logger.info(f"User {owner.id} is not in the group in our DB.")
+
+                    if act_authoritatively:
+                        okta.remove_owner_from_group(group.id, owner.id)
+                    else:
+                        reason = (
+                            "User in Okta group but not in Access group."
+                            if is_managed
+                            else "User was added via Okta group rule."
+                        )
+                        ModifyGroupUsers(
+                            group=group.id,
+                            owners_to_add=[owner.id],
+                            created_reason=reason,
+                        ).execute()
+
+                # User is a owner in okta and an entry exists in our DB
                 else:
-                    reason = (
-                        "User in Okta group but not in Access group."
-                        if is_managed
-                        else "User was added via Okta group rule."
-                    )
-                    ModifyGroupUsers(
-                        group=group.id,
-                        owners_to_add=[owner.id],
-                        created_reason=reason,
-                    ).execute()
+                    db_all_group_owners = {k: v for k, v in db_all_group_owners.items() if v != owner.id}
 
-            # User is a owner in okta and an entry exists in our DB
-            else:
-                db_all_group_owners = {k: v for k, v in db_all_group_owners.items() if v != owner.id}
+            # All remaining values are ownerships that are marked active in our DB
+            # But are not valid ownerships in okta
+            if db_all_group_owners:
+                logger.info(
+                    f"Users were marked as owners in the DB but not in okta. Updating. User IDs: {db_all_group_owners}"
+                )
 
-        # All remaining values are ownerships that are marked active in our DB
-        # But are not valid ownerships in okta
-        if db_all_group_owners:
-            logger.info(
-                f"Users were marked as owners in the DB but not in okta. Updating. User IDs: {db_all_group_owners}"
-            )
+                distinct_owner_ids = set(db_all_group_owners.values())
+                if act_authoritatively:
+                    # Create in okta
+                    for owner_id in distinct_owner_ids:
+                        okta.add_owner_to_group(group.id, owner_id)
+                else:
+                    # Remove the direct group ownerships to this group in our DB
+                    # This will not affect group ownerships that are via other group roles
+                    ModifyGroupUsers(group=group.id, owners_to_remove=list(distinct_owner_ids)).execute()
 
-            distinct_owner_ids = set(db_all_group_owners.values())
-            if act_authoritatively:
-                # Create in okta
-                for owner_id in distinct_owner_ids:
-                    okta.add_owner_to_group(group.id, owner_id)
-            else:
-                # Remove the direct group ownerships to this group in our DB
-                # This will not affect group ownerships that are via other group roles
-                ModifyGroupUsers(group=group.id, owners_to_remove=list(distinct_owner_ids)).execute()
-
-        db.session.commit()
+            db.session.commit()
+        except Exception:
+            logger.exception(f"Failed to sync ownerships for group {group.id}, skipping.")
+            db.session.rollback()
+            continue
 
     logger.info("Ownership sync finished.")
 

--- a/tests/test_group_membership_sync.py
+++ b/tests/test_group_membership_sync.py
@@ -301,6 +301,29 @@ def test_membership_through_multiple_groups_non_authoritative(db: SQLAlchemy, mo
     assert _get_group_membership(db, pk_2).expired_at == date_2
 
 
+def test_membership_sync_continues_after_group_failure(db: SQLAlchemy, mocker: MockerFixture) -> None:
+    initial_okta_users = UserFactory.create_batch(3)
+    initial_okta_groups = GroupFactory.create_batch(3)
+    _, _ = seed_db(db, initial_okta_users, initial_okta_groups)
+
+    def fake_list_users_for_group(group_id: str) -> list[User]:
+        if group_id == initial_okta_groups[0].id:
+            raise Exception("Simulated Okta timeout")
+        if group_id == initial_okta_groups[1].id:
+            return initial_okta_users
+        return []
+
+    _ = run_sync(db, mocker, initial_okta_groups, fake_list_users_for_group, False)
+
+    # Verify the second group still got its members synced despite the first group failing
+    members = _get_group_members(db, initial_okta_groups[1].id)
+    assert len(members) == 3
+
+    # Verify the failing group has no members
+    failed_members = _get_group_members(db, initial_okta_groups[0].id)
+    assert len(failed_members) == 0
+
+
 def seed_db(db: SQLAlchemy, users: list[OktaUser], groups: list[OktaGroup]) -> Tuple[list[OktaUser], list[OktaGroup]]:
     with Session(db.engine) as session:
         session.add_all([Group(g).update_okta_group(OktaGroup(), {}) for g in groups])

--- a/tests/test_okta_retries.py
+++ b/tests/test_okta_retries.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any, Optional, Tuple
 from unittest.mock import Mock
 
@@ -59,3 +60,25 @@ def test_retry_logic_no_error(mocker: MockerFixture, mock_sleep: Mock, okta_serv
     okta_service.get_user("okta_id")
     assert mocked_request.call_count == 1
     assert mock_sleep.call_count == 0
+
+
+def test_retry_logic_all_timeouts_raises(
+    mocker: MockerFixture, mock_sleep: Mock, okta_service: OktaService
+) -> None:
+    mocker.patch("asyncio.wait_for", side_effect=asyncio.TimeoutError())
+
+    with pytest.raises(Exception, match="timed out"):
+        okta_service.get_user("okta_id")
+
+
+def test_retry_logic_timeout_then_success(
+    mocker: MockerFixture, mock_sleep: Mock, okta_service: OktaService
+) -> None:
+    success_response: Tuple[Any, Any, Optional[Exception]] = (UserFactory(), Mock(), None)
+    mocker.patch(
+        "asyncio.wait_for",
+        side_effect=[asyncio.TimeoutError(), success_response],
+    )
+
+    user = okta_service.get_user("okta_id")
+    assert user is not None

--- a/tests/test_okta_retries.py
+++ b/tests/test_okta_retries.py
@@ -62,18 +62,14 @@ def test_retry_logic_no_error(mocker: MockerFixture, mock_sleep: Mock, okta_serv
     assert mock_sleep.call_count == 0
 
 
-def test_retry_logic_all_timeouts_raises(
-    mocker: MockerFixture, mock_sleep: Mock, okta_service: OktaService
-) -> None:
+def test_retry_logic_all_timeouts_raises(mocker: MockerFixture, mock_sleep: Mock, okta_service: OktaService) -> None:
     mocker.patch("asyncio.wait_for", side_effect=asyncio.TimeoutError())
 
     with pytest.raises(Exception, match="timed out"):
         okta_service.get_user("okta_id")
 
 
-def test_retry_logic_timeout_then_success(
-    mocker: MockerFixture, mock_sleep: Mock, okta_service: OktaService
-) -> None:
+def test_retry_logic_timeout_then_success(mocker: MockerFixture, mock_sleep: Mock, okta_service: OktaService) -> None:
     success_response: Tuple[Any, Any, Optional[Exception]] = (UserFactory(), Mock(), None)
     mocker.patch(
         "asyncio.wait_for",


### PR DESCRIPTION
## Summary
- **Fixed `_retry` timeout handling** in `okta_service.py`: The timeout handler created a 2-tuple `(None, e)` but callers expected 3 values, causing `ValueError: not enough values to unpack` when Okta rate-limited (429) and all retries timed out. Now raises a clear exception on final timeout instead of returning a mismatched tuple.
- **Added per-group error isolation** in `syncer.py`: A single group failure in `sync_group_memberships` or `sync_group_ownerships` no longer crashes the entire sync job — it logs the error, rolls back partial DB changes, and continues to the next group.
- **Added tests** for timeout-exhaustion, timeout-then-success, and group-failure resilience scenarios.

## Test plan
- [x] Existing retry tests pass (retriable/non-retriable status codes, no error)
- [x] New `test_retry_logic_all_timeouts_raises` verifies exception on exhausted timeouts
- [x] New `test_retry_logic_timeout_then_success` verifies recovery after transient timeout
- [x] New `test_membership_sync_continues_after_group_failure` verifies sync continues past failing group
- [x] Full test suite passes (253 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213045704094187