### PR TITLE
Initialize OktaService (and logging/Sentry) in CLI bootstrap

### DIFF
--- a/api/manage.py
+++ b/api/manage.py
@@ -29,9 +29,19 @@ def _with_app_context(func: F) -> F:
 
     @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
+        from api.app import _configure_logging, _configure_okta, _configure_sentry
         from api.database import build_engine
         from api.extensions import _session_scope, db
         from api.plugins import load_plugins
+
+        # Mirror create_app()'s bootstrap so CLI runs get the same
+        # token-redacting log filter, Sentry wiring, and OktaService
+        # initialization. Without _configure_okta() in particular, the
+        # module-level `okta` singleton is missing `okta_client` and any
+        # command that touches Okta (sync, notify) raises AttributeError.
+        _configure_logging()
+        _configure_sentry()
+        _configure_okta()
 
         if db._engine is None:
             db.init_app(engine=build_engine())


### PR DESCRIPTION
## Summary

The click CLI introduced in #425 never initializes the module-level `OktaService` singleton, so any command that touches Okta (`sync`, `notify`, `sync-app-group-memberships`) raises:

```
File "api/services/okta_service.py", line 58, in _get_sessioned_okta_request_executor
    return SessionedOktaRequestExecutor(self.okta_client.get_request_executor())
                                        ^^^^^^^^^^^^^^^^
AttributeError: 'OktaService' object has no attribute 'okta_client'
```

### Why

`api/services/__init__.py:3` constructs the singleton: `okta = OktaService()`. `OktaService.__init__` is the default — the `okta_client` attribute is only created when `OktaService.initialize(...)` runs (`api/services/okta_service.py:40-54`). For the HTTP server, `create_app()` does this via `_configure_okta()` (`api/app.py:94-100`, called at `api/app.py:119`). The CLI bypasses `create_app()` and goes through `_with_app_context` (`api/manage.py:24-54`), which previously only bound the SQLAlchemy engine, called `load_plugins()`, and set up a session scope — it skipped `_configure_okta()` entirely.

The same gap also left CLI runs without:
- `_configure_logging()` — which installs `TokenSanitizingFilter`, the filter that strips Okta API tokens from log output.
- `_configure_sentry()` — so cron failures (this very one!) didn't reach Sentry; you only saw them in stderr.

### Fix

Mirror `create_app()`'s bootstrap by calling `_configure_logging`, `_configure_sentry`, and `_configure_okta` from `_with_app_context`. Imports stay local to the wrapper so plain `import api.manage` (e.g. for testing) doesn't pay the cost of loading FastAPI.

`assert_env_explicitly_set()` is intentionally not called from the CLI — its docstring at `api/config.py:139-142` explicitly documents that CLI runs are unaffected, so commands like `access init` against a fresh dev DB still work without `ENV` set.

## Test plan

- [x] `docker build --target false -t access-test:cli-fix .` succeeds.
- [x] In the rebuilt container, `python -m api.manage sync` (with `ENV=staging`, dummy `OKTA_DOMAIN` / `OKTA_API_TOKEN`, and an in-memory SQLite `DATABASE_URI`) no longer raises `AttributeError`. Failure now surfaces as `Exception: {'message': 'Okta HTTP 401 E0000011 Invalid token provided\n'}` — the singleton is initialized and the dummy token actually reaches Okta.
- [x] `python -m api.manage notify` likewise gets past the bootstrap and fails on a downstream concern (missing migration tables in the in-memory DB), proving the wrapper change applies to every command, not just `sync`.
- [x] `python -c "from api.manage import cli"` still imports cleanly — the new local imports inside `_with_app_context` only run when a CLI command is actually invoked.
- [ ] `tox -e py313` (CI will run this; not exercised locally).

## Context for reviewers

A companion PR (#439) makes the `access` console script available on `PATH` in the Docker image. That fix and this one are independent: this PR fixes a bug that affects both `access <cmd>` (post-#439) and `python -m api.manage <cmd>` (today's workaround). They can land in either order.
