### PR TITLE
Unify search behavior on Apps and Users read pages

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -14,3 +14,8 @@ config/config.test.json
 # Local SQLite DB (LOCAL_DB_URI in the Makefile). Carrying it across
 # worktrees skips re-running `make db-init` for each new worktree.
 instance/access.db
+
+# Installed dependencies. Copying these avoids re-running `npm install` /
+# `make install` in every new worktree.
+node_modules/
+venv/

--- a/src/pages/apps/Read.tsx
+++ b/src/pages/apps/Read.tsx
@@ -24,6 +24,7 @@ export default function ReadApp() {
   });
   const [nonOwnerAppGroups, setNonOwnerAppGroups] = React.useState<AppGroup[]>([]);
   const [isExpanded, setIsExpanded] = React.useState(false);
+  const [isSearchActive, setIsSearchActive] = React.useState(false);
 
   const app = data ?? ({} as App);
 
@@ -45,7 +46,7 @@ export default function ReadApp() {
     });
   }, []);
 
-  const handleSearchSubmit = React.useCallback((newAppGroups: AppGroup[]) => {
+  const handleSearchSubmit = React.useCallback((newAppGroups: AppGroup[], isActive: boolean) => {
     setNonOwnerAppGroups((prev) => {
       // Only update if the groups actually changed
       if (prev.length === newAppGroups.length && prev.every((group, index) => group.id === newAppGroups[index]?.id)) {
@@ -53,6 +54,7 @@ export default function ReadApp() {
       }
       return newAppGroups;
     });
+    setIsSearchActive((prev) => (prev === isActive ? prev : isActive));
   }, []);
 
   if (isError) {
@@ -105,7 +107,7 @@ export default function ReadApp() {
             <AppsAccordionListGroup
               app_group={nonOwnerAppGroups}
               list_group_title={nonOwnerAppGroups.length > 1 ? 'App Groups' : 'App Group'}
-              isExpanded={isExpanded}
+              isExpanded={isExpanded || isSearchActive}
             />
           )}
         </Grid>

--- a/src/pages/apps/components/AppsAccordionListGroup.tsx
+++ b/src/pages/apps/components/AppsAccordionListGroup.tsx
@@ -221,6 +221,8 @@ export const AppsAccordionListGroup: React.FC<AppAccordionListGroupProps> = Reac
     const appGroupRef = React.useRef(app_group);
     appGroupRef.current = app_group;
 
+    const groupNamesKey = React.useMemo(() => (app_group ?? []).map((g) => g.name).join('|'), [app_group]);
+
     React.useEffect(() => {
       const currentAppGroup = appGroupRef.current;
       if (currentAppGroup) {
@@ -238,7 +240,7 @@ export const AppsAccordionListGroup: React.FC<AppAccordionListGroupProps> = Reac
           return hasChanges ? newExpanded : prevExpanded;
         });
       }
-    }, [isExpanded]);
+    }, [isExpanded, groupNamesKey]);
 
     const handleChange = React.useCallback(
       (id: string) => (event: React.SyntheticEvent, newExpanded: boolean) => {

--- a/src/pages/apps/components/AppsAdminActionGroup.tsx
+++ b/src/pages/apps/components/AppsAdminActionGroup.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 interface AppsAdminActionGroupProps {
   currentUser: OktaUser;
   app: App;
-  onSearchSubmit?: (appGroup: AppGroup[]) => void;
+  onSearchSubmit?: (appGroup: AppGroup[], isActive: boolean) => void;
   onToggleExpand?: (expanded: boolean) => void;
   isExpanded?: boolean;
 }
@@ -61,7 +61,7 @@ export const AppsAdminActionGroup: React.FC<AppsAdminActionGroupProps> = React.m
       const q = newValue?.trim().toLowerCase() ?? '';
       const fallback = appGroupsRef.current ?? [];
       if (!q) {
-        onSearchSubmitRef.current?.(fallback);
+        onSearchSubmitRef.current?.(fallback, false);
         return;
       }
       const matchedById: Record<string, AppGroup> = {};
@@ -73,7 +73,7 @@ export const AppsAdminActionGroup: React.FC<AppsAdminActionGroupProps> = React.m
           if (g.id) matchedById[g.id] = g;
         });
       });
-      onSearchSubmitRef.current?.(Object.values(matchedById));
+      onSearchSubmitRef.current?.(Object.values(matchedById), true);
     }, []);
 
     const onToggleExpandRef = React.useRef(onToggleExpand);

