### PR TITLE
Make config's APP_CREATOR_ID accept a comma-separated list

### DIFF
--- a/api/auth/permissions.py
+++ b/api/auth/permissions.py
@@ -129,7 +129,7 @@ def require_access_admin_or_app_creator(
     db: DbSession,
     current_user_id: CurrentUserId,
 ) -> str:
-    if settings.APP_CREATOR_ID is not None and current_user_id == settings.APP_CREATOR_ID:
+    if current_user_id in settings.app_creator_ids:
         return current_user_id
     if is_access_admin(db, current_user_id):
         return current_user_id

--- a/api/config.py
+++ b/api/config.py
@@ -97,6 +97,9 @@ class Settings(BaseSettings):
     SECRET_KEY: Optional[str] = Field(default_factory=_read_secret_key)
 
     # App metadata
+    # APP_CREATOR_ID accepts a comma-separated list of identifiers permitted
+    # to create new apps via POST /api/apps (in addition to Access admins). A
+    # single value (no commas) keeps the original single-creator behavior.
     APP_CREATOR_ID: Optional[str] = None
     APP_VERSION: str = "Not Defined"
     APP_NAME: str = "Access"
@@ -116,6 +119,12 @@ class Settings(BaseSettings):
         if "Manager" in attrs:
             attrs.remove("Manager")
         return attrs
+
+    @property
+    def app_creator_ids(self) -> list[str]:
+        if self.APP_CREATOR_ID is None:
+            return []
+        return [s.strip() for s in self.APP_CREATOR_ID.split(",") if s.strip()]
 
 
 def _build_settings() -> Settings:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,7 @@
+from api.config import Settings
+
+
+def test_app_creator_ids() -> None:
+    assert Settings(APP_CREATOR_ID=None).app_creator_ids == []
+    assert Settings(APP_CREATOR_ID="test1").app_creator_ids == ["test1"]
+    assert Settings(APP_CREATOR_ID="test1,test2").app_creator_ids == ["test1", "test2"]


### PR DESCRIPTION
Parsed as comma-separated so multiple identifiers can be permitted to create apps. 
Existing single-value configs parse to a one-element list and are unchanged.