### PR TITLE
Fix audit endpoints dropping rows whose related active_* row is soft-deleted

### DIFF
--- a/api/routers/audit.py
+++ b/api/routers/audit.py
@@ -243,11 +243,8 @@ def _audit_user_group_row(m: OktaUserGroupMember, include_role_associations: boo
         updated_at=getattr(m, "updated_at", None),
         ended_at=m.ended_at,
         user=_user_summary_for_audit(getattr(m, "user", None)),
-        active_user=_user_summary_for_audit(getattr(m, "active_user", None)),
         group=_group_ref_for_audit(getattr(m, "group", None), include_role_associations),
-        active_group=_group_ref_for_audit(getattr(m, "active_group", None), include_role_associations=False),
         role_group_mapping=_role_group_mapping_for_audit(getattr(m, "role_group_mapping", None)),
-        active_role_group_mapping=_role_group_mapping_for_audit(getattr(m, "active_role_group_mapping", None)),
         access_request=_access_request_ref_for_audit(getattr(m, "access_request", None)),
         created_actor=_user_summary_for_audit(getattr(m, "created_actor", None)),
         ended_actor=_user_summary_for_audit(getattr(m, "ended_actor", None)),
@@ -265,9 +262,7 @@ def _audit_group_role_row(rgm: RoleGroupMap) -> AuditGroupRoleRow:
         created_at=rgm.created_at,
         ended_at=rgm.ended_at,
         group=_group_ref_for_audit(getattr(rgm, "group", None), include_role_associations=False),
-        active_group=_group_ref_for_audit(getattr(rgm, "active_group", None), include_role_associations=False),
         role_group=_role_group_ref_for_audit(getattr(rgm, "role_group", None)),
-        active_role_group=_role_group_ref_for_audit(getattr(rgm, "active_role_group", None)),
         created_actor=_user_summary_for_audit(getattr(rgm, "created_actor", None)),
         ended_actor=_user_summary_for_audit(getattr(rgm, "ended_actor", None)),
     )
