### PR TITLE
Add .worktreeinclude for local dev files

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,12 @@
+# Files to copy from the main checkout into new git worktrees.
+# Uses .gitignore syntax. Only paths that match a pattern AND are gitignored
+# are copied; tracked files are skipped automatically.
+# See: https://code.claude.com/docs/en/worktrees#copy-gitignored-files-into-worktrees
+
+# Local environment / secrets (Makefile requires .env to run).
+.env
+
+# Local config overrides (see bottom of .gitignore).
+config/config.override.json
+config/config.development.json
+config/config.test.json


### PR DESCRIPTION
## Summary
Adds a `.worktreeinclude` file at the project root so that `claude --worktree` (and other Claude Code parallel-session flows) automatically copy local-only config into freshly-created worktrees.

## Motivation
A new git worktree is a clean checkout, so untracked files like `.env` aren't present. Without them, running the app fails.

## Description of Changes
Adds `.worktreeinclude` listing:
- `.env` — required by the Makefile to run anything locally.
- `config/config.{override,development,test}.json`: the local override config files explicitly carved out at the bottom of `.gitignore` (lines 499-503), although these aren't uses.

Patterns use `.gitignore` syntax. Per [Claude Code docs](https://code.claude.com/docs/en/worktrees#copy-gitignored-files-into-worktrees), only paths matching a pattern *and* gitignored are copied, so tracked files are never duplicated and missing optional files are silently skipped.

Deliberately **not** included: `node_modules/`, `venv/`, `instance/access.db`, `__pycache__/`, `.mypy_cache/`, `.ruff_cache/`. These are either large/regenerable (rebuilt by `make dev` / `npm install`) or stateful in a way that would cause cross-branch issues — e.g. copying `instance/access.db` would carry one branch's migration state into another worktree on a different branch.

## Validation of Changes
Did a manual smoke test: in a checkout that has this file at root, run `claude --worktree test-include`, then verify the new worktree contains `.env`.

## Guidance for Reviewers
Single-file change, review in one pass. The main judgment call is the include list: Are there other gitignored files contributors routinely need that I missed?

🤖 Generated with [Claude Code](https://claude.com/claude-code)