### PR TITLE
New home page with action bar

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -605,8 +605,8 @@ export default function Home() {
       </Paper>
       <Paper>
         <Grid container spacing={2} direction="row" sx={{padding: 2}}>
-          <Grid item xs={3}>
-            <Grid container spacing={2} justifyContent="center" direction="column">
+          <Grid item xs={12} lg={3}>
+            <Grid container spacing={2}>
               <Grid item xs={12}>
                 <Grid container justifyContent="center">
                   <Grid item>
@@ -617,7 +617,7 @@ export default function Home() {
                 </Grid>
               </Grid>
               {Object.entries(sections).map(([key, [, buttonTitle, icon]]) => (
-                <Grid item xs={12} key={key}>
+                <Grid item xs={6} sm={4} lg={12} key={key}>
                   <Button
                     variant="contained"
                     size="large"
@@ -630,10 +630,13 @@ export default function Home() {
               ))}
             </Grid>
           </Grid>
-          <Grid item xs={0.1}>
+          <Grid item sx={{display: {xs: 'none', lg: 'flex'}}} lg={0.1}>
             <Divider orientation="vertical" />
           </Grid>
-          <Grid item xs={8.8}>
+          <Grid item xs={12} sx={{display: {xs: 'block', lg: 'none'}, py: '0 !important'}}>
+            <Divider />
+          </Grid>
+          <Grid item xs={12} lg={8.8}>
             <AccordionMaker
               which={whichAccordion}
               expandedSlug={expandedSlug}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,8 +8,8 @@ import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
 import Paper from '@mui/material/Paper';
-import Tab from '@mui/material/Tab';
-import Tabs from '@mui/material/Tabs';
+import Button from '@mui/material/Button';
+import Grid from '@mui/material/Grid';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import {alpha, useTheme} from '@mui/material';
@@ -22,16 +22,11 @@ import HowToRegIcon from '@mui/icons-material/HowToReg';
 import GroupRequestIcon from '@mui/icons-material/GroupAdd';
 import RoleRequestIcon from '@mui/icons-material/WorkHistory';
 import AccessRequestIcon from '../components/icons/MoreTime';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import AssistantIcon from '@mui/icons-material/Assistant';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import GeneralIcon from '@mui/icons-material/AllInclusive';
 import LinkIcon from '@mui/icons-material/Link';
 import PeopleLeadIcon from '@mui/icons-material/ContentPaste';
 import FAQIcon from '@mui/icons-material/TipsAndUpdates';
-import SchoolIcon from '@mui/icons-material/School';
-import SummarizeIcon from '@mui/icons-material/Summarize';
 import UserIcon from '@mui/icons-material/AccountBox';
 
 import {appName} from '../config/accessConfig';
@@ -130,6 +125,18 @@ const STAT_CONFIGS: StatConfig[] = [
     id: 'make-group-request',
     Icon: GroupRequestIcon,
     label: 'New group request',
+    isAction: true,
+  },
+  {
+    id: 'explore-user-docs',
+    Icon: UserIcon,
+    label: 'Explore user docs',
+    isAction: true,
+  },
+  {
+    id: 'explore-group-owner-docs',
+    Icon: PeopleLeadIcon,
+    label: 'Explore group owner docs',
     isAction: true,
   },
 ];
@@ -309,7 +316,7 @@ function AccordionMaker({which, expandedSlug, onSlugChange, onInternalLink}: Acc
 
   return (
     <>
-      <Typography variant="h6" color="text.accent" sx={{margin: '10px 0'}}>
+      <Typography variant="h5" color="text.accent" sx={{mt: 0, mb: '15px'}}>
         {sections[which][0]}
       </Typography>
       {Object.entries(guide[which]).map(([question, answer]) => {
@@ -354,12 +361,10 @@ export default function Home() {
   const hashSlug = location.hash.slice(1) || null;
   const sectionFromHash = hashSlug ? hashSlug.split('--')[0] : null;
 
-  // null = show guide cards; a section key = show that guide's accordion
-  const [selectedGuide, setSelectedGuide] = React.useState<string | null>(
-    sectionFromHash && sections[sectionFromHash] && sectionFromHash !== 'general' ? sectionFromHash : null,
+  const [whichAccordion, setWhichAccordion] = React.useState<string>(
+    sectionFromHash && sections[sectionFromHash] ? sectionFromHash : 'general',
   );
   const [expandedSlug, setExpandedSlug] = React.useState<string | null>(hashSlug);
-  const [docTab, setDocTab] = React.useState(sectionFromHash && sectionFromHash !== 'general' ? 1 : 0);
 
   const [openDialog, setOpenDialog] = React.useState<'access' | 'role' | 'group' | null>(null);
 
@@ -495,12 +500,7 @@ export default function Home() {
     if (!hashSlug) return;
     const section = hashSlug.split('--')[0];
     if (sections[section]) {
-      if (section === 'general') {
-        setDocTab(0);
-      } else {
-        setSelectedGuide(section);
-        setDocTab(1);
-      }
+      setWhichAccordion(section);
       setExpandedSlug(hashSlug);
       setTimeout(() => {
         document.getElementById(`${hashSlug}-header`)?.scrollIntoView({behavior: 'smooth', block: 'start'});
@@ -508,14 +508,8 @@ export default function Home() {
     }
   }, [hashSlug]);
 
-  const handleGuideSelect = (key: string) => {
-    setSelectedGuide(key);
-    setExpandedSlug(null);
-    navigate({hash: ''}, {replace: true});
-  };
-
-  const handleBackToGuides = () => {
-    setSelectedGuide(null);
+  const handleSectionChange = (key: string) => {
+    setWhichAccordion(key);
     setExpandedSlug(null);
     navigate({hash: ''}, {replace: true});
   };
@@ -523,13 +517,7 @@ export default function Home() {
   const handleInternalLink = (slug: string) => {
     const section = slug.split('--')[0];
     if (sections[section]) {
-      if (section === 'general') {
-        setDocTab(0);
-        setSelectedGuide(null);
-      } else {
-        setSelectedGuide(section);
-        setDocTab(1);
-      }
+      setWhichAccordion(section);
       setExpandedSlug(slug);
       navigate({hash: `#${slug}`}, {replace: true});
       setTimeout(() => {
@@ -558,6 +546,8 @@ export default function Home() {
                           if (stat.id === 'make-access-request') setOpenDialog('access');
                           else if (stat.id === 'make-role-request') setOpenDialog('role');
                           else if (stat.id === 'make-group-request') setOpenDialog('group');
+                          else if (stat.id === 'explore-user-docs') handleSectionChange('users');
+                          else if (stat.id === 'explore-group-owner-docs') handleSectionChange('people-lead');
                           else if (stat.path) navigate(stat.path);
                         }}
                         sx={{
@@ -614,111 +604,44 @@ export default function Home() {
         )}
       </Paper>
       <Paper>
-        <Box sx={{px: 2.5, pt: 2.5, pb: 1.5, display: 'flex', alignItems: 'center', gap: 1.5}}>
-          <Box
-            sx={{
-              width: 40,
-              height: 40,
-              borderRadius: '12px',
-              backgroundColor: theme.palette.text.accent,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              flexShrink: 0,
-            }}>
-            <SchoolIcon sx={{color: '#fff', fontSize: 20}} />
-          </Box>
-          <Box sx={{display: 'flex', flexDirection: 'column', justifyContent: 'center', gap: 0.25}}>
-            <Typography variant="subtitle1" fontWeight={700} sx={{lineHeight: 1.2}}>
-              {appName} User Guides
-            </Typography>
-            <Typography variant="caption" color="text.secondary" sx={{lineHeight: 1.2}}>
-              Everything you need to know
-            </Typography>
-          </Box>
-        </Box>
-        <Tabs
-          value={docTab}
-          onChange={(_, v) => {
-            setDocTab(v);
-            if (v === 1) setSelectedGuide(null);
-          }}
-          sx={{px: 2, '& .MuiTab-root': {fontSize: 12, minHeight: 38, textTransform: 'none'}}}>
-          <Tab icon={<SummarizeIcon fontSize="small" />} iconPosition="start" label="Overview" />
-          <Tab icon={<AssistantIcon fontSize="small" />} iconPosition="start" label="Guides" />
-        </Tabs>
-        <Divider />
-        {docTab === 0 && (
-          <Box sx={{p: 2}}>
+        <Grid container spacing={2} direction="row" sx={{padding: 2}}>
+          <Grid item xs={3}>
+            <Grid container spacing={2} justifyContent="center" direction="column">
+              <Grid item xs={12}>
+                <Grid container justifyContent="center">
+                  <Grid item>
+                    <Typography variant="h5" fontWeight={500} color="text.accent">
+                      {appName} User Guides
+                    </Typography>
+                  </Grid>
+                </Grid>
+              </Grid>
+              {Object.entries(sections).map(([key, [, buttonTitle, icon]]) => (
+                <Grid item xs={12} key={key}>
+                  <Button
+                    variant="contained"
+                    size="large"
+                    startIcon={icon}
+                    sx={{width: '100%', height: '50px'}}
+                    onClick={() => handleSectionChange(key)}>
+                    {buttonTitle}
+                  </Button>
+                </Grid>
+              ))}
+            </Grid>
+          </Grid>
+          <Grid item xs={0.1}>
+            <Divider orientation="vertical" />
+          </Grid>
+          <Grid item xs={8.8}>
             <AccordionMaker
-              which="general"
+              which={whichAccordion}
               expandedSlug={expandedSlug}
               onSlugChange={setExpandedSlug}
               onInternalLink={handleInternalLink}
             />
-          </Box>
-        )}
-        {docTab === 1 && selectedGuide === null && (
-          <Box sx={{p: 2}}>
-            {Object.entries(sections)
-              .filter(([key]) => key !== 'general')
-              .map(([key, [title, buttonTitle, icon]]) => (
-                <Paper
-                  key={key}
-                  variant="outlined"
-                  sx={{
-                    p: 1.5,
-                    mb: 1,
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 1.5,
-                    cursor: 'pointer',
-                    transition: 'all 0.15s',
-                    '&:hover': {
-                      backgroundColor: alpha(theme.palette.primary.main, 0.05),
-                      borderColor: theme.palette.primary.main,
-                    },
-                  }}
-                  onClick={() => handleGuideSelect(key)}>
-                  <Box sx={{color: theme.palette.primary.main, display: 'flex'}}>{icon}</Box>
-                  <Box sx={{flex: 1}}>
-                    <Typography variant="body2" fontWeight={600}>
-                      {buttonTitle}
-                    </Typography>
-                    {title !== buttonTitle && (
-                      <Typography variant="caption" color="text.secondary">
-                        {title}
-                      </Typography>
-                    )}
-                  </Box>
-                  <ChevronRightIcon sx={{color: theme.palette.text.secondary, fontSize: 18}} />
-                </Paper>
-              ))}
-          </Box>
-        )}
-        {docTab === 1 && selectedGuide !== null && (
-          <>
-            <Box sx={{display: 'flex', alignItems: 'center', px: 1.5, pt: 1, pb: 0.5}}>
-              <Tooltip title="Back to guides">
-                <IconButton size="small" onClick={handleBackToGuides}>
-                  <ArrowBackIcon fontSize="small" />
-                </IconButton>
-              </Tooltip>
-              <Typography variant="subtitle2" sx={{ml: 1}}>
-                Guides
-              </Typography>
-            </Box>
-            <Divider />
-            <Box sx={{p: 2}}>
-              <AccordionMaker
-                which={selectedGuide}
-                expandedSlug={expandedSlug}
-                onSlugChange={setExpandedSlug}
-                onInternalLink={handleInternalLink}
-              />
-            </Box>
-          </>
-        )}
+          </Grid>
+        </Grid>
       </Paper>
       <CreateAccessRequest
         currentUser={currentUser}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,24 +5,134 @@ import Accordion from '@mui/material/Accordion';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import Divider from '@mui/material/Divider';
-import Grid from '@mui/material/Grid';
 import IconButton from '@mui/material/IconButton';
 import Paper from '@mui/material/Paper';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
+import {alpha, useTheme} from '@mui/material';
 
 import AdminIcon from '@mui/icons-material/ManageAccounts';
 import AppOwnerIcon from '@mui/icons-material/AppShortcut';
+import ExpiringGroupsIcon from '@mui/icons-material/RunningWithErrors';
+import ExpiringRolesIcon from '@mui/icons-material/HeartBroken';
+import HowToRegIcon from '@mui/icons-material/HowToReg';
+import GroupRequestIcon from '@mui/icons-material/GroupAdd';
+import RoleRequestIcon from '@mui/icons-material/WorkHistory';
+import AccessRequestIcon from '../components/icons/MoreTime';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import AssistantIcon from '@mui/icons-material/Assistant';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import GeneralIcon from '@mui/icons-material/AllInclusive';
 import LinkIcon from '@mui/icons-material/Link';
 import PeopleLeadIcon from '@mui/icons-material/ContentPaste';
 import FAQIcon from '@mui/icons-material/TipsAndUpdates';
+import SchoolIcon from '@mui/icons-material/School';
+import SummarizeIcon from '@mui/icons-material/Summarize';
 import UserIcon from '@mui/icons-material/AccountBox';
 
 import {appName} from '../config/accessConfig';
+import {useCurrentUser} from '../authentication';
+import CreateAccessRequest from './requests/Create';
+import CreateRoleRequest from './role_requests/Create';
+import CreateGroupRequest from './group_requests/Create';
+import {
+  useGetRequests,
+  useGetRoleRequests,
+  useGetGroupRequests,
+  useGetUserGroupAudits,
+  useGetGroupRoleAudits,
+} from '../api/apiComponents';
+
+interface StatConfig {
+  id: string;
+  Icon: React.ComponentType<{sx?: object}>;
+  label: string;
+  singularLabel?: string;
+  path?: string;
+  color?: string;
+  isAction?: boolean;
+}
+
+// Number of sections shown when the card is at full width
+const INITIAL_SECTIONS = 5;
+
+// Ordered list of stats that can appear in the summary bar.
+// Items with a count of 0 are skipped; action items (isAction) always show.
+const STAT_CONFIGS: StatConfig[] = [
+  {
+    id: 'role-requests',
+    Icon: RoleRequestIcon,
+    label: 'Pending role requests',
+    singularLabel: 'Pending role request',
+    path: '/role-requests?assignee_user_id=@me',
+    color: '#0EA5E9',
+  },
+  {
+    id: 'access-requests',
+    Icon: AccessRequestIcon,
+    label: 'Pending access requests',
+    singularLabel: 'Pending access request',
+    path: '/requests?assignee_user_id=@me',
+    color: '#0EA5E9',
+  },
+  {
+    id: 'group-requests',
+    Icon: GroupRequestIcon,
+    label: 'Pending group creation requests',
+    singularLabel: 'Pending group creation request',
+    path: '/group-requests?assignee_user_id=@me',
+    color: '#0EA5E9',
+  },
+  {
+    id: 'expiring-roles',
+    Icon: ExpiringRolesIcon,
+    label: 'Roles losing access soon',
+    singularLabel: 'Role losing access soon',
+    path: '/expiring-roles?owner_id=@me',
+  },
+  {
+    id: 'expiring-access',
+    Icon: ExpiringGroupsIcon,
+    label: 'Users losing access soon',
+    singularLabel: 'User losing access soon',
+    path: '/expiring-groups?owner_id=@me',
+  },
+  {
+    id: 'my-roles-expiring',
+    Icon: HowToRegIcon,
+    label: 'My roles losing access soon',
+    singularLabel: 'My role losing access soon',
+    path: '/expiring-roles?role_owner_id=@me',
+  },
+  {
+    id: 'my-access-expiring',
+    Icon: UserIcon,
+    label: 'My access expiring soon',
+    path: '/expiring-groups?user_id=@me',
+  },
+  {
+    id: 'make-access-request',
+    Icon: AccessRequestIcon,
+    label: 'New access request',
+    isAction: true,
+  },
+  {
+    id: 'make-role-request',
+    Icon: RoleRequestIcon,
+    label: 'New role request',
+    isAction: true,
+  },
+  {
+    id: 'make-group-request',
+    Icon: GroupRequestIcon,
+    label: 'New group request',
+    isAction: true,
+  },
+];
 
 const sections: Record<string, [string, string, ReactNode]> = {
   // section shorthand --> [guide title, button title, icon]
@@ -199,7 +309,7 @@ function AccordionMaker({which, expandedSlug, onSlugChange, onInternalLink}: Acc
 
   return (
     <>
-      <Typography variant="h4" color="text.accent" sx={{margin: '15px 0'}}>
+      <Typography variant="h6" color="text.accent" sx={{margin: '10px 0'}}>
         {sections[which][0]}
       </Typography>
       {Object.entries(guide[which]).map(([question, answer]) => {
@@ -236,22 +346,161 @@ function AccordionMaker({which, expandedSlug, onSlugChange, onInternalLink}: Acc
 }
 
 export default function Home() {
+  const currentUser = useCurrentUser();
+  const theme = useTheme();
   const location = useLocation();
   const navigate = useNavigate();
 
   const hashSlug = location.hash.slice(1) || null;
   const sectionFromHash = hashSlug ? hashSlug.split('--')[0] : null;
 
-  const [whichAccordion, setWhichAccordion] = React.useState(
-    sectionFromHash && sections[sectionFromHash] ? sectionFromHash : 'general',
+  // null = show guide cards; a section key = show that guide's accordion
+  const [selectedGuide, setSelectedGuide] = React.useState<string | null>(
+    sectionFromHash && sections[sectionFromHash] && sectionFromHash !== 'general' ? sectionFromHash : null,
   );
   const [expandedSlug, setExpandedSlug] = React.useState<string | null>(hashSlug);
+  const [docTab, setDocTab] = React.useState(sectionFromHash && sectionFromHash !== 'general' ? 1 : 0);
+
+  const [openDialog, setOpenDialog] = React.useState<'access' | 'role' | 'group' | null>(null);
+
+  const [now, inOneWeek, inTwoDays] = React.useMemo(() => {
+    const t = Math.floor(Date.now() / 1000);
+    return [t, t + 7 * 24 * 60 * 60, t + 2 * 24 * 60 * 60];
+  }, []);
+
+  const {data: accessRequestsData} = useGetRequests({
+    queryParams: {assignee_user_id: '@me', status: 'PENDING', page: 0, per_page: 1},
+  });
+  const {data: roleRequestsData} = useGetRoleRequests({
+    queryParams: {assignee_user_id: '@me', status: 'PENDING', page: 0, per_page: 1},
+  });
+  const {data: groupRequestsData} = useGetGroupRequests({
+    queryParams: {assignee_user_id: '@me', status: 'PENDING', page: 0, per_page: 1},
+  });
+  const {data: expiringGroupsData} = useGetUserGroupAudits({
+    queryParams: {
+      owner_id: '@me',
+      active: true,
+      start_date: now,
+      end_date: inOneWeek,
+      page: 0,
+      per_page: 1,
+      direct: true,
+      deleted: false,
+    },
+  });
+  const {data: expiringRolesData} = useGetGroupRoleAudits({
+    queryParams: {owner_id: '@me', active: true, start_date: now, end_date: inOneWeek, page: 0, per_page: 1},
+  });
+  const {data: myAccessExpiringData} = useGetUserGroupAudits({
+    queryParams: {
+      user_id: '@me',
+      active: true,
+      start_date: now,
+      end_date: inOneWeek,
+      page: 0,
+      per_page: 1,
+      direct: true,
+      deleted: false,
+    },
+  });
+  const {data: myRolesExpiringData} = useGetGroupRoleAudits({
+    queryParams: {role_owner_id: '@me', active: true, start_date: now, end_date: inOneWeek, page: 0, per_page: 1},
+  });
+  const {data: urgentExpiringGroupsData} = useGetUserGroupAudits({
+    queryParams: {
+      owner_id: '@me',
+      active: true,
+      start_date: now,
+      end_date: inTwoDays,
+      page: 0,
+      per_page: 1,
+      direct: true,
+      deleted: false,
+    },
+  });
+  const {data: urgentExpiringRolesData} = useGetGroupRoleAudits({
+    queryParams: {owner_id: '@me', active: true, start_date: now, end_date: inTwoDays, page: 0, per_page: 1},
+  });
+  const {data: urgentMyAccessData} = useGetUserGroupAudits({
+    queryParams: {
+      user_id: '@me',
+      active: true,
+      start_date: now,
+      end_date: inTwoDays,
+      page: 0,
+      per_page: 1,
+      direct: true,
+      deleted: false,
+    },
+  });
+  const {data: urgentMyRolesData} = useGetGroupRoleAudits({
+    queryParams: {role_owner_id: '@me', active: true, start_date: now, end_date: inTwoDays, page: 0, per_page: 1},
+  });
+
+  const statCounts: Record<string, number> = {
+    'access-requests': accessRequestsData?.total ?? 0,
+    'role-requests': roleRequestsData?.total ?? 0,
+    'group-requests': groupRequestsData?.total ?? 0,
+    'expiring-access': expiringGroupsData?.total ?? 0,
+    'expiring-roles': expiringRolesData?.total ?? 0,
+    'my-access-expiring': myAccessExpiringData?.total ?? 0,
+    'my-roles-expiring': myRolesExpiringData?.total ?? 0,
+  };
+
+  const expiringColor = (urgentData: {total?: number} | undefined) =>
+    (urgentData?.total ?? 0) > 0 ? '#EF4444' : '#F59E0B';
+
+  const statColors: Record<string, string> = {
+    'expiring-access': expiringColor(urgentExpiringGroupsData),
+    'expiring-roles': expiringColor(urgentExpiringRolesData),
+    'my-access-expiring': expiringColor(urgentMyAccessData),
+    'my-roles-expiring': expiringColor(urgentMyRolesData),
+  };
+
+  const cardRef = React.useRef<HTMLDivElement>(null);
+  const [cardWidth, setCardWidth] = React.useState(0);
+  const lockedSectionWidth = React.useRef(0);
+
+  React.useEffect(() => {
+    const el = cardRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(([entry]) => {
+      const w = entry.contentRect.width;
+      if (lockedSectionWidth.current === 0 && w > 0) {
+        // Lock the per-section width based on the initial 5-section layout
+        lockedSectionWidth.current = w / INITIAL_SECTIONS;
+      }
+      setCardWidth(w);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const sectionW = lockedSectionWidth.current;
+  // Filter out items with zero counts (action items always show)
+  const filteredStats = STAT_CONFIGS.filter((s) => s.isAction || (statCounts[s.id] ?? 0) > 0);
+  // How many sections fit in one row
+  const sectionsPerRow =
+    sectionW > 0 && cardWidth > 0
+      ? Math.min(Math.max(1, Math.floor(cardWidth / sectionW)), INITIAL_SECTIONS)
+      : INITIAL_SECTIONS;
+  // Use two rows only when fewer than 3 items fit per row
+  const rows = sectionsPerRow < 3 ? 2 : 1;
+  const visibleStats = filteredStats.slice(0, sectionsPerRow * rows);
+  const row1Stats = visibleStats.slice(0, sectionsPerRow);
+  const row2Stats = rows === 2 ? visibleStats.slice(sectionsPerRow) : [];
 
   useEffect(() => {
     if (!hashSlug) return;
     const section = hashSlug.split('--')[0];
     if (sections[section]) {
-      setWhichAccordion(section);
+      if (section === 'general') {
+        setDocTab(0);
+      } else {
+        setSelectedGuide(section);
+        setDocTab(1);
+      }
       setExpandedSlug(hashSlug);
       setTimeout(() => {
         document.getElementById(`${hashSlug}-header`)?.scrollIntoView({behavior: 'smooth', block: 'start'});
@@ -259,8 +508,14 @@ export default function Home() {
     }
   }, [hashSlug]);
 
-  const handleSectionChange = (key: string) => {
-    setWhichAccordion(key);
+  const handleGuideSelect = (key: string) => {
+    setSelectedGuide(key);
+    setExpandedSlug(null);
+    navigate({hash: ''}, {replace: true});
+  };
+
+  const handleBackToGuides = () => {
+    setSelectedGuide(null);
     setExpandedSlug(null);
     navigate({hash: ''}, {replace: true});
   };
@@ -268,7 +523,13 @@ export default function Home() {
   const handleInternalLink = (slug: string) => {
     const section = slug.split('--')[0];
     if (sections[section]) {
-      setWhichAccordion(section);
+      if (section === 'general') {
+        setDocTab(0);
+        setSelectedGuide(null);
+      } else {
+        setSelectedGuide(section);
+        setDocTab(1);
+      }
       setExpandedSlug(slug);
       navigate({hash: `#${slug}`}, {replace: true});
       setTimeout(() => {
@@ -279,53 +540,202 @@ export default function Home() {
 
   return (
     <React.Fragment>
+      <Paper ref={cardRef} sx={{mb: 3, display: 'flex', flexDirection: 'column', overflow: 'hidden'}}>
+        {[row1Stats, row2Stats].map((rowStats, rowIndex) =>
+          rowStats.length === 0 ? null : (
+            <React.Fragment key={rowIndex}>
+              {rowIndex > 0 && <Divider />}
+              <Box sx={{display: 'flex', alignItems: 'stretch', justifyContent: 'center', minHeight: 98}}>
+                {rowStats.map((stat, i) => {
+                  const color = stat.isAction
+                    ? theme.palette.text.accent
+                    : statColors[stat.id] ?? stat.color ?? theme.palette.text.secondary;
+                  return (
+                    <React.Fragment key={stat.id}>
+                      {i > 0 && <Divider orientation="vertical" flexItem sx={{my: 1.5}} />}
+                      <Box
+                        onClick={() => {
+                          if (stat.id === 'make-access-request') setOpenDialog('access');
+                          else if (stat.id === 'make-role-request') setOpenDialog('role');
+                          else if (stat.id === 'make-group-request') setOpenDialog('group');
+                          else if (stat.path) navigate(stat.path);
+                        }}
+                        sx={{
+                          ...(sectionW > 0 ? {width: sectionW, flexShrink: 0} : {flex: 1}),
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          py: 2.5,
+                          px: 3,
+                          cursor: 'pointer',
+                          transition: 'background-color 0.15s',
+                          '&:hover': {bgcolor: alpha(color, 0.04)},
+                        }}>
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: stat.isAction ? 'center' : 'flex-start',
+                            width: '100%',
+                          }}>
+                          {stat.isAction ? (
+                            <Typography variant="body2" fontWeight={600} sx={{color}}>
+                              {stat.label}
+                            </Typography>
+                          ) : (
+                            <Box>
+                              <Typography variant="h4" fontWeight={700} sx={{color, lineHeight: 1}}>
+                                {statCounts[stat.id] ?? 0}
+                              </Typography>
+                              <Typography variant="caption" color="text.secondary" sx={{mt: 0.5, display: 'block'}}>
+                                {statCounts[stat.id] === 1 ? stat.singularLabel ?? stat.label : stat.label}
+                              </Typography>
+                            </Box>
+                          )}
+                          <Box
+                            sx={{
+                              p: 1,
+                              borderRadius: 2,
+                              backgroundColor: alpha(color, 0.1),
+                              color,
+                              display: 'flex',
+                              flexShrink: 0,
+                            }}>
+                            <stat.Icon />
+                          </Box>
+                        </Box>
+                      </Box>
+                    </React.Fragment>
+                  );
+                })}
+              </Box>
+            </React.Fragment>
+          ),
+        )}
+      </Paper>
       <Paper>
-        <Grid container spacing={2} direction="row" sx={{padding: 2}}>
-          <Grid item xs={3}>
-            <Grid container spacing={2} justifyContent="center" direction="column">
-              <Grid item xs={12}>
-                <Grid container justifyContent="center">
-                  <Grid item>
-                    <Box component="img" src="/logo.png" alt={`${appName} logo`} sx={{width: 250}} />
-                  </Grid>
-                </Grid>
-              </Grid>
-              <Grid item xs={12}>
-                <Grid container justifyContent="center">
-                  <Grid item>
-                    <Typography variant="h5" fontWeight={500} color="text.accent">
-                      {appName} User Guides
-                    </Typography>
-                  </Grid>
-                </Grid>
-              </Grid>
-              {Object.entries(sections).map(([key, [title, buttonTitle, icon]]) => (
-                <Grid item xs={12} key={key}>
-                  <Button
-                    variant="contained"
-                    size="large"
-                    startIcon={icon}
-                    sx={{width: '100%', height: '50px'}}
-                    onClick={() => handleSectionChange(key)}>
-                    {buttonTitle}
-                  </Button>
-                </Grid>
-              ))}
-            </Grid>
-          </Grid>
-          <Grid item xs={0.1}>
-            <Divider orientation="vertical" />
-          </Grid>
-          <Grid item xs={8.8}>
+        <Box sx={{px: 2.5, pt: 2.5, pb: 1.5, display: 'flex', alignItems: 'center', gap: 1.5}}>
+          <Box
+            sx={{
+              width: 40,
+              height: 40,
+              borderRadius: '12px',
+              backgroundColor: theme.palette.text.accent,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+            }}>
+            <SchoolIcon sx={{color: '#fff', fontSize: 20}} />
+          </Box>
+          <Box sx={{display: 'flex', flexDirection: 'column', justifyContent: 'center', gap: 0.25}}>
+            <Typography variant="subtitle1" fontWeight={700} sx={{lineHeight: 1.2}}>
+              {appName} User Guides
+            </Typography>
+            <Typography variant="caption" color="text.secondary" sx={{lineHeight: 1.2}}>
+              Everything you need to know
+            </Typography>
+          </Box>
+        </Box>
+        <Tabs
+          value={docTab}
+          onChange={(_, v) => {
+            setDocTab(v);
+            if (v === 1) setSelectedGuide(null);
+          }}
+          sx={{px: 2, '& .MuiTab-root': {fontSize: 12, minHeight: 38, textTransform: 'none'}}}>
+          <Tab icon={<SummarizeIcon fontSize="small" />} iconPosition="start" label="Overview" />
+          <Tab icon={<AssistantIcon fontSize="small" />} iconPosition="start" label="Guides" />
+        </Tabs>
+        <Divider />
+        {docTab === 0 && (
+          <Box sx={{p: 2}}>
             <AccordionMaker
-              which={whichAccordion}
+              which="general"
               expandedSlug={expandedSlug}
               onSlugChange={setExpandedSlug}
               onInternalLink={handleInternalLink}
             />
-          </Grid>
-        </Grid>
+          </Box>
+        )}
+        {docTab === 1 && selectedGuide === null && (
+          <Box sx={{p: 2}}>
+            {Object.entries(sections)
+              .filter(([key]) => key !== 'general')
+              .map(([key, [title, buttonTitle, icon]]) => (
+                <Paper
+                  key={key}
+                  variant="outlined"
+                  sx={{
+                    p: 1.5,
+                    mb: 1,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1.5,
+                    cursor: 'pointer',
+                    transition: 'all 0.15s',
+                    '&:hover': {
+                      backgroundColor: alpha(theme.palette.primary.main, 0.05),
+                      borderColor: theme.palette.primary.main,
+                    },
+                  }}
+                  onClick={() => handleGuideSelect(key)}>
+                  <Box sx={{color: theme.palette.primary.main, display: 'flex'}}>{icon}</Box>
+                  <Box sx={{flex: 1}}>
+                    <Typography variant="body2" fontWeight={600}>
+                      {buttonTitle}
+                    </Typography>
+                    {title !== buttonTitle && (
+                      <Typography variant="caption" color="text.secondary">
+                        {title}
+                      </Typography>
+                    )}
+                  </Box>
+                  <ChevronRightIcon sx={{color: theme.palette.text.secondary, fontSize: 18}} />
+                </Paper>
+              ))}
+          </Box>
+        )}
+        {docTab === 1 && selectedGuide !== null && (
+          <>
+            <Box sx={{display: 'flex', alignItems: 'center', px: 1.5, pt: 1, pb: 0.5}}>
+              <Tooltip title="Back to guides">
+                <IconButton size="small" onClick={handleBackToGuides}>
+                  <ArrowBackIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+              <Typography variant="subtitle2" sx={{ml: 1}}>
+                Guides
+              </Typography>
+            </Box>
+            <Divider />
+            <Box sx={{p: 2}}>
+              <AccordionMaker
+                which={selectedGuide}
+                expandedSlug={expandedSlug}
+                onSlugChange={setExpandedSlug}
+                onInternalLink={handleInternalLink}
+              />
+            </Box>
+          </>
+        )}
       </Paper>
+      <CreateAccessRequest
+        currentUser={currentUser}
+        open={openDialog === 'access'}
+        setOpen={(o) => setOpenDialog(o ? 'access' : null)}
+      />
+      <CreateRoleRequest
+        currentUser={currentUser}
+        enabled={true}
+        open={openDialog === 'role'}
+        setOpen={(o) => setOpenDialog(o ? 'role' : null)}
+      />
+      <CreateGroupRequest
+        currentUser={currentUser}
+        open={openDialog === 'group'}
+        setOpen={(o) => setOpenDialog(o ? 'group' : null)}
+      />
     </React.Fragment>
   );
 }

--- a/src/pages/group_requests/Create.tsx
+++ b/src/pages/group_requests/Create.tsx
@@ -389,14 +389,18 @@ function CreateRequestDialog(props: CreateRequestDialogProps) {
 
 interface CreateRequestProps {
   currentUser: OktaUser;
+  open?: boolean;
+  setOpen?: (open: boolean) => void;
 }
 
 export default function CreateRequest(props: CreateRequestProps) {
-  const [open, setOpen] = React.useState(false);
+  const [internalOpen, setInternalOpen] = React.useState(false);
+  const open = props.open ?? internalOpen;
+  const setOpen = props.setOpen ?? setInternalOpen;
 
   return (
     <>
-      <CreateRequestButton setOpen={setOpen} />
+      {props.setOpen == null && <CreateRequestButton setOpen={setOpen} />}
       {open && <CreateRequestDialog currentUser={props.currentUser} setOpen={setOpen} />}
     </>
   );

--- a/src/pages/requests/Create.tsx
+++ b/src/pages/requests/Create.tsx
@@ -509,10 +509,14 @@ interface CreateRequestProps {
   owner?: boolean;
   renew?: boolean;
   expired?: boolean;
+  open?: boolean;
+  setOpen?: (open: boolean) => void;
 }
 
 export default function CreateRequest(props: CreateRequestProps) {
-  const [open, setOpen] = React.useState<boolean>(false);
+  const [internalOpen, setInternalOpen] = React.useState<boolean>(false);
+  const open = props.open ?? internalOpen;
+  const setOpen = props.setOpen ?? setInternalOpen;
 
   if (
     props.group?.deleted_at != null ||
@@ -524,12 +528,15 @@ export default function CreateRequest(props: CreateRequestProps) {
 
   return (
     <>
-      <CreateRequestButton
-        setOpen={setOpen}
-        group={props.group}
-        owner={props.owner}
-        renew={props.renew}
-        expired={props.expired}></CreateRequestButton>
+      {props.setOpen == null && (
+        <CreateRequestButton
+          setOpen={setOpen}
+          group={props.group}
+          owner={props.owner}
+          renew={props.renew}
+          expired={props.expired}
+        />
+      )}
       {open ? <CreateRequestDialog setOpen={setOpen} {...props} renew={props.renew} /> : null}
     </>
   );

--- a/src/pages/role_requests/Create.tsx
+++ b/src/pages/role_requests/Create.tsx
@@ -511,10 +511,14 @@ interface CreateRequestProps {
   group?: OktaGroup | AppGroup;
   owner?: boolean;
   renew?: boolean;
+  open?: boolean;
+  setOpen?: (open: boolean) => void;
 }
 
 export default function CreateRequest(props: CreateRequestProps) {
-  const [open, setOpen] = React.useState<boolean>(false);
+  const [internalOpen, setInternalOpen] = React.useState<boolean>(false);
+  const open = props.open ?? internalOpen;
+  const setOpen = props.setOpen ?? setInternalOpen;
 
   if (
     props.role?.deleted_at != null ||
@@ -527,13 +531,16 @@ export default function CreateRequest(props: CreateRequestProps) {
 
   return (
     <>
-      <CreateRequestButton
-        enabled={props.enabled}
-        setOpen={setOpen}
-        role={props.role}
-        group={props.group}
-        owner={props.owner}
-        renew={props.renew}></CreateRequestButton>
+      {props.setOpen == null && (
+        <CreateRequestButton
+          enabled={props.enabled}
+          setOpen={setOpen}
+          role={props.role}
+          group={props.group}
+          owner={props.owner}
+          renew={props.renew}
+        />
+      )}
       {open ? <CreateRequestDialog setOpen={setOpen} {...props} renew={props.renew} /> : null}
     </>
   );


### PR DESCRIPTION
Added an action bar to promp users when they have pending tasks. 

The tasks shown in the bar change depending on what is needed from the user (eg. if the user is not responsible for any pending access requests, that task will not be shown in the bar). When a section is clicked, the user will be navigated to the relevant page in the app (eg. to the "owned by me" page if groups they own have role access expiring soon). 

If there are no pending actions for the user, options to create a request are shown (which when clicked will open the request dialog on that page)


Files changed:
- Create pages: modifications to allow the request creation dialogs to be opened without the normal 'Create Request' button
- Home: all other changes to add in todo task bar


Full width action bar:
<img width="1718" height="856" alt="Screenshot 2026-04-20 at 1 38 21 PM" src="https://github.com/user-attachments/assets/ea60ec9b-f1cc-4fa1-8a8d-7ec2859594ed" />


Narrow window example (number of tasks and rows change dynamically with window size):
<img width="923" height="855" alt="Screenshot 2026-04-20 at 1 46 04 PM" src="https://github.com/user-attachments/assets/51134fcc-f8f0-4b4b-9034-5b8b12202d26" />


Home page when no pending tasks:
<img width="1715" height="855" alt="Screenshot 2026-04-20 at 1 47 31 PM" src="https://github.com/user-attachments/assets/70dc6f21-3650-436c-9ae2-e37a3e31aa41" />


Make a request action clicked opens dialog on the same page:
<img width="1719" height="858" alt="Screenshot 2026-04-20 at 1 48 03 PM" src="https://github.com/user-attachments/assets/1c20f315-7cab-4b70-91d7-ed8817e14db8" />
