### PR TITLE
[markdown_support] adds markdown support to list view for Apps, Groups, Roles, Tags, and the AppsAccordionListGroup

### DIFF
--- a/src/components/MarkdownDescription.tsx
+++ b/src/components/MarkdownDescription.tsx
@@ -1,17 +1,63 @@
 import {Box, Typography} from '@mui/material';
+import type {SxProps, Theme} from '@mui/material';
 import ReactMarkdown from 'react-markdown';
 
 interface MarkdownDescriptionProps {
   description: string | null | undefined;
+  inline?: boolean;
+  sx?: SxProps<Theme>;
 }
 
+const FULL_ELEMENTS = [
+  'p',
+  'strong',
+  'em',
+  'code',
+  'pre',
+  'del',
+  'a',
+  'ul',
+  'ol',
+  'li',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'blockquote',
+  'hr',
+  'br',
+];
+
+const INLINE_ELEMENTS = ['strong', 'em', 'code', 'del', 'br'];
+
 /**
- * Component for rendering markdown descriptions with proper styling.
- * Used on detail pages for apps, groups, and tags.
+ * Renders markdown descriptions. Default mode is for detail-page heroes
+ * (centered, full block-level features). `inline` mode renders inside table
+ * cells whose row is wrapped in <a>: single-line CSS clamp, inline-only
+ * formatting, and links unwrapped to plain text to avoid nested anchors.
  */
-export default function MarkdownDescription({description}: MarkdownDescriptionProps) {
+export default function MarkdownDescription({description, inline, sx}: MarkdownDescriptionProps) {
   if (!description) {
     return null;
+  }
+
+  if (inline) {
+    return (
+      <Box
+        sx={{
+          display: '-webkit-box',
+          WebkitLineClamp: 1,
+          WebkitBoxOrient: 'vertical',
+          overflow: 'hidden',
+          ...sx,
+        }}>
+        <ReactMarkdown allowedElements={INLINE_ELEMENTS} unwrapDisallowed>
+          {description}
+        </ReactMarkdown>
+      </Box>
+    );
   }
 
   return (
@@ -30,32 +76,10 @@ export default function MarkdownDescription({description}: MarkdownDescriptionPr
             textDecoration: 'underline',
           },
         },
+        ...sx,
       }}>
       <Typography variant="body1" component="div">
-        <ReactMarkdown
-          allowedElements={[
-            'p',
-            'strong',
-            'em',
-            'code',
-            'pre',
-            'del',
-            'a',
-            'ul',
-            'ol',
-            'li',
-            'h1',
-            'h2',
-            'h3',
-            'h4',
-            'h5',
-            'h6',
-            'blockquote',
-            'hr',
-            'br',
-          ]}>
-          {description}
-        </ReactMarkdown>
+        <ReactMarkdown allowedElements={FULL_ELEMENTS}>{description}</ReactMarkdown>
       </Typography>
     </Box>
   );

--- a/src/pages/apps/List.tsx
+++ b/src/pages/apps/List.tsx
@@ -27,6 +27,7 @@ import {useGetApps} from '../../api/apiComponents';
 import TablePaginationActions from '../../components/actions/TablePaginationActions';
 import TableTopBar, {TableTopBarAutocomplete} from '../../components/TableTopBar';
 import LinkTableRow from '../../components/LinkTableRow';
+import MarkdownDescription from '../../components/MarkdownDescription';
 
 export default function ListApps() {
   const navigate = useNavigate();
@@ -135,7 +136,7 @@ export default function ListApps() {
               <LinkTableRow to={`/apps/${row.name}`} key={row.id}>
                 <TableCell>{row.name}</TableCell>
                 <TableCell>
-                  {(row.description?.length ?? 0) > 115 ? row.description?.substring(0, 114) + '...' : row.description}
+                  <MarkdownDescription description={row.description} inline />
                 </TableCell>
               </LinkTableRow>
             ))}

--- a/src/pages/apps/components/AppsAccordionListGroup.tsx
+++ b/src/pages/apps/components/AppsAccordionListGroup.tsx
@@ -22,6 +22,7 @@ import React from 'react';
 import {displayUserName, groupBy, groupMemberships, sortGroupMembers} from '../../../helpers';
 import {EmptyListEntry} from '../../../components/EmptyListEntry';
 import Ending from '../../../components/Ending';
+import MarkdownDescription from '../../../components/MarkdownDescription';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {Link as RouterLink, useParams} from 'react-router-dom';
 
