### PR TITLE
Downgrade Okta timeout errors to warnings

### DIFF
--- a/api/services/okta_service.py
+++ b/api/services/okta_service.py
@@ -28,6 +28,12 @@ REQUEST_TIMEOUT = 30
 logger = logging.getLogger(__name__)
 
 
+class OktaTimeout(Exception):
+    """Raised when an Okta API request times out after all retries."""
+
+    pass
+
+
 class OktaService:
     """For interacting with the Okta API"""
 
@@ -59,7 +65,7 @@ class OktaService:
                 result = await asyncio.wait_for(func(*args, **kwargs), timeout=REQUEST_TIMEOUT)
             except asyncio.TimeoutError as e:
                 if attempt == REQUEST_MAX_RETRIES:
-                    raise Exception(f"Okta request timed out after {1 + REQUEST_MAX_RETRIES} attempts") from e
+                    raise OktaTimeout(f"Okta request timed out after {1 + REQUEST_MAX_RETRIES} attempts") from e
                 logger.warning("Timeout on Okta request. Retrying...")
                 await asyncio.sleep(RETRY_BACKOFF_FACTOR * (2**attempt))
                 continue
@@ -219,11 +225,14 @@ class OktaService:
             logger.warning(f"cannot add user with userId of {userId}")
             return
 
-        async with self._get_sessioned_okta_request_executor() as _:
-            _, error = await OktaService._retry(self.okta_client.add_user_to_group, groupId, userId)
+        try:
+            async with self._get_sessioned_okta_request_executor() as _:
+                _, error = await OktaService._retry(self.okta_client.add_user_to_group, groupId, userId)
 
-        if error is not None:
-            raise Exception(error)
+            if error is not None:
+                raise Exception(error)
+        except OktaTimeout:
+            logger.warning(f"Timed out adding user {userId} to group {groupId}")
 
     def add_user_to_group(self, groupId: str, userId: str) -> None:
         asyncio.run(self.async_add_user_to_group(groupId, userId))
@@ -237,11 +246,14 @@ class OktaService:
             logger.warning(f"cannot remove user with userId of {userId}")
             return
 
-        async with self._get_sessioned_okta_request_executor() as _:
-            _, error = await OktaService._retry(self.okta_client.remove_user_from_group, groupId, userId)
+        try:
+            async with self._get_sessioned_okta_request_executor() as _:
+                _, error = await OktaService._retry(self.okta_client.remove_user_from_group, groupId, userId)
 
-        if error is not None:
-            raise Exception(error)
+            if error is not None:
+                raise Exception(error)
+        except OktaTimeout:
+            logger.warning(f"Timed out removing user {userId} from group {groupId}")
 
     def remove_user_from_group(self, groupId: str, userId: str) -> None:
         asyncio.run(self.async_remove_user_from_group(groupId, userId))
@@ -354,23 +366,26 @@ class OktaService:
         if not self.use_group_owners_api:
             return
 
-        async with self._get_sessioned_okta_request_executor() as request_executor:
-            request, error = await request_executor.create_request(
-                method="POST",
-                url="/api/v1/groups/{groupId}/owners".format(groupId=groupId),
-                body={"id": userId, "type": "USER"},
-                headers={},
-                oauth=False,
-            )
+        try:
+            async with self._get_sessioned_okta_request_executor() as request_executor:
+                request, error = await request_executor.create_request(
+                    method="POST",
+                    url="/api/v1/groups/{groupId}/owners".format(groupId=groupId),
+                    body={"id": userId, "type": "USER"},
+                    headers={},
+                    oauth=False,
+                )
 
-            if error is not None:
+                if error is not None:
+                    raise Exception(error)
+
+                _, error = await OktaService._retry(request_executor.execute, request)
+
+            # Ignore error if owner is already assigned to group
+            if error is not None and not error.message.endswith("Provided owner is already assigned to this group"):
                 raise Exception(error)
-
-            _, error = await OktaService._retry(request_executor.execute, request)
-
-        # Ignore error if owner is already assigned to group
-        if error is not None and not error.message.endswith("Provided owner is already assigned to this group"):
-            raise Exception(error)
+        except OktaTimeout:
+            logger.warning(f"Timed out adding owner {userId} to group {groupId}")
 
         return
 
