### PR TITLE
Wire Claude Code Desktop Preview for the dev stack

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,14 +5,14 @@
       "name": "backend",
       "runtimeExecutable": "make",
       "runtimeArgs": ["run-backend"],
-      "port": 8000,
+      "port": 6060,
       "autoPort": true
     },
     {
       "name": "frontend",
       "runtimeExecutable": "make",
       "runtimeArgs": ["run-frontend"],
-      "port": 5173,
+      "port": 3000,
       "autoPort": true
     }
   ]

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "backend",
+      "runtimeExecutable": "make",
+      "runtimeArgs": ["run-backend"],
+      "port": 8000,
+      "autoPort": true
+    },
+    {
+      "name": "frontend",
+      "runtimeExecutable": "make",
+      "runtimeArgs": ["run-frontend"],
+      "port": 5173,
+      "autoPort": true
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 instance/*
 !instance/.gitignore
 .env
+# Port handoff for Claude Code Desktop Preview (see .claude/launch.json)
+.claude/.api-port
 
 ### Python ###
 # Byte-compiled / optimized / DLL files

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -10,3 +10,7 @@
 config/config.override.json
 config/config.development.json
 config/config.test.json
+
+# Local SQLite DB (LOCAL_DB_URI in the Makefile). Carrying it across
+# worktrees skips re-running `make db-init` for each new worktree.
+instance/access.db

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ LOCAL_DB_URI ?= sqlite:///instance/access.db
 
 # Ports — overridable via the PORT env var so Claude Code Desktop Preview's
 # autoPort can pick a free port per worktree. See .claude/launch.json.
-BACKEND_PORT  ?= $(if $(PORT),$(PORT),8000)
-FRONTEND_PORT ?= $(if $(PORT),$(PORT),5173)
+BACKEND_PORT  ?= $(if $(PORT),$(PORT),6060)
+FRONTEND_PORT ?= $(if $(PORT),$(PORT),3000)
 
 .PHONY: help
 help:

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,17 @@ ACTIVATE := $(if $(wildcard venv/bin/activate),. venv/bin/activate &&,)
 # Local sqlite DB used for `make run` / `make db-*` targets
 LOCAL_DB_URI ?= sqlite:///instance/access.db
 
+# Ports — overridable via the PORT env var so Claude Code Desktop Preview's
+# autoPort can pick a free port per worktree. See .claude/launch.json.
+BACKEND_PORT  ?= $(if $(PORT),$(PORT),8000)
+FRONTEND_PORT ?= $(if $(PORT),$(PORT),5173)
+
 .PHONY: help
 help:
 	@echo "Access dev targets:"
-	@echo "  make run                Run backend (port 6060) and frontend together"
-	@echo "  make run-backend        Run uvicorn on port 6060 with --reload"
-	@echo "  make run-frontend       Run Vite dev server on port 3000"
+	@echo "  make run                Run backend (port $(BACKEND_PORT)) and frontend (port $(FRONTEND_PORT)) together"
+	@echo "  make run-backend        Run uvicorn on port $(BACKEND_PORT) with --reload"
+	@echo "  make run-frontend       Run Vite dev server on port $(FRONTEND_PORT)"
 	@echo ""
 	@echo "Database:"
 	@echo "  make db-migrate         alembic upgrade head"
@@ -71,19 +76,23 @@ dev:
 # ----------------------------------------------------------------------
 
 .PHONY: run
-run: .env dev
+run: .env dev db-migrate
+	@mkdir -p .claude
+	@printf '%s\n' "$(BACKEND_PORT)" > .claude/.api-port
 	$(ACTIVATE) DATABASE_URI=$(LOCAL_DB_URI) \
-	uvicorn --reload --host 0.0.0.0 --port 6060 api.asgi:app & \
-	cd . && npm install && npm start
+	uvicorn --reload --host 0.0.0.0 --port $(BACKEND_PORT) api.asgi:app & \
+	npm install && npx vite --host 0.0.0.0 --port $(FRONTEND_PORT)
 
 .PHONY: run-frontend
 run-frontend:
-	npm install && npm start
+	npm install && npx vite --host 0.0.0.0 --port $(FRONTEND_PORT)
 
 .PHONY: run-backend
-run-backend: .env dev
+run-backend: .env dev db-migrate
+	@mkdir -p .claude
+	@printf '%s\n' "$(BACKEND_PORT)" > .claude/.api-port
 	$(ACTIVATE) DATABASE_URI=$(LOCAL_DB_URI) \
-	uvicorn --reload --host 0.0.0.0 --port 6060 api.asgi:app
+	uvicorn --reload --host 0.0.0.0 --port $(BACKEND_PORT) api.asgi:app
 
 # ----------------------------------------------------------------------
 # Database / migrations

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ const PORT_FILE = '.claude/.api-port';
 const DEFAULT_BACKEND_PORT = 6060;
 
 // Resolves the backend port from .claude/.api-port (written by the Makefile),
-// then ACCESS_API_PORT, then the default. Read at Vite startup, so the
+// then BACKEND_PORT, then the default. Read at Vite startup, so the
 // backend should be started before the frontend in Claude Code Desktop
 // Preview; restart Vite if the backend port changes.
 function resolveBackendPort(): number {
@@ -21,7 +21,7 @@ function resolveBackendPort(): number {
   } catch {
     // fall through
   }
-  const fromEnv = parseInt(process.env.ACCESS_API_PORT ?? '', 10);
+  const fromEnv = parseInt(process.env.BACKEND_PORT ?? '', 10);
   if (Number.isFinite(fromEnv) && fromEnv > 0) return fromEnv;
   return DEFAULT_BACKEND_PORT;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,10 +44,10 @@ export default defineConfig(({mode}) => {
       REQUIRE_DESCRIPTIONS: env.REQUIRE_DESCRIPTIONS?.toLowerCase() === 'true',
     },
     server: {
-      port: 5173,
+      port: 3000,
       proxy: {
         '/api': {
-          target: 'http://localhost:8000',
+          target: 'http://localhost:6060',
           changeOrigin: true,
           router: () => {
             try {
@@ -56,7 +56,7 @@ export default defineConfig(({mode}) => {
             } catch {
               // .api-port missing — fall through to default target
             }
-            return 'http://localhost:8000';
+            return 'http://localhost:6060';
           },
         },
       },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,25 @@ import {loadAccessConfig} from './src/config/loadAccessConfig';
 
 const accessConfig = loadAccessConfig();
 
+const PORT_FILE = '.claude/.api-port';
+const DEFAULT_BACKEND_PORT = 6060;
+
+// Resolves the backend port from .claude/.api-port (written by the Makefile),
+// then ACCESS_API_PORT, then the default. Read at Vite startup, so the
+// backend should be started before the frontend in Claude Code Desktop
+// Preview; restart Vite if the backend port changes.
+function resolveBackendPort(): number {
+  try {
+    const fromFile = parseInt(readFileSync(PORT_FILE, 'utf8').trim(), 10);
+    if (Number.isFinite(fromFile) && fromFile > 0) return fromFile;
+  } catch {
+    // fall through
+  }
+  const fromEnv = parseInt(process.env.ACCESS_API_PORT ?? '', 10);
+  if (Number.isFinite(fromEnv) && fromEnv > 0) return fromEnv;
+  return DEFAULT_BACKEND_PORT;
+}
+
 export default defineConfig(({mode}) => {
   // Load env file based on `mode` in the current working directory.
   // Process environment variables take precedence over .env files
@@ -47,17 +66,9 @@ export default defineConfig(({mode}) => {
       port: 3000,
       proxy: {
         '/api': {
-          target: 'http://localhost:6060',
+          target: `http://localhost:${resolveBackendPort()}`,
           changeOrigin: true,
-          router: () => {
-            try {
-              const port = readFileSync('.claude/.api-port', 'utf8').trim();
-              if (port) return `http://localhost:${port}`;
-            } catch {
-              // .api-port missing — fall through to default target
-            }
-            return 'http://localhost:6060';
-          },
+          secure: false,
         },
       },
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 /// <reference types="vitest" />
+import {readFileSync} from 'node:fs';
 import {defineConfig, loadEnv} from 'vite';
 import react from '@vitejs/plugin-react';
 import {sentryVitePlugin} from '@sentry/vite-plugin';
@@ -43,11 +44,20 @@ export default defineConfig(({mode}) => {
       REQUIRE_DESCRIPTIONS: env.REQUIRE_DESCRIPTIONS?.toLowerCase() === 'true',
     },
     server: {
-      port: 3000,
+      port: 5173,
       proxy: {
         '/api': {
-          target: 'http://localhost:6060',
+          target: 'http://localhost:8000',
           changeOrigin: true,
+          router: () => {
+            try {
+              const port = readFileSync('.claude/.api-port', 'utf8').trim();
+              if (port) return `http://localhost:${port}`;
+            } catch {
+              // .api-port missing — fall through to default target
+            }
+            return 'http://localhost:8000';
+          },
         },
       },
     },


### PR DESCRIPTION
## Summary

- Adds `.claude/launch.json` so Claude Code Desktop's **Preview** dropdown can auto-start uvicorn and Vite, open the embedded browser, and run auto-verify after edits.
- Both servers use `autoPort: true` so multiple worktree sessions can run side-by-side without colliding on the dev ports.
- Pushes compound startup logic (venv activation, `alembic upgrade head`, port handoff) into the Makefile so it's reusable from the terminal and discoverable via `make help`.
- Carries the local SQLite DB across new worktrees via `.worktreeinclude`.

## What changed

**`.claude/launch.json`** — two minimal configs that shell out to `make run-backend` / `make run-frontend`, with `autoPort: true` and preferred ports `6060` / `3000` (the historical defaults).

**`Makefile`** —
- New `BACKEND_PORT` / `FRONTEND_PORT` variables that honor the `PORT` env var (which Claude injects when autoPort picks a free port) and fall back to `6060` / `3000`.
- `run-backend` now depends on `db-migrate`, writes the bound port to `.claude/.api-port`, and uses `$(BACKEND_PORT)` for uvicorn's `--port`. Same shape for `run`.
- `run-frontend` switched from `npm start` to `npx vite --port $(FRONTEND_PORT)` so the flag wins over `vite.config.ts`.
- Help text interpolates the variables.

**`vite.config.ts`** — keeps `server.port: 3000` and the static `target: 'http://localhost:6060'` proxy fallback, and reads `.claude/.api-port` at Vite startup to pick up the autoPort-assigned backend port (matches the keysmith pattern; restart Vite if the backend port changes).

**`.gitignore`** — adds `.claude/.api-port`.

**`.worktreeinclude`** — adds `instance/access.db` so new worktrees inherit the local dev SQLite DB instead of starting empty. (Already gitignored via `instance/*`, which `.worktreeinclude` requires.)

## Why the file-based port handoff

`launch.json`'s `env` is static (same value across worktrees), so we can't bake the backend port into the frontend config. The backend writes its assigned port to `.claude/.api-port` when it starts, and Vite reads that file once at startup to configure the `/api` proxy target — so the backend must be started before the frontend, and Vite needs to be restarted if the backend port changes. Each worktree has its own `.claude/` directory, so worktrees stay isolated.

The browser only talks to Vite, which proxies `/api/*` with `changeOrigin: true`, so the backend sees server-to-server requests from Vite — `CLIENT_ORIGIN_URL`/CORS need no changes.

## No port changes for terminal users

Dev port defaults stay at `6060` (backend) and `3000` (frontend), so `make run` from a terminal behaves exactly as before. autoPort only changes ports when the defaults are taken (e.g. a second worktree session running in parallel).

## Test plan

- [x] Single worktree: open Desktop → **Preview** dropdown shows `backend` and `frontend`. Start both. Backend binds 6060, frontend binds 3000, `.claude/.api-port` contains `6060`, embedded browser loads Access, a sample `/api/*` request returns expected JSON.
- [ ] Multi-worktree: open a session in a second worktree and start Preview there. Backend autoports to e.g. 6061, frontend to e.g. 3001, that worktree's `.claude/.api-port` contains `6061`. Confirm in DevTools that `/api/*` from the second worktree's frontend hits the second worktree's backend.
- [ ] Backend-port change requires Vite restart: change the backend port and confirm `/api/*` fails until Vite is restarted (re-reads `.claude/.api-port` at startup).
- [ ] Terminal flow: `make run` in a fresh checkout → backend on 6060, frontend on 3000, app works as before.
- [ ] Fallback: delete `.claude/.api-port` and start Vite. Confirm `/api/*` proxies to `localhost:6060` and the app still works as long as a backend is listening there.
- [ ] Worktree DB carryover: create a new worktree from a checkout with a populated `instance/access.db`; confirm the DB is copied into the new worktree and `make run` doesn't require re-running `make db-init`.
- [ ] Auto-verify: ask Claude to make a frontend edit; confirm Desktop screenshots the preview and verifies the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
