### PR TITLE
[roles_add_groups] updated visibility for "Add Groups"

### DIFF
--- a/src/pages/roles/AddGroups.tsx
+++ b/src/pages/roles/AddGroups.tsx
@@ -108,6 +108,12 @@ function AddGroupsDialog(props: AddGroupsDialogProps) {
     props.group.active_user_memberships?.map((membership) => membership.active_user!.id).includes(currentUser.id) ??
     false;
 
+  const userOwnedNonRoleGroupIds = !isAccessAdmin(currentUser)
+    ? (currentUser.active_group_ownerships ?? [])
+        .filter((ownership) => ownership.active_group != null && ownership.active_group.type !== 'role_group')
+        .map((ownership) => ownership.active_group!.id!)
+    : null;
+
   const [until, setUntil] = React.useState(accessConfig.DEFAULT_ACCESS_TIME);
   const [groupSearchInput, setGroupSearchInput] = React.useState('');
   const [groups, setGroups] = React.useState<Array<OktaGroup | AppGroup>>([]);
@@ -220,6 +226,12 @@ function AddGroupsDialog(props: AddGroupsDialogProps) {
       <FormContainer<AddGroupsForm> onSuccess={(formData) => submit(formData)}>
         <DialogTitle>Add {addGroupsText}</DialogTitle>
         <DialogContent>
+          {!isAccessAdmin(currentUser) ? (
+            <Alert severity="info" sx={{my: 1}}>
+              You can only add groups that you own from this dialog. To add groups that you do not own to this role,
+              please create a role request from the group's page.
+            </Alert>
+          ) : null}
           <Typography variant="subtitle1" color="text.accent">
             {timeLimit
               ? (props.owner ? 'Ownership of ' : 'Membership to ') +
@@ -296,6 +308,7 @@ function AddGroupsDialog(props: AddGroupsDialogProps) {
                     (option) =>
                       option.type != 'role_group' &&
                       option.is_managed == true &&
+                      (userOwnedNonRoleGroupIds == null || userOwnedNonRoleGroupIds.includes(option.id!)) &&
                       (!groups.map((group) => group.id).includes(option.id) ||
                         (currUserRoleGroupMember && !isAccessAdmin(currentUser)
                           ? !disallowedGroups.includes(option.id!)
@@ -387,7 +400,12 @@ interface AddGroupsProps {
 export default function AddGroups(props: AddGroupsProps) {
   const [open, setOpen] = React.useState(false);
 
-  if (props.group.deleted_at != null || !isAccessAdmin(props.currentUser)) {
+  const ownsAtLeastOneNonRoleGroup = (props.currentUser.active_group_ownerships ?? []).some(
+    (ownership) => ownership.active_group != null && ownership.active_group.type !== 'role_group',
+  );
+  const isRoleOwnerWithGroups = isGroupOwner(props.currentUser, props.group.id ?? '') && ownsAtLeastOneNonRoleGroup;
+
+  if (props.group.deleted_at != null || !(isAccessAdmin(props.currentUser) || isRoleOwnerWithGroups)) {
     return null;
   }
 

--- a/src/pages/roles/AddGroups.tsx
+++ b/src/pages/roles/AddGroups.tsx
@@ -405,7 +405,7 @@ export default function AddGroups(props: AddGroupsProps) {
   );
   const isRoleOwnerWithGroups = isGroupOwner(props.currentUser, props.group.id ?? '') && ownsAtLeastOneNonRoleGroup;
 
-  if (props.group.deleted_at != null || !(isAccessAdmin(props.currentUser) || isRoleOwnerWithGroups)) {
+  if (props.group.deleted_at != null || !isAccessAdmin(props.currentUser) || !isRoleOwnerWithGroups) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

Previously the **Add Groups** and **Add Owner Groups** buttons on a role page were gated by `isAccessAdmin`, hiding them from role owners who weren't also Access admins.
  - Visibility is now `isAccessAdmin || (role owner who owns ≥1 non-role group)`.
  - For non-admins, the dialog's autocomplete is restricted to groups the user owns, and an info note explains that unowned groups must be added via a role request from the group's page.
  - This brings the role page in parity with the group page, where `AddRoles` already permits group owners (not just admins).

## Testing
  - [x] Locally stubbed [`isAccessAdmin`](https://github.com/discord/access/blob/main/src/authorization.tsx#L24) to return `false` to simulate a non-admin role owner.

<img width="1911" height="982" alt="image" src="https://github.com/user-attachments/assets/b07041dd-84e9-4ee1-8dbc-ba90ae929fcc" />


  - [x] As role owner of `Role-JeffTestRole` who owns multiple groups, both buttons appear, the dialog shows the info note, and the autocomplete only lists owned groups.


<img width="1583" height="527" alt="Screenshot 2026-05-05 at 10 11 55 AM" src="https://github.com/user-attachments/assets/cfb9b4b6-09dd-4dee-82ad-6d5fdf8dcfc7" />


<img width="1658" height="507" alt="Screenshot 2026-05-05 at 10 12 03 AM" src="https://github.com/user-attachments/assets/ff33acae-2d17-4fa8-a1fa-c296d953f42d" />