@@ -150,9 +151,10 @@ const AccordionItem: React.FC<{
                     {appGroup.name}
                   </Link>
                 </Typography>
-                <Typography variant="body1" color="grey">
-                  {appGroup.description}
-                </Typography>
+                <MarkdownDescription
+                  description={appGroup.description}
+                  sx={{mx: 0, width: 'auto', px: 0, color: 'grey'}}
+                />
               </Stack>
               <Box
                 sx={{
@@ -270,9 +272,7 @@ export const AppsAccordionListGroup: React.FC<AppAccordionListGroupProps> = Reac
             </Typography>
           )}
           {(appGroupList?.length || 0) > 0 && list_group_description && (
-            <Typography variant="body1" component={'div'}>
-              {list_group_description}
-            </Typography>
+            <MarkdownDescription description={list_group_description} sx={{mx: 0, width: 'auto', px: 0}} />
           )}
           {appGroupList.map((appGroup) => (
             <AccordionItem

--- a/src/pages/groups/List.tsx
+++ b/src/pages/groups/List.tsx
@@ -25,6 +25,7 @@ import {useGetGroups} from '../../api/apiComponents';
 import TablePaginationActions from '../../components/actions/TablePaginationActions';
 import TableTopBar, {TableTopBarAutocomplete} from '../../components/TableTopBar';
 import LinkTableRow from '../../components/LinkTableRow';
+import MarkdownDescription from '../../components/MarkdownDescription';
 
 export default function ListGroups() {
   const navigate = useNavigate();
@@ -135,7 +136,7 @@ export default function ListGroups() {
                 <TableCell>{row.name}</TableCell>
                 <TableCell>{displayGroupType(row)}</TableCell>
                 <TableCell colSpan={2}>
-                  {(row.description?.length ?? 0) > 115 ? row.description?.substring(0, 114) + '...' : row.description}
+                  <MarkdownDescription description={row.description} inline />
                 </TableCell>
               </LinkTableRow>
             ))}

--- a/src/pages/roles/List.tsx
+++ b/src/pages/roles/List.tsx
@@ -28,6 +28,7 @@ import TablePaginationActions from '../../components/actions/TablePaginationActi
 import TableTopBar, {TableTopBarAutocomplete} from '../../components/TableTopBar';
 import {EmptyListEntry} from '../../components/EmptyListEntry';
 import LinkTableRow from '../../components/LinkTableRow';
+import MarkdownDescription from '../../components/MarkdownDescription';
 
 export default function ListRoles() {
   const navigate = useNavigate();
@@ -136,9 +137,7 @@ export default function ListRoles() {
               <LinkTableRow to={`/roles/${row.name}`} key={row.id}>
                 <TableCell>{row.name}</TableCell>
                 <TableCell>
-                  {(row.description?.length ?? 0) > 115
-                    ? (row.description?.substring(0, 114) ?? '') + '...'
-                    : row.description}
+                  <MarkdownDescription description={row.description} inline />
                 </TableCell>
               </LinkTableRow>
             ))}

--- a/src/pages/tags/List.tsx
+++ b/src/pages/tags/List.tsx
@@ -24,6 +24,7 @@ import {perPage} from '../../helpers';
 import {useGetTags} from '../../api/apiComponents';
 import TablePaginationActions from '../../components/actions/TablePaginationActions';
 import TableTopBar, {TableTopBarAutocomplete} from '../../components/TableTopBar';
+import MarkdownDescription from '../../components/MarkdownDescription';
 
 export default function ListTags() {
   const navigate = useNavigate();
@@ -134,9 +135,7 @@ export default function ListTags() {
                 </TableCell>
                 <TableCell>
                   <Link to={`/tags/${row.name}`} sx={{textDecoration: 'none', color: 'inherit'}} component={RouterLink}>
-                    {(row.description ?? '').length > 115
-                      ? row.description?.substring(0, 114) + '...'
-                      : row.description ?? ''}
+                    <MarkdownDescription description={row.description} inline />
                   </Link>
                 </TableCell>
               </TableRow>


### PR DESCRIPTION
Fixes a bug in the list views where markdown text was not being rendered correctly. This PR extends MarkdownDescription to cover those cases.

  - Adds `inline` and `sx` props to `MarkdownDescription`. The `inline` mode renders inside table cells whose row is wrapped in `LinkTableRow` which wraps the entire row in an <a>. It also enforces inline-only formatting tags (strong, em, code, del, br), and adds `unwrapDisallowed` so markdown links collapse to their text to avoid nested <a> tags.
  - Replaces raw description rendering in [apps/List.tsx](https://github.com/discord/access/blob/main/src/pages/apps/List.tsx), [groups/List.tsx](https://github.com/discord/access/blob/main/src/pages/groups/List.tsx), [roles/List.tsx](https://github.com/discord/access/blob/main/src/pages/roles/List.tsx), and [tags/List.tsx](https://github.com/discord/access/blob/main/src/pages/tags/List.tsx) with `<MarkdownDescription inline />`
  - Replaces the two raw `<Typography>{description}</Typography>` sites in [AppsAccordionListGroup.tsx](https://github.com/discord/access/blob/main/src/pages/apps/components/AppsAccordionListGroup.tsx) (per-group description and section description) with `<MarkdownDescription>` plus an `sx` prop override that neutralizes the centered hero defaults so the description matches the existing left-aligned accordion layout.

Tested and confirmed markdown is rendered as expected now:

# apps/List.tsx

<img width="778" height="261" alt="image" src="https://github.com/user-attachments/assets/3b01eebb-ca8a-4d25-aaa8-010bd73fb59f" />


# groups/List.tsx

<img width="788" height="168" alt="image" src="https://github.com/user-attachments/assets/ab7a7a8f-d381-45bd-8df8-a3bcb4e094b7" />


# roles/List.tsx

<img width="856" height="176" alt="image" src="https://github.com/user-attachments/assets/30f43f72-468c-4957-9e29-e374b0039a47" />


# tags/List.tsx

<img width="823" height="193" alt="image" src="https://github.com/user-attachments/assets/2ff611e1-9df7-4906-b913-238feeca8faf" />


# AppsAccordianListGroup.tsx

<img width="1276" height="675" alt="image" src="https://github.com/user-attachments/assets/6c51dd1d-39db-4cef-bec1-4fe92be28a6e" />