@@ -324,17 +319,11 @@ def users_and_groups(
         db.query(OktaUserGroupMember)
         .options(
             joinedload(OktaUserGroupMember.user),
-            joinedload(OktaUserGroupMember.active_user),
             joinedload(OktaUserGroupMember.created_actor),
             joinedload(OktaUserGroupMember.ended_actor),
             joinedload(OktaUserGroupMember.access_request),
             group_load,
-            selectinload(OktaUserGroupMember.active_group).options(
-                selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
-                joinedload(AppGroup.app),
-            ),
             selectinload(OktaUserGroupMember.role_group_mapping).joinedload(RoleGroupMap.role_group),
-            selectinload(OktaUserGroupMember.active_role_group_mapping).joinedload(RoleGroupMap.active_role_group),
         )
         .join(OktaUserGroupMember.user)
         .join(OktaUserGroupMember.group.of_type(group_alias))
@@ -539,7 +528,6 @@ def groups_and_roles(
         db.query(RoleGroupMap)
         .options(
             joinedload(RoleGroupMap.role_group),
-            joinedload(RoleGroupMap.active_role_group),
             joinedload(RoleGroupMap.created_actor),
             joinedload(RoleGroupMap.ended_actor),
             selectinload(RoleGroupMap.group).options(
@@ -549,10 +537,6 @@ def groups_and_roles(
                     joinedload(OktaGroupTagMap.active_tag),
                     joinedload(OktaGroupTagMap.active_app_tag_mapping).joinedload(AppTagMap.active_app),
                 ),
-            ),
-            selectinload(RoleGroupMap.active_group).options(
-                selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
-                joinedload(AppGroup.app),
             ),
         )
         .join(RoleGroupMap.role_group)

--- a/api/schemas/audit_rows.py
+++ b/api/schemas/audit_rows.py
@@ -133,11 +133,8 @@ class AuditUserGroupRow(BaseModel):
     updated_at: RFC822DatetimeOpt = None
     ended_at: RFC822DatetimeOpt = None
     user: Optional[_UserSummaryForAudit] = None
-    active_user: Optional[_UserSummaryForAudit] = None
     group: Optional[_GroupRefForAudit] = None
-    active_group: Optional[_GroupRefForAudit] = None
     role_group_mapping: Optional[_RoleGroupMappingForAudit] = None
-    active_role_group_mapping: Optional[_RoleGroupMappingForAudit] = None
     access_request: Optional[_AccessRequestRef] = None
     created_actor: Optional[_UserSummaryForAudit] = None
     ended_actor: Optional[_UserSummaryForAudit] = None
@@ -155,9 +152,7 @@ class AuditGroupRoleRow(BaseModel):
     created_at: RFC822DatetimeOpt = None
     ended_at: RFC822DatetimeOpt = None
     group: Optional[_GroupRefForAudit] = None
-    active_group: Optional[_GroupRefForAudit] = None
     role_group: Optional[_RoleGroupRefForAudit] = None
-    active_role_group: Optional[_RoleGroupRefForAudit] = None
     created_actor: Optional[_UserSummaryForAudit] = None
     ended_actor: Optional[_UserSummaryForAudit] = None
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -720,3 +720,61 @@ def test_groups_audit_q_with_role_and_owner_pin(client: TestClient, db: Db, url_
     assert rep.status_code == 200, rep.text
     rows = rep.json()["results"]
     assert all(r.get("group", {}).get("id") != associated.id for r in rows)
+
+
+def test_users_audit_returns_rows_when_user_is_soft_deleted(
+    client: TestClient, db: Db, url_for: Any
+) -> None:
+    """`/api/audit/users` must surface every membership in a group's history,
+    including those whose user has since been soft-deleted. Pre-fix the query
+    eager-loaded `OktaUserGroupMember.active_user`, whose relationship carries
+    `innerjoin=True` + `deleted_at IS NULL`, so SQLAlchemy emitted an INNER
+    JOIN that silently dropped the row for any soft-deleted user."""
+    group = OktaGroupFactory.create()
+    user = OktaUserFactory.create()
+    db.session.add_all([group, user])
+    db.session.commit()
+    ModifyGroupUsers(group=group, members_to_add=[user.id], sync_to_okta=False).execute()
+
+    user.deleted_at = datetime.now(timezone.utc)
+    db.session.commit()
+
+    rep = client.get(url_for("api-audit.users_and_groups"), params={"group_id": group.id})
+    assert rep.status_code == 200, rep.text
+    rows = rep.json()["results"]
+    matching = [r for r in rows if r["user_id"] == user.id]
+    assert len(matching) == 1
+    row = matching[0]
+    assert row["user"]["id"] == user.id
+    assert row["user"]["deleted_at"] is not None
+    # Pre-migration wire shape — these keys should not appear on audit rows.
+    for absent in ("active_user", "active_group", "active_role_group_mapping"):
+        assert absent not in row, f"audit row should not include {absent!r}"
+
+
+def test_groups_audit_returns_rows_when_role_group_is_soft_deleted(
+    client: TestClient, db: Db, url_for: Any
+) -> None:
+    """Mirror regression for `/api/audit/groups`. The migration added
+    `joinedload(RoleGroupMap.active_role_group)`, and that relationship has
+    the same `innerjoin=True` + `deleted_at IS NULL` shape, so audit rows
+    were silently dropped when the role group was soft-deleted."""
+    role = RoleGroupFactory.create()
+    group = OktaGroupFactory.create()
+    db.session.add_all([role, group])
+    db.session.commit()
+    ModifyRoleGroups(role_group=role, groups_to_add=[group.id], sync_to_okta=False).execute()
+
+    role.deleted_at = datetime.now(timezone.utc)
+    db.session.commit()
+
+    rep = client.get(url_for("api-audit.groups_and_roles"), params={"group_id": group.id})
+    assert rep.status_code == 200, rep.text
+    rows = rep.json()["results"]
+    matching = [r for r in rows if r["role_group_id"] == role.id]
+    assert len(matching) == 1
+    row = matching[0]
+    assert row["role_group"]["id"] == role.id
+    assert row["role_group"]["deleted_at"] is not None
+    for absent in ("active_group", "active_role_group"):
+        assert absent not in row, f"audit row should not include {absent!r}"

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -722,9 +722,7 @@ def test_groups_audit_q_with_role_and_owner_pin(client: TestClient, db: Db, url_
     assert all(r.get("group", {}).get("id") != associated.id for r in rows)
 
 
-def test_users_audit_returns_rows_when_user_is_soft_deleted(
-    client: TestClient, db: Db, url_for: Any
-) -> None:
+def test_users_audit_returns_rows_when_user_is_soft_deleted(client: TestClient, db: Db, url_for: Any) -> None:
     """`/api/audit/users` must surface every membership in a group's history,
     including those whose user has since been soft-deleted. Pre-fix the query
     eager-loaded `OktaUserGroupMember.active_user`, whose relationship carries
@@ -752,9 +750,7 @@ def test_users_audit_returns_rows_when_user_is_soft_deleted(
         assert absent not in row, f"audit row should not include {absent!r}"
 
 
-def test_groups_audit_returns_rows_when_role_group_is_soft_deleted(
-    client: TestClient, db: Db, url_for: Any
-) -> None:
+def test_groups_audit_returns_rows_when_role_group_is_soft_deleted(client: TestClient, db: Db, url_for: Any) -> None:
     """Mirror regression for `/api/audit/groups`. The migration added
     `joinedload(RoleGroupMap.active_role_group)`, and that relationship has
     the same `innerjoin=True` + `deleted_at IS NULL` shape, so audit rows


### PR DESCRIPTION
## Summary

- Removes the `joinedload(active_user)` / `joinedload(active_role_group)` introduced by the FastAPI migration in #425 that caused audit pages to silently drop rows whose user or role group had been soft-deleted (reducing one production page from 398 entries to 19).
- Drops the matching unused `active_*` fields from the audit response schemas — the `user` / `group` / `role_group` fields (with their existing `deleted_at` columns) are all the frontend reads off audit rows; no consumer touches the `active_*` keys.
- Adds regression tests for the soft-deleted user and soft-deleted role-group cases.

## Why

`OktaUserGroupMember.active_user` and `RoleGroupMap.active_role_group` are defined with `innerjoin=True` plus a `primaryjoin` filter on `deleted_at IS NULL`. When the migration eager-loaded them via `joinedload(...)`, SQLAlchemy emitted INNER JOINs that excluded any row whose target had since been soft-deleted, even though the audit row itself is valid history. `selectinload(active_group)` / `selectinload(active_role_group_mapping)` don't cause the same regression but were unused additions on the response and have been dropped for consistency with the pre-migration Flask wire shape. The base `joinedload(user)` / `joinedload(group)` / `joinedload(role_group)` (all unfiltered) plus the existing `deleted_at` on the row helpers give the frontend everything it needs to render soft-deleted entities.

The shared helper `api/routers/_eager.py:40` has the same `joinedload(active_user)` pattern but is used by `groups`/`apps`/`users`/`role_requests` routes whose consumers *do* read `active_user`, so the fix there is `joinedload(..., innerjoin=False)` or `selectinload(...)` rather than deletion — left for a separate follow-up.

## Test plan

- [x] `pytest tests/` — 424 passed
- [x] New `test_users_audit_returns_rows_when_user_is_soft_deleted` and `test_groups_audit_returns_rows_when_role_group_is_soft_deleted` cover the regression
- [x] `ruff check` clean on the touched files
- [ ] UI smoke: `/groups/Role-All-Employees/audit?active=false` shows soft-deleted users with the strikethrough style (handled by the existing `displayUserName` helper off `user.deleted_at`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
