### PR TITLE
Replace requests with httpx in Cloudflare JWKS fetch

### DIFF
--- a/api/auth/cloudflare.py
+++ b/api/auth/cloudflare.py
@@ -12,8 +12,8 @@ import logging
 import threading
 from typing import Any, Dict, Optional
 
+import httpx
 import jwt
-import requests
 from cachetools import TTLCache, cached
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
 from fastapi import HTTPException
@@ -35,7 +35,7 @@ _jwks_cache_lock = threading.RLock()
 
 @cached(cache=TTLCache(maxsize=1, ttl=3600), lock=_jwks_cache_lock)
 def _signing_keys(team_domain: str) -> Dict[str, RSAPrivateKey | RSAPublicKey]:
-    r = requests.get(
+    r = httpx.get(
         f"https://{team_domain}/cdn-cgi/access/certs",
         timeout=10,
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ pg8000==1.31.5
 
 # HTTP
 httpx==0.28.1
-requests==2.33.0
 
 # Security / auth
 PyJWT[crypto]==2.12.1
@@ -42,5 +41,4 @@ ruff==0.8.0
 # Typing
 mypy==1.13.0
 types-python-dateutil==2.9.0.20250822
-types-requests==2.32.0.20241016
 types-cachetools==7.0.0.20260503


### PR DESCRIPTION
## Summary

- The codebase already depends on `httpx` (used by `api/routers/bugs.py`), and the Cloudflare Access JWKS fetcher in `api/auth/cloudflare.py` was the only remaining user of `requests`. Switch it to `httpx` and drop the redundant runtime dep + type stubs.
- `httpx.get`, `raise_for_status`, and `.json()` are API-compatible with `requests` for this call, so the function body is otherwise unchanged.
- Kept the function synchronous — it's wrapped in `cachetools.cached` and called from a sync FastAPI dependency that already runs on `anyio` worker threads. Going async would force a refactor of every caller for no gain.

## Notes for reviewers

- Behavior on network/HTTP errors is preserved: nothing in `cloudflare.py` or its callers catches `requests.exceptions.*`, so swapping in `httpx.RequestError` / `httpx.HTTPStatusError` (the equivalent exception types) doesn't change any handled paths — they bubble up to FastAPI's default handler the same way.
- `httpx`'s `timeout=10` covers connect/read/write/pool; effectively at-least-as-strict as `requests`' single timeout for this call.

## Test plan

- [x] `tox` (or `pytest`) passes
- [x] `mypy api` passes (no more `types-requests`)
- [x] `ruff check .` passes
- [ ] With `CLOUDFLARE_TEAM_DOMAIN` configured, an authenticated request still verifies successfully end-to-end (real JWKS fetch on cache miss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