--- a/src/pages/users/Read.tsx
+++ b/src/pages/users/Read.tsx
@@ -503,6 +503,16 @@ export default function ReadUser() {
   const hasStandardGroups =
     Object.keys(ownerPartitions.standardGroups).length > 0 || Object.keys(memberPartitions.standardGroups).length > 0;
 
+  const searchActive = !!searchSelection?.trim();
+  const rolesHasMatch =
+    !searchActive || sectionContainsGroupName(ownerPartitions.roles, memberPartitions.roles, searchSelection);
+  const standardGroupsHasMatch =
+    !searchActive ||
+    sectionContainsGroupName(ownerPartitions.standardGroups, memberPartitions.standardGroups, searchSelection);
+  const filteredAppEntries = searchActive
+    ? allAppEntries.filter((entry) => sectionContainsGroupName(entry.ownerships, entry.memberships, searchSelection))
+    : allAppEntries;
+
   const showRemoveGroupFromRoleDialog = (removeGroup: PolymorphicGroup, fromRole: RoleGroup, owner: boolean) => {
     setRemoveGroupsFromRoleDialogParameters({
       group: removeGroup,
@@ -635,7 +645,7 @@ export default function ReadUser() {
             </Grid>
           </Grid>
           <Grid item container xs={12} lg={9} rowSpacing={3} order={{xs: 3, lg: 2}}>
-            {hasRoles && (
+            {hasRoles && rolesHasMatch && (
               <Grid item xs={12}>
                 <Typography variant="h5" sx={{mb: 2}}>
                   Roles
@@ -660,7 +670,7 @@ export default function ReadUser() {
                 />
               </Grid>
             )}
-            {hasStandardGroups && (
+            {hasStandardGroups && standardGroupsHasMatch && (
               <Grid item xs={12}>
                 <Typography variant="h5" sx={{mb: 2}}>
                   Groups
@@ -689,13 +699,13 @@ export default function ReadUser() {
                 />
               </Grid>
             )}
-            {hasAppGroups && (
+            {hasAppGroups && filteredAppEntries.length > 0 && (
               <Grid item xs={12}>
                 <Typography variant="h5" sx={{mb: 2}}>
                   Apps
                 </Typography>
                 <Stack spacing={2}>
-                  {allAppEntries.map((appEntry) => {
+                  {filteredAppEntries.map((appEntry) => {
                     const id = `app-${appEntry.appId}`;
                     const hasMatch = sectionContainsGroupName(
                       appEntry.ownerships,


### PR DESCRIPTION
## Summary
Follow-up to #450. The user/group search on the two read pages behaved inconsistently — the Apps page filtered the displayed groups but kept their accordions closed, while the Users page opened matching accordions but left empty Roles/Groups sections and unrelated app cards visible.

This PR unifies the behavior so that on both pages a search query (a) filters down to only the matching sections/groups, and (b) auto-opens their accordions. Clearing the query restores the full list and collapses accordions.

### Apps read
- Track an `isSearchActive` flag in [`Read.tsx`](src/pages/apps/Read.tsx) alongside the existing `isExpanded`. When a search has a query, `isExpanded || isSearchActive` is passed to the non-owner `AppsAccordionListGroup` so the filtered groups auto-expand.
- [`AppsAdminActionGroup`](src/pages/apps/components/AppsAdminActionGroup.tsx) now passes a second arg (`isActive`) alongside the filtered group list.
- Re-run [`AppsAccordionListGroup`](src/pages/apps/components/AppsAccordionListGroup.tsx)'s expansion `useEffect` when the displayed group list changes (via a stable `groupNamesKey`), so newly-filtered groups inherit the current `isExpanded` value instead of defaulting to collapsed.

### Users read
- In [`Read.tsx`](src/pages/users/Read.tsx), when search is active, hide the Roles section, the Groups section, and individual app cards that contain no matches — reusing the existing `sectionContainsGroupName` helper.
- Inner `GroupTable` filtering, accordion auto-open, and `userToggleMap` reset were already working from #450; no changes needed there.

### Other
- Added `node_modules/` and `venv/` to [`.worktreeinclude`](.worktreeinclude) so new worktrees inherit installed Node and Python dependencies and avoid re-running `npm install` / `make install`.

## Test plan
- [x] Users page: search a group name only present in standard Groups → only Groups section shows, accordion open, inner table filtered to the single match.
- [x] Users page: search an app group name (e.g. `App-Access-Owners`) → only the Apps section shows with the matching app's accordion open.
- [x] Users page: clear the search → all sections (Roles, Groups, Apps) restored, accordions collapsed.
- [x] Apps page: search by a user who is a member of one group → only that group's card shows with its accordion expanded.
- [x] Apps page: clear the search → full list restored, accordions collapsed; the global Expand/Collapse button still toggles them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
