### PR TITLE
Should expire bug fix

### DIFF
--- a/api/operations/modify_group_users.py
+++ b/api/operations/modify_group_users.py
@@ -87,6 +87,7 @@ class ModifyGroupUsers:
         if len(members_should_expire) > 0:
             self.members_should_expire = (
                 OktaUserGroupMember.query.filter(OktaUserGroupMember.id.in_(members_should_expire))
+                .filter(OktaUserGroupMember.group_id == self.group.id)
                 .filter(OktaUserGroupMember.ended_at > db.func.now())
                 .filter(OktaUserGroupMember.is_owner.is_(False))
             ).all()
@@ -95,6 +96,7 @@ class ModifyGroupUsers:
         if len(owners_should_expire) > 0:
             self.owners_should_expire = (
                 OktaUserGroupMember.query.filter(OktaUserGroupMember.id.in_(owners_should_expire))
+                .filter(OktaUserGroupMember.group_id == self.group.id)
                 .filter(OktaUserGroupMember.ended_at > db.func.now())
                 .filter(OktaUserGroupMember.is_owner.is_(True))
             ).all()

--- a/api/operations/modify_role_groups.py
+++ b/api/operations/modify_role_groups.py
@@ -83,6 +83,7 @@ class ModifyRoleGroups:
         if len(groups_should_expire) > 0:
             self.groups_should_expire = (
                 RoleGroupMap.query.filter(RoleGroupMap.id.in_(groups_should_expire))
+                .filter(RoleGroupMap.role_group_id == self.role.id)
                 .filter(RoleGroupMap.ended_at > db.func.now())
                 .filter(RoleGroupMap.is_owner.is_(False))
             ).all()
@@ -91,6 +92,7 @@ class ModifyRoleGroups:
         if len(owner_groups_should_expire) > 0:
             self.owner_groups_should_expire = (
                 RoleGroupMap.query.filter(RoleGroupMap.id.in_(owner_groups_should_expire))
+                .filter(RoleGroupMap.role_group_id == self.role.id)
                 .filter(RoleGroupMap.ended_at > db.func.now())
                 .filter(RoleGroupMap.is_owner.is_(True))
             ).all()

--- a/api/views/resources/role.py
+++ b/api/views/resources/role.py
@@ -135,9 +135,13 @@ class RoleMemberResource(MethodResource):
                 RoleGroupMap.id.in_(all_should_expire_ids),
                 RoleGroupMap.role_group_id == role.id,
             ).all()
-            for role_group_map in maps:
-                group = db.session.get(OktaGroup, role_group_map.group_id)
-                if group is not None and not AuthorizationHelpers.can_manage_group(group):
+            groups = (
+                db.session.query(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+                .filter(OktaGroup.deleted_at.is_(None))
+                .filter(OktaGroup.id.in_([m.group_id for m in maps]))
+            )
+            for group in groups:
+                if not AuthorizationHelpers.can_manage_group(group):
                     abort(403, "Current user is not allowed to perform this action")
 
         if not AuthorizationHelpers.is_access_admin():

--- a/api/views/resources/role.py
+++ b/api/views/resources/role.py
@@ -128,9 +128,8 @@ class RoleMemberResource(MethodResource):
             len(group_changes.get("groups_should_expire", [])) > 0
             or len(group_changes.get("owner_groups_should_expire", [])) > 0
         ):
