### PR TITLE
Create app bug fix and tests

### DIFF
--- a/api/operations/approve_group_request.py
+++ b/api/operations/approve_group_request.py
@@ -130,12 +130,11 @@ class ApproveGroupRequest:
             if not is_admin:
                 return self.group_request
 
-        if (
-            resolved_type != "app_group"
-            and resolved_name.startswith(AppGroup.APP_GROUP_NAME_PREFIX)
-            and resolved_name.endswith(
-                f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
-            )
+        if resolved_type != "app_group" and resolved_name.startswith(AppGroup.APP_GROUP_NAME_PREFIX):
+            return self.group_request
+
+        if resolved_type == "app_group" and resolved_name.endswith(
+            f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
         ):
             return self.group_request
 

--- a/api/operations/approve_group_request.py
+++ b/api/operations/approve_group_request.py
@@ -133,6 +133,9 @@ class ApproveGroupRequest:
         if resolved_type != "app_group" and resolved_name.startswith(AppGroup.APP_GROUP_NAME_PREFIX):
             return self.group_request
 
+        if resolved_type != "role_group" and resolved_name.startswith(RoleGroup.ROLE_GROUP_NAME_PREFIX):
+            return self.group_request
+
         if resolved_type == "app_group" and resolved_name.endswith(
             f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
         ):

--- a/api/operations/approve_group_request.py
+++ b/api/operations/approve_group_request.py
@@ -130,6 +130,15 @@ class ApproveGroupRequest:
             if not is_admin:
                 return self.group_request
 
+        if (
+            resolved_type != "app_group"
+            and resolved_name.startswith(AppGroup.APP_GROUP_NAME_PREFIX)
+            and resolved_name.endswith(
+                f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
+            )
+        ):
+            return self.group_request
+
         existing_group = (
             db.session.query(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
             .filter(func.lower(OktaGroup.name) == func.lower(resolved_name))

--- a/api/operations/modify_group_type.py
+++ b/api/operations/modify_group_type.py
@@ -69,6 +69,15 @@ class ModifyGroupType:
                 if self.group.is_owner:
                     raise ValueError("Owner app groups cannot have their type modified")
 
+                # Bail if changing away from AppGroup for a group whose name uses the
+                # reserved App- prefix; non-AppGroup groups must not carry that prefix
+                if type(self.group_changes) is not AppGroup and self.group.name.startswith(
+                    AppGroup.APP_GROUP_NAME_PREFIX
+                ):
+                    raise ValueError(
+                        "The App- prefix cannot be used for non-app groups. Please choose a different group name."
+                    )
+
                 # Invoke group_deleted hook before the AppGroup row is removed so the
                 # plugin can still access group.app and status values (e.g. to delete
                 # the linked GitHub team).

--- a/api/operations/modify_group_type.py
+++ b/api/operations/modify_group_type.py
@@ -47,6 +47,15 @@ class ModifyGroupType:
 
             # Clean-up the old child table row
             if type(self.group) is RoleGroup:
+                # Bail if changing away from RoleGroup for a group whose name uses the
+                # reserved Role- prefix; non-RoleGroup groups must not carry that prefix
+                if type(self.group_changes) is not RoleGroup and self.group.name.startswith(
+                    RoleGroup.ROLE_GROUP_NAME_PREFIX
+                ):
+                    raise ValueError(
+                        "The Role- prefix cannot be used for non-role groups. Please choose a different group name."
+                    )
+
                 # End all group attachments to this role and all group memberships via the role grant
                 active_role_associated_groups = RoleGroupMap.query.filter(
                     db.or_(

--- a/api/views/resources/app.py
+++ b/api/views/resources/app.py
@@ -340,16 +340,16 @@ class AppList(MethodResource):
         poly_group = with_polymorphic(OktaGroup, [AppGroup, RoleGroup])
         existing_owner_group = (
             db.session.query(poly_group)
-            .options(joinedload(poly_group.active_user_memberships_and_ownerships))
+            .options(joinedload(poly_group.active_user_ownerships))
             .filter(func.lower(OktaGroup.name) == func.lower(owner_group_name))
             .filter(OktaGroup.deleted_at.is_(None))
             .first()
         )
-        if existing_owner_group is not None and len(existing_owner_group.active_user_memberships_and_ownerships) > 0:
+        if existing_owner_group is not None and len(existing_owner_group.active_user_ownerships) > 0:
             abort(
                 409,
-                f"An owner group with members and/or owners already exists for this app name. Select a different app"
-                f" name, change the name of {owner_group_name}, or remove the existing members and/or owners of"
+                f"An owner group with existing owners already exists for this app name. Select a different app"
+                f" name, change the name of {owner_group_name}, or remove the existing owners of"
                 f" {owner_group_name} to be able to proceed.",
             )
 

--- a/api/views/resources/app.py
+++ b/api/views/resources/app.py
@@ -4,12 +4,12 @@ from flask import abort, current_app, g, request
 from flask.typing import ResponseReturnValue
 from flask_apispec import MethodResource
 from sqlalchemy import func
-from sqlalchemy.orm import joinedload, selectinload
+from sqlalchemy.orm import joinedload, selectinload, with_polymorphic
 
 from api.apispec import FlaskApiSpecDecorators
 from api.authorization import AuthorizationDecorator, AuthorizationHelpers
 from api.extensions import db
-from api.models import App, AppGroup, AppTagMap, OktaUser, OktaUserGroupMember, RoleGroup, RoleGroupMap
+from api.models import App, AppGroup, AppTagMap, OktaGroup, OktaUser, OktaUserGroupMember, RoleGroup, RoleGroupMap
 from api.models.app_group import app_owners_group_description
 from api.operations import CreateApp, DeleteApp, ModifyAppTags, ModifyGroupDetails
 from api.pagination import paginate
@@ -336,6 +336,22 @@ class AppList(MethodResource):
                     )
 
                 initial_additional_app_groups.append(initial_app_group)
+
+        poly_group = with_polymorphic(OktaGroup, [AppGroup, RoleGroup])
+        existing_owner_group = (
+            db.session.query(poly_group)
+            .options(joinedload(poly_group.active_user_memberships_and_ownerships))
+            .filter(func.lower(OktaGroup.name) == func.lower(owner_group_name))
+            .filter(OktaGroup.deleted_at.is_(None))
+            .first()
+        )
+        if existing_owner_group is not None and len(existing_owner_group.active_user_memberships_and_ownerships) > 0:
+            abort(
+                409,
+                f"An owner group with members and/or owners already exists for this app name. Select a different app"
+                f" name, change the name of {owner_group_name}, or remove the existing members and/or owners of"
+                f" {owner_group_name} to be able to proceed.",
+            )
 
         app = CreateApp(
             owner_id=owner_id,

--- a/api/views/resources/group.py
+++ b/api/views/resources/group.py
@@ -181,9 +181,12 @@ class GroupResource(MethodResource):
                     403,
                     "Current user is not an Access admin and not allowed to change group types",
                 )
-            group = ModifyGroupType(
-                group=group, group_changes=group_changes, current_user_id=g.current_user_id
-            ).execute()
+            try:
+                group = ModifyGroupType(
+                    group=group, group_changes=group_changes, current_user_id=g.current_user_id
+                ).execute()
+            except ValueError as e:
+                abort(400, str(e))
 
         # Store old plugin data for audit logging (must be deep copy to preserve original values)
         old_plugin_data_for_audit = copy.deepcopy(group.plugin_data) if group.plugin_data else {}
@@ -487,6 +490,17 @@ class GroupList(MethodResource):
         )
         if existing_group is not None:
             abort(400, "Group already exists with the same name")
+
+        if type(group) is not AppGroup and group.name.startswith(AppGroup.APP_GROUP_NAME_PREFIX):
+            abort(400, "The App- prefix cannot be used for non-app groups. Please choose a different group name.")
+
+        if type(group) is AppGroup and group.name.endswith(
+            f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
+        ):
+            abort(
+                400,
+                "App owner groups cannot be created directly. They are created automatically when an app is created.",
+            )
 
         group = CreateGroup(
             group=group, tags=request.get_json().get("tags_to_add", []), current_user_id=g.current_user_id

--- a/api/views/resources/group.py
+++ b/api/views/resources/group.py
@@ -161,6 +161,23 @@ class GroupResource(MethodResource):
                     "Only tags can be modifed for application owner groups",
                 )
 
+        # Block renaming to a reserved prefix unless the final type matches.
+        # Checked here—before ModifyGroupDetails—using the target type from group_changes, because
+        # a legitimate OktaGroup→AppGroup/RoleGroup conversion sends both the new name and new type
+        # in the same request, so checking type(group) alone would produce a false positive.
+        if "name" in json_data:
+            final_type = type(group_changes) if "type" in json_data else type(group)
+            if group_changes.name.startswith(AppGroup.APP_GROUP_NAME_PREFIX) and final_type is not AppGroup:
+                abort(
+                    400,
+                    "The App- prefix cannot be used for non-app groups. Please choose a different group name.",
+                )
+            if group_changes.name.startswith(RoleGroup.ROLE_GROUP_NAME_PREFIX) and final_type is not RoleGroup:
+                abort(
+                    400,
+                    "The Role- prefix cannot be used for non-role groups. Please choose a different group name.",
+                )
+
         # Update name and description, sync to Okta, and fire group_updated hook.
         # This runs before ModifyGroupType so the group_created hook (fired inside
         # ModifyGroupType) sees the final name/description.
@@ -493,6 +510,9 @@ class GroupList(MethodResource):
 
         if type(group) is not AppGroup and group.name.startswith(AppGroup.APP_GROUP_NAME_PREFIX):
             abort(400, "The App- prefix cannot be used for non-app groups. Please choose a different group name.")
+
+        if type(group) is not RoleGroup and group.name.startswith(RoleGroup.ROLE_GROUP_NAME_PREFIX):
+            abort(400, "The Role- prefix cannot be used for non-role groups. Please choose a different group name.")
 
         if type(group) is AppGroup and group.name.endswith(
             f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"

--- a/src/pages/group_requests/Read.tsx
+++ b/src/pages/group_requests/Read.tsx
@@ -83,6 +83,7 @@ const UNTIL_JUST_NUMERIC_ID_TO_LABELS: Record<string, string> = Object.fromEntri
 
 const APP_GROUP_PREFIX = 'App-';
 const APP_NAME_APP_GROUP_SEPARATOR = '-';
+const APP_OWNERS_GROUP_SUFFIX = 'Owners';
 const ROLE_GROUP_PREFIX = 'Role-';
 
 const RFC822_FORMAT = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
@@ -812,6 +813,21 @@ export default function ReadGroupRequest() {
                                       validation={{
                                         maxLength: 255,
                                         pattern: new RegExp(accessConfig.NAME_VALIDATION_PATTERN),
+                                        validate: (value: string) => {
+                                          const fullName =
+                                            groupType === 'app_group'
+                                              ? APP_GROUP_PREFIX + appName + APP_NAME_APP_GROUP_SEPARATOR + value
+                                              : groupType === 'role_group'
+                                                ? ROLE_GROUP_PREFIX + value
+                                                : value;
+                                          if (
+                                            fullName.startsWith(APP_GROUP_PREFIX) &&
+                                            fullName.endsWith(APP_NAME_APP_GROUP_SEPARATOR + APP_OWNERS_GROUP_SUFFIX)
+                                          ) {
+                                            return 'This name is reserved for app owner groups and cannot be used';
+                                          }
+                                          return true;
+                                        },
                                       }}
                                       parseError={(error) => {
                                         if (error?.message != '') return error?.message ?? '';

--- a/src/pages/group_requests/Read.tsx
+++ b/src/pages/group_requests/Read.tsx
@@ -822,6 +822,9 @@ export default function ReadGroupRequest() {
                                           if (groupType !== 'app_group' && fullName.startsWith(APP_GROUP_PREFIX)) {
                                             return 'The App- prefix cannot be used for non-app groups. Please choose a different group name.';
                                           }
+                                          if (groupType !== 'role_group' && fullName.startsWith(ROLE_GROUP_PREFIX)) {
+                                            return 'The Role- prefix cannot be used for non-role groups. Please choose a different group name.';
+                                          }
                                           return true;
                                         },
                                       }}

--- a/src/pages/group_requests/Read.tsx
+++ b/src/pages/group_requests/Read.tsx
@@ -83,7 +83,6 @@ const UNTIL_JUST_NUMERIC_ID_TO_LABELS: Record<string, string> = Object.fromEntri
 
 const APP_GROUP_PREFIX = 'App-';
 const APP_NAME_APP_GROUP_SEPARATOR = '-';
-const APP_OWNERS_GROUP_SUFFIX = 'Owners';
 const ROLE_GROUP_PREFIX = 'Role-';
 
 const RFC822_FORMAT = 'ddd, DD MMM YYYY HH:mm:ss ZZ';
@@ -820,11 +819,8 @@ export default function ReadGroupRequest() {
                                               : groupType === 'role_group'
                                                 ? ROLE_GROUP_PREFIX + value
                                                 : value;
-                                          if (
-                                            fullName.startsWith(APP_GROUP_PREFIX) &&
-                                            fullName.endsWith(APP_NAME_APP_GROUP_SEPARATOR + APP_OWNERS_GROUP_SUFFIX)
-                                          ) {
-                                            return 'This name is reserved for app owner groups and cannot be used';
+                                          if (groupType !== 'app_group' && fullName.startsWith(APP_GROUP_PREFIX)) {
+                                            return 'The App- prefix cannot be used for non-app groups. Please choose a different group name.';
                                           }
                                           return true;
                                         },

--- a/src/pages/groups/CreateUpdate.tsx
+++ b/src/pages/groups/CreateUpdate.tsx
@@ -284,6 +284,9 @@ function GroupDialog(props: GroupDialogProps) {
                     if (groupType !== 'app_group' && fullName.startsWith(APP_GROUP_PREFIX)) {
                       return 'The App- prefix cannot be used for non-app groups. Please choose a different group name.';
                     }
+                    if (groupType !== 'role_group' && fullName.startsWith(ROLE_GROUP_PREFIX)) {
+                      return 'The Role- prefix cannot be used for non-role groups. Please choose a different group name.';
+                    }
                     return true;
                   },
                 }}

--- a/src/pages/groups/CreateUpdate.tsx
+++ b/src/pages/groups/CreateUpdate.tsx
@@ -78,6 +78,7 @@ const GROUP_TYPE_OPTIONS = Object.entries(GROUP_TYPE_ID_TO_LABELS).map(([id, lab
 
 const APP_GROUP_PREFIX = 'App-';
 const APP_NAME_APP_GROUP_SEPARATOR = '-';
+const APP_OWNERS_GROUP_SUFFIX = 'Owners';
 const ROLE_GROUP_PREFIX = 'Role-';
 
 function GroupDialog(props: GroupDialogProps) {
@@ -274,6 +275,21 @@ function GroupDialog(props: GroupDialogProps) {
                 validation={{
                   maxLength: 255,
                   pattern: new RegExp(accessConfig.NAME_VALIDATION_PATTERN),
+                  validate: (value: string) => {
+                    const fullName =
+                      groupType === 'app_group'
+                        ? APP_GROUP_PREFIX + appName + APP_NAME_APP_GROUP_SEPARATOR + value
+                        : groupType === 'role_group'
+                          ? ROLE_GROUP_PREFIX + value
+                          : value;
+                    if (
+                      fullName.startsWith(APP_GROUP_PREFIX) &&
+                      fullName.endsWith(APP_NAME_APP_GROUP_SEPARATOR + APP_OWNERS_GROUP_SUFFIX)
+                    ) {
+                      return 'This name is reserved for app owner groups and cannot be used';
+                    }
+                    return true;
+                  },
                 }}
                 parseError={(error) => {
                   if (error?.message != '') {

--- a/src/pages/groups/CreateUpdate.tsx
+++ b/src/pages/groups/CreateUpdate.tsx
@@ -78,7 +78,6 @@ const GROUP_TYPE_OPTIONS = Object.entries(GROUP_TYPE_ID_TO_LABELS).map(([id, lab
 
 const APP_GROUP_PREFIX = 'App-';
 const APP_NAME_APP_GROUP_SEPARATOR = '-';
-const APP_OWNERS_GROUP_SUFFIX = 'Owners';
 const ROLE_GROUP_PREFIX = 'Role-';
 
 function GroupDialog(props: GroupDialogProps) {
@@ -282,11 +281,8 @@ function GroupDialog(props: GroupDialogProps) {
                         : groupType === 'role_group'
                           ? ROLE_GROUP_PREFIX + value
                           : value;
-                    if (
-                      fullName.startsWith(APP_GROUP_PREFIX) &&
-                      fullName.endsWith(APP_NAME_APP_GROUP_SEPARATOR + APP_OWNERS_GROUP_SUFFIX)
-                    ) {
-                      return 'This name is reserved for app owner groups and cannot be used';
+                    if (groupType !== 'app_group' && fullName.startsWith(APP_GROUP_PREFIX)) {
+                      return 'The App- prefix cannot be used for non-app groups. Please choose a different group name.';
                     }
                     return true;
                   },

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -658,3 +658,38 @@ def test_create_app_succeeds_with_empty_preexisting_owner_group(
     data = rep.get_json()
     assert data["name"] == "Payments"
     assert App.query.filter(App.name == "Payments").filter(App.deleted_at.is_(None)).first() is not None
+
+
+def test_create_app_succeeds_with_members_only_preexisting_owner_group(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    mocker: MockerFixture,
+    faker: Faker,  # type: ignore[type-arg]
+    user: OktaUser,
+) -> None:
+    db.session.add(user)
+    db.session.commit()
+
+    mocker.patch.object(
+        okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
+    )
+    mocker.patch.object(okta, "async_add_user_to_group")
+    mocker.patch.object(okta, "async_add_owner_to_group")
+
+    owner_group_name = (
+        f"{AppGroup.APP_GROUP_NAME_PREFIX}Payments"
+        f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
+    )
+    group_with_members = OktaGroupFactory.create(name=owner_group_name)
+    db.session.add(group_with_members)
+    db.session.commit()
+    db.session.add(OktaUserGroupMember(user_id=user.id, group_id=group_with_members.id, is_owner=False))
+    db.session.commit()
+
+    apps_url = url_for("api-apps.apps")
+    rep = client.post(apps_url, json={"name": "Payments"})
+    assert rep.status_code == 201
+
+    data = rep.get_json()
+    assert data["name"] == "Payments"
+    assert App.query.filter(App.name == "Payments").filter(App.deleted_at.is_(None)).first() is not None

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -21,7 +21,7 @@ from api.models import (
 )
 from api.operations import ModifyGroupUsers, ModifyRoleGroups
 from api.services import okta
-from tests.factories import AppFactory, AppGroupFactory
+from tests.factories import AppFactory, AppGroupFactory, OktaGroupFactory
 
 
 def test_get_app(
@@ -596,3 +596,65 @@ def test_partial_app_update_preserves_description(
     result = rep.get_json()
     assert result["name"] == "UpdatedName2"
     assert result["description"] == "Updated description"
+
+
+def test_create_app_fails_when_preexisting_owner_group_is_occupied(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    mocker: MockerFixture,
+    faker: Faker,  # type: ignore[type-arg]
+    user: OktaUser,
+) -> None:
+    db.session.add(user)
+    db.session.commit()
+
+    mocker.patch.object(
+        okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
+    )
+    mocker.patch.object(okta, "async_add_user_to_group")
+    mocker.patch.object(okta, "async_add_owner_to_group")
+
+    owner_group_name = (
+        f"{AppGroup.APP_GROUP_NAME_PREFIX}Payments"
+        f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
+    )
+    squatted_group = OktaGroupFactory.create(name=owner_group_name)
+    db.session.add(squatted_group)
+    db.session.commit()
+    db.session.add(OktaUserGroupMember(user_id=user.id, group_id=squatted_group.id, is_owner=True))
+    db.session.commit()
+
+    apps_url = url_for("api-apps.apps")
+    rep = client.post(apps_url, json={"name": "Payments"})
+    assert rep.status_code == 409
+
+    assert App.query.filter(App.name == "Payments").filter(App.deleted_at.is_(None)).first() is None
+
+
+def test_create_app_succeeds_with_empty_preexisting_owner_group(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    mocker: MockerFixture,
+    faker: Faker,  # type: ignore[type-arg]
+) -> None:
+    mocker.patch.object(
+        okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
+    )
+    mocker.patch.object(okta, "async_add_user_to_group")
+    mocker.patch.object(okta, "async_add_owner_to_group")
+
+    owner_group_name = (
+        f"{AppGroup.APP_GROUP_NAME_PREFIX}Payments"
+        f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
+    )
+    empty_group = OktaGroupFactory.create(name=owner_group_name)
+    db.session.add(empty_group)
+    db.session.commit()
+
+    apps_url = url_for("api-apps.apps")
+    rep = client.post(apps_url, json={"name": "Payments"})
+    assert rep.status_code == 201
+
+    data = rep.get_json()
+    assert data["name"] == "Payments"
+    assert App.query.filter(App.name == "Payments").filter(App.deleted_at.is_(None)).first() is not None

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1118,3 +1118,115 @@ def test_cannot_create_group_with_reserved_app_prefix(
         groups_url, json={"type": "app_group", "app_id": access_app.id, "name": non_owners_name, "description": ""}
     )
     assert rep.status_code == 201
+
+
+def test_cannot_rename_non_app_group_to_app_prefix(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    mocker: MockerFixture,
+    access_app: App,
+) -> None:
+    mocker.patch.object(okta, "update_group")
+
+    okta_group = OktaGroupFactory.create(name="Payments-Owners")
+    db.session.add(access_app)
+    db.session.add(okta_group)
+    db.session.commit()
+
+    group_url = url_for("api-groups.group_by_id", group_id=okta_group.id)
+
+    # Renaming an okta_group to App- prefix without changing the type is blocked
+    rep = client.put(group_url, json={"type": "okta_group", "name": "App-Payments-Owners", "description": ""})
+    assert rep.status_code == 400
+
+    # Renaming to a non-App- prefix is still allowed
+    rep = client.put(group_url, json={"type": "okta_group", "name": "Legitimate-Payments-Owners", "description": ""})
+    assert rep.status_code == 200
+
+    # Simultaneous conversion to app_group and rename to App- prefix is allowed
+    members_name = f"{AppGroup.APP_GROUP_NAME_PREFIX}{access_app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}Members"
+    rep = client.put(
+        group_url,
+        json={"type": "app_group", "app_id": access_app.id, "name": members_name, "description": ""},
+    )
+    assert rep.status_code == 200
+
+
+def test_cannot_create_group_with_reserved_role_prefix(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    mocker: MockerFixture,
+    faker: Faker,  # type: ignore[type-arg]
+) -> None:
+    mocker.patch.object(
+        okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
+    )
+
+    groups_url = url_for("api-groups.groups")
+
+    # okta_group with Role- prefix is blocked
+    rep = client.post(groups_url, json={"type": "okta_group", "name": "Role-SomeName", "description": ""})
+    assert rep.status_code == 400
+
+    # app_group with Role- prefix is blocked
+    rep = client.post(groups_url, json={"type": "app_group", "name": "Role-SomeName", "description": ""})
+    assert rep.status_code == 400
+
+    # role_group with Role- prefix is allowed
+    rep = client.post(
+        groups_url, json={"type": "role_group", "name": f"{RoleGroup.ROLE_GROUP_NAME_PREFIX}Admins", "description": ""}
+    )
+    assert rep.status_code == 201
+
+
+def test_cannot_rename_non_role_group_to_role_prefix(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch.object(okta, "update_group")
+
+    okta_group = OktaGroupFactory.create(name="Some-Group")
+    db.session.add(okta_group)
+    db.session.commit()
+
+    group_url = url_for("api-groups.group_by_id", group_id=okta_group.id)
+
+    # Renaming an okta_group to Role- prefix without changing the type is blocked
+    rep = client.put(group_url, json={"type": "okta_group", "name": "Role-SomeName", "description": ""})
+    assert rep.status_code == 400
+
+    # Renaming to a non-Role- prefix is still allowed
+    rep = client.put(group_url, json={"type": "okta_group", "name": "Legitimate-SomeName", "description": ""})
+    assert rep.status_code == 200
+
+    # Simultaneous conversion to role_group and rename to Role- prefix is allowed
+    rep = client.put(
+        group_url,
+        json={"type": "role_group", "name": f"{RoleGroup.ROLE_GROUP_NAME_PREFIX}Admins", "description": ""},
+    )
+    assert rep.status_code == 200
+
+
+def test_cannot_convert_role_prefixed_group_to_non_role_type(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch.object(okta, "update_group")
+
+    role_group = RoleGroupFactory.create(name=f"{RoleGroup.ROLE_GROUP_NAME_PREFIX}Admins")
+    db.session.add(role_group)
+    db.session.commit()
+
+    group_url = url_for("api-groups.group_by_id", group_id=role_group.id)
+
+    rep = client.put(group_url, json={"type": "okta_group", "name": role_group.name, "description": "desc"})
+    assert rep.status_code == 400
+
+    rep = client.put(group_url, json={"type": "app_group", "name": role_group.name, "description": "desc"})
+    assert rep.status_code == 400
+
+    # Keeping it as role_group is still allowed
+    rep = client.put(group_url, json={"type": "role_group", "name": role_group.name, "description": "desc"})
+    assert rep.status_code == 200

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1037,3 +1037,84 @@ def test_partial_group_update_preserves_description(
     result = rep.get_json()
     assert result["name"] == "UpdatedName2"
     assert result["description"] == "New description"
+
+
+def test_cannot_convert_app_prefixed_group_to_non_app_type(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    mocker: MockerFixture,
+    access_app: App,
+) -> None:
+    mocker.patch.object(okta, "update_group")
+
+    app_group = AppGroupFactory.create(
+        name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{access_app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}Members",
+        app_id=access_app.id,
+        is_owner=False,
+    )
+    db.session.add(access_app)
+    db.session.add(app_group)
+    db.session.commit()
+
+    group_url = url_for("api-groups.group_by_id", group_id=app_group.id)
+    rep = client.put(group_url, json={"type": "okta_group", "name": app_group.name, "description": "desc"})
+    assert rep.status_code == 400
+
+    rep = client.put(group_url, json={"type": "role_group", "name": app_group.name, "description": "desc"})
+    assert rep.status_code == 400
+
+    # Changing to app_group (same type, different app) is still allowed
+    rep = client.put(
+        group_url,
+        json={
+            "type": "app_group",
+            "name": app_group.name,
+            "description": "desc",
+            "app_id": access_app.id,
+        },
+    )
+    assert rep.status_code == 200
+
+
+def test_cannot_create_group_with_reserved_app_prefix(
+    client: FlaskClient,
+    db: SQLAlchemy,
+    mocker: MockerFixture,
+    faker: Faker,  # type: ignore[type-arg]
+    access_app: App,
+) -> None:
+    mocker.patch.object(
+        okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
+    )
+
+    db.session.add(access_app)
+    db.session.commit()
+
+    groups_url = url_for("api-groups.groups")
+
+    # okta_group with App- prefix is blocked
+    rep = client.post(groups_url, json={"type": "okta_group", "name": "App-SomeName", "description": ""})
+    assert rep.status_code == 400
+
+    # role_group with App- prefix is blocked
+    rep = client.post(groups_url, json={"type": "role_group", "name": "App-SomeName", "description": ""})
+    assert rep.status_code == 400
+
+    # app_group with App-*-Owners name is blocked
+    owners_name = (
+        f"{AppGroup.APP_GROUP_NAME_PREFIX}{access_app.name}"
+        f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
+    )
+    rep = client.post(
+        groups_url, json={"type": "app_group", "app_id": access_app.id, "name": owners_name, "description": ""}
+    )
+    assert rep.status_code == 400
+
+    # app_group with App-*-NonOwners name is allowed
+    non_owners_name = (
+        f"{AppGroup.APP_GROUP_NAME_PREFIX}{access_app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}Members"
+    )
+    rep = client.post(
+        groups_url, json={"type": "app_group", "app_id": access_app.id, "name": non_owners_name, "description": ""}
+    )
+    assert rep.status_code == 201

--- a/tests/test_group_request.py
+++ b/tests/test_group_request.py
@@ -1952,3 +1952,55 @@ def test_cannot_approve_app_group_request_with_owners_group_name(
         .first()
         is None
     )
+
+
+def test_cannot_approve_non_role_group_request_with_role_prefix(
+    app: Flask,
+    client: FlaskClient,
+    db: SQLAlchemy,
+    mocker: MockerFixture,
+    faker: Faker,  # type: ignore[type-arg]
+    user: OktaUser,
+) -> None:
+    admin = OktaUserFactory.create()
+    db.session.add(user)
+    db.session.add(admin)
+    db.session.commit()
+
+    mocker.patch.object(
+        okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
+    )
+    mocker.patch.object(okta, "async_add_user_to_group")
+    mocker.patch.object(okta, "async_add_owner_to_group")
+
+    access_admin_group = RoleGroupFactory.create(name="App-Access-Owners")
+    db.session.add(access_admin_group)
+    db.session.commit()
+    db.session.add(OktaUserGroupMember(user_id=admin.id, group_id=access_admin_group.id, is_owner=False))
+    db.session.commit()
+
+    group_request = CreateGroupRequest(
+        requester_user=user,
+        requested_group_name=f"{RoleGroup.ROLE_GROUP_NAME_PREFIX}Admins",
+        requested_group_description="A role group",
+        requested_group_type="role_group",
+        request_reason="Need a role",
+    ).execute()
+    assert group_request is not None
+
+    # Override the resolved name/type to use the Role- prefix with a non-role type
+    group_request.resolved_group_name = f"{RoleGroup.ROLE_GROUP_NAME_PREFIX}Admins"
+    group_request.resolved_group_type = "okta_group"
+    db.session.commit()
+
+    ApproveGroupRequest(
+        group_request=group_request,
+        approver_user=admin,
+        approval_reason="Approved",
+    ).execute()
+
+    db.session.refresh(group_request)
+    assert (
+        group_request.status == AccessRequestStatus.PENDING
+    ), "approval must be blocked for any non-role_group resolved_group_name that starts with the Role- prefix"
+    assert group_request.resolved_at is None

--- a/tests/test_group_request.py
+++ b/tests/test_group_request.py
@@ -1684,3 +1684,133 @@ def test_app_owner_cannot_hijack_group_via_resolved_name_case_insensitive(
         .first()
     )
     assert hijacked_ownership is None
+
+
+def test_cannot_approve_okta_group_with_reserved_app_owners_name(
+    app: Flask,
+    client: FlaskClient,
+    db: SQLAlchemy,
+    mocker: MockerFixture,
+    faker: Faker,  # type: ignore[type-arg]
+    user: OktaUser,
+) -> None:
+    app_owner = OktaUserFactory.create()
+    app_obj = AppFactory.create()
+
+    db.session.add(user)
+    db.session.add(app_owner)
+    db.session.add(app_obj)
+    db.session.commit()
+
+    mocker.patch.object(
+        okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
+    )
+    mocker.patch.object(okta, "async_add_user_to_group")
+    mocker.patch.object(okta, "async_add_owner_to_group")
+
+    owner_group = AppGroupFactory.create(
+        name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}"
+        f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
+        app_id=app_obj.id,
+        is_owner=True,
+    )
+    db.session.add(owner_group)
+    db.session.commit()
+    db.session.add(OktaUserGroupMember(user_id=app_owner.id, group_id=owner_group.id, is_owner=False))
+    db.session.commit()
+
+    group_request = CreateGroupRequest(
+        requester_user=user,
+        requested_group_name=f"App-{app_obj.name}-NewGroup",
+        requested_group_description="New group",
+        requested_group_type="app_group",
+        requested_app_id=app_obj.id,
+        request_reason="Need a new group",
+    ).execute()
+    assert group_request is not None
+
+    group_request.resolved_group_name = "App-Payments-Owners"
+    group_request.resolved_group_type = "okta_group"
+    db.session.commit()
+
+    ApproveGroupRequest(
+        group_request=group_request,
+        approver_user=app_owner,
+        approval_reason="Approved",
+    ).execute()
+
+    db.session.refresh(group_request)
+    assert (
+        group_request.status == AccessRequestStatus.PENDING
+    ), "approval must be blocked when resolved_group_name matches the reserved App-*-Owners pattern for a non-app_group type"
+    assert group_request.resolved_at is None
+
+    assert (
+        OktaGroup.query.filter(OktaGroup.name == "App-Payments-Owners").filter(OktaGroup.deleted_at.is_(None)).first()
+        is None
+    )
+
+
+def test_cannot_approve_role_group_with_reserved_app_owners_name(
+    app: Flask,
+    client: FlaskClient,
+    db: SQLAlchemy,
+    mocker: MockerFixture,
+    faker: Faker,  # type: ignore[type-arg]
+    user: OktaUser,
+) -> None:
+    app_owner = OktaUserFactory.create()
+    app_obj = AppFactory.create()
+
+    db.session.add(user)
+    db.session.add(app_owner)
+    db.session.add(app_obj)
+    db.session.commit()
+
+    mocker.patch.object(
+        okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
+    )
+    mocker.patch.object(okta, "async_add_user_to_group")
+    mocker.patch.object(okta, "async_add_owner_to_group")
+
+    owner_group = AppGroupFactory.create(
+        name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}"
+        f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
+        app_id=app_obj.id,
+        is_owner=True,
+    )
+    db.session.add(owner_group)
+    db.session.commit()
+    db.session.add(OktaUserGroupMember(user_id=app_owner.id, group_id=owner_group.id, is_owner=False))
+    db.session.commit()
+
+    group_request = CreateGroupRequest(
+        requester_user=user,
+        requested_group_name=f"App-{app_obj.name}-NewGroup",
+        requested_group_description="New group",
+        requested_group_type="app_group",
+        requested_app_id=app_obj.id,
+        request_reason="Need a new group",
+    ).execute()
+    assert group_request is not None
+
+    group_request.resolved_group_name = "App-Payments-Owners"
+    group_request.resolved_group_type = "role_group"
+    db.session.commit()
+
+    ApproveGroupRequest(
+        group_request=group_request,
+        approver_user=app_owner,
+        approval_reason="Approved",
+    ).execute()
+
+    db.session.refresh(group_request)
+    assert (
+        group_request.status == AccessRequestStatus.PENDING
+    ), "approval must be blocked when resolved_group_name matches the reserved App-*-Owners pattern for a non-app_group type"
+    assert group_request.resolved_at is None
+
+    assert (
+        OktaGroup.query.filter(OktaGroup.name == "App-Payments-Owners").filter(OktaGroup.deleted_at.is_(None)).first()
+        is None
+    )

--- a/tests/test_group_request.py
+++ b/tests/test_group_request.py
@@ -1742,7 +1742,7 @@ def test_cannot_approve_okta_group_with_reserved_app_owners_name(
     db.session.refresh(group_request)
     assert (
         group_request.status == AccessRequestStatus.PENDING
-    ), "approval must be blocked when resolved_group_name matches the reserved App-*-Owners pattern for a non-app_group type"
+    ), "approval must be blocked when resolved_group_name uses the reserved App- prefix for a non-app_group type"
     assert group_request.resolved_at is None
 
     assert (
@@ -1807,10 +1807,148 @@ def test_cannot_approve_role_group_with_reserved_app_owners_name(
     db.session.refresh(group_request)
     assert (
         group_request.status == AccessRequestStatus.PENDING
-    ), "approval must be blocked when resolved_group_name matches the reserved App-*-Owners pattern for a non-app_group type"
+    ), "approval must be blocked when resolved_group_name uses the reserved App- prefix for a non-app_group type"
     assert group_request.resolved_at is None
 
     assert (
         OktaGroup.query.filter(OktaGroup.name == "App-Payments-Owners").filter(OktaGroup.deleted_at.is_(None)).first()
+        is None
+    )
+
+
+def test_cannot_approve_okta_group_with_any_reserved_app_prefix(
+    app: Flask,
+    client: FlaskClient,
+    db: SQLAlchemy,
+    mocker: MockerFixture,
+    faker: Faker,  # type: ignore[type-arg]
+    user: OktaUser,
+) -> None:
+    app_owner = OktaUserFactory.create()
+    app_obj = AppFactory.create()
+
+    db.session.add(user)
+    db.session.add(app_owner)
+    db.session.add(app_obj)
+    db.session.commit()
+
+    mocker.patch.object(
+        okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
+    )
+    mocker.patch.object(okta, "async_add_user_to_group")
+    mocker.patch.object(okta, "async_add_owner_to_group")
+
+    owner_group = AppGroupFactory.create(
+        name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}"
+        f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
+        app_id=app_obj.id,
+        is_owner=True,
+    )
+    db.session.add(owner_group)
+    db.session.commit()
+    db.session.add(OktaUserGroupMember(user_id=app_owner.id, group_id=owner_group.id, is_owner=False))
+    db.session.commit()
+
+    group_request = CreateGroupRequest(
+        requester_user=user,
+        requested_group_name=f"App-{app_obj.name}-NewGroup",
+        requested_group_description="New group",
+        requested_group_type="app_group",
+        requested_app_id=app_obj.id,
+        request_reason="Need a new group",
+    ).execute()
+    assert group_request is not None
+
+    # Non-Owners suffix: rule is broader than just App-*-Owners
+    group_request.resolved_group_name = "App-Payments-Members"
+    group_request.resolved_group_type = "okta_group"
+    db.session.commit()
+
+    ApproveGroupRequest(
+        group_request=group_request,
+        approver_user=app_owner,
+        approval_reason="Approved",
+    ).execute()
+
+    db.session.refresh(group_request)
+    assert (
+        group_request.status == AccessRequestStatus.PENDING
+    ), "approval must be blocked for any non-app_group resolved_group_name that starts with the App- prefix"
+    assert group_request.resolved_at is None
+
+    assert (
+        OktaGroup.query.filter(OktaGroup.name == "App-Payments-Members").filter(OktaGroup.deleted_at.is_(None)).first()
+        is None
+    )
+
+
+def test_cannot_approve_app_group_request_with_owners_group_name(
+    app: Flask,
+    client: FlaskClient,
+    db: SQLAlchemy,
+    mocker: MockerFixture,
+    faker: Faker,  # type: ignore[type-arg]
+    user: OktaUser,
+) -> None:
+    app_owner = OktaUserFactory.create()
+    app_obj = AppFactory.create()
+
+    db.session.add(user)
+    db.session.add(app_owner)
+    db.session.add(app_obj)
+    db.session.commit()
+
+    mocker.patch.object(
+        okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
+    )
+    mocker.patch.object(okta, "async_add_user_to_group")
+    mocker.patch.object(okta, "async_add_owner_to_group")
+
+    owner_group = AppGroupFactory.create(
+        name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}"
+        f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
+        app_id=app_obj.id,
+        is_owner=True,
+    )
+    db.session.add(owner_group)
+    db.session.commit()
+    db.session.add(OktaUserGroupMember(user_id=app_owner.id, group_id=owner_group.id, is_owner=False))
+    db.session.commit()
+
+    group_request = CreateGroupRequest(
+        requester_user=user,
+        requested_group_name=f"App-{app_obj.name}-NewGroup",
+        requested_group_description="New group",
+        requested_group_type="app_group",
+        requested_app_id=app_obj.id,
+        request_reason="Need a new group",
+    ).execute()
+    assert group_request is not None
+
+    owners_group_name = (
+        f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}"
+        f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
+    )
+    group_request.resolved_group_name = owners_group_name
+    group_request.resolved_group_type = "app_group"
+    db.session.commit()
+
+    ApproveGroupRequest(
+        group_request=group_request,
+        approver_user=app_owner,
+        approval_reason="Approved",
+    ).execute()
+
+    db.session.refresh(group_request)
+    assert (
+        group_request.status == AccessRequestStatus.PENDING
+    ), "approval must be blocked when resolved_group_name matches the App-*-Owners pattern even for app_group type"
+    assert group_request.resolved_at is None
+
+    assert (
+        OktaGroup.query.filter(OktaGroup.name == owners_group_name)
+        .filter(OktaGroup.deleted_at.is_(None))
+        .filter(OktaGroup.id != owner_group.id)
+        .first()
         is None
     )


### PR DESCRIPTION
If an attacker can pre-create a group named App-<target>-Owners, it to be silently adopted as the owner group when the target app is later created, granting any existing group owners ownership of that app.

Added fix and tests. 
- Groups with the app group owner name pattern will only be used as the owner group during app creation if the group has no owners
- Banned the use of the reserved 'app group prefix'-name-'app owner group suffix' name pattern in group creation and group requests
- Banned the reserved app group prefix from being used with vanilla groups (both new groups/group requests and changing group type)