### PR TITLE
Collapse user read sections + free-text search

### DIFF
--- a/src/pages/apps/components/AppsAdminActionGroup.tsx
+++ b/src/pages/apps/components/AppsAdminActionGroup.tsx
@@ -1,8 +1,10 @@
-import {Autocomplete, Button, Grid, Paper, Stack, TextField, Box} from '@mui/material';
+import {Autocomplete, Button, Grid, Paper, TextField, Box} from '@mui/material';
+import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
+import UnfoldMoreIcon from '@mui/icons-material/UnfoldMore';
 import CreateUpdateGroup from '../../groups/CreateUpdate';
 import {OktaUser, App, AppGroup} from '../../../api/apiSchemas';
 import {renderUserOption} from '../../../components/TableTopBar';
-import {displayUserName, extractEmailFromDisplayName, sortGroupMemberRecords, sortGroupMembers} from '../../../helpers';
+import {displayUserName, sortGroupMemberRecords} from '../../../helpers';
 import React from 'react';
 
 interface AppsAdminActionGroupProps {
@@ -45,20 +47,33 @@ export const AppsAdminActionGroup: React.FC<AppsAdminActionGroupProps> = React.m
       return {allMembers, memberGroups, sortedUserOptions};
     }, [app.active_non_owner_app_groups]);
 
+    const allMembersRef = React.useRef(allMembers);
     const memberGroupsRef = React.useRef(memberGroups);
     const appGroupsRef = React.useRef(app.active_non_owner_app_groups);
     const onSearchSubmitRef = React.useRef(onSearchSubmit);
 