-            all_should_expire_ids = (
-                group_changes.get("groups_should_expire", [])
-                + group_changes.get("owner_groups_should_expire", [])
+            all_should_expire_ids = group_changes.get("groups_should_expire", []) + group_changes.get(
+                "owner_groups_should_expire", []
             )
             maps = RoleGroupMap.query.filter(
                 RoleGroupMap.id.in_(all_should_expire_ids),

--- a/api/views/resources/role.py
+++ b/api/views/resources/role.py
@@ -124,7 +124,23 @@ class RoleMemberResource(MethodResource):
         schema = RoleMemberSchema()
         group_changes = schema.load(request.get_json())
 
-        # If they're an Access admin they can modify any role
+        if (
+            len(group_changes.get("groups_should_expire", [])) > 0
+            or len(group_changes.get("owner_groups_should_expire", [])) > 0
+        ):
+            all_should_expire_ids = (
+                group_changes.get("groups_should_expire", [])
+                + group_changes.get("owner_groups_should_expire", [])
+            )
+            maps = RoleGroupMap.query.filter(
+                RoleGroupMap.id.in_(all_should_expire_ids),
+                RoleGroupMap.role_group_id == role.id,
+            ).all()
+            for role_group_map in maps:
+                group = db.session.get(OktaGroup, role_group_map.group_id)
+                if group is not None and not AuthorizationHelpers.can_manage_group(group):
+                    abort(403, "Current user is not allowed to perform this action")
+
         if not AuthorizationHelpers.is_access_admin():
             groups = (
                 db.session.query(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -894,9 +894,7 @@ def test_do_not_renew_scoped_to_route_group(
         sync_to_okta=False,
     ).execute()
 
-    victim_membership = OktaUserGroupMember.query.filter(
-        OktaUserGroupMember.user_id == victim_user.id
-    ).first()
+    victim_membership = OktaUserGroupMember.query.filter(OktaUserGroupMember.user_id == victim_user.id).first()
     assert victim_membership is not None
 
     mocker.patch.object(AuthorizationHelpers, "can_manage_group", return_value=True)

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -863,6 +863,64 @@ def test_do_not_renew(
     assert membership_user2[0].should_expire is True
 
 
+def test_do_not_renew_scoped_to_route_group(
+    db: SQLAlchemy,
+    client: FlaskClient,
+    mocker: MockerFixture,
+    user: OktaUser,
+    okta_group: OktaGroup,
+) -> None:
+    victim_group = OktaGroup(id="victim-group-id", name="Victim-Group", type="okta_group")
+    victim_user = OktaUserFactory.create()
+
+    db.session.add(okta_group)
+    db.session.add(victim_group)
+    db.session.add(user)
+    db.session.add(victim_user)
+    db.session.commit()
+
+    expiration_datetime = datetime.now() + timedelta(days=1)
+
+    ModifyGroupUsers(
+        group=okta_group,
+        users_added_ended_at=expiration_datetime,
+        members_to_add=[user.id],
+        sync_to_okta=False,
+    ).execute()
+    ModifyGroupUsers(
+        group=victim_group,
+        users_added_ended_at=expiration_datetime,
+        members_to_add=[victim_user.id],
+        sync_to_okta=False,
+    ).execute()
+
+    victim_membership = OktaUserGroupMember.query.filter(
+        OktaUserGroupMember.user_id == victim_user.id
+    ).first()
+    assert victim_membership is not None
+
+    mocker.patch.object(AuthorizationHelpers, "can_manage_group", return_value=True)
+    mocker.patch.object(okta, "async_add_user_to_group")
+    mocker.patch.object(okta, "async_remove_user_from_group")
+    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "async_remove_owner_from_group")
+
+    data: dict[str, Any] = {
+        "members_to_add": [],
+        "owners_to_add": [],
+        "members_should_expire": [victim_membership.id],
+        "owners_should_expire": [],
+        "members_to_remove": [],
+        "owners_to_remove": [],
+    }
+    group_url = url_for("api-groups.group_members_by_id", group_id=okta_group.id)
+    rep = client.put(group_url, json=data)
+    assert rep.status_code == 200
+
+    db.session.refresh(victim_membership)
+    assert victim_membership.should_expire is False
+
+
 @pytest.mark.parametrize("app", [False, True], indirect=True)
 def test_create_groups_with_and_without_description(
     app: Flask,

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -19,7 +19,7 @@ from api.models import (
 from api.authorization import AuthorizationHelpers
 from api.operations import CreateAccessRequest, ModifyGroupUsers, ModifyRoleGroups
 from api.services import okta
-from tests.factories import OktaUserFactory, RoleGroupFactory
+from tests.factories import RoleGroupFactory
 
 
 def test_get_role(

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -16,9 +16,10 @@ from api.models import (
     RoleGroup,
     RoleGroupMap,
 )
+from api.authorization import AuthorizationHelpers
 from api.operations import CreateAccessRequest, ModifyGroupUsers, ModifyRoleGroups
 from api.services import okta
-from tests.factories import RoleGroupFactory
+from tests.factories import OktaUserFactory, RoleGroupFactory
 
 
 def test_get_role(
@@ -1372,3 +1373,109 @@ def test_do_not_renew(
     assert len(membership_role) == 1
     assert membership_role[0].ended_at == expiration_datetime
     assert membership_role[0].should_expire is True
+
+
+def test_do_not_renew_scoped_to_route_role(
+    db: SQLAlchemy,
+    client: FlaskClient,
+    role_group: RoleGroup,
+    okta_group: OktaGroup,
+    user: OktaUser,
+) -> None:
+    victim_role = RoleGroupFactory.create()
+    victim_okta_group = OktaGroup(
+        id="victim-group-id",
+        name="Victim-Group",
+        type="okta_group",
+    )
+
+    db.session.add(role_group)
+    db.session.add(okta_group)
+    db.session.add(victim_role)
+    db.session.add(victim_okta_group)
+    db.session.add(user)
+    db.session.commit()
+
+    expiration_datetime = datetime.now() + timedelta(days=1)
+
+    ModifyGroupUsers(
+        group=role_group, users_added_ended_at=expiration_datetime, members_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    ModifyRoleGroups(
+        role_group=role_group,
+        groups_added_ended_at=expiration_datetime,
+        groups_to_add=[okta_group.id],
+        sync_to_okta=False,
+    ).execute()
+    ModifyRoleGroups(
+        role_group=victim_role,
+        groups_added_ended_at=expiration_datetime,
+        groups_to_add=[victim_okta_group.id],
+        sync_to_okta=False,
+    ).execute()
+
+    victim_map = RoleGroupMap.query.filter(RoleGroupMap.role_group_id == victim_role.id).first()
+    assert victim_map is not None
+
+    data: dict[str, Any] = {
+        "groups_to_add": [],
+        "owner_groups_to_add": [],
+        "groups_should_expire": [victim_map.id],
+        "owner_groups_should_expire": [],
+        "groups_to_remove": [],
+        "owner_groups_to_remove": [],
+    }
+    role_url = url_for("api-roles.role_members_by_id", role_id=role_group.id)
+    rep = client.put(role_url, json=data)
+    assert rep.status_code == 200
+
+    db.session.refresh(victim_map)
+    assert victim_map.should_expire is False
+
+
+def test_do_not_renew_requires_group_ownership(
+    db: SQLAlchemy,
+    client: FlaskClient,
+    mocker: MockerFixture,
+    role_group: RoleGroup,
+    okta_group: OktaGroup,
+    user: OktaUser,
+) -> None:
+    db.session.add(role_group)
+    db.session.add(okta_group)
+    db.session.add(user)
+    db.session.commit()
+
+    expiration_datetime = datetime.now() + timedelta(days=1)
+
+    ModifyGroupUsers(
+        group=role_group, users_added_ended_at=expiration_datetime, members_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    ModifyRoleGroups(
+        role_group=role_group,
+        groups_added_ended_at=expiration_datetime,
+        groups_to_add=[okta_group.id],
+        sync_to_okta=False,
+    ).execute()
+
+    role_group_map = RoleGroupMap.query.filter(RoleGroupMap.role_group_id == role_group.id).first()
+    assert role_group_map is not None
+
+    # User is not an admin and not an owner of the group in the mapping
+    mocker.patch.object(AuthorizationHelpers, "is_access_admin", return_value=False)
+    mocker.patch.object(AuthorizationHelpers, "is_group_owner", return_value=False)
+
+    data: dict[str, Any] = {
+        "groups_to_add": [],
+        "owner_groups_to_add": [],
+        "groups_should_expire": [role_group_map.id],
+        "owner_groups_should_expire": [],
+        "groups_to_remove": [],
+        "owner_groups_to_remove": [],
+    }
+    role_url = url_for("api-roles.role_members_by_id", role_id=role_group.id)
+    rep = client.put(role_url, json=data)
+    assert rep.status_code == 403
+
+    db.session.refresh(role_group_map)
+    assert role_group_map.should_expire is False


### PR DESCRIPTION
Arbitrary RoleGroupMap or OktaUserGroupMember IDs could be passed to the should_expire fields to mark unrelated access grants as "do not renew," with no check that the IDs belong to the role/group in the current request and no authorization check that the caller owns the affected group.

Added fix and tests