### PR TITLE
Make toolbar role owner check more efficient

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -38,7 +38,6 @@ import {
   useGetRequests,
   useGetRoleRequests,
   useGetGroupRequests,
-  useGetRoles,
   useGetUserGroupAudits,
   useGetGroupRoleAudits,
 } from '../api/apiComponents';
@@ -383,9 +382,7 @@ export default function Home() {
   const {data: groupRequestsData} = useGetGroupRequests({
     queryParams: {assignee_user_id: '@me', status: 'PENDING', page: 0, per_page: 1},
   });
-  const {data: ownedRolesData} = useGetRoles({
-    queryParams: {owner_id: '@me', page: 0, per_page: 1},
-  });
+
   const {data: expiringGroupsData} = useGetUserGroupAudits({
     queryParams: {
       owner_id: '@me',
@@ -488,7 +485,8 @@ export default function Home() {
 
   const sectionW = lockedSectionWidth.current;
   // Filter out items with zero counts (action items always show)
-  const userOwnsRoles = (ownedRolesData?.total ?? 0) > 0;
+  const userOwnsRoles =
+    currentUser.active_group_ownerships?.some((m) => (m.active_group ?? m.group)?.type === 'role_group') ?? false;
   const filteredStats = STAT_CONFIGS.filter((s) => {
     if (s.id === 'make-role-request' && !userOwnsRoles) return false;
     return s.isAction || (statCounts[s.id] ?? 0) > 0;


### PR DESCRIPTION
Reverts the changes made in https://github.com/discord/access/pull/419

Instead, using the /users/@me endpoint to determine if the current user owns any roles (in order to determine whether or not "New role request" should be shown in the home page task bar)