### PR TITLE
Bundle config/*.json as package_data and allow ACCESS_CONFIG_FILE to override the lookup dir

### DIFF
--- a/api/access_config.py
+++ b/api/access_config.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from typing import Any
+from typing import Any, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -46,22 +46,20 @@ def _validate_override_config(config: dict[str, Any]) -> None:
         )
 
 
-def _merge_override_config(config: dict[str, Any], top_level_dir: str) -> None:
-    access_config_file = os.getenv("ACCESS_CONFIG_FILE")
-    if access_config_file:
-        override_config_path = os.path.join(top_level_dir, "config", access_config_file)
-        if os.path.exists(override_config_path):
-            logger.debug(f"Loading access config override from {override_config_path}")
-            with open(override_config_path, "r") as f:
-                override_config = json.load(f).get(BACKEND, {})
-                _validate_override_config(override_config)
-                config.update(override_config)
-        else:
-            raise ConfigFileNotFoundError(str(override_config_path))
+def _merge_override_config(config: dict[str, Any], config_dir: str, override_filename: str) -> None:
+    override_config_path = os.path.join(config_dir, override_filename)
+    if os.path.exists(override_config_path):
+        logger.debug(f"Loading access config override from {override_config_path}")
+        with open(override_config_path, "r") as f:
+            override_config = json.load(f).get(BACKEND, {})
+            _validate_override_config(override_config)
+            config.update(override_config)
+    else:
+        raise ConfigFileNotFoundError(str(override_config_path))
 
 
-def _load_default_config(top_level_dir: str) -> dict[str, Any]:
-    default_config_path = os.path.join(top_level_dir, "config", "config.default.json")
+def _load_default_config(config_dir: str) -> dict[str, Any]:
+    default_config_path = os.path.join(config_dir, "config.default.json")
     if not os.path.exists(default_config_path):
         raise ConfigFileNotFoundError(str(default_config_path))
     with open(default_config_path, "r") as f:
@@ -69,10 +67,29 @@ def _load_default_config(top_level_dir: str) -> dict[str, Any]:
     return config
 
 
+def _resolve_config_paths() -> Tuple[str, Optional[str]]:
+    """Resolve the directory holding config.default.json and an optional override filename.
+
+    ACCESS_CONFIG_FILE accepts either of two shapes:
+      - bare filename (e.g. "config.production.json"): existing behavior --
+        looked up inside the package's bundled `config/` dir.
+      - absolute path (e.g. "/etc/access/config.production.json"): the
+        containing directory becomes the lookup dir for BOTH the default
+        and the override, so operators can mount a ConfigMap (or any
+        other directory) without rebuilding the image.
+    """
+    bundled_config_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "config")
+    access_config_file = os.getenv("ACCESS_CONFIG_FILE")
+    if access_config_file and os.path.isabs(access_config_file):
+        return os.path.dirname(access_config_file), os.path.basename(access_config_file)
+    return bundled_config_dir, access_config_file
+
+
 def _load_access_config() -> AccessConfig:
-    top_level_dir = os.path.dirname(os.path.dirname(__file__))
-    config = _load_default_config(top_level_dir)
-    _merge_override_config(config, top_level_dir)
+    config_dir, override_filename = _resolve_config_paths()
+    config = _load_default_config(config_dir)
+    if override_filename:
+        _merge_override_config(config, config_dir, override_filename)
 
     name_pattern = _get_config_value(config, NAME_VALIDATION_PATTERN)
     name_validation_error = _get_config_value(config, NAME_VALIDATION_ERROR)

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,12 @@ setup(
     name="access",
     version=__version__,
     packages=find_packages(exclude=["tests"]),
+    # Bundle config/*.json with the wheel so `pip install .` produces a
+    # self-contained install. Without this the `access` console script
+    # fails at import time with ConfigFileNotFoundError because the
+    # default config lookup is relative to the install location of
+    # api/access_config.py (site-packages), not the source tree.
+    package_data={"config": ["*.json"]},
     install_requires=[
         "fastapi",
         "uvicorn[standard]",

--- a/tests/test_access_config.py
+++ b/tests/test_access_config.py
@@ -15,6 +15,7 @@ from api.access_config import (
     _get_config_value,
     BACKEND,
     _merge_override_config,
+    _resolve_config_paths,
     NAME_VALIDATION_PATTERN,
     NAME_VALIDATION_ERROR,
     ConfigValidationError,
@@ -37,7 +38,7 @@ def mock_load_default_config() -> Generator[Any, Any, Any]:
 @pytest.fixture
 def mock_merge_override_config() -> Generator[Any, Any, Any]:
     with patch("api.access_config._merge_override_config") as mock_merge:
-        mock_merge.side_effect = lambda config, _: config.update(
+        mock_merge.side_effect = lambda config, _config_dir, _filename: config.update(
             {
                 NAME_VALIDATION_PATTERN: "override_name_pattern",
                 NAME_VALIDATION_ERROR: "override_name_error",
@@ -53,7 +54,14 @@ def test_load_config_default(mock_load_default_config: None) -> None:
     assert config.name_validation_error == "name_error"
 
 
-def test_load_config_with_override(mock_load_default_config: None, mock_merge_override_config: None) -> None:
+def test_load_config_with_override(
+    mock_load_default_config: None,
+    mock_merge_override_config: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # _load_access_config only calls _merge_override_config when an override
+    # is requested; ACCESS_CONFIG_FILE is how a caller asks for one.
+    monkeypatch.setenv("ACCESS_CONFIG_FILE", "override.json")
     config = _load_access_config()
     assert isinstance(config, AccessConfig)
     assert config.name_pattern == "override_name_pattern"
@@ -61,10 +69,7 @@ def test_load_config_with_override(mock_load_default_config: None, mock_merge_ov
 
 
 def test_load_default_config() -> None:
-    with tempfile.TemporaryDirectory() as temp_dir:
-        config_dir = os.path.join(temp_dir, "config")
-        os.makedirs(config_dir)
-
+    with tempfile.TemporaryDirectory() as config_dir:
         config_file_path = os.path.join(config_dir, "config.default.json")
         with open(config_file_path, "w") as config_file:
             json.dump(
@@ -77,16 +82,13 @@ def test_load_default_config() -> None:
                 config_file,
             )
 
-        config = _load_default_config(temp_dir)
+        config = _load_default_config(config_dir)
         assert config[NAME_VALIDATION_PATTERN] == "name_pattern"
         assert config[NAME_VALIDATION_ERROR] == "name_error"
 
 
-def test_merge_override_config(monkeypatch: pytest.MonkeyPatch) -> None:
-    with tempfile.TemporaryDirectory() as temp_dir:
-        config_dir = os.path.join(temp_dir, "config")
-        os.makedirs(config_dir)
-
+def test_merge_override_config() -> None:
+    with tempfile.TemporaryDirectory() as config_dir:
         filename = "override_config1.json"
         override_config_path = os.path.join(config_dir, filename)
         override_config = {
@@ -98,15 +100,12 @@ def test_merge_override_config(monkeypatch: pytest.MonkeyPatch) -> None:
         with open(override_config_path, "w") as config_file:
             json.dump(override_config, config_file)
 
-        # Mock the ACCESS_CONFIG_FILE environment variable
-        monkeypatch.setenv("ACCESS_CONFIG_FILE", filename)
-
         config = {
             NAME_VALIDATION_PATTERN: "group_pattern",
             NAME_VALIDATION_ERROR: "name_error",
         }
 
-        _merge_override_config(config, temp_dir)
+        _merge_override_config(config, config_dir, filename)
 
         assert config[NAME_VALIDATION_PATTERN] == "override_name_pattern"
         assert config[NAME_VALIDATION_ERROR] == "override_name_error"
@@ -117,13 +116,8 @@ def test_load_default_config_file_not_found() -> None:
         _load_default_config("/non/existent/path")
 
 
-def test_merge_override_config_ignores_frontend_override(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    with tempfile.TemporaryDirectory() as temp_dir:
-        config_dir = os.path.join(temp_dir, "config")
-        os.makedirs(config_dir)
-
+def test_merge_override_config_ignores_frontend_override() -> None:
+    with tempfile.TemporaryDirectory() as config_dir:
         filename = "override_config2.json"
         override_config_path = os.path.join(config_dir, filename)
         override_config = {
@@ -137,19 +131,42 @@ def test_merge_override_config_ignores_frontend_override(
         with open(override_config_path, "w") as config_file:
             json.dump(override_config, config_file)
 
-        # Mock the ACCESS_CONFIG_FILE environment variable
-        monkeypatch.setenv("ACCESS_CONFIG_FILE", filename)
-
         config = {
             NAME_VALIDATION_PATTERN: "name_pattern",
             NAME_VALIDATION_ERROR: "name_error",
         }
-        _merge_override_config(config, temp_dir)
+        _merge_override_config(config, config_dir, filename)
         # no overrides from FRONTEND keys!
         assert config[NAME_VALIDATION_PATTERN] == "name_pattern"
         assert config[NAME_VALIDATION_ERROR] == "name_error"
         # extra key from FRONTEND not there either
         assert "FOO" not in config
+
+
+def test_resolve_config_paths_bare_filename_uses_bundled_dir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ACCESS_CONFIG_FILE", "config.production.json")
+    config_dir, override_filename = _resolve_config_paths()
+    # Bare filenames keep existing semantics: the bundled config dir is used.
+    assert os.path.basename(config_dir) == "config"
+    assert override_filename == "config.production.json"
+
+
+def test_resolve_config_paths_absolute_path_overrides_dir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ACCESS_CONFIG_FILE", "/etc/access-config/config.production.json")
+    config_dir, override_filename = _resolve_config_paths()
+    assert config_dir == "/etc/access-config"
+    assert override_filename == "config.production.json"
+
+
+def test_resolve_config_paths_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ACCESS_CONFIG_FILE", raising=False)
+    config_dir, override_filename = _resolve_config_paths()
+    assert os.path.basename(config_dir) == "config"
+    assert override_filename is None
 
 
 def test_get_config_value_raises_undefined_config_key_error() -> None:


### PR DESCRIPTION
## Summary

After #439 installs the project via `pip install --no-deps .`, the `access` console script lives at `/usr/local/bin/access` and imports `api.access_config` from `site-packages`. The default-config lookup at `api/access_config.py:64` resolves relative to `__file__` (two levels up from the installed module), but `setup.py` only declared the `api` package — not `config/` — so the config directory never shipped with the wheel. The first import via the `access` CLI raised:

```
ConfigFileNotFoundError: Config override file not found:
    /usr/local/lib/python3.13/site-packages/config/config.default.json
```

The web pod isn't affected because gunicorn explicitly inserts `cfg.chdir` (`/app`) into `sys.path`, so `api.access_config` loads from `/app/api/` and the relative lookup lands on `/app/config/`. The CLI path doesn't do that, and `python -m api.manage` would work only because `-m` puts cwd at the front of `sys.path`.

## Changes

1. **Bundle config files via `package_data`.** `config/` becomes a tiny Python package (empty `__init__.py` + the JSON files) so `find_packages()` picks it up, and `setup.py` declares `package_data={"config": ["*.json"]}` so the JSON ships in the wheel. After install: `site-packages/config/config.default.json` exists, and the existing `__file__`-relative lookup finds it without any code change at the call site.

2. **Reinterpret `ACCESS_CONFIG_FILE` to also override the lookup directory.** The env var is already documented in the README for selecting an override filename inside the project-level `config/` dir. Bare filenames keep that exact semantics. **Absolute paths** are new: they become the override file *and* their directory becomes the lookup dir for `config.default.json` too. This lets operators mount a ConfigMap (or any other directory) at e.g. `/etc/access-config/` and set `ACCESS_CONFIG_FILE=/etc/access-config/config.production.json` without rebuilding the image.

3. **Small refactor in `_load_access_config`.** The two private helpers (`_load_default_config`, `_merge_override_config`) now take an explicit `config_dir` rather than `top_level_dir`, so the "find config.default.json inside `<dir>/config/`" join is no longer baked into them. A new `_resolve_config_paths()` returns `(config_dir, override_filename | None)` and encapsulates the env-var logic.

## Test plan

- [x] `docker build --target false -t access-test:config-fix .` succeeds; the wheel built via `pip install --no-deps .` now contains both `api/` and `config/`. Confirmed with `ls /usr/local/lib/python3.13/site-packages/config/` showing `config.default.json` and `__init__.py`.
- [x] In the rebuilt image, `access sync` (with `ENV=staging`, dummy `OKTA_DOMAIN`/`OKTA_API_TOKEN`, in-memory SQLite) no longer raises `ConfigFileNotFoundError`. Failure now surfaces as `Exception: Okta HTTP 401 E0000011 Invalid token provided` — the schema modules load cleanly, the OktaService initializes, and the dummy token reaches Okta.
- [x] `ACCESS_CONFIG_FILE=/etc/access-config/config.default.json` (absolute path, with `/etc/access-config` mounted from a directory containing the JSON) correctly redirects the lookup. `_resolve_config_paths()` returns `('/etc/access-config', 'config.default.json')` and `get_access_config()` loads it.
- [x] Bare-filename `ACCESS_CONFIG_FILE=config.production.json` keeps existing semantics (joined with the bundled config dir).
- [x] `gunicorn api.asgi:app` web boot path is unaffected — the `__file__`-relative fallback still resolves to `/app/config/` when cwd is `/app` and `/app/api/` is on `sys.path` ahead of site-packages (same behavior as before this PR).
- [ ] `tox -e py313` (CI will run this; not exercised locally).

## Context for reviewers

This is the fourth follow-up to the FastAPI migration in #425, alongside #438 (sentry env-var rename), #439 (`pip install .` in Dockerfile), and #440 (CLI OktaService bootstrap). Once this lands and a new image rolls, downstream consumers that invoke `access sync` / `access notify` directly will work without per-deployment `WORKDIR` or `PYTHONPATH` hacks.
