### PR TITLE
Allow APP_GROUP_DELETER_ID users to delete managed app groups

### DIFF
--- a/api/auth/permissions.py
+++ b/api/auth/permissions.py
@@ -113,6 +113,12 @@ def can_manage_group(db: Session, current_user_id: str, group: OktaGroup) -> boo
     return False
 
 
+def can_delete_group(db: Session, current_user_id: str, group: OktaGroup) -> bool:
+    if current_user_id in settings.app_group_deleter_ids and type(group) is AppGroup and group.is_managed:
+        return True
+    return can_manage_group(db, current_user_id, group)
+
+
 # --- Depends factories -----------------------------------------------------
 
 

--- a/api/config.py
+++ b/api/config.py
@@ -101,6 +101,10 @@ class Settings(BaseSettings):
     # to create new apps via POST /api/apps (in addition to Access admins). A
     # single value (no commas) keeps the original single-creator behavior.
     APP_CREATOR_ID: Optional[str] = None
+    # APP_GROUP_DELETER_ID accepts a comma-separated list of identifiers
+    # permitted to delete managed AppGroups (in addition to the existing
+    # group-owner / app-owner / access-admin paths).
+    APP_GROUP_DELETER_ID: Optional[str] = None
     APP_VERSION: str = "Not Defined"
     APP_NAME: str = "Access"
 
@@ -125,6 +129,12 @@ class Settings(BaseSettings):
         if self.APP_CREATOR_ID is None:
             return []
         return [s.strip() for s in self.APP_CREATOR_ID.split(",") if s.strip()]
+
+    @property
+    def app_group_deleter_ids(self) -> list[str]:
+        if self.APP_GROUP_DELETER_ID is None:
+            return []
+        return [s.strip() for s in self.APP_GROUP_DELETER_ID.split(",") if s.strip()]
 
 
 def _build_settings() -> Settings:

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -383,7 +383,7 @@ def delete_group(group_id: str, db: DbSession, current_user_id: CurrentUserId) -
     group = _load_group_with_options(db, group_id)
     if group is None:
         raise HTTPException(404, "Not Found")
-    if not _perms.can_manage_group(db, current_user_id, group):
+    if not _perms.can_delete_group(db, current_user_id, group):
         raise HTTPException(403, "Current user is not allowed to perform this action")
     if not group.is_managed:
         raise HTTPException(400, "Groups not managed by Access cannot be modified")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,3 +5,9 @@ def test_app_creator_ids() -> None:
     assert Settings(APP_CREATOR_ID=None).app_creator_ids == []
     assert Settings(APP_CREATOR_ID="test1").app_creator_ids == ["test1"]
     assert Settings(APP_CREATOR_ID="test1,test2").app_creator_ids == ["test1", "test2"]
+
+
+def test_app_group_deleter_ids() -> None:
+    assert Settings(APP_GROUP_DELETER_ID=None).app_group_deleter_ids == []
+    assert Settings(APP_GROUP_DELETER_ID="test1").app_group_deleter_ids == ["test1"]
+    assert Settings(APP_GROUP_DELETER_ID="test1,test2").app_group_deleter_ids == ["test1", "test2"]

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -733,6 +733,41 @@ def test_delete_group(
     assert AppTagMap.query.filter(AppTagMap.ended_at.is_(None)).count() == 1
 
 
+def test_delete_group_as_app_group_deleter(
+    client: TestClient,
+    db: Db,
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    okta_group: OktaGroup,
+    app_group: AppGroup,
+    access_app: App,
+    user: OktaUser,
+    url_for: Any,
+    mock_user: Any,
+) -> None:
+    db.session.add_all([user, access_app, okta_group])
+    db.session.commit()
+    app_group.app_id = access_app.id
+    app_group.is_owner = False
+    db.session.add(app_group)
+    unmanaged = AppGroupFactory.build(app_id=access_app.id, is_owner=False, is_managed=False)
+    db.session.add(unmanaged)
+    db.session.commit()
+
+    mocker.patch.object(okta, "async_delete_group")
+    mock_user(user.id)
+    monkeypatch.setattr(settings, "APP_GROUP_DELETER_ID", f"someone-else,{user.id}")
+
+    # Managed AppGroup: allowed.
+    rep = client.delete(url_for("api-groups.group_by_id", group_id=app_group.id))
+    assert rep.status_code == 200
+    assert db.session.get(OktaGroup, app_group.id).deleted_at is not None
+
+    # Plain OktaGroup and unmanaged AppGroup: still 403.
+    assert client.delete(url_for("api-groups.group_by_id", group_id=okta_group.id)).status_code == 403
+    assert client.delete(url_for("api-groups.group_by_id", group_id=unmanaged.id)).status_code == 403
+
+
 def test_create_group(
     client: TestClient,
     db: Db,


### PR DESCRIPTION
Adds a dedicated `APP_GROUP_DELETER_ID` config, parsed comma-separated like `APP_CREATOR_ID` in #444. Identifiers in the list may DELETE managed AppGroups via `/api/groups/{id}`. The grant is scoped narrowly: plain OktaGroups and unmanaged AppGroups still 403, and the existing group-owner / app-owner / access-admin paths are unchanged.