@@ -388,22 +403,25 @@ class OktaService:
         if not self.use_group_owners_api:
             return
 
-        async with self._get_sessioned_okta_request_executor() as request_executor:
-            request, error = await request_executor.create_request(
-                method="DELETE",
-                url="/api/v1/groups/{groupId}/owners/{userId}".format(groupId=groupId, userId=userId),
-                body={},
-                headers={},
-                oauth=False,
-            )
+        try:
+            async with self._get_sessioned_okta_request_executor() as request_executor:
+                request, error = await request_executor.create_request(
+                    method="DELETE",
+                    url="/api/v1/groups/{groupId}/owners/{userId}".format(groupId=groupId, userId=userId),
+                    body={},
+                    headers={},
+                    oauth=False,
+                )
+
+                if error is not None:
+                    raise Exception(error)
+
+                _, error = await OktaService._retry(request_executor.execute, request)
 
             if error is not None:
                 raise Exception(error)
-
-            _, error = await OktaService._retry(request_executor.execute, request)
-
-        if error is not None:
-            raise Exception(error)
+        except OktaTimeout:
+            logger.warning(f"Timed out removing owner {userId} from group {groupId}")
 
         return
 

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -34,7 +34,7 @@ from api.operations import (
 )
 from api.plugins import get_notification_hook
 from api.services import okta
-from api.services.okta_service import is_managed_group
+from api.services.okta_service import OktaTimeout, is_managed_group
 
 logger = logging.getLogger(__name__)
 
@@ -255,6 +255,10 @@ def sync_group_memberships(act_as_authority: bool) -> None:
             logger.info("Members in DB synced to Okta.")
 
             db.session.commit()
+        except OktaTimeout:
+            logger.warning(f"Timed out syncing memberships for group {group.id}, skipping.", exc_info=True)
+            db.session.rollback()
+            continue
         except Exception:
             logger.exception(f"Failed to sync memberships for group {group.id}, skipping.")
             db.session.rollback()
@@ -364,6 +368,10 @@ def sync_group_ownerships(act_as_authority: bool) -> None:
                     ModifyGroupUsers(group=group.id, owners_to_remove=list(distinct_owner_ids)).execute()
 
             db.session.commit()
+        except OktaTimeout:
+            logger.warning(f"Timed out syncing ownerships for group {group.id}, skipping.", exc_info=True)
+            db.session.rollback()
+            continue
         except Exception:
             logger.exception(f"Failed to sync ownerships for group {group.id}, skipping.")
             db.session.rollback()

--- a/tests/test_okta_retries.py
+++ b/tests/test_okta_retries.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 import pytest
 from pytest_mock import MockerFixture
 
-from api.services.okta_service import REQUEST_MAX_RETRIES, RETRIABLE_STATUS_CODES, OktaService
+from api.services.okta_service import REQUEST_MAX_RETRIES, RETRIABLE_STATUS_CODES, OktaService, OktaTimeout
 from tests.factories import UserFactory
 
 
@@ -65,7 +65,7 @@ def test_retry_logic_no_error(mocker: MockerFixture, mock_sleep: Mock, okta_serv
 def test_retry_logic_all_timeouts_raises(mocker: MockerFixture, mock_sleep: Mock, okta_service: OktaService) -> None:
     mocker.patch("asyncio.wait_for", side_effect=asyncio.TimeoutError())
 
-    with pytest.raises(Exception, match="timed out"):
+    with pytest.raises(OktaTimeout, match="timed out"):
         okta_service.get_user("okta_id")
 
 


### PR DESCRIPTION
## Summary
- **Added `OktaTimeout` exception class** to distinguish timeouts from real API failures
- **Catch timeouts in async fire-and-forget methods** (`async_add/remove_user/owner_to/from_group`) — log at WARNING instead of propagating as unhandled task exceptions that Sentry captures
- **Split syncer.py catch blocks** — `OktaTimeout` logs at WARNING level, other errors remain at ERROR

Follows up on #411 which fixed the tuple-unpacking crash and added per-group error isolation.

## Test plan
- [x] `test_retry_logic_all_timeouts_raises` updated to assert `OktaTimeout`
- [x] Full test suite passes (253 tests)
- [x] ruff format/check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)