+    allMembersRef.current = allMembers;
     memberGroupsRef.current = memberGroups;
     appGroupsRef.current = app.active_non_owner_app_groups;
     onSearchSubmitRef.current = onSearchSubmit;
 
     const handleSearchSubmit = React.useCallback((_: unknown, newValue: string | null) => {
-      const email = extractEmailFromDisplayName(newValue);
-      const appGroups = memberGroupsRef.current[email] ?? appGroupsRef.current;
-      if (!!onSearchSubmitRef.current) {
-        onSearchSubmitRef.current(appGroups);
+      const q = newValue?.trim().toLowerCase() ?? '';
+      const fallback = appGroupsRef.current ?? [];
+      if (!q) {
+        onSearchSubmitRef.current?.(fallback);
+        return;
       }
+      const matchedById: Record<string, AppGroup> = {};
+      Object.values(allMembersRef.current).forEach((user) => {
+        const name = displayUserName(user).toLowerCase();
+        const email = user.email.toLowerCase();
+        if (!name.includes(q) && !email.includes(q)) return;
+        (memberGroupsRef.current[email] ?? []).forEach((g) => {
+          if (g.id) matchedById[g.id] = g;
+        });
+      });
+      onSearchSubmitRef.current?.(Object.values(matchedById));
     }, []);
 
     const onToggleExpandRef = React.useRef(onToggleExpand);
@@ -75,84 +90,35 @@ export const AppsAdminActionGroup: React.FC<AppsAdminActionGroupProps> = React.m
 
     return (
       <Grid item xs={12} className={'app-detail app-detail-admin-action-group'}>
-        <Paper
-          sx={{
-            p: 2,
-            display: 'flex',
-            alignItems: 'center',
-          }}>
+        <Paper sx={{p: 2}}>
           <Box
             sx={{
               display: 'flex',
-              width: '100%',
-              flexDirection: {xs: 'column', md: 'row'},
-              gap: {xs: 2, md: 0},
-              alignItems: {xs: 'stretch', md: 'center'},
-              justifyContent: 'space-between',
-              '@media (max-width: 680px)': {
-                flexDirection: 'column',
-                gap: 2,
-                alignItems: 'stretch',
-              },
-              '@media (min-width: 681px)': {
-                flexDirection: 'row',
-                gap: 0,
-                alignItems: 'center',
-              },
+              flexWrap: 'wrap',
+              alignItems: 'center',
+              gap: 2,
             }}>
-            <Box
-              sx={{
-                flex: {xs: 'none', md: '1 1 auto'},
-                '@media (max-width: 680px)': {
-                  flex: 'none',
-                },
-                '@media (min-width: 681px)': {
-                  flex: '1 1 auto',
-                },
-              }}>
+            <Box sx={{flexShrink: 0}}>
               <CreateUpdateGroup defaultGroupType={'app_group'} currentUser={currentUser} app={app} />
             </Box>
             <Box
               sx={{
                 display: 'flex',
-                flexDirection: {xs: 'column', md: 'row'},
+                flexWrap: 'wrap',
+                alignItems: 'center',
                 gap: 2,
-                alignItems: {xs: 'stretch', md: 'center'},
-                flex: {xs: 'none', md: '0 0 auto'},
-                minWidth: {md: 'auto', lg: '400px'},
-                '@media (max-width: 680px)': {
-                  flexDirection: 'column',
-                  flex: 'none',
-                  alignItems: 'stretch',
-                },
-                '@media (min-width: 681px)': {
-                  flexDirection: 'row',
-                  flex: '0 0 auto',
-                  alignItems: 'center',
-                },
+                flex: '1 1 auto',
+                minWidth: 0,
+                marginLeft: 'auto',
+                justifyContent: 'flex-end',
               }}>
               <Autocomplete
                 size="small"
-                sx={{
-                  flex: {xs: '1 1 auto', md: '1 1 320px'},
-                  minWidth: {xs: '100%', md: '200px'},
-                  maxWidth: {md: '320px'},
-                  '@media (max-width: 680px)': {
-                    flex: '1 1 auto',
-                    minWidth: '100%',
-                  },
-                  '@media (min-width: 681px)': {
-                    flex: '1 1 320px',
-                    minWidth: '200px',
-                    maxWidth: '320px',
-                  },
-                }}
-                renderInput={(params) => <TextField {...params} label="Search" />}
+                sx={{flex: '1 1 220px', minWidth: 0, maxWidth: 320}}
+                renderInput={(params) => <TextField {...params} label="Search Users" />}
                 options={sortedUserOptions}
                 onChange={handleSearchSubmit}
                 renderOption={renderUserOption}
-                autoHighlight
-                autoSelect
                 clearOnEscape
                 freeSolo
                 autoFocus
@@ -161,20 +127,10 @@ export const AppsAdminActionGroup: React.FC<AppsAdminActionGroupProps> = React.m
                 variant="contained"
                 color="primary"
                 size="small"
+                startIcon={isExpanded ? <UnfoldLessIcon /> : <UnfoldMoreIcon />}
                 onClick={handleToggleExpand}
-                sx={{
-                  flex: {xs: 'none', md: '0 0 auto'},
-                  minWidth: {xs: '100%', md: 'auto'},
-                  '@media (max-width: 680px)': {
-                    flex: 'none',
-                    minWidth: '100%',
-                  },
-                  '@media (min-width: 681px)': {
-                    flex: '0 0 auto',
-                    minWidth: 'auto',
-                  },
-                }}>
-                {isExpanded ? 'Collapse All' : 'Expand All'}
+                sx={{flexShrink: 0}}>
+                {isExpanded ? 'Collapse' : 'Expand'}
               </Button>
             </Box>
           </Box>

--- a/src/pages/users/Read.tsx
+++ b/src/pages/users/Read.tsx
@@ -2,7 +2,15 @@ import React from 'react';
 import {Link as RouterLink, useParams, useNavigate} from 'react-router-dom';
 
 import AuditIcon from '@mui/icons-material/History';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
+import UnfoldMoreIcon from '@mui/icons-material/UnfoldMore';
+import Accordion from '@mui/material/Accordion';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import Autocomplete from '@mui/material/Autocomplete';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Chip from '@mui/material/Chip';
@@ -24,6 +32,7 @@ import TableContainer from '@mui/material/TableContainer';
 import TableFooter from '@mui/material/TableFooter';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
+import TextField from '@mui/material/TextField';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 
@@ -177,6 +186,7 @@ interface GroupTableProps {
   groups: Record<string, OktaUserGroupMember[]>;
   user: OktaUser;
   owner: boolean;
+  filterGroupName?: string | null;
   onClickRemoveGroupFromRole: (removeGroup: PolymorphicGroup, fromRole: RoleGroup, owner: boolean) => void;
   onClickRemoveDirectAccess: (id: string, fromGroup: PolymorphicGroup, owner: boolean) => void;
 }
@@ -186,6 +196,7 @@ function GroupTable({
   groups,
   user,
   owner,
+  filterGroupName,
   onClickRemoveGroupFromRole,
   onClickRemoveDirectAccess,
 }: GroupTableProps) {
@@ -207,6 +218,12 @@ function GroupTable({
     [putGroupUsers, owner, user.id],
   );
 
+  const filterQuery = filterGroupName?.trim().toLowerCase() ?? '';
+  const filteredEntries = Object.entries(groups).filter(([_, members]) => {
+    if (!filterQuery) return true;
+    return (members[0]?.active_group?.name ?? '').toLowerCase().includes(filterQuery);
+  });
+
   return (
     <TableContainer component={Paper}>
       <Table size="small" aria-label={title.toLowerCase()}>
@@ -219,7 +236,7 @@ function GroupTable({
                 </Typography>
                 <Box sx={{display: 'flex', alignItems: 'center'}}>
                   <Divider sx={{mx: 2}} orientation="vertical" flexItem />
-                  Total: {Object.keys(groups).length}
+                  Total: {filteredEntries.length}
                 </Box>
               </Box>
             </TableCell>
@@ -231,8 +248,8 @@ function GroupTable({
           </TableRow>
         </TableHead>
         <TableBody>
-          {Object.keys(groups).length > 0 ? (
-            Object.entries(groups)
+          {filteredEntries.length > 0 ? (
+            filteredEntries
               .sort(sortUserGroups)
               .map(([groupId, groupMembers]: [string, Array<OktaUserGroupMember>]) => (
                 <TableRow key={groupId}>
@@ -299,6 +316,7 @@ interface SideBySideTablesProps {
   ownerships: Record<string, OktaUserGroupMember[]>;
   memberships: Record<string, OktaUserGroupMember[]>;
   user: OktaUser;
+  filterGroupName?: string | null;
   onClickRemoveGroupFromRole: (removeGroup: PolymorphicGroup, fromRole: RoleGroup, owner: boolean) => void;
   onClickRemoveDirectAccess: (id: string, fromGroup: PolymorphicGroup, owner: boolean) => void;
 }
@@ -307,6 +325,7 @@ function SideBySideTables({
   ownerships,
   memberships,
   user,
+  filterGroupName,
   onClickRemoveGroupFromRole,
   onClickRemoveDirectAccess,
 }: SideBySideTablesProps) {
@@ -318,6 +337,7 @@ function SideBySideTables({
           groups={ownerships}
           user={user}
           owner={true}
+          filterGroupName={filterGroupName}
           onClickRemoveGroupFromRole={onClickRemoveGroupFromRole}
           onClickRemoveDirectAccess={onClickRemoveDirectAccess}
         />
@@ -328,12 +348,96 @@ function SideBySideTables({
           groups={memberships}
           user={user}
           owner={false}
+          filterGroupName={filterGroupName}
           onClickRemoveGroupFromRole={onClickRemoveGroupFromRole}
           onClickRemoveDirectAccess={onClickRemoveDirectAccess}
         />
       </Grid>
     </Grid>
   );
+}
+
+interface CollapsibleSectionProps {
+  summaryLeft: React.ReactNode;
+  ownerships: Record<string, OktaUserGroupMember[]>;
+  memberships: Record<string, OktaUserGroupMember[]>;
+  user: OktaUser;
+  filterGroupName?: string | null;
+  expanded: boolean;
+  onToggle: (event: React.SyntheticEvent, expanded: boolean) => void;
+  onClickRemoveGroupFromRole: (removeGroup: PolymorphicGroup, fromRole: RoleGroup, owner: boolean) => void;
+  onClickRemoveDirectAccess: (id: string, fromGroup: PolymorphicGroup, owner: boolean) => void;
+}
+
+function CollapsibleSection({
+  summaryLeft,
+  ownerships,
+  memberships,
+  user,
+  filterGroupName,
+  expanded,
+  onToggle,
+  onClickRemoveGroupFromRole,
+  onClickRemoveDirectAccess,
+}: CollapsibleSectionProps) {
+  const ownerCount = Object.keys(ownerships).length;
+  const memberCount = Object.keys(memberships).length;
+
+  return (
+    <Accordion expanded={expanded} onChange={onToggle} TransitionProps={{unmountOnExit: true}}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Box sx={{display: 'inline-flex', flexGrow: 1, alignItems: 'center'}}>
+          <Box sx={{flexGrow: 0.95}}>{summaryLeft}</Box>
+          <Box sx={{display: 'flex', alignItems: 'center', justifyContent: 'flex-end'}}>
+            <Divider sx={{mx: 2}} orientation="vertical" flexItem />
+            <Box>
+              Ownerships: {ownerCount}
+              <br />
+              Memberships: {memberCount}
+            </Box>
+          </Box>
+        </Box>
+      </AccordionSummary>
+      <AccordionDetails>
+        <SideBySideTables
+          ownerships={ownerships}
+          memberships={memberships}
+          user={user}
+          filterGroupName={filterGroupName}
+          onClickRemoveGroupFromRole={onClickRemoveGroupFromRole}
+          onClickRemoveDirectAccess={onClickRemoveDirectAccess}
+        />
+      </AccordionDetails>
+    </Accordion>
+  );
+}
+
+function sectionContainsGroupName(
+  ownerships: Record<string, OktaUserGroupMember[]>,
+  memberships: Record<string, OktaUserGroupMember[]>,
+  groupName: string | null,
+): boolean {
+  const q = groupName?.trim().toLowerCase() ?? '';
+  if (!q) return false;
+  const all = [...Object.values(ownerships), ...Object.values(memberships)];
+  return all.some((members) => (members[0]?.active_group?.name ?? '').toLowerCase().includes(q));
+}
+
+function collectGroupNames(ownerPartitions: PartitionedGroups, memberPartitions: PartitionedGroups): string[] {
+  const names = new Set<string>();
+  const visit = (groupsById: Record<string, OktaUserGroupMember[]>) => {
+    for (const members of Object.values(groupsById)) {
+      const name = members[0]?.active_group?.name;
+      if (name) names.add(name);
+    }
+  };
+  visit(ownerPartitions.roles);
+  visit(ownerPartitions.appGroups);
+  visit(ownerPartitions.standardGroups);
+  visit(memberPartitions.roles);
+  visit(memberPartitions.appGroups);
+  visit(memberPartitions.standardGroups);
+  return Array.from(names).sort((a, b) => a.localeCompare(b));
 }
 
 export default function ReadUser() {
@@ -348,6 +452,10 @@ export default function ReadUser() {
   const [removeOwnDirectAccessDialogOpen, setRemoveOwnDirectAccessDialogOpen] = React.useState(false);
   const [removeOwnDirectAccessDialogParameters, setRemoveOwnDirectAccessDialogParameters] =
     React.useState<RemoveOwnDirectAccessDialogParameters>({} as RemoveOwnDirectAccessDialogParameters);
+
+  const [searchSelection, setSearchSelection] = React.useState<string | null>(null);
+  const [isExpandedAll, setIsExpandedAll] = React.useState(false);
+  const [userToggleMap, setUserToggleMap] = React.useState<Record<string, boolean>>({});
 
   const {data, isError, isLoading} = useGetUserById({
     pathParams: {userId: id ?? ''},
@@ -413,6 +521,30 @@ export default function ReadUser() {
     setRemoveOwnDirectAccessDialogOpen(true);
   };
 
+  const allGroupNames = collectGroupNames(ownerPartitions, memberPartitions);
+
+  const accordionExpanded = (id: string, hasMatch: boolean): boolean => {
+    if (id in userToggleMap) return userToggleMap[id];
+    if (searchSelection && hasMatch) return true;
+    return isExpandedAll;
+  };
+
+  const handleAccordionToggle =
+    (id: string) =>
+    (_: React.SyntheticEvent, expanded: boolean): void => {
+      setUserToggleMap((prev) => ({...prev, [id]: expanded}));
+    };
+
+  const handleToggleExpandAll = (): void => {
+    setIsExpandedAll((prev) => !prev);
+    setUserToggleMap({});
+  };
+
+  const handleSearchChange = (_: React.SyntheticEvent, value: string | null): void => {
+    setSearchSelection(value);
+    setUserToggleMap({});
+  };
+
   const moveTooltip = {modifiers: [{name: 'offset', options: {offset: [0, -10]}}]};
 
   return (
@@ -444,13 +576,44 @@ export default function ReadUser() {
                   </Typography>
                 </Stack>
                 <Divider />
-                <Stack justifyContent="center" direction="row" gap={1}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    alignItems: 'center',
+                    gap: 2,
+                  }}>
+                  {(hasRoles || hasAppGroups || hasStandardGroups) && (
+                    <>
+                      <Autocomplete
+                        size="small"
+                        freeSolo
+                        sx={{flex: '1 1 220px', minWidth: 0, maxWidth: 360}}
+                        renderInput={(params) => <TextField {...params} label="Search Roles, Groups, and App Groups" />}
+                        options={allGroupNames}
+                        value={searchSelection}
+                        onChange={handleSearchChange}
+                        clearOnEscape
+                      />
+                      <Button
+                        variant="contained"
+                        color="primary"
+                        size="small"
+                        startIcon={isExpandedAll ? <UnfoldLessIcon /> : <UnfoldMoreIcon />}
+                        onClick={handleToggleExpandAll}
+                        sx={{flexShrink: 0}}>
+                        {isExpandedAll ? 'Collapse' : 'Expand'}
+                      </Button>
+                    </>
+                  )}
                   <Tooltip title="Audit" placement="top" PopperProps={moveTooltip}>
                     <IconButton
                       aria-label="audit"
                       to={`/users/${id}/audit`}
                       component={RouterLink}
                       sx={{
+                        marginLeft: 'auto',
+                        flexShrink: 0,
                         '&:hover': {
                           backgroundColor: 'primary.main',
                           color: 'primary.contrastText',
@@ -459,7 +622,7 @@ export default function ReadUser() {
                       <AuditIcon />
                     </IconButton>
                   </Tooltip>
-                </Stack>
+                </Box>
               </Stack>
             </Paper>
           </Grid>
@@ -477,10 +640,50 @@ export default function ReadUser() {
                 <Typography variant="h5" sx={{mb: 2}}>
                   Roles
                 </Typography>
-                <SideBySideTables
+                <CollapsibleSection
+                  summaryLeft={
+                    <Typography variant="h6" color="text.accent">
+                      All Roles
+                    </Typography>
+                  }
                   ownerships={ownerPartitions.roles}
                   memberships={memberPartitions.roles}
                   user={user}
+                  filterGroupName={searchSelection}
+                  expanded={accordionExpanded(
+                    'roles',
+                    sectionContainsGroupName(ownerPartitions.roles, memberPartitions.roles, searchSelection),
+                  )}
+                  onToggle={handleAccordionToggle('roles')}
+                  onClickRemoveGroupFromRole={showRemoveGroupFromRoleDialog}
+                  onClickRemoveDirectAccess={removeOwnDirectAccess}
+                />
+              </Grid>
+            )}
+            {hasStandardGroups && (
+              <Grid item xs={12}>
+                <Typography variant="h5" sx={{mb: 2}}>
+                  Groups
+                </Typography>
+                <CollapsibleSection
+                  summaryLeft={
+                    <Typography variant="h6" color="text.accent">
+                      All Groups
+                    </Typography>
+                  }
+                  ownerships={ownerPartitions.standardGroups}
+                  memberships={memberPartitions.standardGroups}
+                  user={user}
+                  filterGroupName={searchSelection}
+                  expanded={accordionExpanded(
+                    'groups',
+                    sectionContainsGroupName(
+                      ownerPartitions.standardGroups,
+                      memberPartitions.standardGroups,
+                      searchSelection,
+                    ),
+                  )}
+                  onToggle={handleAccordionToggle('groups')}
                   onClickRemoveGroupFromRole={showRemoveGroupFromRoleDialog}
                   onClickRemoveDirectAccess={removeOwnDirectAccess}
                 />
@@ -491,45 +694,46 @@ export default function ReadUser() {
                 <Typography variant="h5" sx={{mb: 2}}>
                   Apps
                 </Typography>
-                {allAppEntries.map((appEntry) => (
-                  <Box key={appEntry.appId} sx={{mb: 3}}>
-                    <Typography variant="h6" sx={{mb: 1}}>
-                      <Link
-                        to={`/apps/${appEntry.appName}`}
-                        sx={{
-                          textDecoration: 'none',
-                          color: 'inherit',
-                          '&:hover': {
-                            color: (theme) => theme.palette.primary.main,
-                          },
-                        }}
-                        component={RouterLink}>
-                        {appEntry.appName}
-                      </Link>
-                    </Typography>
-                    <SideBySideTables
-                      ownerships={appEntry.ownerships}
-                      memberships={appEntry.memberships}
-                      user={user}
-                      onClickRemoveGroupFromRole={showRemoveGroupFromRoleDialog}
-                      onClickRemoveDirectAccess={removeOwnDirectAccess}
-                    />
-                  </Box>
-                ))}
-              </Grid>
-            )}
-            {hasStandardGroups && (
-              <Grid item xs={12}>
-                <Typography variant="h5" sx={{mb: 2}}>
-                  Groups
-                </Typography>
-                <SideBySideTables
-                  ownerships={ownerPartitions.standardGroups}
-                  memberships={memberPartitions.standardGroups}
-                  user={user}
-                  onClickRemoveGroupFromRole={showRemoveGroupFromRoleDialog}
-                  onClickRemoveDirectAccess={removeOwnDirectAccess}
-                />
+                <Stack spacing={2}>
+                  {allAppEntries.map((appEntry) => {
+                    const id = `app-${appEntry.appId}`;
+                    const hasMatch = sectionContainsGroupName(
+                      appEntry.ownerships,
+                      appEntry.memberships,
+                      searchSelection,
+                    );
+                    return (
+                      <CollapsibleSection
+                        key={appEntry.appId}
+                        summaryLeft={
+                          <Typography variant="h6" color="text.accent">
+                            <Link
+                              to={`/apps/${appEntry.appName}`}
+                              sx={{
+                                textDecoration: 'none',
+                                color: 'inherit',
+                                '&:hover': {
+                                  color: (theme) => theme.palette.primary.main,
+                                },
+                              }}
+                              component={RouterLink}
+                              onClick={(e) => e.stopPropagation()}>
+                              {appEntry.appName}
+                            </Link>
+                          </Typography>
+                        }
+                        ownerships={appEntry.ownerships}
+                        memberships={appEntry.memberships}
+                        user={user}
+                        filterGroupName={searchSelection}
+                        expanded={accordionExpanded(id, hasMatch)}
+                        onToggle={handleAccordionToggle(id)}
+                        onClickRemoveGroupFromRole={showRemoveGroupFromRoleDialog}
+                        onClickRemoveDirectAccess={removeOwnDirectAccess}
+                      />
+                    );
+                  })}
+                </Stack>
               </Grid>
             )}
           </Grid>


### PR DESCRIPTION
## Summary

Follow-up to [#376](https://github.com/discord/access/pull/376). The user read page is too long for users with many app groups, so each section is now collapsed by default with a client-side search box (mirroring the Apps Read pattern). Also brings the Apps Read search up to par with true free-text matching.

## What changed

**`src/pages/users/Read.tsx`**
- Wraps each section in an MUI `Accordion`. Roles and Groups become a single accordion containing the side-by-side Ownerships/Memberships tables; Apps becomes one accordion per app.
- Section order changed from Roles → Apps → Groups to **Roles → Groups → Apps**, putting the bulkiest section last.
- New search `Autocomplete` (freeSolo, case-insensitive substring) and Expand/Collapse toggle button live in the user header card alongside the audit icon. Search auto-expands matching accordions and filters rows inside them; clearing the search returns to the collapsed default.
- Action row uses `flex-wrap` + `flex-basis` sizing so the search shrinks with the viewport and components stack to additional rows on narrow widths. Audit icon stays right-aligned via `marginLeft: auto`.

<img width="2056" height="948" alt="Screenshot 2026-05-20 at 9 21 25 PM" src="https://github.com/user-attachments/assets/5181b2fa-a240-45eb-9875-030c0673061c" />
<img width="568" height="1179" alt="Screenshot 2026-05-20 at 9 21 40 PM" src="https://github.com/user-attachments/assets/359998fd-2fe4-4ffb-b9fa-bfc794ac6601" />
<img width="1961" height="1032" alt="Screenshot 2026-05-20 at 9 21 52 PM" src="https://github.com/user-attachments/assets/66920e7e-4e6a-488b-b665-db195062a250" />
<img width="1946" height="1200" alt="Screenshot 2026-05-20 at 9 22 07 PM" src="https://github.com/user-attachments/assets/e5086a48-0385-4ce7-b87e-dbf25537ac8f" />


**`src/pages/apps/components/AppsAdminActionGroup.tsx`**
- The Search Users `Autocomplete` is now true free-text: `autoHighlight` and `autoSelect` removed so typing "john" + Enter no longer auto-picks the first matching option. Filter is a case-insensitive substring match against both `displayUserName(user)` and `user.email`, unioning matched users' app groups.
- Expand/Collapse text button gains a `startIcon` (`UnfoldMore` / `UnfoldLess`) while keeping its label.
- Action row migrated to the same `flex-wrap` layout so it shrinks and stacks gracefully on narrow viewports.

<img width="2055" height="829" alt="Screenshot 2026-05-20 at 9 22 28 PM" src="https://github.com/user-attachments/assets/4b1c2c43-55f7-4e6d-ad2c-56028a342b3a" />


## Test plan

- [x] User page: open a user with multiple Roles / Standard Groups / App Groups → all three sections render their headers and the accordion below each starts collapsed.
- [x] Click an accordion individually → opens with its side-by-side Ownerships/Memberships tables.
- [x] Click Expand → all accordions open and the button label/icon flip to Collapse; click again → all close.
- [x] Type a substring in the search box and press Enter (e.g. `Access`) → every accordion containing a matching group name auto-expands; non-matching stay collapsed; only matching rows are visible inside each opened accordion.
- [x] Clear the search → state returns to fully collapsed.
- [x] Apps page: free-text search (e.g. `discord`) filters the non-owner App Groups list to those containing at least one user whose name or email matches; Enter without selecting an option uses the literal typed substring.
- [x] Both pages: at viewport widths ≥ ~1000px the action row sits in a single row; at narrower widths the components shrink with the viewport and wrap to additional rows.
- [x] `npm run tsc -- --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
