### PR TITLE
Remove the db compatibility shim

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -4,13 +4,6 @@ strict = True
 warn_return_any = False
 ignore_missing_imports = True
 
-[mypy-api.models.*]
-# `db.Model` is provided by the `api.extensions` shim at runtime; mypy
-# doesn't see it as a class statement. The shim is intentionally
-# transitional (POST_MIGRATION_TODO #1).
-disallow_subclassing_any = False
-disable_error_code = name-defined,union-attr,return-value,assignment
-
 # Per POST_MIGRATION_TODO #14, strict mypy on api/routers/ and api/schemas/
 # is a deferred follow-up. The migration prioritized wire-compatibility over
 # clean type annotations; tightening these modules is a separate task that
@@ -29,9 +22,10 @@ disallow_untyped_calls = False
 disable_error_code = attr-defined,union-attr,arg-type,var-annotated,type-arg,return-value,no-untyped-def
 
 [mypy-api.operations.*]
-# Operations rely on the `db` shim's `Query` / `first_or_404` / `paginate`
-# helpers, which mypy can't see through. Goes loose until the shim is
-# removed (POST_MIGRATION_TODO #1).
+# Operations heavily use `db.session.query(Model).filter(...).first()` and
+# treat the `Optional` result as non-None. Tightening to full strict mypy
+# requires either `.one()` (raise on missing) or explicit None checks
+# across ~28 files — a separate cleanup beyond shim removal.
 disallow_untyped_defs = False
 disallow_untyped_calls = False
 disable_error_code = attr-defined,union-attr,arg-type,var-annotated,type-arg,return-value,assignment,no-untyped-def,no-untyped-call
@@ -54,25 +48,15 @@ disable_error_code = attr-defined,union-attr,arg-type,no-untyped-call
 [mypy-api.exception_handlers]
 disable_error_code = no-untyped-call
 
-[mypy-api.extensions]
-# The `db` compatibility shim wraps SQLAlchemy primitives that aren't fully
-# typed; subclassing Mutable / scoped_session / SAQuery is intentional.
-disallow_subclassing_any = False
-disable_error_code = type-arg,assignment,return-value,no-untyped-call,attr-defined
-
-[mypy-api.syncer]
-disable_error_code = attr-defined,union-attr,arg-type,no-untyped-call,return-value
-
-[mypy-api.integrity]
-disable_error_code = attr-defined,union-attr,no-untyped-call
-
-[mypy-api.context]
-disallow_subclassing_any = False
-
 [mypy-tests.*]
-# Tests use the `db` shim's Query helpers, the `mock_user` fixture-as-callable
-# pattern, and a TestClient subclass whose `request` signature is
-# deliberately wider than the parent's.
+# Tests use the `mock_user` fixture-as-callable pattern and a TestClient
+# subclass whose `request` signature is deliberately wider than the
+# parent's. They routinely call `.first()` and pass the (`Optional`)
+# result into helpers expecting non-Optional — the fixture invariants
+# guarantee non-None at runtime but mypy can't see that. The
+# `api.schemas` re-exports are also caught by `attr-defined` since the
+# package uses `# noqa: F401` rather than the explicit `from X import Y
+# as Y` re-export style.
 disallow_untyped_defs = False
 disallow_untyped_calls = False
 disable_error_code = attr-defined,union-attr,arg-type,override,no-untyped-call,no-untyped-def,assignment

--- a/POST_MIGRATION_TODO.md
+++ b/POST_MIGRATION_TODO.md
@@ -8,23 +8,6 @@ Items grouped roughly by surface area; ordering within each group is rough prior
 
 ## Database / SQLAlchemy
 
-### 1. Remove the `db` compatibility shim
-
-The shim in `api/extensions.py` keeps the legacy `db.Model` / `db.session` /
-`Model.query` API alive on top of plain SQLAlchemy 2.0. It was added so the
-migration could touch models and operations as little as possible.
-
-**What's involved:**
-- `db.Model` → `Base` (a `DeclarativeBase`)
-- `db.Column` → `mapped_column`
-- `db.relationship` → `relationship`
-- `db.func` / `db.or_` / `db.not_` / `db.and_` → direct `sqlalchemy` imports
-- `Model.query.filter(...)` → `db.session.query(Model).filter(...)` or
-  `session.execute(select(Model).filter(...))`
-
-**Net change:** removes ~150 lines of shim, makes the model layer indistinguishable
-from any other SQLAlchemy 2.0 project. Mostly mechanical.
-
 ### 2. Switch to async SQLAlchemy
 
 The migration kept SQLAlchemy synchronous. To go async:
@@ -35,8 +18,7 @@ The migration kept SQLAlchemy synchronous. To go async:
 - Routers: `def` → `async def`
 
 Major lift — every operation file changes — but unlocks concurrent I/O and
-removes the sync-thread-pool overhead per request. Should be done **after**
-#1 (removing the shim) since the shim's `Query` class assumes sync.
+removes the sync-thread-pool overhead per request.
 
 ### 3. Replace the `_session_scope` ContextVar dance with `async_scoped_session`
 

--- a/api/app.py
+++ b/api/app.py
@@ -138,9 +138,9 @@ def create_app(testing: Optional[bool] = False) -> FastAPI:
         dependencies=[Depends(require_authenticated)],
     )
 
-    # Bind the SQLAlchemy engine to the shim. In tests the `db` fixture
-    # rebuilds with a sqlite-in-memory engine, so we only bind here when not
-    # testing.
+    # Bind the SQLAlchemy engine to the session facade. In tests the `db`
+    # fixture rebuilds with a sqlite-in-memory engine, so we only bind here
+    # when not testing.
     if not testing and (settings.SQLALCHEMY_DATABASE_URI or settings.CLOUDSQL_CONNECTION_NAME):
         db.init_app(engine=build_engine())
 

--- a/api/auth/permissions.py
+++ b/api/auth/permissions.py
@@ -11,13 +11,12 @@ from __future__ import annotations
 from typing import Annotated, Optional
 
 from fastapi import Depends, HTTPException
-from sqlalchemy import or_
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session, selectinload
 
 from api.auth.dependencies import CurrentUserId
 from api.config import settings
 from api.database import DbSession
-from api.extensions import db as _db_shim
 from api.models import App, AppGroup, OktaGroup, OktaUserGroupMember
 
 
@@ -30,7 +29,7 @@ def is_group_owner(db: Session, current_user_id: str, group: OktaGroup) -> bool:
         .filter(
             or_(
                 OktaUserGroupMember.ended_at.is_(None),
-                OktaUserGroupMember.ended_at > _db_shim.func.now(),
+                OktaUserGroupMember.ended_at > func.now(),
             )
         )
         .count()
@@ -69,7 +68,7 @@ def is_app_owner_group_owner(
         .filter(
             or_(
                 OktaUserGroupMember.ended_at.is_(None),
-                OktaUserGroupMember.ended_at > _db_shim.func.now(),
+                OktaUserGroupMember.ended_at > func.now(),
             )
         )
         .count()
@@ -95,7 +94,7 @@ def is_access_admin(db: Session, current_user_id: str) -> bool:
         .filter(
             or_(
                 OktaUserGroupMember.ended_at.is_(None),
-                OktaUserGroupMember.ended_at > _db_shim.func.now(),
+                OktaUserGroupMember.ended_at > func.now(),
             )
         )
         .count()

--- a/api/database.py
+++ b/api/database.py
@@ -1,6 +1,6 @@
 """SQLAlchemy engine creation and the FastAPI `get_db` dependency.
 
-The shim in `api.extensions` holds the `db` namespace. This module wires the
+`api.extensions` holds the `db` session/engine facade; this module wires the
 engine into it and provides the request-scoped session dependency.
 """
 

--- a/api/extensions.py
+++ b/api/extensions.py
@@ -1,17 +1,11 @@
-"""SQLAlchemy compatibility shim.
+"""SQLAlchemy session/engine plumbing.
 
-The model layer was originally written against Flask-SQLAlchemy's `db.X`
-API and the application has not yet been ported off it (POST_MIGRATION_TODO
-#1). Until that follow-up lands, this module exposes the same surface on
-top of plain SQLAlchemy 2.0:
+Exposes:
 
-    - `db.Model`         → declarative `Base`
-    - `db.session`       → request-scoped Session via ContextVar
-    - `db.Column`, `db.relationship`, `db.ForeignKey`, `db.Index`, `db.func`,
-      `db.or_`, `db.not_`, `db.text`, and the column type re-exports
-      (`db.BigInteger`, `db.Integer`, `db.Boolean`, `db.Unicode`, `db.DateTime`,
-      `db.JSON`, `db.Enum`)
-    - `Model.query` proxy supporting `.filter()`, `.first_or_404()`, `.paginate()`
+- `Base`: declarative base for all ORM models.
+- `db.session`: the request-scoped Session bound to the active `_session_scope`.
+- `db.engine`: the configured Engine.
+- `db.init_app(engine=...)`, `db.remove()`, `db.create_all()`, `db.drop_all()`.
 
 The session is bound to a `ContextVar` so each FastAPI request (or CLI
 invocation) gets its own Session. The dependency in `api.database.get_db`
@@ -21,41 +15,16 @@ sets and clears this var per request.
 from __future__ import annotations
 
 import contextvars
-import math
-from typing import Any, Callable, Generic, Optional, TypeVar
+from typing import Any, Callable, Optional
 
-from fastapi import HTTPException
 from google.cloud.sql.connector import Connector, IPTypes
-from sqlalchemy import (
-    BigInteger,
-    Boolean,
-    Column,
-    DateTime,
-    Engine,
-    Enum,
-    ForeignKey,
-    Index,
-    Integer,
-    JSON,
-    MetaData,
-    Unicode,
-    and_,
-    cast,
-    func,
-    not_,
-    or_,
-    text,
-)
+from sqlalchemy import Engine, MetaData
 from sqlalchemy.orm import (
     DeclarativeBase,
-    Query as SAQuery,
     Session,
-    relationship,
     scoped_session,
     sessionmaker,
 )
-
-T = TypeVar("T")
 
 
 # Per-request session scope. The FastAPI dependency sets this to a unique
@@ -107,87 +76,9 @@ class Base(DeclarativeBase):
         super().__init_subclass__(**kwargs)
 
 
-class Pagination(Generic[T]):
-    """Pagination object used by the `db` shim's `Query.paginate(...)` helper.
-    Exposes the `items / page / per_page / total / pages / has_next /
-    has_prev / next_num / prev_num` attributes the legacy operations were
-    written against; will go away with the shim (POST_MIGRATION_TODO #1)."""
-
-    def __init__(self, items: list[T], page: int, per_page: int, total: int):
-        self.items = items
-        self.page = page
-        self.per_page = per_page
-        self.total = total
-        self.pages = max(1, math.ceil(total / per_page)) if per_page > 0 else 1
-        self.has_next = page < self.pages
-        self.has_prev = page > 1
-        self.next_num = page + 1 if self.has_next else page
-        self.prev_num = page - 1 if self.has_prev else page
-
-
-class Query(SAQuery):
-    """SQLAlchemy Query subclass with the helpers (`first_or_404`,
-    `get_or_404`, `paginate`) the operations layer is written against.
-    Goes away with the shim (POST_MIGRATION_TODO #1)."""
-
-    def first_or_404(self, description: str = "Not Found") -> Any:
-        obj = self.first()
-        if obj is None:
-            raise HTTPException(status_code=404, detail=description)
-        return obj
-
-    def get_or_404(self, ident: Any, description: str = "Not Found") -> Any:
-        obj = self.get(ident)
-        if obj is None:
-            raise HTTPException(status_code=404, detail=description)
-        return obj
-
-    def paginate(self, *, page: int = 1, per_page: int = 50) -> Pagination:
-        if per_page <= 0:
-            # Sentinel "all"
-            items = self.all()
-            total = len(items)
-            return Pagination(items=items, page=1, per_page=max(total, 1), total=total)
-        total = self.order_by(None).count()
-        items = self.limit(per_page).offset((page - 1) * per_page).all()
-        return Pagination(items=items, page=page, per_page=per_page, total=total)
-
-
-class _QueryProperty:
-    """Class-level descriptor that exposes `Model.query` returning a `Query`
-    bound to the active scoped session."""
-
-    def __get__(self, _instance: Any, owner: type[Any]) -> Query:
-        return db.session.query(owner)  # type: ignore[return-value]
-
-
 class _DB:
-    """The `db` namespace. Exposes the SQLAlchemy types and helpers the
-    models + operations layer were written against, backed by plain
-    SQLAlchemy 2.0. Goes away with the shim (POST_MIGRATION_TODO #1)."""
-
-    # Model + metadata
-    Model = Base
-    metadata = Base.metadata
-
-    # SQLAlchemy types and helpers (re-exports)
-    Column = staticmethod(Column)
-    ForeignKey = staticmethod(ForeignKey)
-    Index = staticmethod(Index)
-    BigInteger = BigInteger
-    Integer = Integer
-    Boolean = Boolean
-    Unicode = Unicode
-    DateTime = DateTime
-    JSON = JSON
-    Enum = staticmethod(Enum)
-    relationship = staticmethod(relationship)
-    func = func
-    or_ = staticmethod(or_)
-    and_ = staticmethod(and_)
-    not_ = staticmethod(not_)
-    text = staticmethod(text)
-    cast = staticmethod(cast)
+    """Session/engine facade. Provides per-request scoped session via
+    `db.session`, plus startup/teardown plumbing (`init_app`, `remove`)."""
 
     def __init__(self) -> None:
         self._engine: Optional[Engine] = None
@@ -195,14 +86,13 @@ class _DB:
         self._scoped: Optional[scoped_session[Session]] = None
 
     def init_app(self, *, engine: Engine) -> None:
-        """Bind the shim to a SQLAlchemy engine. Must be called once at app
-        (or CLI) startup before any ORM operation."""
+        """Bind the session facade to a SQLAlchemy engine. Must be called
+        once at app (or CLI) startup before any ORM operation."""
         self._engine = engine
         self._sessionmaker = sessionmaker(
             bind=engine,
             autoflush=False,
             expire_on_commit=True,
-            query_cls=Query,
         )
         self._scoped = scoped_session(self._sessionmaker, scopefunc=lambda: _session_scope.get())
 
@@ -232,15 +122,10 @@ class _DB:
         Base.metadata.drop_all(self.engine)
 
 
-# Attach the query property so every model has `Model.query`. Done after
-# `_DB` is defined because the property delegates to `db.session`.
-Base.query = _QueryProperty()
-
-
 db = _DB()
 
-# Public alias for the shim's class so callers (notably tests) can type-annotate
-# parameters that take the shim instance — `_DB` itself is private.
+# Public alias for the facade's class so callers (notably tests) can type-annotate
+# parameters that take the instance — `_DB` itself is private.
 Db = _DB
 
 
@@ -268,8 +153,6 @@ def get_cloudsql_conn(
 __all__ = [
     "Base",
     "Db",
-    "Pagination",
-    "Query",
     "_session_scope",
     "db",
     "get_cloudsql_conn",

--- a/api/integrity.py
+++ b/api/integrity.py
@@ -1,5 +1,6 @@
 import logging
 
+from sqlalchemy import func, or_
 from api.extensions import db
 from api.models import OktaGroup, OktaUserGroupMember, RoleGroupMap
 from api.operations import UnmanageGroup
@@ -10,26 +11,31 @@ logger = logging.getLogger(__name__)
 
 def verify_and_fix_unmanaged_groups(dry_run: bool = False) -> None:
     active_unmanaged_groups = (
-        OktaGroup.query.filter(OktaGroup.is_managed.is_(False)).filter(OktaGroup.deleted_at.is_(None)).all()
+        db.session.query(OktaGroup).filter(OktaGroup.is_managed.is_(False)).filter(OktaGroup.deleted_at.is_(None)).all()
     )
     for group in active_unmanaged_groups:
         UnmanageGroup(group=group.id).execute(dry_run=dry_run)
 
 
 def verify_and_fix_role_memberships(dry_run: bool = False) -> None:
-    active_role_group_maps = RoleGroupMap.query.filter(
-        db.or_(
-            RoleGroupMap.ended_at.is_(None),
-            RoleGroupMap.ended_at > db.func.now(),
+    active_role_group_maps = (
+        db.session.query(RoleGroupMap)
+        .filter(
+            or_(
+                RoleGroupMap.ended_at.is_(None),
+                RoleGroupMap.ended_at > func.now(),
+            )
         )
-    ).all()
+        .all()
+    )
     for active_role_group_map in active_role_group_maps:
         active_role_group_members_query = (
-            OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == active_role_group_map.role_group_id)
+            db.session.query(OktaUserGroupMember)
+            .filter(OktaUserGroupMember.group_id == active_role_group_map.role_group_id)
             .filter(
-                db.or_(
+                or_(
                     OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > db.func.now(),
+                    OktaUserGroupMember.ended_at > func.now(),
                 )
             )
             .filter(OktaUserGroupMember.is_owner.is_(False))
@@ -37,10 +43,11 @@ def verify_and_fix_role_memberships(dry_run: bool = False) -> None:
         active_role_group_members_ids = [m.user_id for m in active_role_group_members_query.all()]
 
         active_group_users_for_role = (
-            OktaUserGroupMember.query.filter(
-                db.or_(
+            db.session.query(OktaUserGroupMember)
+            .filter(
+                or_(
                     OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > db.func.now(),
+                    OktaUserGroupMember.ended_at > func.now(),
                 )
             )
             .filter(OktaUserGroupMember.role_group_map_id == active_role_group_map.id)
@@ -61,6 +68,10 @@ def verify_and_fix_role_memberships(dry_run: bool = False) -> None:
                     role_group_membership = active_role_group_members_query.filter(
                         OktaUserGroupMember.user_id == member
                     ).first()
+                    # `member` came out of `active_role_group_members_ids` which we
+                    # just built from this same query, so the filter must return a
+                    # row. Assert to narrow `Optional` for type checking.
+                    assert role_group_membership is not None
                     if not active_role_group_map.is_owner:
                         # Add user to okta group members
                         okta.add_user_to_group(
@@ -104,15 +115,15 @@ def verify_and_fix_role_memberships(dry_run: bool = False) -> None:
             )
             if not dry_run:
                 # End all extra OktaUserGroupMembers the users not members of the role group
-                OktaUserGroupMember.query.filter(
-                    db.or_(
+                db.session.query(OktaUserGroupMember).filter(
+                    or_(
                         OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > db.func.now(),
+                        OktaUserGroupMember.ended_at > func.now(),
                     )
                 ).filter(OktaUserGroupMember.role_group_map_id == active_role_group_map.id).filter(
                     OktaUserGroupMember.user_id.in_(extra_group_users_for_role)
                 ).update(
-                    {OktaUserGroupMember.ended_at: db.func.now()},
+                    {OktaUserGroupMember.ended_at: func.now()},
                     synchronize_session="fetch",
                 )
                 db.session.commit()
@@ -121,10 +132,11 @@ def verify_and_fix_role_memberships(dry_run: bool = False) -> None:
                 # combination before removing membership, there can be multiple role groups
                 # which allow group access for this user
                 removed_users_with_other_access = (
-                    OktaUserGroupMember.query.filter(
-                        db.or_(
+                    db.session.query(OktaUserGroupMember)
+                    .filter(
+                        or_(
                             OktaUserGroupMember.ended_at.is_(None),
-                            OktaUserGroupMember.ended_at > db.func.now(),
+                            OktaUserGroupMember.ended_at > func.now(),
                         )
                     )
                     .filter(OktaUserGroupMember.is_owner == active_role_group_map.is_owner)

--- a/api/manage.py
+++ b/api/manage.py
@@ -17,6 +17,7 @@ import uuid
 from typing import Any, Callable, List, TypeVar
 
 import click
+from sqlalchemy import func, or_
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -118,7 +119,7 @@ def _import_from_okta() -> None:
     from api.services import okta
 
     click.echo("Starting Okta Import")
-    if db.session.query(db.func.count(OktaUser.id)).scalar() > 0:
+    if db.session.query(func.count(OktaUser.id)).scalar() > 0:
         click.echo("Skipping import of Okta Users as they were previously imported")
     else:
         click.echo("Importing Okta Users")
@@ -137,7 +138,7 @@ def _import_from_okta() -> None:
 
         db.session.commit()
 
-    if db.session.query(db.func.count(OktaGroup.id)).scalar() > 0:
+    if db.session.query(func.count(OktaGroup.id)).scalar() > 0:
         click.echo("Skipping import of Okta Groups as they were previously imported")
     else:
         click.echo("Importing Okta Groups")
@@ -149,7 +150,7 @@ def _import_from_okta() -> None:
             db.session.add(group.update_okta_group(OktaGroup(), group_ids_with_group_rules))
         db.session.commit()
 
-    if db.session.query(db.func.count(OktaUserGroupMember.id)).scalar() > 0:
+    if db.session.query(func.count(OktaUserGroupMember.id)).scalar() > 0:
         click.echo("Skipping import of Okta Group Memberships as they were previously imported")
     else:
         click.echo("Importing Okta Group Memberships")
@@ -176,15 +177,18 @@ def _init_builtin_apps(admin_okta_user_email: str) -> None:
     from api.models import App, OktaUser
     from api.operations import CreateApp
 
-    existing_app = App.query.filter(App.name == App.ACCESS_APP_RESERVED_NAME).filter(App.deleted_at.is_(None)).first()
+    existing_app = (
+        db.session.query(App).filter(App.name == App.ACCESS_APP_RESERVED_NAME).filter(App.deleted_at.is_(None)).first()
+    )
     if existing_app is not None:
         click.echo("Access app and groups already exist, skipping init of built-in apps")
         return
 
     admin_okta_user = (
-        OktaUser.query.filter(OktaUser.deleted_at.is_(None))
+        db.session.query(OktaUser)
+        .filter(OktaUser.deleted_at.is_(None))
         .filter(
-            db.or_(
+            or_(
                 OktaUser.id == admin_okta_user_email,
                 OktaUser.email.ilike(admin_okta_user_email),
             )
@@ -316,7 +320,7 @@ def sync_app_group_memberships() -> None:
     click.echo("Starting app group lifecycle plugin sync")
 
     apps: List[App] = (
-        App.query.filter(App.deleted_at.is_(None)).filter(App.app_group_lifecycle_plugin.isnot(None)).all()
+        db.session.query(App).filter(App.deleted_at.is_(None)).filter(App.app_group_lifecycle_plugin.isnot(None)).all()
     )
 
     if len(apps) == 0:

--- a/api/models/access_request.py
+++ b/api/models/access_request.py
@@ -1,4 +1,4 @@
-from typing import Set
+from typing import List, Set
 
 from api.models.app_group import get_access_owners, get_app_managers
 from api.models.core_models import AccessRequest, AppGroup, GroupRequest, OktaUser, RoleRequest
@@ -10,22 +10,24 @@ def get_all_possible_request_approvers(access_request: AccessRequest | RoleReque
     # to ensure that even if the resolved set of approvers changes
     # we still are able to mark the request as resolved for any users
     # that were notified of the request.
-    group_owners = []
+    group_owners: List[OktaUser] = []
+    app_managers: List[OktaUser] = []
 
-    if type(access_request) is not GroupRequest:
+    # AccessRequest / RoleRequest have `requested_group_id` + `requested_group`;
+    # GroupRequest doesn't (it tracks a *requested* group as separate name/type
+    # fields, since the group hasn't been created yet). Branch on the type so
+    # mypy narrows the union accurately.
+    if isinstance(access_request, (AccessRequest, RoleRequest)):
         group_owners = get_group_managers(access_request.requested_group_id)
-
-    access_app_owners = get_access_owners()
-
-    app_managers = []
-
-    if type(access_request) is not GroupRequest and type(access_request.requested_group) is AppGroup:
-        app_managers = get_app_managers(access_request.requested_group.app_id)
+        if isinstance(access_request.requested_group, AppGroup):
+            app_managers = get_app_managers(access_request.requested_group.app_id)
     elif (
-        type(access_request) is GroupRequest
+        isinstance(access_request, GroupRequest)
         and access_request.requested_group_type == "app_group"
         and access_request.requested_app_id is not None
     ):
         app_managers = get_app_managers(access_request.requested_app_id)
+
+    access_app_owners = get_access_owners()
 
     return set(group_owners + access_app_owners + app_managers)

--- a/api/models/app_group.py
+++ b/api/models/app_group.py
@@ -1,5 +1,7 @@
 from typing import List
 
+from sqlalchemy import func, or_
+
 from api.extensions import db
 from api.models.core_models import App, AppGroup, OktaGroup, OktaUser, OktaUserGroupMember
 
@@ -7,20 +9,22 @@ from api.models.core_models import App, AppGroup, OktaGroup, OktaUser, OktaUserG
 def get_app_managers(app_id: str) -> List[OktaUser]:
     """Returns the users that can manage members of the app"""
     owner_app_groups = (
-        AppGroup.query.filter(OktaGroup.deleted_at.is_(None))
+        db.session.query(AppGroup)
+        .filter(OktaGroup.deleted_at.is_(None))
         .filter(AppGroup.app_id == app_id)
         .filter(AppGroup.is_owner.is_(True))
     )
 
     if owner_app_groups.count() > 0:
         return (
-            OktaUser.query.join(OktaUser.all_group_memberships_and_ownerships)
+            db.session.query(OktaUser)
+            .join(OktaUser.all_group_memberships_and_ownerships)
             .filter(OktaUserGroupMember.group_id.in_([ag.id for ag in owner_app_groups]))
             .filter(OktaUserGroupMember.is_owner.is_(True))
             .filter(
-                db.or_(
+                or_(
                     OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > db.func.now(),
+                    OktaUserGroupMember.ended_at > func.now(),
                 )
             )
             .all()
@@ -32,23 +36,30 @@ def get_app_managers(app_id: str) -> List[OktaUser]:
 def get_access_owners() -> List[OktaUser]:
     """Returns the access super admins that are members of the owners group"""
 
-    access_app = App.query.filter(App.deleted_at.is_(None)).filter(App.name == App.ACCESS_APP_RESERVED_NAME).first()
+    access_app = (
+        db.session.query(App).filter(App.deleted_at.is_(None)).filter(App.name == App.ACCESS_APP_RESERVED_NAME).first()
+    )
+
+    if access_app is None:
+        return []
 
     owner_app_groups = (
-        AppGroup.query.filter(OktaGroup.deleted_at.is_(None))
+        db.session.query(AppGroup)
+        .filter(OktaGroup.deleted_at.is_(None))
         .filter(AppGroup.app_id == access_app.id)
         .filter(AppGroup.is_owner.is_(True))
     )
 
     if owner_app_groups.count() > 0:
         return (
-            OktaUser.query.join(OktaUser.all_group_memberships_and_ownerships)
+            db.session.query(OktaUser)
+            .join(OktaUser.all_group_memberships_and_ownerships)
             .filter(OktaUserGroupMember.group_id.in_([ag.id for ag in owner_app_groups]))
             .filter(OktaUserGroupMember.is_owner.is_(False))
             .filter(
-                db.or_(
+                or_(
                     OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > db.func.now(),
+                    OktaUserGroupMember.ended_at > func.now(),
                 )
             )
             .all()

--- a/api/models/core_models.py
+++ b/api/models/core_models.py
@@ -2,58 +2,69 @@ from datetime import datetime
 from enum import StrEnum
 from typing import Any, Callable, Dict, List, Optional
 
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Index,
+    Integer,
+    JSON,
+    Unicode,
+    func,
+    text,
+)
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import Mapped, mapped_column, validates
+from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
 from sqlalchemy.sql import expression
 from sqlalchemy_json import mutable_json_type
 
 from api import config
-from api.extensions import db
+from api.extensions import Base, db
 
 
-class OktaUserGroupMember(db.Model):
+class OktaUserGroupMember(Base):
     # See https://stackoverflow.com/a/60840921
     id: Mapped[int] = mapped_column(
-        db.BigInteger().with_variant(db.Integer, "sqlite"),
+        BigInteger().with_variant(Integer, "sqlite"),
         autoincrement=True,
         primary_key=True,
     )
-    user_id: Mapped[str] = mapped_column(db.Unicode(50), db.ForeignKey("okta_user.id"))
-    group_id: Mapped[str] = mapped_column(db.Unicode(50), db.ForeignKey("okta_group.id"))
+    user_id: Mapped[str] = mapped_column(Unicode(50), ForeignKey("okta_user.id"))
+    group_id: Mapped[str] = mapped_column(Unicode(50), ForeignKey("okta_group.id"))
     # If this membership is via a role group map
     # See https://stackoverflow.com/a/60840921
     role_group_map_id: Mapped[Optional[int]] = mapped_column(
-        db.BigInteger().with_variant(db.Integer, "sqlite"),
-        db.ForeignKey("role_group_map.id"),
+        BigInteger().with_variant(Integer, "sqlite"),
+        ForeignKey("role_group_map.id"),
     )
     # Is this user an owner of the group and can administer the group and manage membership?
     # Or is this user only a member of this group?
-    is_owner: Mapped[bool] = mapped_column(db.Boolean, nullable=False, server_default=expression.false(), default=False)
-    created_at: Mapped[datetime] = mapped_column(db.DateTime(), nullable=False, default=db.func.now())
-    updated_at: Mapped[datetime] = mapped_column(
-        db.DateTime(), nullable=False, default=db.func.now(), onupdate=db.func.now()
-    )
-    ended_at: Mapped[Optional[datetime]] = mapped_column(db.DateTime())
+    is_owner: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=expression.false(), default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now(), onupdate=func.now())
+    ended_at: Mapped[Optional[datetime]] = mapped_column(DateTime())
 
     # Save the user IDs of the person who added/removed someone from a group
-    created_actor_id: Mapped[Optional[str]] = mapped_column(db.Unicode(50), db.ForeignKey("okta_user.id"))
-    ended_actor_id: Mapped[Optional[str]] = mapped_column(db.Unicode(50), db.ForeignKey("okta_user.id"))
+    created_actor_id: Mapped[Optional[str]] = mapped_column(Unicode(50), ForeignKey("okta_user.id"))
+    ended_actor_id: Mapped[Optional[str]] = mapped_column(Unicode(50), ForeignKey("okta_user.id"))
 
-    created_reason: Mapped[str] = mapped_column(db.Unicode(1024), nullable=False, default="", server_default="")
+    created_reason: Mapped[str] = mapped_column(Unicode(1024), nullable=False, default="", server_default="")
 
     # This field is set to True when an owner chooses to not renew access in the Expiring Access workflow
     should_expire: Mapped[bool] = mapped_column(
-        db.Boolean, nullable=False, server_default=expression.false(), default=False
+        Boolean, nullable=False, server_default=expression.false(), default=False
     )
 
     # See more details on specifying alternative join conditions for relationships at
     # https://docs.sqlalchemy.org/en/14/orm/join_conditions.html#specifying-alternate-join-conditions
-    group: Mapped["OktaGroup"] = db.relationship(
+    group: Mapped["OktaGroup"] = relationship(
         "OktaGroup",
         back_populates="all_user_memberships_and_ownerships",
         lazy="raise_on_sql",
     )
-    active_group: Mapped["OktaGroup"] = db.relationship(
+    active_group: Mapped["OktaGroup"] = relationship(
         "OktaGroup",
         primaryjoin="and_(OktaGroup.id == OktaUserGroupMember.group_id, " "OktaGroup.deleted_at.is_(None))",
         back_populates="active_user_memberships_and_ownerships",
@@ -62,13 +73,13 @@ class OktaUserGroupMember(db.Model):
         innerjoin=True,
     )
 
-    user: Mapped["OktaUser"] = db.relationship(
+    user: Mapped["OktaUser"] = relationship(
         "OktaUser",
         back_populates="all_group_memberships_and_ownerships",
         foreign_keys=[user_id],
         lazy="raise_on_sql",
     )
-    active_user: Mapped["OktaUser"] = db.relationship(
+    active_user: Mapped["OktaUser"] = relationship(
         "OktaUser",
         primaryjoin="and_(OktaUser.id == OktaUserGroupMember.user_id, " "OktaUser.deleted_at.is_(None))",
         back_populates="active_group_memberships_and_ownerships",
@@ -77,13 +88,13 @@ class OktaUserGroupMember(db.Model):
         innerjoin=True,
     )
 
-    role_group_mapping: Mapped["RoleGroupMap"] = db.relationship(
+    role_group_mapping: Mapped["RoleGroupMap"] = relationship(
         "RoleGroupMap",
         back_populates="all_group_memberships_and_ownerships",
         foreign_keys=[role_group_map_id],
         lazy="raise_on_sql",
     )
-    active_role_group_mapping: Mapped["RoleGroupMap"] = db.relationship(
+    active_role_group_mapping: Mapped["RoleGroupMap"] = relationship(
         "RoleGroupMap",
         primaryjoin="and_(RoleGroupMap.id == OktaUserGroupMember.role_group_map_id, "
         "or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))",
@@ -93,54 +104,52 @@ class OktaUserGroupMember(db.Model):
         lazy="raise_on_sql",
     )
 
-    access_request: Mapped["AccessRequest"] = db.relationship(
+    access_request: Mapped["AccessRequest"] = relationship(
         "AccessRequest",
         back_populates="approved_membership",
         lazy="raise_on_sql",
         uselist=False,
     )
 
-    created_actor: Mapped["OktaUser"] = db.relationship(
+    created_actor: Mapped["OktaUser"] = relationship(
         "OktaUser", foreign_keys=[created_actor_id], lazy="raise_on_sql", viewonly=True
     )
 
-    ended_actor: Mapped["OktaUser"] = db.relationship(
+    ended_actor: Mapped["OktaUser"] = relationship(
         "OktaUser", foreign_keys=[ended_actor_id], lazy="raise_on_sql", viewonly=True
     )
 
 
-class OktaUser(db.Model):
-    id: Mapped[str] = mapped_column(db.Unicode(50), primary_key=True, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(db.DateTime(), nullable=False, default=db.func.now())
-    updated_at: Mapped[datetime] = mapped_column(
-        db.DateTime(), nullable=False, default=db.func.now(), onupdate=db.func.now()
-    )
-    deleted_at: Mapped[Optional[datetime]] = mapped_column(db.DateTime())
+class OktaUser(Base):
+    id: Mapped[str] = mapped_column(Unicode(50), primary_key=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now(), onupdate=func.now())
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(DateTime())
     # https://developer.okta.com/docs/reference/api/users/#default-profile-properties
-    email: Mapped[str] = mapped_column(db.Unicode(100), nullable=False)
-    first_name: Mapped[str] = mapped_column(db.Unicode(50), nullable=False)
-    last_name: Mapped[str] = mapped_column(db.Unicode(50), nullable=False)
-    display_name: Mapped[Optional[str]] = mapped_column(db.Unicode(100))
-    employee_number: Mapped[Optional[str]] = mapped_column(db.Unicode(50))
-    manager_id: Mapped[Optional[str]] = mapped_column(db.Unicode(50), db.ForeignKey("okta_user.id"))
+    email: Mapped[str] = mapped_column(Unicode(100), nullable=False)
+    first_name: Mapped[str] = mapped_column(Unicode(50), nullable=False)
+    last_name: Mapped[str] = mapped_column(Unicode(50), nullable=False)
+    display_name: Mapped[Optional[str]] = mapped_column(Unicode(100))
+    employee_number: Mapped[Optional[str]] = mapped_column(Unicode(50))
+    manager_id: Mapped[Optional[str]] = mapped_column(Unicode(50), ForeignKey("okta_user.id"))
 
     # These 2 indexes are equivalent to a unique index on (email,deleted_at) with UNIQUE NULLS NOT DISTINCT
     # SQL alchemy 1.4 does not support UNIQUE NULLS NOT DISTINCT, but 2.0 does.
     __table_args__ = (
-        db.Index(
+        Index(
             "idx_email_deleted_at",
             "email",
             "deleted_at",
             unique=True,
-            postgresql_where=db.text("deleted_at IS NOT NULL"),
-            sqlite_where=db.text("deleted_at IS NOT NULL"),
+            postgresql_where=text("deleted_at IS NOT NULL"),
+            sqlite_where=text("deleted_at IS NOT NULL"),
         ),
-        db.Index(
+        Index(
             "idx_email",
             "email",
             unique=True,
-            postgresql_where=db.text("deleted_at IS NULL"),
-            sqlite_where=db.text("deleted_at IS NULL"),
+            postgresql_where=text("deleted_at IS NULL"),
+            sqlite_where=text("deleted_at IS NULL"),
         ),
     )
 
@@ -149,21 +158,21 @@ class OktaUser(db.Model):
     # https://amercader.net/blog/beware-of-json-fields-in-sqlalchemy/
     profile: Mapped[Dict[str, Any]] = mapped_column(
         mutable_json_type(
-            dbtype=db.JSON().with_variant(JSONB, "postgresql"),
+            dbtype=JSON().with_variant(JSONB, "postgresql"),
             nested=True,
         ),
         nullable=False,
         server_default="{}",
     )
 
-    manager: Mapped["OktaUser"] = db.relationship(
+    manager: Mapped["OktaUser"] = relationship(
         "OktaUser",
         back_populates="reports",
         remote_side=[id],
         lazy="raise_on_sql",
     )
 
-    reports: Mapped[List["OktaUser"]] = db.relationship(
+    reports: Mapped[List["OktaUser"]] = relationship(
         "OktaUser",
         back_populates="manager",
         lazy="raise_on_sql",
@@ -171,13 +180,13 @@ class OktaUser(db.Model):
 
     # See more details on specifying alternative join conditions for relationships at
     # https://docs.sqlalchemy.org/en/14/orm/join_conditions.html#specifying-alternate-join-conditions
-    all_group_memberships_and_ownerships: Mapped[List[OktaUserGroupMember]] = db.relationship(
+    all_group_memberships_and_ownerships: Mapped[List[OktaUserGroupMember]] = relationship(
         "OktaUserGroupMember",
         primaryjoin="OktaUser.id == OktaUserGroupMember.user_id",
         back_populates="user",
         lazy="raise_on_sql",
     )
-    active_group_memberships_and_ownerships: Mapped[List[OktaUserGroupMember]] = db.relationship(
+    active_group_memberships_and_ownerships: Mapped[List[OktaUserGroupMember]] = relationship(
         "OktaUserGroupMember",
         primaryjoin="and_(OktaUser.id == OktaUserGroupMember.user_id, "
         "or_(OktaUserGroupMember.ended_at.is_(None), OktaUserGroupMember.ended_at > func.now()))",
@@ -186,7 +195,7 @@ class OktaUser(db.Model):
         lazy="raise_on_sql",
         innerjoin=True,
     )
-    active_group_memberships: Mapped[List[OktaUserGroupMember]] = db.relationship(
+    active_group_memberships: Mapped[List[OktaUserGroupMember]] = relationship(
         "OktaUserGroupMember",
         primaryjoin="and_(OktaUser.id == OktaUserGroupMember.user_id, "
         "OktaUserGroupMember.is_owner.is_(False), "
@@ -195,7 +204,7 @@ class OktaUser(db.Model):
         lazy="raise_on_sql",
         innerjoin=True,
     )
-    active_group_ownerships: Mapped[List[OktaUserGroupMember]] = db.relationship(
+    active_group_ownerships: Mapped[List[OktaUserGroupMember]] = relationship(
         "OktaUserGroupMember",
         primaryjoin="and_(OktaUser.id == OktaUserGroupMember.user_id, "
         "OktaUserGroupMember.is_owner.is_(True), "
@@ -205,7 +214,7 @@ class OktaUser(db.Model):
         innerjoin=True,
     )
 
-    all_access_requests: Mapped[List["AccessRequest"]] = db.relationship(
+    all_access_requests: Mapped[List["AccessRequest"]] = relationship(
         "AccessRequest",
         primaryjoin="OktaUser.id == AccessRequest.requester_user_id",
         back_populates="requester",
@@ -213,7 +222,7 @@ class OktaUser(db.Model):
         innerjoin=True,
     )
 
-    all_resolved_access_requests: Mapped[List["AccessRequest"]] = db.relationship(
+    all_resolved_access_requests: Mapped[List["AccessRequest"]] = relationship(
         "AccessRequest",
         primaryjoin="OktaUser.id == AccessRequest.resolver_user_id",
         back_populates="resolver",
@@ -221,7 +230,7 @@ class OktaUser(db.Model):
         innerjoin=True,
     )
 
-    all_resolved_role_requests: Mapped[List["RoleRequest"]] = db.relationship(
+    all_resolved_role_requests: Mapped[List["RoleRequest"]] = relationship(
         "RoleRequest",
         primaryjoin="OktaUser.id == RoleRequest.resolver_user_id",
         back_populates="resolver",
@@ -229,7 +238,7 @@ class OktaUser(db.Model):
         innerjoin=True,
     )
 
-    all_resolved_group_requests: Mapped[List["GroupRequest"]] = db.relationship(
+    all_resolved_group_requests: Mapped[List["GroupRequest"]] = relationship(
         "GroupRequest",
         primaryjoin="OktaUser.id == GroupRequest.resolver_user_id",
         back_populates="resolver",
@@ -237,7 +246,7 @@ class OktaUser(db.Model):
         innerjoin=True,
     )
 
-    pending_access_requests: Mapped[List["AccessRequest"]] = db.relationship(
+    pending_access_requests: Mapped[List["AccessRequest"]] = relationship(
         "AccessRequest",
         primaryjoin="and_(OktaUser.id == AccessRequest.requester_user_id, "
         "AccessRequest.status == 'PENDING', "
@@ -247,7 +256,7 @@ class OktaUser(db.Model):
         innerjoin=True,
     )
 
-    resolved_access_requests: Mapped[List["AccessRequest"]] = db.relationship(
+    resolved_access_requests: Mapped[List["AccessRequest"]] = relationship(
         "AccessRequest",
         primaryjoin="and_(OktaUser.id == AccessRequest.resolver_user_id, "
         "AccessRequest.status != 'PENDING', "
@@ -258,26 +267,24 @@ class OktaUser(db.Model):
     )
 
 
-class OktaGroup(db.Model):
+class OktaGroup(Base):
     __tablename__ = "okta_group"
-    id: Mapped[str] = mapped_column(db.Unicode(50), primary_key=True, nullable=False)
-    type: Mapped[str] = mapped_column(db.Unicode(50), nullable=False)
-    created_at: Mapped[datetime] = mapped_column(db.DateTime(), nullable=False, default=db.func.now())
-    updated_at: Mapped[datetime] = mapped_column(
-        db.DateTime(), nullable=False, default=db.func.now(), onupdate=db.func.now()
-    )
-    deleted_at: Mapped[Optional[datetime]] = mapped_column(db.DateTime())
+    id: Mapped[str] = mapped_column(Unicode(50), primary_key=True, nullable=False)
+    type: Mapped[str] = mapped_column(Unicode(50), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now(), onupdate=func.now())
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(DateTime())
     # https://developer.okta.com/docs/reference/api/groups/#default-profile-properties
-    name: Mapped[str] = mapped_column(db.Unicode(255), nullable=False)
-    description: Mapped[str] = mapped_column(db.Unicode(1024), nullable=False, default="")
+    name: Mapped[str] = mapped_column(Unicode(255), nullable=False)
+    description: Mapped[str] = mapped_column(Unicode(1024), nullable=False, default="")
 
     # Is this group managed by Access or is it managed externally (Built-in Okta group? via Okta Group rule?)
-    is_managed: Mapped[bool] = mapped_column(db.Boolean, nullable=False, server_default=expression.true(), default=True)
+    is_managed: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=expression.true(), default=True)
 
     # Field containing additional data about externally managed groups
     externally_managed_data: Mapped[Dict[str, Any]] = mapped_column(
         mutable_json_type(
-            dbtype=db.JSON().with_variant(JSONB, "postgresql"),
+            dbtype=JSON().with_variant(JSONB, "postgresql"),
             nested=True,
         ),
         nullable=False,
@@ -288,19 +295,19 @@ class OktaGroup(db.Model):
     # https://github.com/edelooff/sqlalchemy-json
     # https://amercader.net/blog/beware-of-json-fields-in-sqlalchemy/
     plugin_data: Mapped[Dict[str, Any]] = mapped_column(
-        mutable_json_type(dbtype=db.JSON().with_variant(JSONB, "postgresql"), nested=True),
+        mutable_json_type(dbtype=JSON().with_variant(JSONB, "postgresql"), nested=True),
         nullable=False,
         server_default="{}",
     )
 
     # See more details on specifying alternative join conditions for relationships at
     # https://docs.sqlalchemy.org/en/14/orm/join_conditions.html#specifying-alternate-join-conditions
-    all_user_memberships_and_ownerships: Mapped[List[OktaUserGroupMember]] = db.relationship(
+    all_user_memberships_and_ownerships: Mapped[List[OktaUserGroupMember]] = relationship(
         "OktaUserGroupMember",
         back_populates="group",
         lazy="raise_on_sql",
     )
-    active_user_memberships_and_ownerships: Mapped[List[OktaUserGroupMember]] = db.relationship(
+    active_user_memberships_and_ownerships: Mapped[List[OktaUserGroupMember]] = relationship(
         "OktaUserGroupMember",
         primaryjoin="and_(OktaGroup.id == OktaUserGroupMember.group_id, "
         "or_(OktaUserGroupMember.ended_at.is_(None), OktaUserGroupMember.ended_at > func.now()))",
@@ -309,7 +316,7 @@ class OktaGroup(db.Model):
         lazy="raise_on_sql",
         innerjoin=True,
     )
-    active_user_memberships: Mapped[List[OktaUserGroupMember]] = db.relationship(
+    active_user_memberships: Mapped[List[OktaUserGroupMember]] = relationship(
         "OktaUserGroupMember",
         primaryjoin="and_(OktaGroup.id == OktaUserGroupMember.group_id, "
         "OktaUserGroupMember.is_owner.is_(False), "
@@ -318,7 +325,7 @@ class OktaGroup(db.Model):
         lazy="raise_on_sql",
         innerjoin=True,
     )
-    active_user_ownerships: Mapped[List[OktaUserGroupMember]] = db.relationship(
+    active_user_ownerships: Mapped[List[OktaUserGroupMember]] = relationship(
         "OktaUserGroupMember",
         primaryjoin="and_(OktaGroup.id == OktaUserGroupMember.group_id, "
         "OktaUserGroupMember.is_owner.is_(True), "
@@ -327,7 +334,7 @@ class OktaGroup(db.Model):
         lazy="raise_on_sql",
         innerjoin=True,
     )
-    active_non_role_user_memberships: Mapped[List[OktaUserGroupMember]] = db.relationship(
+    active_non_role_user_memberships: Mapped[List[OktaUserGroupMember]] = relationship(
         "OktaUserGroupMember",
         primaryjoin="and_(OktaGroup.id == OktaUserGroupMember.group_id, "
         "OktaUserGroupMember.is_owner.is_(False), "
@@ -337,7 +344,7 @@ class OktaGroup(db.Model):
         lazy="raise_on_sql",
         innerjoin=True,
     )
-    active_non_role_user_ownerships: Mapped[List[OktaUserGroupMember]] = db.relationship(
+    active_non_role_user_ownerships: Mapped[List[OktaUserGroupMember]] = relationship(
         "OktaUserGroupMember",
         primaryjoin="and_(OktaGroup.id == OktaUserGroupMember.group_id, "
         "OktaUserGroupMember.is_owner.is_(True), "
@@ -348,13 +355,13 @@ class OktaGroup(db.Model):
         innerjoin=True,
     )
 
-    all_role_mappings: Mapped[List["RoleGroupMap"]] = db.relationship(
+    all_role_mappings: Mapped[List["RoleGroupMap"]] = relationship(
         "RoleGroupMap",
         back_populates="group",
         foreign_keys="RoleGroupMap.group_id",
         lazy="raise_on_sql",
     )
-    active_role_mappings: Mapped[List["RoleGroupMap"]] = db.relationship(
+    active_role_mappings: Mapped[List["RoleGroupMap"]] = relationship(
         "RoleGroupMap",
         primaryjoin="and_(OktaGroup.id == RoleGroupMap.group_id, "
         "or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))",
@@ -363,7 +370,7 @@ class OktaGroup(db.Model):
         lazy="raise_on_sql",
         innerjoin=True,
     )
-    active_role_member_mappings: Mapped[List["RoleGroupMap"]] = db.relationship(
+    active_role_member_mappings: Mapped[List["RoleGroupMap"]] = relationship(
         "RoleGroupMap",
         primaryjoin="and_(OktaGroup.id == RoleGroupMap.group_id, "
         "RoleGroupMap.is_owner.is_(False), "
@@ -372,7 +379,7 @@ class OktaGroup(db.Model):
         lazy="raise_on_sql",
         innerjoin=True,
     )
-    active_role_owner_mappings: Mapped[List["RoleGroupMap"]] = db.relationship(
+    active_role_owner_mappings: Mapped[List["RoleGroupMap"]] = relationship(
         "RoleGroupMap",
         primaryjoin="and_(OktaGroup.id == RoleGroupMap.group_id, "
         "RoleGroupMap.is_owner.is_(True), "
@@ -382,11 +389,11 @@ class OktaGroup(db.Model):
         innerjoin=True,
     )
 
-    all_access_requests: Mapped[List["AccessRequest"]] = db.relationship(
+    all_access_requests: Mapped[List["AccessRequest"]] = relationship(
         "AccessRequest", back_populates="requested_group", lazy="raise_on_sql"
     )
 
-    pending_access_requests: Mapped[List["AccessRequest"]] = db.relationship(
+    pending_access_requests: Mapped[List["AccessRequest"]] = relationship(
         "AccessRequest",
         primaryjoin="and_(OktaGroup.id == AccessRequest.requested_group_id, "
         "AccessRequest.status == 'PENDING', "
@@ -397,7 +404,7 @@ class OktaGroup(db.Model):
     )
 
     # requests to join group
-    all_role_requests_to: Mapped[List["RoleRequest"]] = db.relationship(
+    all_role_requests_to: Mapped[List["RoleRequest"]] = relationship(
         "RoleRequest",
         back_populates="requested_group",
         primaryjoin="OktaGroup.id == RoleRequest.requested_group_id",
@@ -405,14 +412,14 @@ class OktaGroup(db.Model):
     )
 
     # request by role group to join group
-    all_role_requests_from: Mapped[List["RoleRequest"]] = db.relationship(
+    all_role_requests_from: Mapped[List["RoleRequest"]] = relationship(
         "RoleRequest",
         back_populates="requester_role",
         primaryjoin="OktaGroup.id == RoleRequest.requester_role_id",
         lazy="raise_on_sql",
     )
 
-    pending_role_requests: Mapped[List["RoleRequest"]] = db.relationship(
+    pending_role_requests: Mapped[List["RoleRequest"]] = relationship(
         "RoleRequest",
         primaryjoin="and_(OktaGroup.id == RoleRequest.requested_group_id, "
         "RoleRequest.status == 'PENDING', "
@@ -422,14 +429,14 @@ class OktaGroup(db.Model):
         innerjoin=True,
     )
 
-    group_request: Mapped["GroupRequest"] = db.relationship(
+    group_request: Mapped["GroupRequest"] = relationship(
         "GroupRequest",
         back_populates="approved_group",
         lazy="raise_on_sql",
         uselist=False,
     )
 
-    all_group_tags: Mapped[List["OktaGroupTagMap"]] = db.relationship(
+    all_group_tags: Mapped[List["OktaGroupTagMap"]] = relationship(
         "OktaGroupTagMap",
         back_populates="group",
         lazy="raise_on_sql",
@@ -437,7 +444,7 @@ class OktaGroup(db.Model):
     # SQLAlchemy doesn't seem to support loading
     # group.active_role_associated_group_[member|owner]_mappings.active_group when a group_id or user_id is specified
     # in GET /api/audit/users so we have to enable "select" lazy loading.
-    active_group_tags: Mapped[List["OktaGroupTagMap"]] = db.relationship(
+    active_group_tags: Mapped[List["OktaGroupTagMap"]] = relationship(
         "OktaGroupTagMap",
         primaryjoin="and_(OktaGroup.id == OktaGroupTagMap.group_id, "
         "or_(OktaGroupTagMap.ended_at.is_(None), OktaGroupTagMap.ended_at > func.now()))",
@@ -452,44 +459,42 @@ class OktaGroup(db.Model):
     }
 
 
-class RoleGroupMap(db.Model):
+class RoleGroupMap(Base):
     # See https://stackoverflow.com/a/60840921
     id: Mapped[int] = mapped_column(
-        db.BigInteger().with_variant(db.Integer, "sqlite"),
+        BigInteger().with_variant(Integer, "sqlite"),
         autoincrement=True,
         primary_key=True,
     )
-    role_group_id: Mapped[str] = mapped_column("role_id", db.Unicode(50), db.ForeignKey("okta_group.id"))
-    group_id: Mapped[str] = mapped_column("group_id", db.Unicode(50), db.ForeignKey("okta_group.id"))
+    role_group_id: Mapped[str] = mapped_column("role_id", Unicode(50), ForeignKey("okta_group.id"))
+    group_id: Mapped[str] = mapped_column("group_id", Unicode(50), ForeignKey("okta_group.id"))
     # Does this role grant ownership of the group and allow role members to administer the group and manage membership?
     # Or does this role grant only membership to the group?
-    is_owner: Mapped[bool] = mapped_column(db.Boolean, nullable=False, server_default=expression.false(), default=False)
-    created_at: Mapped[datetime] = mapped_column(db.DateTime(), nullable=False, default=db.func.now())
-    updated_at: Mapped[datetime] = mapped_column(
-        db.DateTime(), nullable=False, default=db.func.now(), onupdate=db.func.now()
-    )
-    ended_at: Mapped[Optional[datetime]] = mapped_column(db.DateTime())
+    is_owner: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=expression.false(), default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now(), onupdate=func.now())
+    ended_at: Mapped[Optional[datetime]] = mapped_column(DateTime())
 
     # Save the user IDs of the person who added/removed someone from a group
-    created_actor_id: Mapped[Optional[str]] = mapped_column(db.Unicode(50), db.ForeignKey("okta_user.id"))
-    ended_actor_id: Mapped[Optional[str]] = mapped_column(db.Unicode(50), db.ForeignKey("okta_user.id"))
+    created_actor_id: Mapped[Optional[str]] = mapped_column(Unicode(50), ForeignKey("okta_user.id"))
+    ended_actor_id: Mapped[Optional[str]] = mapped_column(Unicode(50), ForeignKey("okta_user.id"))
 
-    created_reason: Mapped[str] = mapped_column(db.Unicode(1024), nullable=False, default="", server_default="")
+    created_reason: Mapped[str] = mapped_column(Unicode(1024), nullable=False, default="", server_default="")
 
     # This field is set to True when an owner chooses to not renew access in the Expiring Access workflow
     should_expire: Mapped[bool] = mapped_column(
-        db.Boolean, nullable=False, server_default=expression.false(), default=False
+        Boolean, nullable=False, server_default=expression.false(), default=False
     )
 
     # See more details on specifying alternative join conditions for relationships at
     # https://docs.sqlalchemy.org/en/14/orm/join_conditions.html#specifying-alternate-join-conditions
-    role_group: Mapped["RoleGroup"] = db.relationship(
+    role_group: Mapped["RoleGroup"] = relationship(
         "RoleGroup",
         back_populates="all_role_associated_group_mappings",
         foreign_keys=[role_group_id],
         lazy="raise_on_sql",
     )
-    active_role_group: Mapped["RoleGroup"] = db.relationship(
+    active_role_group: Mapped["RoleGroup"] = relationship(
         "RoleGroup",
         primaryjoin="and_(remote(OktaGroup.id) == RoleGroupMap.role_group_id, " "OktaGroup.deleted_at.is_(None))",
         back_populates="active_role_associated_group_mappings",
@@ -499,13 +504,13 @@ class RoleGroupMap(db.Model):
         innerjoin=True,
     )
 
-    group: Mapped[OktaGroup] = db.relationship(
+    group: Mapped[OktaGroup] = relationship(
         "OktaGroup",
         back_populates="all_role_mappings",
         foreign_keys=[group_id],
         lazy="raise_on_sql",
     )
-    active_group: Mapped[OktaGroup] = db.relationship(
+    active_group: Mapped[OktaGroup] = relationship(
         "OktaGroup",
         primaryjoin="and_(OktaGroup.id == RoleGroupMap.group_id, " "OktaGroup.deleted_at.is_(None))",
         back_populates="active_role_mappings",
@@ -518,10 +523,10 @@ class RoleGroupMap(db.Model):
         innerjoin=True,
     )
 
-    all_group_memberships_and_ownerships: Mapped[List[OktaUserGroupMember]] = db.relationship(
+    all_group_memberships_and_ownerships: Mapped[List[OktaUserGroupMember]] = relationship(
         "OktaUserGroupMember", back_populates="role_group_mapping", lazy="raise_on_sql"
     )
-    active_group_memberships_and_ownerships: Mapped[List[OktaUserGroupMember]] = db.relationship(
+    active_group_memberships_and_ownerships: Mapped[List[OktaUserGroupMember]] = relationship(
         "OktaUserGroupMember",
         primaryjoin="and_(RoleGroupMap.id == OktaUserGroupMember.role_group_map_id, "
         "or_(OktaUserGroupMember.ended_at.is_(None), OktaUserGroupMember.ended_at > func.now()))",
@@ -531,15 +536,15 @@ class RoleGroupMap(db.Model):
         innerjoin=True,
     )
 
-    created_actor: Mapped[OktaUser] = db.relationship(
+    created_actor: Mapped[OktaUser] = relationship(
         "OktaUser", foreign_keys=[created_actor_id], lazy="raise_on_sql", viewonly=True
     )
 
-    ended_actor: Mapped[OktaUser] = db.relationship(
+    ended_actor: Mapped[OktaUser] = relationship(
         "OktaUser", foreign_keys=[ended_actor_id], lazy="raise_on_sql", viewonly=True
     )
 
-    role_request: Mapped["RoleRequest"] = db.relationship(
+    role_request: Mapped["RoleRequest"] = relationship(
         "RoleRequest",
         back_populates="approved_membership",
         lazy="raise_on_sql",
@@ -557,17 +562,17 @@ class RoleGroup(OktaGroup):
     ROLE_GROUP_NAME_PREFIX = "Role-"
 
     __tablename__ = "role_group"
-    id: Mapped[str] = mapped_column(db.Unicode(50), db.ForeignKey("okta_group.id"), primary_key=True)
+    id: Mapped[str] = mapped_column(Unicode(50), ForeignKey("okta_group.id"), primary_key=True)
 
     # See more details on specifying alternative join conditions for relationships at
     # https://docs.sqlalchemy.org/en/14/orm/join_conditions.html#specifying-alternate-join-conditions
-    all_role_associated_group_mappings: Mapped[List[RoleGroupMap]] = db.relationship(
+    all_role_associated_group_mappings: Mapped[List[RoleGroupMap]] = relationship(
         "RoleGroupMap",
         back_populates="role_group",
         foreign_keys="RoleGroupMap.role_group_id",
         lazy="raise_on_sql",
     )
-    active_role_associated_group_mappings: Mapped[List[RoleGroupMap]] = db.relationship(
+    active_role_associated_group_mappings: Mapped[List[RoleGroupMap]] = relationship(
         "RoleGroupMap",
         primaryjoin="and_(OktaGroup.id == foreign(RoleGroupMap.role_group_id), "
         "or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))",
@@ -577,7 +582,7 @@ class RoleGroup(OktaGroup):
         lazy="raise_on_sql",
         innerjoin=True,
     )
-    active_role_associated_group_member_mappings: Mapped[List[RoleGroupMap]] = db.relationship(
+    active_role_associated_group_member_mappings: Mapped[List[RoleGroupMap]] = relationship(
         "RoleGroupMap",
         primaryjoin="and_(RoleGroup.id == foreign(RoleGroupMap.role_group_id), "
         "RoleGroupMap.is_owner.is_(False), "
@@ -586,7 +591,7 @@ class RoleGroup(OktaGroup):
         lazy="raise_on_sql",
         innerjoin=True,
     )
-    active_role_associated_group_owner_mappings: Mapped[List[RoleGroupMap]] = db.relationship(
+    active_role_associated_group_owner_mappings: Mapped[List[RoleGroupMap]] = relationship(
         "RoleGroupMap",
         primaryjoin="and_(RoleGroup.id == foreign(RoleGroupMap.role_group_id), "
         "RoleGroupMap.is_owner.is_(True), "
@@ -607,18 +612,18 @@ class AppGroup(OktaGroup):
     APP_OWNERS_GROUP_NAME_SUFFIX = "Owners"
 
     __tablename__ = "app_group"
-    id: Mapped[str] = mapped_column(db.Unicode(50), db.ForeignKey("okta_group.id"), primary_key=True)
+    id: Mapped[str] = mapped_column(Unicode(50), ForeignKey("okta_group.id"), primary_key=True)
 
-    app_id: Mapped[str] = mapped_column(db.Unicode(50), db.ForeignKey("app.id"), nullable=False)
+    app_id: Mapped[str] = mapped_column(Unicode(50), ForeignKey("app.id"), nullable=False)
     # Is this group the app owner group and can administer the app and other app groups?
     # Membership to an app onwer group implicitly grants group owner permissions on the
     # group to administer and manage membership of the app owner group
-    is_owner: Mapped[bool] = mapped_column(db.Boolean, nullable=False, server_default=expression.false(), default=False)
+    is_owner: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=expression.false(), default=False)
 
     # SQLAlchemy doesn't seem to support loading
     # group.active_role_associated_group_[member|owner]_mappings.active_group when a group_id or user_id is specified
     # in GET /api/audit/users so we have to enable "select" lazy loading.
-    app: Mapped["App"] = db.relationship("App", back_populates="app_groups", lazy="select")
+    app: Mapped["App"] = relationship("App", back_populates="app_groups", lazy="select")
 
     __mapper_args__ = {
         "polymorphic_identity": "app_group",
@@ -626,7 +631,7 @@ class AppGroup(OktaGroup):
 
     @validates("name")
     def validate_group(self, key: str, name: str) -> str:
-        app = App.query.filter(App.id == self.app_id).filter(App.deleted_at.is_(None)).first()
+        app = db.session.query(App).filter(App.id == self.app_id).filter(App.deleted_at.is_(None)).first()
         if app is None:
             raise ValueError(f"Specified App with app_id: {self.app_id} does not exist")
         # app_groups should have app name prepended always
@@ -640,35 +645,33 @@ class AppGroup(OktaGroup):
         return name
 
 
-class App(db.Model):
+class App(Base):
     ACCESS_APP_RESERVED_NAME = config.APP_NAME
 
     # A 20 character random string like Okta IDs
-    id: Mapped[str] = mapped_column(db.Unicode(20), primary_key=True, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(db.DateTime(), nullable=False, default=db.func.now())
-    updated_at: Mapped[datetime] = mapped_column(
-        db.DateTime(), nullable=False, default=db.func.now(), onupdate=db.func.now()
-    )
-    deleted_at: Mapped[Optional[datetime]] = mapped_column(db.DateTime())
+    id: Mapped[str] = mapped_column(Unicode(20), primary_key=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now(), onupdate=func.now())
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(DateTime())
 
-    name: Mapped[str] = mapped_column(db.Unicode(255), nullable=False)
-    description: Mapped[str] = mapped_column(db.Unicode(1024), nullable=False, default="")
+    name: Mapped[str] = mapped_column(Unicode(255), nullable=False)
+    description: Mapped[str] = mapped_column(Unicode(1024), nullable=False, default="")
 
     # Optional plugin ID for managing app group lifecycle
-    app_group_lifecycle_plugin: Mapped[Optional[str]] = mapped_column(db.Unicode(255))
+    app_group_lifecycle_plugin: Mapped[Optional[str]] = mapped_column(Unicode(255))
 
     # A JSON field for App plugin integrations in the form of {"unique_plugin_name": plugin_data }
     # https://github.com/edelooff/sqlalchemy-json
     # https://amercader.net/blog/beware-of-json-fields-in-sqlalchemy/
     plugin_data: Mapped[Dict[str, Any]] = mapped_column(
-        mutable_json_type(dbtype=db.JSON().with_variant(JSONB, "postgresql"), nested=True),
+        mutable_json_type(dbtype=JSON().with_variant(JSONB, "postgresql"), nested=True),
         nullable=False,
         server_default="{}",
     )
 
-    app_groups: Mapped[List[AppGroup]] = db.relationship("AppGroup", back_populates="app", lazy="raise_on_sql")
+    app_groups: Mapped[List[AppGroup]] = relationship("AppGroup", back_populates="app", lazy="raise_on_sql")
 
-    active_app_groups: Mapped[List[AppGroup]] = db.relationship(
+    active_app_groups: Mapped[List[AppGroup]] = relationship(
         "AppGroup",
         primaryjoin="and_(App.id == AppGroup.app_id, AppGroup.deleted_at.is_(None))",
         viewonly=True,
@@ -677,7 +680,7 @@ class App(db.Model):
         order_by="AppGroup.name",
     )
 
-    active_owner_app_groups: Mapped[List[AppGroup]] = db.relationship(
+    active_owner_app_groups: Mapped[List[AppGroup]] = relationship(
         "AppGroup",
         primaryjoin="and_(App.id == AppGroup.app_id, " "AppGroup.deleted_at.is_(None), " "AppGroup.is_owner.is_(True))",
         viewonly=True,
@@ -686,7 +689,7 @@ class App(db.Model):
         order_by="AppGroup.name",
     )
 
-    active_non_owner_app_groups: Mapped[List[AppGroup]] = db.relationship(
+    active_non_owner_app_groups: Mapped[List[AppGroup]] = relationship(
         "AppGroup",
         primaryjoin="and_(App.id == AppGroup.app_id, "
         "AppGroup.deleted_at.is_(None), "
@@ -697,12 +700,12 @@ class App(db.Model):
         order_by="AppGroup.name",
     )
 
-    all_app_tags: Mapped[List["AppTagMap"]] = db.relationship(
+    all_app_tags: Mapped[List["AppTagMap"]] = relationship(
         "AppTagMap",
         back_populates="app",
         lazy="raise_on_sql",
     )
-    active_app_tags: Mapped[List["AppTagMap"]] = db.relationship(
+    active_app_tags: Mapped[List["AppTagMap"]] = relationship(
         "AppTagMap",
         primaryjoin="and_(App.id == AppTagMap.app_id, "
         "or_(AppTagMap.ended_at.is_(None), AppTagMap.ended_at > func.now()))",
@@ -720,46 +723,44 @@ class AccessRequestStatus(StrEnum):
     REJECTED = "REJECTED"
 
 
-class AccessRequest(db.Model):
+class AccessRequest(Base):
     # A 20 character random string like Okta IDs
-    id: Mapped[str] = mapped_column(db.Unicode(20), primary_key=True, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(db.DateTime(), nullable=False, default=db.func.now())
-    updated_at: Mapped[datetime] = mapped_column(
-        db.DateTime(), nullable=False, default=db.func.now(), onupdate=db.func.now()
-    )
-    resolved_at: Mapped[Optional[datetime]] = mapped_column(db.DateTime())
+    id: Mapped[str] = mapped_column(Unicode(20), primary_key=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now(), onupdate=func.now())
+    resolved_at: Mapped[Optional[datetime]] = mapped_column(DateTime())
 
     status: Mapped[AccessRequestStatus] = mapped_column(
-        db.Enum(AccessRequestStatus),
+        Enum(AccessRequestStatus),
         nullable=False,
         default=AccessRequestStatus.PENDING,
     )
 
-    requester_user_id: Mapped[str] = mapped_column(db.Unicode(50), db.ForeignKey("okta_user.id"))
-    requested_group_id: Mapped[str] = mapped_column(db.Unicode(50), db.ForeignKey("okta_group.id"))
-    request_ownership: Mapped[bool] = mapped_column(db.Boolean, nullable=False, default=False)
-    request_reason: Mapped[str] = mapped_column(db.Unicode(1024), nullable=False, default="")
-    request_ending_at: Mapped[Optional[datetime]] = mapped_column(db.DateTime())
+    requester_user_id: Mapped[str] = mapped_column(Unicode(50), ForeignKey("okta_user.id"))
+    requested_group_id: Mapped[str] = mapped_column(Unicode(50), ForeignKey("okta_group.id"))
+    request_ownership: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    request_reason: Mapped[str] = mapped_column(Unicode(1024), nullable=False, default="")
+    request_ending_at: Mapped[Optional[datetime]] = mapped_column(DateTime())
 
-    resolver_user_id: Mapped[Optional[str]] = mapped_column(db.Unicode(50), db.ForeignKey("okta_user.id"))
-    resolution_reason: Mapped[str] = mapped_column(db.Unicode(1024), nullable=False, default="")
+    resolver_user_id: Mapped[Optional[str]] = mapped_column(Unicode(50), ForeignKey("okta_user.id"))
+    resolution_reason: Mapped[str] = mapped_column(Unicode(1024), nullable=False, default="")
 
-    approval_ending_at: Mapped[Optional[datetime]] = mapped_column(db.DateTime())
+    approval_ending_at: Mapped[Optional[datetime]] = mapped_column(DateTime())
 
     # See https://stackoverflow.com/a/60840921
     approved_membership_id: Mapped[Optional[int]] = mapped_column(
-        db.BigInteger().with_variant(db.Integer, "sqlite"),
-        db.ForeignKey("okta_user_group_member.id"),
+        BigInteger().with_variant(Integer, "sqlite"),
+        ForeignKey("okta_user_group_member.id"),
     )
 
-    requester: Mapped[OktaUser] = db.relationship(
+    requester: Mapped[OktaUser] = relationship(
         "OktaUser",
         back_populates="all_access_requests",
         foreign_keys=[requester_user_id],
         lazy="raise_on_sql",
     )
 
-    active_requester: Mapped[OktaUser] = db.relationship(
+    active_requester: Mapped[OktaUser] = relationship(
         "OktaUser",
         primaryjoin="and_(OktaUser.id == AccessRequest.requester_user_id, " "OktaUser.deleted_at.is_(None))",
         viewonly=True,
@@ -767,14 +768,14 @@ class AccessRequest(db.Model):
         innerjoin=True,
     )
 
-    requested_group: Mapped[OktaGroup] = db.relationship(
+    requested_group: Mapped[OktaGroup] = relationship(
         "OktaGroup",
         back_populates="all_access_requests",
         foreign_keys=[requested_group_id],
         lazy="raise_on_sql",
     )
 
-    active_requested_group: Mapped[OktaGroup] = db.relationship(
+    active_requested_group: Mapped[OktaGroup] = relationship(
         "OktaGroup",
         primaryjoin="and_(OktaGroup.id == AccessRequest.requested_group_id, " "OktaGroup.deleted_at.is_(None))",
         viewonly=True,
@@ -782,21 +783,21 @@ class AccessRequest(db.Model):
         innerjoin=True,
     )
 
-    resolver: Mapped[OktaUser] = db.relationship(
+    resolver: Mapped[OktaUser] = relationship(
         "OktaUser",
         back_populates="all_resolved_access_requests",
         foreign_keys=[resolver_user_id],
         lazy="raise_on_sql",
     )
 
-    active_resolver: Mapped[OktaUser] = db.relationship(
+    active_resolver: Mapped[OktaUser] = relationship(
         "OktaUser",
         primaryjoin="and_(OktaUser.id == AccessRequest.resolver_user_id, " "OktaUser.deleted_at.is_(None))",
         viewonly=True,
         lazy="raise_on_sql",
     )
 
-    approved_membership: Mapped[OktaUserGroupMember] = db.relationship(
+    approved_membership: Mapped[OktaUserGroupMember] = relationship(
         "OktaUserGroupMember",
         back_populates="access_request",
         foreign_keys=[approved_membership_id],
@@ -804,42 +805,40 @@ class AccessRequest(db.Model):
     )
 
 
-class RoleRequest(db.Model):
+class RoleRequest(Base):
     # A 20 character random string like Okta IDs
-    id: Mapped[str] = mapped_column(db.Unicode(20), primary_key=True, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(db.DateTime(), nullable=False, default=db.func.now())
-    updated_at: Mapped[datetime] = mapped_column(
-        db.DateTime(), nullable=False, default=db.func.now(), onupdate=db.func.now()
-    )
-    resolved_at: Mapped[Optional[datetime]] = mapped_column(db.DateTime())
+    id: Mapped[str] = mapped_column(Unicode(20), primary_key=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now(), onupdate=func.now())
+    resolved_at: Mapped[Optional[datetime]] = mapped_column(DateTime())
 
     status: Mapped[AccessRequestStatus] = mapped_column(
-        db.Enum(AccessRequestStatus),
+        Enum(AccessRequestStatus),
         nullable=False,
         default=AccessRequestStatus.PENDING,
     )
 
     # must be an owner of the role
-    requester_user_id: Mapped[str] = mapped_column(db.Unicode(50), db.ForeignKey("okta_user.id"))
+    requester_user_id: Mapped[str] = mapped_column(Unicode(50), ForeignKey("okta_user.id"))
     # role to be added to the requested group
-    requester_role_id: Mapped[str] = mapped_column(db.Unicode(50), db.ForeignKey("okta_group.id"))
-    requested_group_id: Mapped[str] = mapped_column(db.Unicode(50), db.ForeignKey("okta_group.id"))
-    request_ownership: Mapped[bool] = mapped_column(db.Boolean, nullable=False, default=False)
-    request_reason: Mapped[str] = mapped_column(db.Unicode(1024), nullable=False, default="")
-    request_ending_at: Mapped[Optional[datetime]] = mapped_column(db.DateTime())
+    requester_role_id: Mapped[str] = mapped_column(Unicode(50), ForeignKey("okta_group.id"))
+    requested_group_id: Mapped[str] = mapped_column(Unicode(50), ForeignKey("okta_group.id"))
+    request_ownership: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    request_reason: Mapped[str] = mapped_column(Unicode(1024), nullable=False, default="")
+    request_ending_at: Mapped[Optional[datetime]] = mapped_column(DateTime())
 
-    resolver_user_id: Mapped[Optional[str]] = mapped_column(db.Unicode(50), db.ForeignKey("okta_user.id"))
-    resolution_reason: Mapped[str] = mapped_column(db.Unicode(1024), nullable=False, default="")
+    resolver_user_id: Mapped[Optional[str]] = mapped_column(Unicode(50), ForeignKey("okta_user.id"))
+    resolution_reason: Mapped[str] = mapped_column(Unicode(1024), nullable=False, default="")
 
-    approval_ending_at: Mapped[Optional[datetime]] = mapped_column(db.DateTime())
+    approval_ending_at: Mapped[Optional[datetime]] = mapped_column(DateTime())
 
     # See https://stackoverflow.com/a/60840921
     approved_membership_id: Mapped[Optional[int]] = mapped_column(
-        db.BigInteger().with_variant(db.Integer, "sqlite"),
-        db.ForeignKey("role_group_map.id"),
+        BigInteger().with_variant(Integer, "sqlite"),
+        ForeignKey("role_group_map.id"),
     )
 
-    requester: Mapped[OktaUser] = db.relationship(
+    requester: Mapped[OktaUser] = relationship(
         "OktaUser",
         primaryjoin="OktaUser.id == RoleRequest.requester_user_id",
         viewonly=True,
@@ -847,7 +846,7 @@ class RoleRequest(db.Model):
         innerjoin=True,
     )
 
-    active_requester: Mapped[OktaUser] = db.relationship(
+    active_requester: Mapped[OktaUser] = relationship(
         "OktaUser",
         primaryjoin="and_(OktaUser.id == RoleRequest.requester_user_id, " "OktaUser.deleted_at.is_(None))",
         viewonly=True,
@@ -855,14 +854,14 @@ class RoleRequest(db.Model):
         innerjoin=True,
     )
 
-    requester_role: Mapped[OktaGroup] = db.relationship(
+    requester_role: Mapped[OktaGroup] = relationship(
         "OktaGroup",
         back_populates="all_role_requests_from",
         foreign_keys=[requester_role_id],
         lazy="raise_on_sql",
     )
 
-    active_requester_role: Mapped[OktaGroup] = db.relationship(
+    active_requester_role: Mapped[OktaGroup] = relationship(
         "OktaGroup",
         primaryjoin="and_(OktaGroup.id == RoleRequest.requested_group_id, " "OktaGroup.deleted_at.is_(None))",
         viewonly=True,
@@ -870,14 +869,14 @@ class RoleRequest(db.Model):
         innerjoin=True,
     )
 
-    requested_group: Mapped[OktaGroup] = db.relationship(
+    requested_group: Mapped[OktaGroup] = relationship(
         "OktaGroup",
         back_populates="all_role_requests_to",
         foreign_keys=[requested_group_id],
         lazy="raise_on_sql",
     )
 
-    active_requested_group: Mapped[OktaGroup] = db.relationship(
+    active_requested_group: Mapped[OktaGroup] = relationship(
         "OktaGroup",
         primaryjoin="and_(OktaGroup.id == RoleRequest.requested_group_id, " "OktaGroup.deleted_at.is_(None))",
         viewonly=True,
@@ -885,21 +884,21 @@ class RoleRequest(db.Model):
         innerjoin=True,
     )
 
-    resolver: Mapped[OktaUser] = db.relationship(
+    resolver: Mapped[OktaUser] = relationship(
         "OktaUser",
         back_populates="all_resolved_role_requests",
         foreign_keys=[resolver_user_id],
         lazy="raise_on_sql",
     )
 
-    active_resolver: Mapped[OktaUser] = db.relationship(
+    active_resolver: Mapped[OktaUser] = relationship(
         "OktaUser",
         primaryjoin="and_(OktaUser.id == RoleRequest.resolver_user_id, " "OktaUser.deleted_at.is_(None))",
         viewonly=True,
         lazy="raise_on_sql",
     )
 
-    approved_membership: Mapped[RoleGroupMap] = db.relationship(
+    approved_membership: Mapped[RoleGroupMap] = relationship(
         "RoleGroupMap",
         back_populates="role_request",
         foreign_keys=[approved_membership_id],
@@ -907,34 +906,32 @@ class RoleRequest(db.Model):
     )
 
 
-class GroupRequest(db.Model):
+class GroupRequest(Base):
     # A 20 character random string like Okta IDs
-    id: Mapped[str] = mapped_column(db.Unicode(20), primary_key=True, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(db.DateTime(), nullable=False, default=db.func.now())
-    updated_at: Mapped[datetime] = mapped_column(
-        db.DateTime(), nullable=False, default=db.func.now(), onupdate=db.func.now()
-    )
-    resolved_at: Mapped[Optional[datetime]] = mapped_column(db.DateTime())
+    id: Mapped[str] = mapped_column(Unicode(20), primary_key=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now(), onupdate=func.now())
+    resolved_at: Mapped[Optional[datetime]] = mapped_column(DateTime())
 
     status: Mapped[AccessRequestStatus] = mapped_column(
-        db.Enum(AccessRequestStatus),
+        Enum(AccessRequestStatus),
         nullable=False,
         default=AccessRequestStatus.PENDING,
     )
 
     # For now, the requester will be set as the owner of the group, may expand in the future to allow the
     # requester to set other users or roles as proposed owners
-    requester_user_id: Mapped[str] = mapped_column(db.Unicode(50), db.ForeignKey("okta_user.id"))
+    requester_user_id: Mapped[str] = mapped_column(Unicode(50), ForeignKey("okta_user.id"))
     # https://developer.okta.com/docs/reference/api/groups/#default-profile-properties
-    requested_group_name: Mapped[str] = mapped_column(db.Unicode(255), nullable=False)
-    requested_group_description: Mapped[str] = mapped_column(db.Unicode(1024), nullable=False, default="")
-    requested_group_type: Mapped[str] = mapped_column(db.Unicode(50), nullable=False)
-    requested_app_id: Mapped[Optional[str]] = mapped_column(db.Unicode(20), db.ForeignKey("app.id"))
-    requested_ownership_ending_at: Mapped[Optional[datetime]] = mapped_column(db.DateTime())
+    requested_group_name: Mapped[str] = mapped_column(Unicode(255), nullable=False)
+    requested_group_description: Mapped[str] = mapped_column(Unicode(1024), nullable=False, default="")
+    requested_group_type: Mapped[str] = mapped_column(Unicode(50), nullable=False)
+    requested_app_id: Mapped[Optional[str]] = mapped_column(Unicode(20), ForeignKey("app.id"))
+    requested_ownership_ending_at: Mapped[Optional[datetime]] = mapped_column(DateTime())
     # Tag ids
     requested_group_tags: Mapped[List[str]] = mapped_column(
         mutable_json_type(
-            dbtype=db.JSON().with_variant(JSONB, "postgresql"),
+            dbtype=JSON().with_variant(JSONB, "postgresql"),
             nested=True,
         ),
         nullable=False,
@@ -942,34 +939,34 @@ class GroupRequest(db.Model):
         server_default="[]",
     )
     # Will also be used to populate owner access reason field
-    request_reason: Mapped[str] = mapped_column(db.Unicode(1024), nullable=False, default="")
+    request_reason: Mapped[str] = mapped_column(Unicode(1024), nullable=False, default="")
 
     # Since resolver can edit all fields before group is created, have 'resolved' version
-    resolver_user_id: Mapped[Optional[str]] = mapped_column(db.Unicode(50), db.ForeignKey("okta_user.id"))
+    resolver_user_id: Mapped[Optional[str]] = mapped_column(Unicode(50), ForeignKey("okta_user.id"))
     # https://developer.okta.com/docs/reference/api/groups/#default-profile-properties
-    resolved_group_name: Mapped[str] = mapped_column(db.Unicode(255), nullable=False, default="")
-    resolved_group_description: Mapped[str] = mapped_column(db.Unicode(1024), nullable=False, default="")
-    resolved_group_type: Mapped[str] = mapped_column(db.Unicode(50), nullable=False, default="")
-    resolved_app_id: Mapped[Optional[str]] = mapped_column(db.Unicode(20), db.ForeignKey("app.id"))
-    resolved_ownership_ending_at: Mapped[Optional[datetime]] = mapped_column(db.DateTime())
+    resolved_group_name: Mapped[str] = mapped_column(Unicode(255), nullable=False, default="")
+    resolved_group_description: Mapped[str] = mapped_column(Unicode(1024), nullable=False, default="")
+    resolved_group_type: Mapped[str] = mapped_column(Unicode(50), nullable=False, default="")
+    resolved_app_id: Mapped[Optional[str]] = mapped_column(Unicode(20), ForeignKey("app.id"))
+    resolved_ownership_ending_at: Mapped[Optional[datetime]] = mapped_column(DateTime())
     # Tag ids
     resolved_group_tags: Mapped[List[str]] = mapped_column(
         mutable_json_type(
-            dbtype=db.JSON().with_variant(JSONB, "postgresql"),
+            dbtype=JSON().with_variant(JSONB, "postgresql"),
             nested=True,
         ),
         nullable=False,
         default=list,
         server_default="[]",
     )
-    resolution_reason: Mapped[str] = mapped_column(db.Unicode(1024), nullable=False, default="")
+    resolution_reason: Mapped[str] = mapped_column(Unicode(1024), nullable=False, default="")
 
     approved_group_id: Mapped[Optional[str]] = mapped_column(
-        db.Unicode(50),
-        db.ForeignKey("okta_group.id"),
+        Unicode(50),
+        ForeignKey("okta_group.id"),
     )
 
-    requester: Mapped[OktaUser] = db.relationship(
+    requester: Mapped[OktaUser] = relationship(
         "OktaUser",
         primaryjoin="OktaUser.id == GroupRequest.requester_user_id",
         viewonly=True,
@@ -977,7 +974,7 @@ class GroupRequest(db.Model):
         innerjoin=True,
     )
 
-    active_requester: Mapped[OktaUser] = db.relationship(
+    active_requester: Mapped[OktaUser] = relationship(
         "OktaUser",
         primaryjoin="and_(OktaUser.id == GroupRequest.requester_user_id, " "OktaUser.deleted_at.is_(None))",
         viewonly=True,
@@ -985,28 +982,28 @@ class GroupRequest(db.Model):
         innerjoin=True,
     )
 
-    resolver: Mapped[OktaUser] = db.relationship(
+    resolver: Mapped[OktaUser] = relationship(
         "OktaUser",
         back_populates="all_resolved_group_requests",
         foreign_keys=[resolver_user_id],
         lazy="raise_on_sql",
     )
 
-    active_resolver: Mapped[OktaUser] = db.relationship(
+    active_resolver: Mapped[OktaUser] = relationship(
         "OktaUser",
         primaryjoin="and_(OktaUser.id == GroupRequest.resolver_user_id, " "OktaUser.deleted_at.is_(None))",
         viewonly=True,
         lazy="raise_on_sql",
     )
 
-    approved_group: Mapped[OktaGroup] = db.relationship(
+    approved_group: Mapped[OktaGroup] = relationship(
         "OktaGroup",
         back_populates="group_request",
         foreign_keys=[approved_group_id],
         lazy="raise_on_sql",
     )
 
-    requested_app: Mapped[Optional["App"]] = db.relationship(
+    requested_app: Mapped[Optional["App"]] = relationship(
         "App",
         foreign_keys=[requested_app_id],
     )
@@ -1026,7 +1023,7 @@ class TagConstraint:
         self.coalesce = coalesce
 
 
-class Tag(db.Model):
+class Tag(Base):
     MEMBER_TIME_LIMIT_CONSTRAINT_KEY = "member_time_limit"
     OWNER_TIME_LIMIT_CONSTRAINT_KEY = "owner_time_limit"
     REQUIRE_MEMBER_REASON_CONSTRAINT_KEY = "require_member_reason"
@@ -1078,34 +1075,32 @@ class Tag(db.Model):
         ),
     }
 
-    id: Mapped[str] = mapped_column(db.Unicode(50), primary_key=True, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(db.DateTime(), nullable=False, default=db.func.now())
-    updated_at: Mapped[datetime] = mapped_column(
-        db.DateTime(), nullable=False, default=db.func.now(), onupdate=db.func.now()
-    )
-    deleted_at: Mapped[Optional[datetime]] = mapped_column(db.DateTime())
+    id: Mapped[str] = mapped_column(Unicode(50), primary_key=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now(), onupdate=func.now())
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(DateTime())
 
-    name: Mapped[str] = mapped_column(db.Unicode(255), nullable=False)
-    description: Mapped[str] = mapped_column(db.Unicode(1024), nullable=False, default="")
+    name: Mapped[str] = mapped_column(Unicode(255), nullable=False)
+    description: Mapped[str] = mapped_column(Unicode(1024), nullable=False, default="")
 
-    enabled: Mapped[bool] = mapped_column(db.Boolean(), nullable=False, default=True)
+    enabled: Mapped[bool] = mapped_column(Boolean(), nullable=False, default=True)
 
     # Field containing additional data about externally managed groups
     constraints: Mapped[Dict[str, Any]] = mapped_column(
         mutable_json_type(
-            dbtype=db.JSON().with_variant(JSONB, "postgresql"),
+            dbtype=JSON().with_variant(JSONB, "postgresql"),
             nested=True,
         ),
         nullable=False,
         server_default="{}",
     )
 
-    all_group_tags: Mapped[List["OktaGroupTagMap"]] = db.relationship(
+    all_group_tags: Mapped[List["OktaGroupTagMap"]] = relationship(
         "OktaGroupTagMap",
         back_populates="tag",
         lazy="raise_on_sql",
     )
-    active_group_tags: Mapped[List["OktaGroupTagMap"]] = db.relationship(
+    active_group_tags: Mapped[List["OktaGroupTagMap"]] = relationship(
         "OktaGroupTagMap",
         primaryjoin="and_(Tag.id == OktaGroupTagMap.tag_id, "
         "or_(OktaGroupTagMap.ended_at.is_(None), OktaGroupTagMap.ended_at > func.now()))",
@@ -1115,12 +1110,12 @@ class Tag(db.Model):
         innerjoin=True,
     )
 
-    all_app_tags: Mapped[List["AppTagMap"]] = db.relationship(
+    all_app_tags: Mapped[List["AppTagMap"]] = relationship(
         "AppTagMap",
         back_populates="tag",
         lazy="raise_on_sql",
     )
-    active_app_tags: Mapped[List["AppTagMap"]] = db.relationship(
+    active_app_tags: Mapped[List["AppTagMap"]] = relationship(
         "AppTagMap",
         primaryjoin="and_(Tag.id == AppTagMap.tag_id, "
         "or_(AppTagMap.ended_at.is_(None), AppTagMap.ended_at > func.now()))",
@@ -1131,29 +1126,27 @@ class Tag(db.Model):
     )
 
 
-class OktaGroupTagMap(db.Model):
+class OktaGroupTagMap(Base):
     # See https://stackoverflow.com/a/60840921
     id: Mapped[int] = mapped_column(
-        db.BigInteger().with_variant(db.Integer, "sqlite"),
+        BigInteger().with_variant(Integer, "sqlite"),
         autoincrement=True,
         primary_key=True,
     )
-    tag_id: Mapped[str] = mapped_column(db.Unicode(50), db.ForeignKey("tag.id"))
-    group_id: Mapped[str] = mapped_column(db.Unicode(50), db.ForeignKey("okta_group.id"))
+    tag_id: Mapped[str] = mapped_column(Unicode(50), ForeignKey("tag.id"))
+    group_id: Mapped[str] = mapped_column(Unicode(50), ForeignKey("okta_group.id"))
     # If this tag is via a AppTagMap
     # See https://stackoverflow.com/a/60840921
     app_tag_map_id: Mapped[Optional[int]] = mapped_column(
-        db.BigInteger().with_variant(db.Integer, "sqlite"),
-        db.ForeignKey("app_tag_map.id"),
+        BigInteger().with_variant(Integer, "sqlite"),
+        ForeignKey("app_tag_map.id"),
     )
 
-    created_at: Mapped[datetime] = mapped_column(db.DateTime(), nullable=False, default=db.func.now())
-    updated_at: Mapped[datetime] = mapped_column(
-        db.DateTime(), nullable=False, default=db.func.now(), onupdate=db.func.now()
-    )
-    ended_at: Mapped[Optional[datetime]] = mapped_column(db.DateTime())
+    created_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now(), onupdate=func.now())
+    ended_at: Mapped[Optional[datetime]] = mapped_column(DateTime())
 
-    tag: Mapped[Tag] = db.relationship(
+    tag: Mapped[Tag] = relationship(
         "Tag",
         back_populates="all_group_tags",
         foreign_keys=[tag_id],
@@ -1162,7 +1155,7 @@ class OktaGroupTagMap(db.Model):
     # SQLAlchemy doesn't seem to support loading
     # group.active_role_associated_group_[member|owner]_mappings.active_group when a group_id or user_id is specified
     # in GET /api/audit/users so we have to enable "select" lazy loading.
-    active_tag: Mapped[Tag] = db.relationship(
+    active_tag: Mapped[Tag] = relationship(
         "Tag",
         primaryjoin="and_(Tag.id == OktaGroupTagMap.tag_id, " "Tag.deleted_at.is_(None))",
         back_populates="active_group_tags",
@@ -1170,7 +1163,7 @@ class OktaGroupTagMap(db.Model):
         lazy="select",
         innerjoin=True,
     )
-    enabled_active_tag: Mapped[Tag] = db.relationship(
+    enabled_active_tag: Mapped[Tag] = relationship(
         "Tag",
         primaryjoin="and_(Tag.id == OktaGroupTagMap.tag_id, " "Tag.deleted_at.is_(None), Tag.enabled.is_(True))",
         viewonly=True,
@@ -1178,12 +1171,12 @@ class OktaGroupTagMap(db.Model):
         innerjoin=True,
     )
 
-    group: Mapped[OktaGroup] = db.relationship(
+    group: Mapped[OktaGroup] = relationship(
         "OktaGroup",
         back_populates="all_group_tags",
         lazy="raise_on_sql",
     )
-    active_group: Mapped[OktaGroup] = db.relationship(
+    active_group: Mapped[OktaGroup] = relationship(
         "OktaGroup",
         primaryjoin="and_(OktaGroup.id == OktaGroupTagMap.group_id, " "OktaGroup.deleted_at.is_(None))",
         back_populates="active_group_tags",
@@ -1192,7 +1185,7 @@ class OktaGroupTagMap(db.Model):
         innerjoin=True,
     )
 
-    app_tag_mapping: Mapped["AppTagMap"] = db.relationship(
+    app_tag_mapping: Mapped["AppTagMap"] = relationship(
         "AppTagMap",
         back_populates="group_tag_mappings",
         foreign_keys=[app_tag_map_id],
@@ -1201,7 +1194,7 @@ class OktaGroupTagMap(db.Model):
     # SQLAlchemy doesn't seem to support loading
     # group.active_role_associated_group_[member|owner]_mappings.active_group when a group_id or user_id is specified
     # in GET /api/audit/users so we have to enable "select" lazy loading.
-    active_app_tag_mapping: Mapped["AppTagMap"] = db.relationship(
+    active_app_tag_mapping: Mapped["AppTagMap"] = relationship(
         "AppTagMap",
         primaryjoin="and_(AppTagMap.id == OktaGroupTagMap.app_tag_map_id, "
         "or_(AppTagMap.ended_at.is_(None), AppTagMap.ended_at > func.now()))",
@@ -1212,29 +1205,27 @@ class OktaGroupTagMap(db.Model):
     )
 
 
-class AppTagMap(db.Model):
+class AppTagMap(Base):
     # See https://stackoverflow.com/a/60840921
     id: Mapped[int] = mapped_column(
-        db.BigInteger().with_variant(db.Integer, "sqlite"),
+        BigInteger().with_variant(Integer, "sqlite"),
         autoincrement=True,
         primary_key=True,
     )
-    tag_id: Mapped[str] = mapped_column(db.Unicode(50), db.ForeignKey("tag.id"))
-    app_id: Mapped[str] = mapped_column(db.Unicode(50), db.ForeignKey("app.id"))
+    tag_id: Mapped[str] = mapped_column(Unicode(50), ForeignKey("tag.id"))
+    app_id: Mapped[str] = mapped_column(Unicode(50), ForeignKey("app.id"))
 
-    created_at: Mapped[datetime] = mapped_column(db.DateTime(), nullable=False, default=db.func.now())
-    updated_at: Mapped[datetime] = mapped_column(
-        db.DateTime(), nullable=False, default=db.func.now(), onupdate=db.func.now()
-    )
-    ended_at: Mapped[Optional[datetime]] = mapped_column(db.DateTime())
+    created_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(), nullable=False, default=func.now(), onupdate=func.now())
+    ended_at: Mapped[Optional[datetime]] = mapped_column(DateTime())
 
-    tag: Mapped[Tag] = db.relationship(
+    tag: Mapped[Tag] = relationship(
         "Tag",
         back_populates="all_app_tags",
         foreign_keys=[tag_id],
         lazy="raise_on_sql",
     )
-    active_tag: Mapped[Tag] = db.relationship(
+    active_tag: Mapped[Tag] = relationship(
         "Tag",
         primaryjoin="and_(Tag.id == AppTagMap.tag_id, " "Tag.deleted_at.is_(None))",
         back_populates="active_app_tags",
@@ -1242,7 +1233,7 @@ class AppTagMap(db.Model):
         lazy="raise_on_sql",
         innerjoin=True,
     )
-    enabled_active_tag: Mapped[Tag] = db.relationship(
+    enabled_active_tag: Mapped[Tag] = relationship(
         "Tag",
         primaryjoin="and_(Tag.id == AppTagMap.tag_id, " "Tag.deleted_at.is_(None), Tag.enabled.is_(True))",
         viewonly=True,
@@ -1250,12 +1241,12 @@ class AppTagMap(db.Model):
         innerjoin=True,
     )
 
-    app: Mapped[App] = db.relationship(
+    app: Mapped[App] = relationship(
         "App",
         back_populates="all_app_tags",
         lazy="raise_on_sql",
     )
-    active_app: Mapped[App] = db.relationship(
+    active_app: Mapped[App] = relationship(
         "App",
         primaryjoin="and_(App.id == AppTagMap.app_id, " "App.deleted_at.is_(None))",
         back_populates="active_app_tags",
@@ -1264,10 +1255,10 @@ class AppTagMap(db.Model):
         innerjoin=True,
     )
 
-    group_tag_mappings: Mapped[List[OktaGroupTagMap]] = db.relationship(
+    group_tag_mappings: Mapped[List[OktaGroupTagMap]] = relationship(
         "OktaGroupTagMap", back_populates="app_tag_mapping", lazy="raise_on_sql"
     )
-    active_group_tag_mappings: Mapped[List[OktaGroupTagMap]] = db.relationship(
+    active_group_tag_mappings: Mapped[List[OktaGroupTagMap]] = relationship(
         "OktaGroupTagMap",
         primaryjoin="and_(AppTagMap.id == OktaGroupTagMap.app_tag_map_id, "
         "or_(OktaGroupTagMap.ended_at.is_(None), OktaGroupTagMap.ended_at > func.now()))",

--- a/api/models/okta_group.py
+++ b/api/models/okta_group.py
@@ -1,18 +1,21 @@
 from typing import List
 
+from sqlalchemy import func, or_
+
 from api.extensions import db
 from api.models.core_models import OktaUser, OktaUserGroupMember
 
 
 def get_group_managers(group_id: str) -> List[OktaUser]:
     return (
-        OktaUser.query.join(OktaUserGroupMember, OktaUser.id == OktaUserGroupMember.user_id)
+        db.session.query(OktaUser)
+        .join(OktaUserGroupMember, OktaUser.id == OktaUserGroupMember.user_id)
         .filter(OktaUserGroupMember.group_id == group_id)
         .filter(OktaUserGroupMember.is_owner.is_(True))
         .filter(
-            db.or_(
+            or_(
                 OktaUserGroupMember.ended_at.is_(None),
-                OktaUserGroupMember.ended_at > db.func.now(),
+                OktaUserGroupMember.ended_at > func.now(),
             )
         )
         .all()

--- a/api/operations/approve_access_request.py
+++ b/api/operations/approve_access_request.py
@@ -25,7 +25,8 @@ class ApproveAccessRequest:
         notify: bool = True,
     ):
         self.access_request = (
-            AccessRequest.query.options(joinedload(AccessRequest.active_requested_group))
+            db.session.query(AccessRequest)
+            .options(joinedload(AccessRequest.active_requested_group))
             .filter(AccessRequest.id == (access_request if isinstance(access_request, str) else access_request.id))
             .first()
         )
@@ -81,7 +82,7 @@ class ApproveAccessRequest:
 
         # Now handled inside ModifyGroupUsers
         # self.access_request.status = AccessRequestStatus.APPROVED
-        # self.access_request.resolved_at = db.func.now()
+        # self.access_request.resolved_at = func.now()
         # self.access_request.resolver_user_id = self.approver_id
         # self.access_request.resolution_reason = self.approval_reason
         # self.access_request.approval_ending_at = self.ending_at
@@ -133,7 +134,7 @@ class ApproveAccessRequest:
 
         # Now handled inside ModifyGroupUsers
         # self.access_request.approved_membership_id = (
-        #     OktaUserGroupMember.query.filter(
+        #     db.session.query(OktaUserGroupMember).filter(
         #         OktaUserGroupMember.user_id == self.access_request.requester_user_id
         #     )
         #     .filter(

--- a/api/operations/approve_group_request.py
+++ b/api/operations/approve_group_request.py
@@ -39,7 +39,8 @@ class ApproveGroupRequest:
         bypass_self_approval: bool = False,
     ):
         self.group_request = (
-            GroupRequest.query.options(joinedload(GroupRequest.active_requester))
+            db.session.query(GroupRequest)
+            .options(joinedload(GroupRequest.active_requester))
             .filter(GroupRequest.id == (group_request if isinstance(group_request, str) else group_request.id))
             .first()
         )
@@ -245,7 +246,7 @@ class ApproveGroupRequest:
             ).execute()
 
         self.group_request.status = AccessRequestStatus.APPROVED
-        self.group_request.resolved_at = db.func.now()
+        self.group_request.resolved_at = func.now()
         self.group_request.resolver_user_id = self.approver_id
         self.group_request.resolution_reason = self.approval_reason
         self.group_request.approved_group_id = created_group.id

--- a/api/operations/approve_role_request.py
+++ b/api/operations/approve_role_request.py
@@ -25,9 +25,8 @@ class ApproveRoleRequest:
         notify: bool = True,
     ):
         self.role_request = (
-            RoleRequest.query.options(
-                joinedload(RoleRequest.active_requested_group), joinedload(RoleRequest.active_requester_role)
-            )
+            db.session.query(RoleRequest)
+            .options(joinedload(RoleRequest.active_requested_group), joinedload(RoleRequest.active_requester_role))
             .filter(RoleRequest.id == (role_request if isinstance(role_request, str) else role_request.id))
             .first()
         )

--- a/api/operations/constraints/check_for_reason.py
+++ b/api/operations/constraints/check_for_reason.py
@@ -98,9 +98,8 @@ class CheckForReason:
         if self.invalid_reason(self.reason):
             if len(self.members_to_add) > 0:
                 new_member_groups = (
-                    OktaGroup.query.options(
-                        selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag)
-                    )
+                    db.session.query(OktaGroup)
+                    .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
                     .filter(OktaGroup.is_managed.is_(True))
                     .filter(OktaGroup.id.in_(self.members_to_add))
                     .filter(OktaGroup.deleted_at.is_(None))
@@ -120,9 +119,8 @@ class CheckForReason:
 
             if len(self.owners_to_add) > 0:
                 new_owner_groups = (
-                    OktaGroup.query.options(
-                        selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag)
-                    )
+                    db.session.query(OktaGroup)
+                    .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
                     .filter(OktaGroup.is_managed.is_(True))
                     .filter(OktaGroup.id.in_(self.owners_to_add))
                     .filter(OktaGroup.deleted_at.is_(None))

--- a/api/operations/constraints/check_for_self_add.py
+++ b/api/operations/constraints/check_for_self_add.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import (
     selectinload,
 )
 
+from sqlalchemy import func, or_
 from api.auth.permissions import is_access_admin as _is_access_admin
 from api.extensions import db
 from api.models import AppGroup, OktaGroup, OktaGroupTagMap, OktaUser, OktaUserGroupMember, RoleGroup, RoleGroupMap, Tag
@@ -42,7 +43,8 @@ class CheckForSelfAdd:
             self.current_user = None
         else:
             self.current_user = (
-                OktaUser.query.filter(OktaUser.deleted_at.is_(None))
+                db.session.query(OktaUser)
+                .filter(OktaUser.deleted_at.is_(None))
                 .filter(OktaUser.id == (current_user if isinstance(current_user, str) else current_user.id))
                 .first()
             )
@@ -118,13 +120,14 @@ class CheckForSelfAdd:
         # Check to see if the current user is a member of the role,
         # which would grant them access to the newly added groups associated with the role
         if (
-            OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == self.group.id)
+            db.session.query(OktaUserGroupMember)
+            .filter(OktaUserGroupMember.group_id == self.group.id)
             .filter(OktaUserGroupMember.user_id == self.current_user.id)
             .filter(OktaUserGroupMember.is_owner.is_(False))
             .filter(
-                db.or_(
+                or_(
                     OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > db.func.now(),
+                    OktaUserGroupMember.ended_at > func.now(),
                 )
             )
             .count()
@@ -132,9 +135,8 @@ class CheckForSelfAdd:
         ):
             if len(self.members_to_add) > 0:
                 new_member_groups = (
-                    OktaGroup.query.options(
-                        selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag)
-                    )
+                    db.session.query(OktaGroup)
+                    .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
                     .filter(OktaGroup.is_managed.is_(True))
                     .filter(OktaGroup.id.in_(self.members_to_add))
                     .filter(OktaGroup.deleted_at.is_(None))
@@ -155,9 +157,8 @@ class CheckForSelfAdd:
 
             if len(self.owners_to_add) > 0:
                 new_owner_groups = (
-                    OktaGroup.query.options(
-                        selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag)
-                    )
+                    db.session.query(OktaGroup)
+                    .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
                     .filter(OktaGroup.is_managed.is_(True))
                     .filter(OktaGroup.id.in_(self.owners_to_add))
                     .filter(OktaGroup.deleted_at.is_(None))

--- a/api/operations/create_app.py
+++ b/api/operations/create_app.py
@@ -5,7 +5,7 @@ from typing import Optional, TypedDict
 import logging
 
 from api.context import get_request_context
-from sqlalchemy import func
+from sqlalchemy import func, or_
 from sqlalchemy.orm import with_polymorphic
 
 from api.extensions import db
@@ -41,15 +41,22 @@ class CreateApp:
             app.id = id
             self.app = app
 
-        self.tag_ids = [tag.id for tag in Tag.query.filter(Tag.deleted_at.is_(None)).filter(Tag.id.in_(tags)).all()]
+        self.tag_ids = [
+            tag.id for tag in db.session.query(Tag).filter(Tag.deleted_at.is_(None)).filter(Tag.id.in_(tags)).all()
+        ]
 
         self.owner_id = getattr(
-            OktaUser.query.filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == owner_id).first(), "id", None
+            db.session.query(OktaUser).filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == owner_id).first(),
+            "id",
+            None,
         )
         self.owner_role_ids = None
         if owner_role_ids is not None:
             self.owner_roles = (
-                RoleGroup.query.filter(RoleGroup.id.in_(owner_role_ids)).filter(RoleGroup.deleted_at.is_(None)).all()
+                db.session.query(RoleGroup)
+                .filter(RoleGroup.id.in_(owner_role_ids))
+                .filter(RoleGroup.deleted_at.is_(None))
+                .all()
             )
             self.owner_role_ids = [role.id for role in self.owner_roles]
 
@@ -74,7 +81,10 @@ class CreateApp:
                     continue
                 self.additional_app_groups.append(AppGroup(is_owner=False, name=name, description=description))
         self.current_user_id = getattr(
-            OktaUser.query.filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first(),
+            db.session.query(OktaUser)
+            .filter(OktaUser.deleted_at.is_(None))
+            .filter(OktaUser.id == current_user_id)
+            .first(),
             "id",
             None,
         )
@@ -82,7 +92,10 @@ class CreateApp:
     def execute(self) -> App:
         # Do not allow non-deleted apps with the same name
         existing_app = (
-            App.query.filter(func.lower(App.name) == func.lower(self.app.name)).filter(App.deleted_at.is_(None)).first()
+            db.session.query(App)
+            .filter(func.lower(App.name) == func.lower(self.app.name))
+            .filter(App.deleted_at.is_(None))
+            .first()
         )
         if existing_app is not None:
             return existing_app
@@ -136,7 +149,7 @@ class CreateApp:
                     group_changes=AppGroup(app_id=app_id, is_owner=True),
                     current_user_id=self.current_user_id,
                 ).execute()
-            owner_app_group = AppGroup.query.filter(AppGroup.id == group_id).first()
+            owner_app_group = db.session.query(AppGroup).filter(AppGroup.id == group_id).first()
             owner_app_group.app_id = app_id
             owner_app_group.is_owner = True
             db.session.commit()
@@ -201,14 +214,14 @@ class CreateApp:
                             group_changes=AppGroup(app_id=app_id, is_owner=False),
                             current_user_id=self.current_user_id,
                         ).execute()
-                    app_group = AppGroup.query.filter(AppGroup.id == group_id).first()
+                    app_group = db.session.query(AppGroup).filter(AppGroup.id == group_id).first()
                     app_group.app_id = app_id
                     app_group.is_owner = False
                     db.session.commit()
 
         if len(self.tag_ids) > 0:
             all_app_groups = (
-                AppGroup.query.filter(AppGroup.app_id == app_id).filter(AppGroup.deleted_at.is_(None)).all()
+                db.session.query(AppGroup).filter(AppGroup.app_id == app_id).filter(AppGroup.deleted_at.is_(None)).all()
             )
 
             for tag_id in self.tag_ids:
@@ -221,11 +234,12 @@ class CreateApp:
             db.session.commit()
 
             new_app_tag_maps = (
-                AppTagMap.query.filter(AppTagMap.app_id == app_id)
+                db.session.query(AppTagMap)
+                .filter(AppTagMap.app_id == app_id)
                 .filter(
-                    db.or_(
+                    or_(
                         AppTagMap.ended_at.is_(None),
-                        AppTagMap.ended_at > db.func.now(),
+                        AppTagMap.ended_at > func.now(),
                     )
                 )
                 .all()

--- a/api/operations/create_group.py
+++ b/api/operations/create_group.py
@@ -3,7 +3,7 @@ from typing import Optional, TypedDict, TypeVar
 import logging
 
 from api.context import get_request_context
-from sqlalchemy import func
+from sqlalchemy import func, or_
 from sqlalchemy.orm import joinedload, selectin_polymorphic, with_polymorphic
 
 from api.extensions import db
@@ -27,10 +27,13 @@ class CreateGroup:
         else:
             self.group = group
 
-        self.tags = Tag.query.filter(Tag.deleted_at.is_(None)).filter(Tag.id.in_(tags)).all()
+        self.tags = db.session.query(Tag).filter(Tag.deleted_at.is_(None)).filter(Tag.id.in_(tags)).all()
 
         self.current_user_id = getattr(
-            OktaUser.query.filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first(),
+            db.session.query(OktaUser)
+            .filter(OktaUser.deleted_at.is_(None))
+            .filter(OktaUser.id == current_user_id)
+            .first(),
             "id",
             None,
         )
@@ -49,7 +52,8 @@ class CreateGroup:
         # Make sure the app exists if we're creating an app group
         if (
             type(self.group) is AppGroup
-            and App.query.filter(App.id == self.group.app_id).filter(App.deleted_at.is_(None)).first() is None
+            and db.session.query(App).filter(App.id == self.group.app_id).filter(App.deleted_at.is_(None)).first()
+            is None
         ):
             raise ValueError("App for AppGroup does not exist")
 
@@ -63,11 +67,12 @@ class CreateGroup:
         # If this is an app group, add any app tags
         if type(self.group) is AppGroup:
             app_tag_maps = (
-                AppTagMap.query.filter(AppTagMap.app_id == self.group.app_id)
+                db.session.query(AppTagMap)
+                .filter(AppTagMap.app_id == self.group.app_id)
                 .filter(
-                    db.or_(
+                    or_(
                         AppTagMap.ended_at.is_(None),
-                        AppTagMap.ended_at > db.func.now(),
+                        AppTagMap.ended_at > func.now(),
                     )
                 )
                 .all()

--- a/api/operations/create_role_request.py
+++ b/api/operations/create_role_request.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 import logging
 
+from sqlalchemy import func, or_
 from api.context import get_request_context
 from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload
 
@@ -49,7 +50,10 @@ class CreateRoleRequest:
 
         if isinstance(requester_role, str):
             self.requester_role = (
-                RoleGroup.query.filter(RoleGroup.deleted_at.is_(None)).filter(RoleGroup.id == requester_role).first()
+                db.session.query(RoleGroup)
+                .filter(RoleGroup.deleted_at.is_(None))
+                .filter(RoleGroup.id == requester_role)
+                .first()
             )
             # self.requester_role = (
             #     db.session.query(RoleGroup)
@@ -111,12 +115,13 @@ class CreateRoleRequest:
         role_memberships = [
             u.user_id
             for u in (
-                OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == self.requester_role.id)
+                db.session.query(OktaUserGroupMember)
+                .filter(OktaUserGroupMember.group_id == self.requester_role.id)
                 .filter(OktaUserGroupMember.is_owner.is_(False))
                 .filter(
-                    db.or_(
+                    or_(
                         OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > db.func.now(),
+                        OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
                 .all()

--- a/api/operations/create_tag.py
+++ b/api/operations/create_tag.py
@@ -28,7 +28,10 @@ class CreateTag:
             self.tag = tag
 
         self.current_user_id = getattr(
-            OktaUser.query.filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first(),
+            db.session.query(OktaUser)
+            .filter(OktaUser.deleted_at.is_(None))
+            .filter(OktaUser.id == current_user_id)
+            .first(),
             "id",
             None,
         )
@@ -36,7 +39,10 @@ class CreateTag:
     def execute(self) -> Tag:
         # Do not allow non-deleted groups with the same name (case-insensitive)
         existing_tag = (
-            Tag.query.filter(func.lower(Tag.name) == func.lower(self.tag.name)).filter(Tag.deleted_at.is_(None)).first()
+            db.session.query(Tag)
+            .filter(func.lower(Tag.name) == func.lower(self.tag.name))
+            .filter(Tag.deleted_at.is_(None))
+            .first()
         )
         if existing_tag is not None:
             return existing_tag

--- a/api/operations/delete_app.py
+++ b/api/operations/delete_app.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import logging
 
+from sqlalchemy import func, or_
 from api.context import get_request_context
 
 from api.extensions import db
@@ -13,12 +14,15 @@ from api.schemas import AuditLogSchema, EventType
 class DeleteApp:
     def __init__(self, *, app: App | str, current_user_id: Optional[str] = None):
         if isinstance(app, str):
-            self.app = App.query.filter(App.deleted_at.is_(None)).filter(App.id == app).first()
+            self.app = db.session.query(App).filter(App.deleted_at.is_(None)).filter(App.id == app).first()
         else:
             self.app = app
 
         self.current_user_id = getattr(
-            OktaUser.query.filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first(),
+            db.session.query(OktaUser)
+            .filter(OktaUser.deleted_at.is_(None))
+            .filter(OktaUser.id == current_user_id)
+            .first(),
             "id",
             None,
         )
@@ -48,23 +52,25 @@ class DeleteApp:
             )
         )
 
-        self.app.deleted_at = db.func.now()
+        self.app.deleted_at = func.now()
         db.session.commit()
 
         # Delete all associated Okta App Groups and end their membership
-        app_groups = AppGroup.query.filter(AppGroup.deleted_at.is_(None)).filter(AppGroup.app_id == self.app.id)
+        app_groups = (
+            db.session.query(AppGroup).filter(AppGroup.deleted_at.is_(None)).filter(AppGroup.app_id == self.app.id)
+        )
         app_group_ids = [ag.id for ag in app_groups]
         for app_group_id in app_group_ids:
             DeleteGroup(group=app_group_id, current_user_id=self.current_user_id).execute()
 
         # End all tag mappings for this app (OktaGroupTagMaps are ended by the DeleteGroup operation above)
-        AppTagMap.query.filter(AppTagMap.app_id == self.app.id).filter(
-            db.or_(
+        db.session.query(AppTagMap).filter(AppTagMap.app_id == self.app.id).filter(
+            or_(
                 AppTagMap.ended_at.is_(None),
-                AppTagMap.ended_at > db.func.now(),
+                AppTagMap.ended_at > func.now(),
             )
         ).update(
-            {AppTagMap.ended_at: db.func.now()},
+            {AppTagMap.ended_at: func.now()},
             synchronize_session="fetch",
         )
         db.session.commit()

--- a/api/operations/delete_group.py
+++ b/api/operations/delete_group.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import logging
 
+from sqlalchemy import func, or_
 from api.context import get_request_context
 from sqlalchemy.orm import joinedload, selectin_polymorphic
 
@@ -37,7 +38,10 @@ class DeleteGroup:
         self.sync_to_okta = sync_to_okta
 
         self.current_user_id = getattr(
-            OktaUser.query.filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first(),
+            db.session.query(OktaUser)
+            .filter(OktaUser.deleted_at.is_(None))
+            .filter(OktaUser.id == current_user_id)
+            .first(),
             "id",
             None,
         )
@@ -52,7 +56,7 @@ class DeleteGroup:
 
         # Prevent deletion of the Access owner group
         if type(self.group) is AppGroup and self.group.is_owner:
-            app = App.query.filter(App.id == self.group.app_id).filter(App.deleted_at.is_(None)).first()
+            app = db.session.query(App).filter(App.id == self.group.app_id).filter(App.deleted_at.is_(None)).first()
             if app is not None and app.name == App.ACCESS_APP_RESERVED_NAME:
                 raise ValueError("Access application owner group cannot be deleted")
 
@@ -79,15 +83,19 @@ class DeleteGroup:
         if self.sync_to_okta:
             okta_tasks.append(asyncio.create_task(okta.async_delete_group(self.group.id)))
 
-        self.group.deleted_at = db.func.now()
+        self.group.deleted_at = func.now()
 
         # End all group members including group members via a role
-        group_memberships_query = OktaUserGroupMember.query.filter(
-            db.or_(
-                OktaUserGroupMember.ended_at.is_(None),
-                OktaUserGroupMember.ended_at > db.func.now(),
+        group_memberships_query = (
+            db.session.query(OktaUserGroupMember)
+            .filter(
+                or_(
+                    OktaUserGroupMember.ended_at.is_(None),
+                    OktaUserGroupMember.ended_at > func.now(),
+                )
             )
-        ).filter(OktaUserGroupMember.group_id == self.group.id)
+            .filter(OktaUserGroupMember.group_id == self.group.id)
+        )
 
         direct_members_to_remove_ids = [
             m.user_id
@@ -102,58 +110,61 @@ class DeleteGroup:
             .all()
         ]
 
-        group_memberships_query.update({OktaUserGroupMember.ended_at: db.func.now()}, synchronize_session="fetch")
+        group_memberships_query.update({OktaUserGroupMember.ended_at: func.now()}, synchronize_session="fetch")
 
         # End all roles associations where this group was a member
-        RoleGroupMap.query.filter(
-            db.or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > db.func.now())
+        db.session.query(RoleGroupMap).filter(
+            or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now())
         ).filter(RoleGroupMap.group_id == self.group.id).update(
-            {RoleGroupMap.ended_at: db.func.now()}, synchronize_session="fetch"
+            {RoleGroupMap.ended_at: func.now()}, synchronize_session="fetch"
         )
 
         if type(self.group) is RoleGroup:
             # End all group memberships via the role grant
-            OktaUserGroupMember.query.filter(
-                db.or_(
+            db.session.query(OktaUserGroupMember).filter(
+                or_(
                     OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > db.func.now(),
+                    OktaUserGroupMember.ended_at > func.now(),
                 )
             ).filter(
                 OktaUserGroupMember.role_group_map_id.in_(
                     db.session.query(RoleGroupMap.id)
                     .filter(
-                        db.or_(
+                        or_(
                             RoleGroupMap.ended_at.is_(None),
-                            RoleGroupMap.ended_at > db.func.now(),
+                            RoleGroupMap.ended_at > func.now(),
                         )
                     )
                     .filter(RoleGroupMap.role_group_id == self.group.id)
                 )
             ).update(
-                {OktaUserGroupMember.ended_at: db.func.now()},
+                {OktaUserGroupMember.ended_at: func.now()},
                 synchronize_session="fetch",
             )
 
             # Check if there are other OktaUserGroupMembers for this user/group
             # combination before removing group membership in Okta, there can be multiple role groups
             # which allow group access for this user
-            role_associated_groups_mappings_query = RoleGroupMap.query.filter(
-                db.or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > db.func.now())
-            ).filter(RoleGroupMap.role_group_id == self.group.id)
+            role_associated_groups_mappings_query = (
+                db.session.query(RoleGroupMap)
+                .filter(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
+                .filter(RoleGroupMap.role_group_id == self.group.id)
+            )
 
             if self.sync_to_okta:
                 role_associated_groups_mappings = role_associated_groups_mappings_query.all()
 
                 removed_role_group_users_with_other_access = (
-                    OktaUserGroupMember.query.with_entities(
+                    db.session.query(OktaUserGroupMember)
+                    .with_entities(
                         OktaUserGroupMember.user_id,
                         OktaUserGroupMember.group_id,
                         OktaUserGroupMember.is_owner,
                     )
                     .filter(
-                        db.or_(
+                        or_(
                             OktaUserGroupMember.ended_at.is_(None),
-                            OktaUserGroupMember.ended_at > db.func.now(),
+                            OktaUserGroupMember.ended_at > func.now(),
                         )
                     )
                     .filter(OktaUserGroupMember.user_id.in_(direct_members_to_remove_ids + direct_owners_to_remove_ids))
@@ -202,14 +213,15 @@ class DeleteGroup:
 
             # End all group attachments to this role
             role_associated_groups_mappings_query.update(
-                {RoleGroupMap.ended_at: db.func.now()}, synchronize_session="fetch"
+                {RoleGroupMap.ended_at: func.now()}, synchronize_session="fetch"
             )
 
         db.session.commit()
 
         # Reject all pending access requests for this group
         obsolete_access_requests = (
-            AccessRequest.query.filter(AccessRequest.requested_group_id == self.group.id)
+            db.session.query(AccessRequest)
+            .filter(AccessRequest.requested_group_id == self.group.id)
             .filter(AccessRequest.status == AccessRequestStatus.PENDING)
             .filter(AccessRequest.resolved_at.is_(None))
             .all()
@@ -222,15 +234,15 @@ class DeleteGroup:
             ).execute()
 
         # End all tag mappings for this group
-        OktaGroupTagMap.query.filter(
-            db.or_(
+        db.session.query(OktaGroupTagMap).filter(
+            or_(
                 OktaGroupTagMap.ended_at.is_(None),
-                OktaGroupTagMap.ended_at > db.func.now(),
+                OktaGroupTagMap.ended_at > func.now(),
             )
         ).filter(
             OktaGroupTagMap.group_id == self.group.id,
         ).update(
-            {OktaGroupTagMap.ended_at: db.func.now()},
+            {OktaGroupTagMap.ended_at: func.now()},
             synchronize_session="fetch",
         )
         db.session.commit()

--- a/api/operations/delete_tag.py
+++ b/api/operations/delete_tag.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import logging
 
+from sqlalchemy import func, or_
 from api.context import get_request_context
 
 from api.extensions import db
@@ -11,9 +12,12 @@ from api.schemas import AuditLogSchema, EventType
 
 class DeleteTag:
     def __init__(self, *, tag: Tag | str, current_user_id: Optional[str] = None):
-        self.tag = Tag.query.filter(Tag.id == (tag if isinstance(tag, str) else tag.id)).first()
+        self.tag = db.session.query(Tag).filter(Tag.id == (tag if isinstance(tag, str) else tag.id)).first()
         self.current_user_id = getattr(
-            OktaUser.query.filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first(),
+            db.session.query(OktaUser)
+            .filter(OktaUser.deleted_at.is_(None))
+            .filter(OktaUser.id == current_user_id)
+            .first(),
             "id",
             None,
         )
@@ -41,26 +45,24 @@ class DeleteTag:
 
         # Disable and delete tag
         self.tag.enabled = False
-        self.tag.deleted_at = db.func.now()
+        self.tag.deleted_at = func.now()
 
         # End all active group tag mappings for tag
-        OktaGroupTagMap.query.filter(
-            db.or_(
+        db.session.query(OktaGroupTagMap).filter(
+            or_(
                 OktaGroupTagMap.ended_at.is_(None),
-                OktaGroupTagMap.ended_at > db.func.now(),
+                OktaGroupTagMap.ended_at > func.now(),
             )
         ).filter(OktaGroupTagMap.tag_id == self.tag.id).update(
-            {OktaGroupTagMap.ended_at: db.func.now()}, synchronize_session="fetch"
+            {OktaGroupTagMap.ended_at: func.now()}, synchronize_session="fetch"
         )
 
         # End all active app tag mappings for tag
-        AppTagMap.query.filter(
-            db.or_(
+        db.session.query(AppTagMap).filter(
+            or_(
                 AppTagMap.ended_at.is_(None),
-                AppTagMap.ended_at > db.func.now(),
+                AppTagMap.ended_at > func.now(),
             )
-        ).filter(AppTagMap.tag_id == self.tag.id).update(
-            {AppTagMap.ended_at: db.func.now()}, synchronize_session="fetch"
-        )
+        ).filter(AppTagMap.tag_id == self.tag.id).update({AppTagMap.ended_at: func.now()}, synchronize_session="fetch")
 
         db.session.commit()

--- a/api/operations/delete_user.py
+++ b/api/operations/delete_user.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import (
     joinedload,
 )
 
+from sqlalchemy import func, or_
 from api.extensions import db
 from api.models import AccessRequest, AccessRequestStatus, OktaGroup, OktaUser, OktaUserGroupMember
 from api.operations import RejectAccessRequest
@@ -14,14 +15,17 @@ from api.services import okta
 class DeleteUser:
     def __init__(self, *, user: OktaUser | str, sync_to_okta: bool = True, current_user_id: Optional[str] = None):
         if isinstance(user, str):
-            self.user = OktaUser.query.filter(OktaUser.id == user).first()
+            self.user = db.session.query(OktaUser).filter(OktaUser.id == user).first()
         else:
             self.user = user
 
         self.sync_to_okta = sync_to_okta
 
         self.current_user_id = getattr(
-            OktaUser.query.filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first(),
+            db.session.query(OktaUser)
+            .filter(OktaUser.deleted_at.is_(None))
+            .filter(OktaUser.id == current_user_id)
+            .first(),
             "id",
             None,
         )
@@ -35,15 +39,19 @@ class DeleteUser:
         okta_tasks = []
 
         if self.user.deleted_at is None:
-            self.user.deleted_at = db.func.now()
+            self.user.deleted_at = func.now()
 
         # End all user memberships including group memberships via a role
-        group_access_query = OktaUserGroupMember.query.filter(
-            db.or_(
-                OktaUserGroupMember.ended_at.is_(None),
-                OktaUserGroupMember.ended_at > db.func.now(),
+        group_access_query = (
+            db.session.query(OktaUserGroupMember)
+            .filter(
+                or_(
+                    OktaUserGroupMember.ended_at.is_(None),
+                    OktaUserGroupMember.ended_at > func.now(),
+                )
             )
-        ).filter(OktaUserGroupMember.user_id == self.user.id)
+            .filter(OktaUserGroupMember.user_id == self.user.id)
+        )
 
         if self.sync_to_okta:
             # Don't sync group access changes back to Okta for unmanaged groups
@@ -68,12 +76,13 @@ class DeleteUser:
             for group_id in group_ownerships_to_remove_ids:
                 okta_tasks.append(asyncio.create_task(okta.async_remove_owner_from_group(group_id, self.user.id)))
 
-        group_access_query.update({OktaUserGroupMember.ended_at: db.func.now()}, synchronize_session="fetch")
+        group_access_query.update({OktaUserGroupMember.ended_at: func.now()}, synchronize_session="fetch")
 
         db.session.commit()
 
         obsolete_access_requests = (
-            AccessRequest.query.filter(AccessRequest.requester_user_id == self.user.id)
+            db.session.query(AccessRequest)
+            .filter(AccessRequest.requester_user_id == self.user.id)
             .filter(AccessRequest.status == AccessRequestStatus.PENDING)
             .filter(AccessRequest.resolved_at.is_(None))
             .all()

--- a/api/operations/modify_app_tags.py
+++ b/api/operations/modify_app_tags.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import logging
 
+from sqlalchemy import func, or_
 from api.context import get_request_context
 
 from api.extensions import db
@@ -20,17 +21,23 @@ class ModifyAppTags:
         current_user_id: Optional[str],
     ):
         self.app = (
-            App.query.filter(App.deleted_at.is_(None))
+            db.session.query(App)
+            .filter(App.deleted_at.is_(None))
             .filter(App.id == (app if isinstance(app, str) else app.id))
             .first()
         )
 
-        self.tags_to_add = Tag.query.filter(Tag.deleted_at.is_(None)).filter(Tag.id.in_(tags_to_add)).all()
+        self.tags_to_add = db.session.query(Tag).filter(Tag.deleted_at.is_(None)).filter(Tag.id.in_(tags_to_add)).all()
 
-        self.tags_to_remove = Tag.query.filter(Tag.deleted_at.is_(None)).filter(Tag.id.in_(tags_to_remove)).all()
+        self.tags_to_remove = (
+            db.session.query(Tag).filter(Tag.deleted_at.is_(None)).filter(Tag.id.in_(tags_to_remove)).all()
+        )
 
         self.current_user_id = getattr(
-            OktaUser.query.filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first(),
+            db.session.query(OktaUser)
+            .filter(OktaUser.deleted_at.is_(None))
+            .filter(OktaUser.id == current_user_id)
+            .first(),
             "id",
             None,
         )
@@ -40,10 +47,11 @@ class ModifyAppTags:
             # Only add tags that are not already associated with this app
             tag_ids_to_add = [t.id for t in self.tags_to_add]
             existing_tag_maps = (
-                AppTagMap.query.filter(
-                    db.or_(
+                db.session.query(AppTagMap)
+                .filter(
+                    or_(
                         AppTagMap.ended_at.is_(None),
-                        AppTagMap.ended_at > db.func.now(),
+                        AppTagMap.ended_at > func.now(),
                     )
                 )
                 .filter(
@@ -67,19 +75,23 @@ class ModifyAppTags:
             db.session.commit()
 
             new_app_tag_maps = (
-                AppTagMap.query.filter(AppTagMap.tag_id.in_(new_tag_ids_to_add))
+                db.session.query(AppTagMap)
+                .filter(AppTagMap.tag_id.in_(new_tag_ids_to_add))
                 .filter(AppTagMap.app_id == self.app.id)
                 .filter(
-                    db.or_(
+                    or_(
                         AppTagMap.ended_at.is_(None),
-                        AppTagMap.ended_at > db.func.now(),
+                        AppTagMap.ended_at > func.now(),
                     )
                 )
                 .all()
             )
 
             all_app_groups = (
-                AppGroup.query.filter(AppGroup.app_id == self.app.id).filter(AppGroup.deleted_at.is_(None)).all()
+                db.session.query(AppGroup)
+                .filter(AppGroup.app_id == self.app.id)
+                .filter(AppGroup.deleted_at.is_(None))
+                .all()
             )
             for app_tag_map in new_app_tag_maps:
                 for app_group in all_app_groups:
@@ -100,31 +112,32 @@ class ModifyAppTags:
         if len(self.tags_to_remove) > 0:
             tag_ids_to_remove = [t.id for t in self.tags_to_remove]
             existing_tag_maps_query = (
-                AppTagMap.query.filter(AppTagMap.tag_id.in_(tag_ids_to_remove))
+                db.session.query(AppTagMap)
+                .filter(AppTagMap.tag_id.in_(tag_ids_to_remove))
                 .filter(AppTagMap.app_id == self.app.id)
                 .filter(
-                    db.or_(
+                    or_(
                         AppTagMap.ended_at.is_(None),
-                        AppTagMap.ended_at > db.func.now(),
+                        AppTagMap.ended_at > func.now(),
                     )
                 )
             )
 
             existing_tag_maps = existing_tag_maps_query.all()
-            OktaGroupTagMap.query.filter(
-                db.or_(
+            db.session.query(OktaGroupTagMap).filter(
+                or_(
                     OktaGroupTagMap.ended_at.is_(None),
-                    OktaGroupTagMap.ended_at > db.func.now(),
+                    OktaGroupTagMap.ended_at > func.now(),
                 )
             ).filter(
                 OktaGroupTagMap.app_tag_map_id.in_([m.id for m in existing_tag_maps]),
             ).update(
-                {OktaGroupTagMap.ended_at: db.func.now()},
+                {OktaGroupTagMap.ended_at: func.now()},
                 synchronize_session="fetch",
             )
 
             existing_tag_maps_query.update(
-                {AppTagMap.ended_at: db.func.now()},
+                {AppTagMap.ended_at: func.now()},
                 synchronize_session="fetch",
             )
             db.session.commit()

--- a/api/operations/modify_group_tags.py
+++ b/api/operations/modify_group_tags.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import logging
 
+from sqlalchemy import func, or_
 from api.context import get_request_context
 from sqlalchemy.orm import joinedload, selectin_polymorphic
 
@@ -28,12 +29,17 @@ class ModifyGroupTags:
             .first()
         )
 
-        self.tags_to_add = Tag.query.filter(Tag.deleted_at.is_(None)).filter(Tag.id.in_(tags_to_add)).all()
+        self.tags_to_add = db.session.query(Tag).filter(Tag.deleted_at.is_(None)).filter(Tag.id.in_(tags_to_add)).all()
 
-        self.tags_to_remove = Tag.query.filter(Tag.deleted_at.is_(None)).filter(Tag.id.in_(tags_to_remove)).all()
+        self.tags_to_remove = (
+            db.session.query(Tag).filter(Tag.deleted_at.is_(None)).filter(Tag.id.in_(tags_to_remove)).all()
+        )
 
         self.current_user_id = getattr(
-            OktaUser.query.filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first(),
+            db.session.query(OktaUser)
+            .filter(OktaUser.deleted_at.is_(None))
+            .filter(OktaUser.id == current_user_id)
+            .first(),
             "id",
             None,
         )
@@ -43,10 +49,11 @@ class ModifyGroupTags:
             # Only add tags that are not already associated with the group
             tag_ids_to_add = [t.id for t in self.tags_to_add]
             existing_tag_maps = (
-                OktaGroupTagMap.query.filter(
-                    db.or_(
+                db.session.query(OktaGroupTagMap)
+                .filter(
+                    or_(
                         OktaGroupTagMap.ended_at.is_(None),
-                        OktaGroupTagMap.ended_at > db.func.now(),
+                        OktaGroupTagMap.ended_at > func.now(),
                     )
                 )
                 .filter(
@@ -78,10 +85,10 @@ class ModifyGroupTags:
             db.session.commit()
 
         if len(self.tags_to_remove) > 0:
-            OktaGroupTagMap.query.filter(
-                db.or_(
+            db.session.query(OktaGroupTagMap).filter(
+                or_(
                     OktaGroupTagMap.ended_at.is_(None),
-                    OktaGroupTagMap.ended_at > db.func.now(),
+                    OktaGroupTagMap.ended_at > func.now(),
                 )
             ).filter(
                 OktaGroupTagMap.group_id == self.group.id,
@@ -90,7 +97,7 @@ class ModifyGroupTags:
             ).filter(
                 OktaGroupTagMap.app_tag_map_id.is_(None),
             ).update(
-                {OktaGroupTagMap.ended_at: db.func.now()},
+                {OktaGroupTagMap.ended_at: func.now()},
                 synchronize_session="fetch",
             )
             db.session.commit()

--- a/api/operations/modify_group_type.py
+++ b/api/operations/modify_group_type.py
@@ -3,7 +3,7 @@ from typing import Optional
 import logging
 
 from api.context import get_request_context
-from sqlalchemy import delete, insert
+from sqlalchemy import delete, func, insert, or_
 from sqlalchemy.orm import joinedload, selectin_polymorphic
 
 from api.extensions import db
@@ -36,7 +36,10 @@ class ModifyGroupType:
 
         self.group_changes = group_changes
         self.current_user_id = getattr(
-            OktaUser.query.filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first(),
+            db.session.query(OktaUser)
+            .filter(OktaUser.deleted_at.is_(None))
+            .filter(OktaUser.id == current_user_id)
+            .first(),
             "id",
             None,
         )
@@ -59,12 +62,16 @@ class ModifyGroupType:
                     )
 
                 # End all group attachments to this role and all group memberships via the role grant
-                active_role_associated_groups = RoleGroupMap.query.filter(
-                    db.or_(
-                        RoleGroupMap.ended_at.is_(None),
-                        RoleGroupMap.ended_at > db.func.now(),
+                active_role_associated_groups = (
+                    db.session.query(RoleGroupMap)
+                    .filter(
+                        or_(
+                            RoleGroupMap.ended_at.is_(None),
+                            RoleGroupMap.ended_at > func.now(),
+                        )
                     )
-                ).filter(RoleGroupMap.role_group_id == self.group.id)
+                    .filter(RoleGroupMap.role_group_id == self.group.id)
+                )
                 ModifyRoleGroups(
                     role_group=self.group,
                     current_user_id=self.current_user_id,
@@ -105,10 +112,10 @@ class ModifyGroupType:
                         db.session.rollback()
 
                 # Remove app tag map for this group that is no longer attached to an app
-                OktaGroupTagMap.query.filter(
-                    db.or_(
+                db.session.query(OktaGroupTagMap).filter(
+                    or_(
                         OktaGroupTagMap.ended_at.is_(None),
-                        OktaGroupTagMap.ended_at > db.func.now(),
+                        OktaGroupTagMap.ended_at > func.now(),
                     )
                 ).filter(OktaGroupTagMap.group_id == self.group.id).filter(
                     OktaGroupTagMap.app_tag_map_id.isnot(None)
@@ -128,16 +135,22 @@ class ModifyGroupType:
             self.group.type = OktaGroup.__mapper_args__["polymorphic_identity"]
             db.session.commit()
 
-            self.group = OktaGroup.query.filter(OktaGroup.deleted_at.is_(None)).filter(OktaGroup.id == group_id).first()
+            self.group = (
+                db.session.query(OktaGroup)
+                .filter(OktaGroup.deleted_at.is_(None))
+                .filter(OktaGroup.id == group_id)
+                .first()
+            )
 
             # Create new child table row
             if type(self.group_changes) is RoleGroup:
                 # Convert any group memberships and ownerships via a role to direct group memberships and ownerships
                 active_group_users_from_role = (
-                    OktaUserGroupMember.query.filter(
-                        db.or_(
+                    db.session.query(OktaUserGroupMember)
+                    .filter(
+                        or_(
                             OktaUserGroupMember.ended_at.is_(None),
-                            OktaUserGroupMember.ended_at > db.func.now(),
+                            OktaUserGroupMember.ended_at > func.now(),
                         )
                     )
                     .filter(OktaUserGroupMember.role_group_map_id.is_not(None))
@@ -164,10 +177,11 @@ class ModifyGroupType:
 
                 # Remove all group memberships and ownerships via a role grant
                 active_role_associated_groups = (
-                    RoleGroupMap.query.filter(
-                        db.or_(
+                    db.session.query(RoleGroupMap)
+                    .filter(
+                        or_(
                             RoleGroupMap.ended_at.is_(None),
-                            RoleGroupMap.ended_at > db.func.now(),
+                            RoleGroupMap.ended_at > func.now(),
                         )
                     )
                     .filter(RoleGroupMap.group_id == group_id)
@@ -207,11 +221,12 @@ class ModifyGroupType:
             # Add all app tags to this new app group, after we've updated the group type
             if type(self.group_changes) is AppGroup:
                 app_tag_maps = (
-                    AppTagMap.query.options(joinedload(AppTagMap.active_tag))
+                    db.session.query(AppTagMap)
+                    .options(joinedload(AppTagMap.active_tag))
                     .filter(
-                        db.or_(
+                        or_(
                             AppTagMap.ended_at.is_(None),
-                            AppTagMap.ended_at > db.func.now(),
+                            AppTagMap.ended_at > func.now(),
                         )
                     )
                     .filter(

--- a/api/operations/modify_group_users.py
+++ b/api/operations/modify_group_users.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional
 
 import logging
 
+from sqlalchemy import func, or_
 from api.context import get_request_context
 from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload
 
@@ -37,8 +38,8 @@ class ModifyGroupUsers:
         users_added_ended_at: Optional[datetime] = None,
         members_to_add: list[str] = [],
         owners_to_add: list[str] = [],
-        members_should_expire: list[str] = [],
-        owners_should_expire: list[str] = [],
+        members_should_expire: list[int] = [],
+        owners_should_expire: list[int] = [],
         members_to_remove: list[str] = [],
         owners_to_remove: list[str] = [],
         sync_to_okta: bool = True,
@@ -76,49 +77,66 @@ class ModifyGroupUsers:
         self.members_to_add = []
         if len(members_to_add) > 0:
             self.members_to_add = (
-                OktaUser.query.filter(OktaUser.id.in_(members_to_add)).filter(OktaUser.deleted_at.is_(None)).all()
+                db.session.query(OktaUser)
+                .filter(OktaUser.id.in_(members_to_add))
+                .filter(OktaUser.deleted_at.is_(None))
+                .all()
             )
 
         self.owners_to_add = []
         if len(owners_to_add) > 0:
             self.owners_to_add = (
-                OktaUser.query.filter(OktaUser.id.in_(owners_to_add)).filter(OktaUser.deleted_at.is_(None)).all()
+                db.session.query(OktaUser)
+                .filter(OktaUser.id.in_(owners_to_add))
+                .filter(OktaUser.deleted_at.is_(None))
+                .all()
             )
 
         self.members_should_expire = []
         if len(members_should_expire) > 0:
             self.members_should_expire = (
-                OktaUserGroupMember.query.filter(OktaUserGroupMember.id.in_(members_should_expire))
+                db.session.query(OktaUserGroupMember)
+                .filter(OktaUserGroupMember.id.in_(members_should_expire))
                 .filter(OktaUserGroupMember.group_id == self.group.id)
-                .filter(OktaUserGroupMember.ended_at > db.func.now())
+                .filter(OktaUserGroupMember.ended_at > func.now())
                 .filter(OktaUserGroupMember.is_owner.is_(False))
             ).all()
 
         self.owners_should_expire = []
         if len(owners_should_expire) > 0:
             self.owners_should_expire = (
-                OktaUserGroupMember.query.filter(OktaUserGroupMember.id.in_(owners_should_expire))
+                db.session.query(OktaUserGroupMember)
+                .filter(OktaUserGroupMember.id.in_(owners_should_expire))
                 .filter(OktaUserGroupMember.group_id == self.group.id)
-                .filter(OktaUserGroupMember.ended_at > db.func.now())
+                .filter(OktaUserGroupMember.ended_at > func.now())
                 .filter(OktaUserGroupMember.is_owner.is_(True))
             ).all()
 
         self.members_to_remove = []
         if len(members_to_remove) > 0:
             self.members_to_remove = (
-                OktaUser.query.filter(OktaUser.id.in_(members_to_remove)).filter(OktaUser.deleted_at.is_(None)).all()
+                db.session.query(OktaUser)
+                .filter(OktaUser.id.in_(members_to_remove))
+                .filter(OktaUser.deleted_at.is_(None))
+                .all()
             )
 
         self.owners_to_remove = []
         if len(owners_to_remove) > 0:
             self.owners_to_remove = (
-                OktaUser.query.filter(OktaUser.id.in_(owners_to_remove)).filter(OktaUser.deleted_at.is_(None)).all()
+                db.session.query(OktaUser)
+                .filter(OktaUser.id.in_(owners_to_remove))
+                .filter(OktaUser.deleted_at.is_(None))
+                .all()
             )
 
         self.sync_to_okta = sync_to_okta
 
         self.current_user_id = getattr(
-            OktaUser.query.filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first(),
+            db.session.query(OktaUser)
+            .filter(OktaUser.deleted_at.is_(None))
+            .filter(OktaUser.id == current_user_id)
+            .first(),
             "id",
             None,
         )
@@ -206,51 +224,53 @@ class ModifyGroupUsers:
 
         # End group memberships and ownerships
         if len(remove_changed_members) > 0 or len(remove_changed_owners) > 0:
-            OktaUserGroupMember.query.filter(
-                db.or_(
+            db.session.query(OktaUserGroupMember).filter(
+                or_(
                     OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > db.func.now(),
+                    OktaUserGroupMember.ended_at > func.now(),
                 )
             ).filter(OktaUserGroupMember.group_id == self.group.id).filter(
                 OktaUserGroupMember.is_owner.is_(False)
             ).filter(OktaUserGroupMember.user_id.in_([m.id for m in remove_changed_members])).filter(
                 OktaUserGroupMember.role_group_map_id.is_(None)
             ).update(
-                {OktaUserGroupMember.ended_at: db.func.now(), OktaUserGroupMember.ended_actor_id: self.current_user_id},
+                {OktaUserGroupMember.ended_at: func.now(), OktaUserGroupMember.ended_actor_id: self.current_user_id},
                 synchronize_session="fetch",
             )
 
-            OktaUserGroupMember.query.filter(
-                db.or_(
+            db.session.query(OktaUserGroupMember).filter(
+                or_(
                     OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > db.func.now(),
+                    OktaUserGroupMember.ended_at > func.now(),
                 )
             ).filter(OktaUserGroupMember.group_id == self.group.id).filter(
                 OktaUserGroupMember.is_owner.is_(True)
             ).filter(OktaUserGroupMember.user_id.in_([m.id for m in remove_changed_owners])).filter(
                 OktaUserGroupMember.role_group_map_id.is_(None)
             ).update(
-                {OktaUserGroupMember.ended_at: db.func.now(), OktaUserGroupMember.ended_actor_id: self.current_user_id},
+                {OktaUserGroupMember.ended_at: func.now(), OktaUserGroupMember.ended_actor_id: self.current_user_id},
                 synchronize_session="fetch",
             )
 
             # For role groups, members to be removed should also be removed from all role associated groups
             if type(self.group) is RoleGroup:
                 role_associated_groups_mappings = (
-                    RoleGroupMap.query.filter(
-                        db.or_(
+                    db.session.query(RoleGroupMap)
+                    .filter(
+                        or_(
                             RoleGroupMap.ended_at.is_(None),
-                            RoleGroupMap.ended_at > db.func.now(),
+                            RoleGroupMap.ended_at > func.now(),
                         )
                     )
                     .filter(RoleGroupMap.role_group_id == self.group.id)
                     .all()
                 )
                 role_associated_group_memberships = (
-                    OktaUserGroupMember.query.filter(
-                        db.or_(
+                    db.session.query(OktaUserGroupMember)
+                    .filter(
+                        or_(
                             OktaUserGroupMember.ended_at.is_(None),
-                            OktaUserGroupMember.ended_at > db.func.now(),
+                            OktaUserGroupMember.ended_at > func.now(),
                         )
                     )
                     .filter(OktaUserGroupMember.user_id.in_([m.id for m in remove_changed_members]))
@@ -259,7 +279,7 @@ class ModifyGroupUsers:
 
                 role_associated_group_memberships.update(
                     {
-                        OktaUserGroupMember.ended_at: db.func.now(),
+                        OktaUserGroupMember.ended_at: func.now(),
                         OktaUserGroupMember.ended_actor_id: self.current_user_id,
                     },
                     synchronize_session="fetch",
@@ -273,11 +293,12 @@ class ModifyGroupUsers:
             members_to_remove_ids = [m.id for m in self.members_to_remove]
             owners_to_remove_ids = [m.id for m in self.owners_to_remove]
             removed_users_with_other_access = (
-                OktaUserGroupMember.query.with_entities(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
+                db.session.query(OktaUserGroupMember)
+                .with_entities(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
                 .filter(
-                    db.or_(
+                    or_(
                         OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > db.func.now(),
+                        OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
                 .filter(OktaUserGroupMember.group_id == self.group.id)
@@ -311,13 +332,14 @@ class ModifyGroupUsers:
             # For role groups, members to be removed should also be removed from all role associated groups
             if type(self.group) is RoleGroup:
                 role_associated_groups_mappings = (
-                    RoleGroupMap.query.options(joinedload(RoleGroupMap.active_group))
+                    db.session.query(RoleGroupMap)
+                    .options(joinedload(RoleGroupMap.active_group))
                     .join(RoleGroupMap.active_group)
                     .filter(OktaGroup.is_managed.is_(True))
                     .filter(
-                        db.or_(
+                        or_(
                             RoleGroupMap.ended_at.is_(None),
-                            RoleGroupMap.ended_at > db.func.now(),
+                            RoleGroupMap.ended_at > func.now(),
                         )
                     )
                     .filter(RoleGroupMap.role_group_id == self.group.id)
@@ -327,15 +349,16 @@ class ModifyGroupUsers:
                 # combination before removing group membership, there can be multiple role groups
                 # which allow group access for this user
                 removed_role_group_users_with_other_access = (
-                    OktaUserGroupMember.query.with_entities(
+                    db.session.query(OktaUserGroupMember)
+                    .with_entities(
                         OktaUserGroupMember.user_id,
                         OktaUserGroupMember.group_id,
                         OktaUserGroupMember.is_owner,
                     )
                     .filter(
-                        db.or_(
+                        or_(
                             OktaUserGroupMember.ended_at.is_(None),
-                            OktaUserGroupMember.ended_at > db.func.now(),
+                            OktaUserGroupMember.ended_at > func.now(),
                         )
                     )
                     .filter(OktaUserGroupMember.user_id.in_(members_to_remove_ids + owners_to_remove_ids))
@@ -420,7 +443,7 @@ class ModifyGroupUsers:
         # Only relevant for the expiring groups page so not adding checks for this field anywhere else since OK if marked to expire
         # then manually renewed from group page or with an access request
         if len(self.members_should_expire) > 0:
-            OktaUserGroupMember.query.filter(
+            db.session.query(OktaUserGroupMember).filter(
                 OktaUserGroupMember.id.in_(m.id for m in self.members_should_expire)
             ).update(
                 {OktaUserGroupMember.should_expire: True},
@@ -428,7 +451,7 @@ class ModifyGroupUsers:
             )
 
         if len(self.owners_should_expire) > 0:
-            OktaUserGroupMember.query.filter(
+            db.session.query(OktaUserGroupMember).filter(
                 OktaUserGroupMember.id.in_(m.id for m in self.owners_should_expire)
             ).update(
                 {OktaUserGroupMember.should_expire: True},
@@ -443,11 +466,12 @@ class ModifyGroupUsers:
             # Check which members being added currently have NO active memberships (to track first-time access)
             members_to_add_ids = [m.id for m in self.members_to_add]
             existing_members_with_access = (
-                OktaUserGroupMember.query.with_entities(OktaUserGroupMember.user_id)
+                db.session.query(OktaUserGroupMember)
+                .with_entities(OktaUserGroupMember.user_id)
                 .filter(
-                    db.or_(
+                    or_(
                         OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > db.func.now(),
+                        OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
                 .filter(OktaUserGroupMember.group_id == self.group.id)
@@ -503,13 +527,14 @@ class ModifyGroupUsers:
             # For role groups, new members should also be added to all Access-managed role associated groups
             if type(self.group) is RoleGroup:
                 role_associated_groups_mappings = (
-                    RoleGroupMap.query.options(joinedload(RoleGroupMap.active_group))
+                    db.session.query(RoleGroupMap)
+                    .options(joinedload(RoleGroupMap.active_group))
                     .join(RoleGroupMap.active_group)
                     .filter(OktaGroup.is_managed.is_(True))
                     .filter(
-                        db.or_(
+                        or_(
                             RoleGroupMap.ended_at.is_(None),
-                            RoleGroupMap.ended_at > db.func.now(),
+                            RoleGroupMap.ended_at > func.now(),
                         )
                     )
                     .filter(RoleGroupMap.role_group_id == self.group.id)
@@ -525,14 +550,15 @@ class ModifyGroupUsers:
                         existing_access_by_group[group_id] = set()
 
                     existing_role_members_with_access = (
-                        OktaUserGroupMember.query.with_entities(
+                        db.session.query(OktaUserGroupMember)
+                        .with_entities(
                             OktaUserGroupMember.user_id,
                             OktaUserGroupMember.group_id,
                         )
                         .filter(
-                            db.or_(
+                            or_(
                                 OktaUserGroupMember.ended_at.is_(None),
-                                OktaUserGroupMember.ended_at > db.func.now(),
+                                OktaUserGroupMember.ended_at > func.now(),
                             )
                         )
                         .filter(OktaUserGroupMember.user_id.in_(members_to_add_ids))
@@ -628,7 +654,8 @@ class ModifyGroupUsers:
 
             # Approve any pending access requests for access granted by this operation
             pending_requests_query = (
-                AccessRequest.query.options(joinedload(AccessRequest.requested_group))
+                db.session.query(AccessRequest)
+                .options(joinedload(AccessRequest.requested_group))
                 .filter(AccessRequest.status == AccessRequestStatus.PENDING)
                 .filter(AccessRequest.resolved_at.is_(None))
             )
@@ -692,7 +719,7 @@ class ModifyGroupUsers:
         self, access_request: AccessRequest, added_okta_user_group_member: OktaUserGroupMember
     ) -> asyncio.Task[None]:
         access_request.status = AccessRequestStatus.APPROVED
-        access_request.resolved_at = db.func.now()
+        access_request.resolved_at = func.now()
         access_request.resolver_user_id = self.current_user_id
         access_request.resolution_reason = self.created_reason
         access_request.approval_ending_at = added_okta_user_group_member.ended_at

--- a/api/operations/modify_groups_time_limit.py
+++ b/api/operations/modify_groups_time_limit.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime, timedelta
 
+from sqlalchemy import func, or_
 from api.extensions import db
 from api.models import OktaGroup, OktaUserGroupMember, RoleGroup, RoleGroupMap, Tag
 from api.models.tag import coalesce_constraints
@@ -9,19 +10,21 @@ class ModifyGroupsTimeLimit:
     def __init__(self, groups: list[str] | set[str], tags: list[str] | set[str]):
         # Only include groups that are managed
         self.groups = (
-            OktaGroup.query.filter(OktaGroup.id.in_(groups))
+            db.session.query(OktaGroup)
+            .filter(OktaGroup.id.in_(groups))
             .filter(OktaGroup.deleted_at.is_(None))
             .filter(OktaGroup.is_managed.is_(True))
             .all()
         )
         self.role_groups = (
-            RoleGroup.query.filter(RoleGroup.id.in_(groups))
+            db.session.query(RoleGroup)
+            .filter(RoleGroup.id.in_(groups))
             .filter(RoleGroup.deleted_at.is_(None))
             .filter(RoleGroup.is_managed.is_(True))
             .all()
         )
 
-        self.tags = Tag.query.filter(Tag.id.in_(tags)).filter(Tag.deleted_at.is_(None)).all()
+        self.tags = db.session.query(Tag).filter(Tag.id.in_(tags)).filter(Tag.deleted_at.is_(None)).all()
 
     def execute(self) -> None:
         if len(self.groups) == 0:
@@ -34,10 +37,10 @@ class ModifyGroupsTimeLimit:
         if membership_seconds_limit is not None:
             membership_time_limit_from_now = datetime.now(UTC) + timedelta(seconds=membership_seconds_limit)
             # Reduce all user memberships for the given groups to minimum allowed time limit
-            OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id.in_([g.id for g in self.groups])).filter(
-                OktaUserGroupMember.is_owner.is_(False)
-            ).filter(
-                db.or_(
+            db.session.query(OktaUserGroupMember).filter(
+                OktaUserGroupMember.group_id.in_([g.id for g in self.groups])
+            ).filter(OktaUserGroupMember.is_owner.is_(False)).filter(
+                or_(
                     OktaUserGroupMember.ended_at.is_(None),
                     OktaUserGroupMember.ended_at > membership_time_limit_from_now,
                 )
@@ -46,10 +49,10 @@ class ModifyGroupsTimeLimit:
                 synchronize_session="fetch",
             )
             # Reduce all role memberships for the given groups to the minimum allowed time limit
-            RoleGroupMap.query.filter(RoleGroupMap.group_id.in_([g.id for g in self.groups])).filter(
+            db.session.query(RoleGroupMap).filter(RoleGroupMap.group_id.in_([g.id for g in self.groups])).filter(
                 RoleGroupMap.is_owner.is_(False)
             ).filter(
-                db.or_(
+                or_(
                     RoleGroupMap.ended_at.is_(None),
                     RoleGroupMap.ended_at > membership_time_limit_from_now,
                 )
@@ -60,20 +63,21 @@ class ModifyGroupsTimeLimit:
             # Reduce all user memberships for groups associated with any given role groups
             # to the minimum allowed time limit
             role_group_map_associations = (
-                RoleGroupMap.query.filter(RoleGroupMap.role_group_id.in_([g.id for g in self.role_groups]))
+                db.session.query(RoleGroupMap)
+                .filter(RoleGroupMap.role_group_id.in_([g.id for g in self.role_groups]))
                 .filter(RoleGroupMap.is_owner.is_(False))
                 .filter(
-                    db.or_(
+                    or_(
                         RoleGroupMap.ended_at.is_(None),
-                        RoleGroupMap.ended_at > db.func.now(),
+                        RoleGroupMap.ended_at > func.now(),
                     )
                 )
                 .all()
             )
-            OktaUserGroupMember.query.filter(
+            db.session.query(OktaUserGroupMember).filter(
                 OktaUserGroupMember.role_group_map_id.in_([m.id for m in role_group_map_associations])
             ).filter(OktaUserGroupMember.is_owner.is_(False)).filter(
-                db.or_(
+                or_(
                     OktaUserGroupMember.ended_at.is_(None),
                     OktaUserGroupMember.ended_at > membership_time_limit_from_now,
                 )
@@ -85,10 +89,10 @@ class ModifyGroupsTimeLimit:
         if ownership_seconds_limit is not None:
             ownership_time_limit_from_now = datetime.now(UTC) + timedelta(seconds=ownership_seconds_limit)
             # Reduce all user ownerships for the given groups to minimum allowed time limit
-            OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id.in_([g.id for g in self.groups])).filter(
-                OktaUserGroupMember.is_owner.is_(True)
-            ).filter(
-                db.or_(
+            db.session.query(OktaUserGroupMember).filter(
+                OktaUserGroupMember.group_id.in_([g.id for g in self.groups])
+            ).filter(OktaUserGroupMember.is_owner.is_(True)).filter(
+                or_(
                     OktaUserGroupMember.ended_at.is_(None),
                     OktaUserGroupMember.ended_at > ownership_time_limit_from_now,
                 )
@@ -97,10 +101,10 @@ class ModifyGroupsTimeLimit:
                 synchronize_session="fetch",
             )
             # Reduce all role ownerships for the given groups to the minimum allowed time limit
-            RoleGroupMap.query.filter(RoleGroupMap.group_id.in_([g.id for g in self.groups])).filter(
+            db.session.query(RoleGroupMap).filter(RoleGroupMap.group_id.in_([g.id for g in self.groups])).filter(
                 RoleGroupMap.is_owner.is_(True)
             ).filter(
-                db.or_(
+                or_(
                     RoleGroupMap.ended_at.is_(None),
                     RoleGroupMap.ended_at > ownership_time_limit_from_now,
                 )
@@ -111,20 +115,21 @@ class ModifyGroupsTimeLimit:
             # Reduce all user ownerships for groups associated with any given role groups
             # to the minimum allowed time limit
             role_group_map_associations = (
-                RoleGroupMap.query.filter(RoleGroupMap.role_group_id.in_([g.id for g in self.role_groups]))
+                db.session.query(RoleGroupMap)
+                .filter(RoleGroupMap.role_group_id.in_([g.id for g in self.role_groups]))
                 .filter(RoleGroupMap.is_owner.is_(True))
                 .filter(
-                    db.or_(
+                    or_(
                         RoleGroupMap.ended_at.is_(None),
-                        RoleGroupMap.ended_at > db.func.now(),
+                        RoleGroupMap.ended_at > func.now(),
                     )
                 )
                 .all()
             )
-            OktaUserGroupMember.query.filter(
+            db.session.query(OktaUserGroupMember).filter(
                 OktaUserGroupMember.role_group_map_id.in_([m.id for m in role_group_map_associations])
             ).filter(OktaUserGroupMember.is_owner.is_(True)).filter(
-                db.or_(
+                or_(
                     OktaUserGroupMember.ended_at.is_(None),
                     OktaUserGroupMember.ended_at > membership_time_limit_from_now,
                 )

--- a/api/operations/modify_role_groups.py
+++ b/api/operations/modify_role_groups.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional
 
 import logging
 
+from sqlalchemy import func, or_
 from api.context import get_request_context
 from sqlalchemy.orm import selectinload
 
@@ -36,8 +37,8 @@ class ModifyRoleGroups:
         groups_added_ended_at: Optional[datetime] = None,
         groups_to_add: list[str] = [],
         owner_groups_to_add: list[str] = [],
-        groups_should_expire: list[str] = [],
-        owner_groups_should_expire: list[str] = [],
+        groups_should_expire: list[int] = [],
+        owner_groups_should_expire: list[int] = [],
         groups_to_remove: list[str] = [],
         owner_groups_to_remove: list[str] = [],
         sync_to_okta: bool = True,
@@ -47,7 +48,10 @@ class ModifyRoleGroups:
     ):
         if isinstance(role_group, str):
             self.role = (
-                RoleGroup.query.filter(RoleGroup.deleted_at.is_(None)).filter(RoleGroup.id == role_group).first()
+                db.session.query(RoleGroup)
+                .filter(RoleGroup.deleted_at.is_(None))
+                .filter(RoleGroup.id == role_group)
+                .first()
             )
         else:
             self.role = role_group
@@ -57,9 +61,8 @@ class ModifyRoleGroups:
         self.groups_to_add = []
         if len(groups_to_add) > 0:
             self.groups_to_add = (
-                OktaGroup.query.options(
-                    selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag)
-                )
+                db.session.query(OktaGroup)
+                .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
                 .filter(OktaGroup.id.in_(groups_to_add))
                 .filter(OktaGroup.is_managed.is_(True))
                 .filter(OktaGroup.deleted_at.is_(None))
@@ -70,9 +73,8 @@ class ModifyRoleGroups:
         self.owner_groups_to_add = []
         if len(owner_groups_to_add) > 0:
             self.owner_groups_to_add = (
-                OktaGroup.query.options(
-                    selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag)
-                )
+                db.session.query(OktaGroup)
+                .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
                 .filter(OktaGroup.id.in_(owner_groups_to_add))
                 .filter(OktaGroup.is_managed.is_(True))
                 .filter(OktaGroup.deleted_at.is_(None))
@@ -84,31 +86,37 @@ class ModifyRoleGroups:
         self.groups_should_expire = []
         if len(groups_should_expire) > 0:
             self.groups_should_expire = (
-                RoleGroupMap.query.filter(RoleGroupMap.id.in_(groups_should_expire))
+                db.session.query(RoleGroupMap)
+                .filter(RoleGroupMap.id.in_(groups_should_expire))
                 .filter(RoleGroupMap.role_group_id == self.role.id)
-                .filter(RoleGroupMap.ended_at > db.func.now())
+                .filter(RoleGroupMap.ended_at > func.now())
                 .filter(RoleGroupMap.is_owner.is_(False))
             ).all()
 
         self.owner_groups_should_expire = []
         if len(owner_groups_should_expire) > 0:
             self.owner_groups_should_expire = (
-                RoleGroupMap.query.filter(RoleGroupMap.id.in_(owner_groups_should_expire))
+                db.session.query(RoleGroupMap)
+                .filter(RoleGroupMap.id.in_(owner_groups_should_expire))
                 .filter(RoleGroupMap.role_group_id == self.role.id)
-                .filter(RoleGroupMap.ended_at > db.func.now())
+                .filter(RoleGroupMap.ended_at > func.now())
                 .filter(RoleGroupMap.is_owner.is_(True))
             ).all()
 
         self.groups_to_remove = []
         if len(groups_to_remove) > 0:
             self.groups_to_remove = (
-                OktaGroup.query.filter(OktaGroup.id.in_(groups_to_remove)).filter(OktaGroup.deleted_at.is_(None)).all()
+                db.session.query(OktaGroup)
+                .filter(OktaGroup.id.in_(groups_to_remove))
+                .filter(OktaGroup.deleted_at.is_(None))
+                .all()
             )
 
         self.owner_groups_to_remove = []
         if len(owner_groups_to_remove) > 0:
             self.owner_groups_to_remove = (
-                OktaGroup.query.filter(OktaGroup.id.in_(owner_groups_to_remove))
+                db.session.query(OktaGroup)
+                .filter(OktaGroup.id.in_(owner_groups_to_remove))
                 .filter(OktaGroup.deleted_at.is_(None))
                 .all()
             )
@@ -116,7 +124,10 @@ class ModifyRoleGroups:
         self.sync_to_okta = sync_to_okta
 
         self.current_user_id = getattr(
-            OktaUser.query.filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first(),
+            db.session.query(OktaUser)
+            .filter(OktaUser.deleted_at.is_(None))
+            .filter(OktaUser.id == current_user_id)
+            .first(),
             "id",
             None,
         )
@@ -210,10 +221,11 @@ class ModifyRoleGroups:
             # which allow group access for this user
 
             active_role_members = (
-                OktaUserGroupMember.query.filter(
-                    db.or_(
+                db.session.query(OktaUserGroupMember)
+                .filter(
+                    or_(
                         OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > db.func.now(),
+                        OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
                 .filter(OktaUserGroupMember.group_id == self.role.id)
@@ -224,15 +236,16 @@ class ModifyRoleGroups:
             groups_to_remove_ids = [m.id for m in self.groups_to_remove]
             owner_groups_to_remove_ids = [m.id for m in self.owner_groups_to_remove]
             removed_role_group_users_with_other_access = (
-                OktaUserGroupMember.query.with_entities(
+                db.session.query(OktaUserGroupMember)
+                .with_entities(
                     OktaUserGroupMember.user_id,
                     OktaUserGroupMember.group_id,
                     OktaUserGroupMember.is_owner,
                 )
                 .filter(
-                    db.or_(
+                    or_(
                         OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > db.func.now(),
+                        OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
                 .filter(OktaUserGroupMember.user_id.in_(role_members_to_remove_ids))
@@ -261,7 +274,8 @@ class ModifyRoleGroups:
                     plugin_id = get_app_group_lifecycle_plugin_to_invoke(group)
                     if plugin_id is not None:
                         members_losing_access = (
-                            OktaUser.query.filter(OktaUser.id.in_(okta_members_to_remove_ids))
+                            db.session.query(OktaUser)
+                            .filter(OktaUser.id.in_(okta_members_to_remove_ids))
                             .filter(OktaUser.deleted_at.is_(None))
                             .all()
                         )
@@ -301,13 +315,15 @@ class ModifyRoleGroups:
         # Only relevant for the expiring roles page so not adding checks for this field anywhere else since OK if marked to expire
         # then manually renewed from group/role page or with an access request
         if len(self.groups_should_expire) > 0:
-            RoleGroupMap.query.filter(RoleGroupMap.id.in_(m.id for m in self.groups_should_expire)).update(
+            db.session.query(RoleGroupMap).filter(RoleGroupMap.id.in_(m.id for m in self.groups_should_expire)).update(
                 {RoleGroupMap.should_expire: True},
                 synchronize_session="fetch",
             )
 
         if len(self.owner_groups_should_expire) > 0:
-            RoleGroupMap.query.filter(RoleGroupMap.id.in_(m.id for m in self.owner_groups_should_expire)).update(
+            db.session.query(RoleGroupMap).filter(
+                RoleGroupMap.id.in_(m.id for m in self.owner_groups_should_expire)
+            ).update(
                 {RoleGroupMap.should_expire: True},
                 synchronize_session="fetch",
             )
@@ -367,10 +383,11 @@ class ModifyRoleGroups:
             # Group members of a role should be added as members to all newly added groups
             # and owner groups associated with that role
             active_role_memberships = (
-                OktaUserGroupMember.query.filter(
-                    db.or_(
+                db.session.query(OktaUserGroupMember)
+                .filter(
+                    or_(
                         OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > db.func.now(),
+                        OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
                 .filter(OktaUserGroupMember.group_id == self.role.id)
@@ -384,10 +401,9 @@ class ModifyRoleGroups:
                 # Check which members being added currently have NO active memberships (to track first-time access)
                 members_to_add_ids = [m.user_id for m in active_role_memberships]
                 existing_members_with_access = (
-                    OktaUserGroupMember.query.with_entities(OktaUserGroupMember.user_id)
-                    .filter(
-                        db.or_(OktaUserGroupMember.ended_at.is_(None), OktaUserGroupMember.ended_at > db.func.now())
-                    )
+                    db.session.query(OktaUserGroupMember)
+                    .with_entities(OktaUserGroupMember.user_id)
+                    .filter(or_(OktaUserGroupMember.ended_at.is_(None), OktaUserGroupMember.ended_at > func.now()))
                     .filter(OktaUserGroupMember.group_id == role_associated_group_map.group_id)
                     .filter(OktaUserGroupMember.user_id.in_(members_to_add_ids))
                     .filter(OktaUserGroupMember.is_owner.is_(False))
@@ -403,7 +419,8 @@ class ModifyRoleGroups:
                     plugin_id = get_app_group_lifecycle_plugin_to_invoke(group)
                     if plugin_id is not None:
                         members_gaining_access = (
-                            OktaUser.query.filter(OktaUser.id.in_(members_gaining_access_ids))
+                            db.session.query(OktaUser)
+                            .filter(OktaUser.id.in_(members_gaining_access_ids))
                             .filter(OktaUser.deleted_at.is_(None))
                             .all()
                         )
@@ -491,9 +508,11 @@ class ModifyRoleGroups:
             db.session.commit()
 
             # Approve any pending access requests for access granted by this operation
-            pending_requests_query = AccessRequest.query.filter(
-                AccessRequest.status == AccessRequestStatus.PENDING
-            ).filter(AccessRequest.resolved_at.is_(None))
+            pending_requests_query = (
+                db.session.query(AccessRequest)
+                .filter(AccessRequest.status == AccessRequestStatus.PENDING)
+                .filter(AccessRequest.resolved_at.is_(None))
+            )
             active_role_membership_ids = [m.user_id for m in active_role_memberships]
 
             # Find all pending membership requests to approve for groups added as members via this role
@@ -528,7 +547,8 @@ class ModifyRoleGroups:
 
             # Approve any pending role requests for memberships granted by this operation
             pending_role_requests_query = (
-                RoleRequest.query.filter(RoleRequest.status == AccessRequestStatus.PENDING)
+                db.session.query(RoleRequest)
+                .filter(RoleRequest.status == AccessRequestStatus.PENDING)
                 .filter(RoleRequest.resolved_at.is_(None))
                 .filter(RoleRequest.requester_role == self.role)
             )
@@ -572,10 +592,11 @@ class ModifyRoleGroups:
 
         # Role user members should be removed from any groups associated with that role being removed
         old_role_associated_groups_mappings = (
-            RoleGroupMap.query.filter(
-                db.or_(
+            db.session.query(RoleGroupMap)
+            .filter(
+                or_(
                     RoleGroupMap.ended_at.is_(None),
-                    RoleGroupMap.ended_at > db.func.now(),
+                    RoleGroupMap.ended_at > func.now(),
                 )
             )
             .filter(RoleGroupMap.role_group_id == self.role.id)
@@ -585,23 +606,23 @@ class ModifyRoleGroups:
         )
 
         # End group memberships via role
-        OktaUserGroupMember.query.filter(
-            db.or_(
+        db.session.query(OktaUserGroupMember).filter(
+            or_(
                 OktaUserGroupMember.ended_at.is_(None),
-                OktaUserGroupMember.ended_at > db.func.now(),
+                OktaUserGroupMember.ended_at > func.now(),
             )
         ).filter(OktaUserGroupMember.role_group_map_id.in_([m.id for m in old_role_associated_groups_mappings])).update(
-            {OktaUserGroupMember.ended_at: db.func.now(), OktaUserGroupMember.ended_actor_id: self.current_user_id},
+            {OktaUserGroupMember.ended_at: func.now(), OktaUserGroupMember.ended_actor_id: self.current_user_id},
             synchronize_session="fetch",
         )
 
         # End mappings of role associated group to role
-        RoleGroupMap.query.filter(
-            db.or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > db.func.now())
+        db.session.query(RoleGroupMap).filter(
+            or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now())
         ).filter(RoleGroupMap.role_group_id == self.role.id).filter(
             RoleGroupMap.group_id.in_([g.id for g in groups_to_remove])
         ).filter(RoleGroupMap.is_owner == owner_groups).update(
-            {RoleGroupMap.ended_at: db.func.now(), RoleGroupMap.ended_actor_id: self.current_user_id},
+            {RoleGroupMap.ended_at: func.now(), RoleGroupMap.ended_actor_id: self.current_user_id},
             synchronize_session="fetch",
         )
 
@@ -609,7 +630,7 @@ class ModifyRoleGroups:
         self, access_request: AccessRequest, added_okta_user_group_member: OktaUserGroupMember
     ) -> asyncio.Task[None]:
         access_request.status = AccessRequestStatus.APPROVED
-        access_request.resolved_at = db.func.now()
+        access_request.resolved_at = func.now()
         access_request.resolver_user_id = self.current_user_id
         access_request.resolution_reason = self.created_reason
         access_request.approval_ending_at = added_okta_user_group_member.ended_at
@@ -634,7 +655,7 @@ class ModifyRoleGroups:
         self, role_request: RoleRequest, added_role_group_map: RoleGroupMap
     ) -> asyncio.Task[None]:
         role_request.status = AccessRequestStatus.APPROVED
-        role_request.resolved_at = db.func.now()
+        role_request.resolved_at = func.now()
         role_request.resolver_user_id = self.current_user_id
         role_request.resolution_reason = self.created_reason
         role_request.approval_ending_at = added_role_group_map.ended_at

--- a/api/operations/reject_access_request.py
+++ b/api/operations/reject_access_request.py
@@ -3,7 +3,7 @@ from typing import Optional
 import logging
 
 from api.context import get_request_context
-from sqlalchemy import nullsfirst
+from sqlalchemy import func, nullsfirst
 from sqlalchemy.orm import joinedload, selectin_polymorphic
 
 from api.extensions import db
@@ -32,7 +32,10 @@ class RejectAccessRequest:
             self.rejecter_id = None
         elif isinstance(current_user_id, str):
             self.rejecter_id = getattr(
-                OktaUser.query.filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first(),
+                db.session.query(OktaUser)
+                .filter(OktaUser.deleted_at.is_(None))
+                .filter(OktaUser.id == current_user_id)
+                .first(),
                 "id",
                 None,
             )
@@ -51,7 +54,7 @@ class RejectAccessRequest:
             return self.access_request
 
         self.access_request.status = AccessRequestStatus.REJECTED
-        self.access_request.resolved_at = db.func.now()
+        self.access_request.resolved_at = func.now()
         self.access_request.resolver_user_id = self.rejecter_id
         self.access_request.resolution_reason = self.rejection_reason
 

--- a/api/operations/reject_group_request.py
+++ b/api/operations/reject_group_request.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import logging
 
+from sqlalchemy import func
 from api.context import get_request_context
 
 from api.extensions import db
@@ -30,7 +31,12 @@ class RejectGroupRequest:
         if current_user_id is None:
             self.rejecter_id = None
         elif isinstance(current_user_id, str):
-            user = OktaUser.query.filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first()
+            user = (
+                db.session.query(OktaUser)
+                .filter(OktaUser.deleted_at.is_(None))
+                .filter(OktaUser.id == current_user_id)
+                .first()
+            )
             self.rejecter_id = user.id if user else None
         else:
             self.rejecter_id = current_user_id.id
@@ -99,7 +105,7 @@ class RejectGroupRequest:
         )
 
         self.group_request.status = AccessRequestStatus.REJECTED
-        self.group_request.resolved_at = db.func.now()
+        self.group_request.resolved_at = func.now()
         self.group_request.resolver_user_id = self.rejecter_id
         self.group_request.resolution_reason = self.rejection_reason
 

--- a/api/operations/reject_role_request.py
+++ b/api/operations/reject_role_request.py
@@ -3,7 +3,7 @@ from typing import Optional
 import logging
 
 from api.context import get_request_context
-from sqlalchemy import nullsfirst
+from sqlalchemy import func, nullsfirst
 from sqlalchemy.orm import joinedload, selectin_polymorphic
 
 from api.extensions import db
@@ -32,7 +32,10 @@ class RejectRoleRequest:
             self.rejecter_id = None
         elif isinstance(current_user_id, str):
             self.rejecter_id = getattr(
-                OktaUser.query.filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first(),
+                db.session.query(OktaUser)
+                .filter(OktaUser.deleted_at.is_(None))
+                .filter(OktaUser.id == current_user_id)
+                .first(),
                 "id",
                 None,
             )
@@ -51,7 +54,7 @@ class RejectRoleRequest:
             return self.role_request
 
         self.role_request.status = AccessRequestStatus.REJECTED
-        self.role_request.resolved_at = db.func.now()
+        self.role_request.resolved_at = func.now()
         self.role_request.resolver_user_id = self.rejecter_id
         self.role_request.resolution_reason = self.rejection_reason
 

--- a/api/operations/unmanage_group.py
+++ b/api/operations/unmanage_group.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from sqlalchemy.orm import selectin_polymorphic
 
+from sqlalchemy import func, or_
 from api.extensions import db
 from api.models import (
     AccessRequest,
@@ -30,7 +31,10 @@ class UnmanageGroup:
         )
 
         self.current_user_id = getattr(
-            OktaUser.query.filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first(),
+            db.session.query(OktaUser)
+            .filter(OktaUser.deleted_at.is_(None))
+            .filter(OktaUser.id == current_user_id)
+            .first(),
             "id",
             None,
         )
@@ -43,10 +47,11 @@ class UnmanageGroup:
 
         # End all group memberships and ownerships via a role (not direct memberships or ownerships)
         active_access_via_roles_query = (
-            OktaUserGroupMember.query.filter(
-                db.or_(
+            db.session.query(OktaUserGroupMember)
+            .filter(
+                or_(
                     OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > db.func.now(),
+                    OktaUserGroupMember.ended_at > func.now(),
                 )
             )
             .filter(OktaUserGroupMember.group_id == self.group.id)
@@ -62,14 +67,16 @@ class UnmanageGroup:
 
         if not dry_run:
             active_access_via_roles_query.update(
-                {OktaUserGroupMember.ended_at: db.func.now()}, synchronize_session="fetch"
+                {OktaUserGroupMember.ended_at: func.now()}, synchronize_session="fetch"
             )
             db.session.commit()
 
         # End all roles associations where this group was a member
-        active_role_assignments_query = RoleGroupMap.query.filter(
-            db.or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > db.func.now())
-        ).filter(RoleGroupMap.group_id == self.group.id)
+        active_role_assignments_query = (
+            db.session.query(RoleGroupMap)
+            .filter(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
+            .filter(RoleGroupMap.group_id == self.group.id)
+        )
 
         for active_role_assignment in active_role_assignments_query.all():
             logger.info(
@@ -79,7 +86,7 @@ class UnmanageGroup:
             )
 
         if not dry_run:
-            active_role_assignments_query.update({RoleGroupMap.ended_at: db.func.now()}, synchronize_session="fetch")
+            active_role_assignments_query.update({RoleGroupMap.ended_at: func.now()}, synchronize_session="fetch")
             db.session.commit()
 
         # If this groups is a RoleGroup, do not remove the groups associated with the role
@@ -87,7 +94,8 @@ class UnmanageGroup:
 
         # Reject all pending access requests for this group
         obsolete_access_requests = (
-            AccessRequest.query.filter(AccessRequest.requested_group_id == self.group.id)
+            db.session.query(AccessRequest)
+            .filter(AccessRequest.requested_group_id == self.group.id)
             .filter(AccessRequest.status == AccessRequestStatus.PENDING)
             .filter(AccessRequest.resolved_at.is_(None))
             .all()

--- a/api/routers/access_requests.py
+++ b/api/routers/access_requests.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query
-from sqlalchemy import String, cast
+from sqlalchemy import String, cast, or_
 from sqlalchemy.orm import aliased, joinedload, selectin_polymorphic, selectinload
 from starlette.requests import Request
 
 from api.auth.dependencies import CurrentUserId
 from api.database import DbSession
-from api.extensions import db as _db
 from api.models import (
     AccessRequest,
     AccessRequestStatus,
@@ -97,7 +96,7 @@ def list_access_requests(
         else:
             requester_alias = aliased(OktaUser)
             query = query.join(AccessRequest.requester.of_type(requester_alias)).filter(
-                _db.or_(
+                or_(
                     AccessRequest.requester_user_id == q_args.requester_user_id,
                     requester_alias.email.ilike(q_args.requester_user_id),
                 )
@@ -105,7 +104,7 @@ def list_access_requests(
 
     if q_args.requested_group_id:
         query = query.join(AccessRequest.requested_group).filter(
-            _db.or_(
+            or_(
                 AccessRequest.requested_group_id == q_args.requested_group_id,
                 OktaGroup.name.ilike(q_args.requested_group_id),
             )
@@ -115,7 +114,7 @@ def list_access_requests(
         assignee_user_id = current_user_id if q_args.assignee_user_id == "@me" else q_args.assignee_user_id
         assignee_user = (
             db.query(OktaUser)
-            .filter(_db.or_(OktaUser.id == assignee_user_id, OktaUser.email.ilike(assignee_user_id)))
+            .filter(or_(OktaUser.id == assignee_user_id, OktaUser.email.ilike(assignee_user_id)))
             .first()
         )
         if assignee_user is not None:
@@ -143,7 +142,7 @@ def list_access_requests(
                 .subquery()
             )
             query = query.join(AccessRequest.requested_group).filter(
-                _db.or_(
+                or_(
                     OktaGroup.id.in_(groups_owned_subquery),
                     OktaGroup.id.in_(app_groups_owned_subquery),
                 )
@@ -157,7 +156,7 @@ def list_access_requests(
         else:
             resolver_alias = aliased(OktaUser)
             query = query.outerjoin(AccessRequest.resolver.of_type(resolver_alias)).filter(
-                _db.or_(
+                or_(
                     AccessRequest.resolver_user_id == q_args.resolver_user_id,
                     resolver_alias.email.ilike(q_args.resolver_user_id),
                 )
@@ -174,7 +173,7 @@ def list_access_requests(
             .join(AccessRequest.requested_group)
             .outerjoin(AccessRequest.resolver.of_type(q_resolver_alias))
             .filter(
-                _db.or_(
+                or_(
                     AccessRequest.id.like(f"{q_args.q}%"),
                     cast(AccessRequest.status, String).ilike(like),
                     q_requester_alias.email.ilike(like),

--- a/api/routers/apps.py
+++ b/api/routers/apps.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import func
+from sqlalchemy import func, or_
 from sqlalchemy.orm import joinedload, selectinload
 from starlette.requests import Request
 
@@ -15,7 +15,6 @@ from api.auth.permissions import (
     require_app_owner_or_access_admin_for_app,
 )
 from api.database import DbSession
-from api.extensions import db as _db
 from api.models import (
     App,
     AppGroup,
@@ -68,7 +67,7 @@ def list_apps(
     query = db.query(App).filter(App.deleted_at.is_(None)).order_by(func.lower(App.name))
     if q_args.q:
         like = f"%{q_args.q}%"
-        query = query.filter(_db.or_(App.name.ilike(like), App.description.ilike(like)))
+        query = query.filter(or_(App.name.ilike(like), App.description.ilike(like)))
     return paginate(request, query, AppPagination, extract=lambda: (q_args.page, q_args.per_page))
 
 
@@ -78,7 +77,7 @@ def get_app(app_id: str, db: DbSession, current_user_id: CurrentUserId) -> AppDe
         db.query(App)
         .options(*APP_LOAD_OPTIONS)
         .filter(App.deleted_at.is_(None))
-        .filter(_db.or_(App.id == app_id, App.name == app_id))
+        .filter(or_(App.id == app_id, App.name == app_id))
         .first()
     )
     if app is None:
@@ -113,7 +112,7 @@ def post_app(
             db.query(OktaUser)
             .filter(OktaUser.deleted_at.is_(None))
             .filter(
-                _db.or_(
+                or_(
                     OktaUser.id == body.initial_owner_id,
                     OktaUser.email.ilike(body.initial_owner_id),
                 )

--- a/api/routers/audit.py
+++ b/api/routers/audit.py
@@ -15,13 +15,13 @@ from datetime import datetime, timezone
 from typing import Annotated, Any
 
 from fastapi import APIRouter, HTTPException, Query
-from sqlalchemy import func, inspect as sa_inspect, nullsfirst, nullslast
+from sqlalchemy import and_, func, not_, nullsfirst, nullslast, or_
+from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.orm import aliased, joinedload, selectin_polymorphic, selectinload, with_polymorphic
 from starlette.requests import Request
 
 from api.auth.dependencies import CurrentUserId
 from api.database import DbSession
-from api.extensions import db as _db
 from api.models import (
     AppGroup,
     AppTagMap,
@@ -77,7 +77,7 @@ def _resolve_user(db: DbSession, value: str | None) -> OktaUser | None:
         return None
     user = (
         db.query(OktaUser)
-        .filter(_db.or_(OktaUser.id == value, OktaUser.email.ilike(value)))
+        .filter(or_(OktaUser.id == value, OktaUser.email.ilike(value)))
         .order_by(nullsfirst(OktaUser.deleted_at.desc()))
         .first()
     )
@@ -91,7 +91,7 @@ def _resolve_group(db: DbSession, value: str | None) -> OktaGroup | None:
         return None
     group = (
         db.query(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-        .filter(_db.or_(OktaGroup.id == value, OktaGroup.name == value))
+        .filter(or_(OktaGroup.id == value, OktaGroup.name == value))
         .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
         .first()
     )
@@ -105,7 +105,7 @@ def _resolve_role(db: DbSession, value: str | None) -> RoleGroup | None:
         return None
     role = (
         db.query(RoleGroup)
-        .filter(_db.or_(RoleGroup.id == value, RoleGroup.name == value))
+        .filter(or_(RoleGroup.id == value, RoleGroup.name == value))
         .order_by(nullsfirst(RoleGroup.deleted_at.desc()))
         .first()
     )
@@ -343,9 +343,9 @@ def users_and_groups(
             .filter(OktaUserGroupMember.user_id == owner.id)
             .filter(OktaUserGroupMember.is_owner.is_(True))
             .filter(
-                _db.or_(
+                or_(
                     OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > _db.func.now(),
+                    OktaUserGroupMember.ended_at > func.now(),
                 )
             )
             .all()
@@ -367,7 +367,7 @@ def users_and_groups(
         ]
         if q_args.app_owner is True:
             query = query.filter(
-                _db.or_(
+                or_(
                     OktaUserGroupMember.group_id.in_(owner_group_ids),
                     OktaUserGroupMember.group_id.in_(app_groups_owned_ids),
                 )
@@ -381,16 +381,16 @@ def users_and_groups(
                 .filter(OktaUserGroupMember.user_id != owner.id)
                 .filter(OktaUserGroupMember.is_owner.is_(True))
                 .filter(
-                    _db.or_(
+                    or_(
                         OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > _db.func.now(),
+                        OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
                 .all()
             ]
             visible_app_groups = set(app_groups_owned_ids) - set(directly_owned_by_others_ids)
             query = query.filter(
-                _db.or_(
+                or_(
                     OktaUserGroupMember.group_id.in_(owner_group_ids),
                     OktaUserGroupMember.group_id.in_(visible_app_groups),
                 )
@@ -405,16 +405,16 @@ def users_and_groups(
 
     if q_args.active is True:
         query = query.filter(
-            _db.or_(
+            or_(
                 OktaUserGroupMember.ended_at.is_(None),
-                OktaUserGroupMember.ended_at > _db.func.now(),
+                OktaUserGroupMember.ended_at > func.now(),
             )
         )
     elif q_args.active is False:
         query = query.filter(
-            _db.and_(
+            and_(
                 OktaUserGroupMember.ended_at.is_not(None),
-                OktaUserGroupMember.ended_at < _db.func.now(),
+                OktaUserGroupMember.ended_at < func.now(),
             )
         )
 
@@ -422,7 +422,7 @@ def users_and_groups(
         query = query.filter(OktaUserGroupMember.should_expire.is_(False))
 
     if q_args.direct is True:
-        query = query.filter(_db.not_(OktaUserGroupMember.active_role_group_mapping.has()))
+        query = query.filter(not_(OktaUserGroupMember.active_role_group_mapping.has()))
 
     if q_args.deleted is False:
         query = query.filter(OktaUser.deleted_at.is_(None))
@@ -432,7 +432,7 @@ def users_and_groups(
 
     if q_args.start_date is not None and q_args.end_date is not None:
         query = query.filter(
-            _db.and_(
+            and_(
                 OktaUserGroupMember.ended_at.is_not(None),
                 OktaUserGroupMember.ended_at > _unix_to_utc_naive(q_args.start_date),
                 OktaUserGroupMember.ended_at < _unix_to_utc_naive(q_args.end_date),
@@ -459,11 +459,11 @@ def users_and_groups(
             (OktaUser.first_name + " " + OktaUser.last_name).ilike(like),
         )
         if user is not None:
-            query = query.filter(_db.or_(*group_cols))
+            query = query.filter(or_(*group_cols))
         if group is not None:
-            query = query.filter(_db.or_(*user_cols))
+            query = query.filter(or_(*user_cols))
         if owner is not None or (user is None and group is None):
-            query = query.filter(_db.or_(*group_cols, *user_cols))
+            query = query.filter(or_(*group_cols, *user_cols))
 
     # Compound order_by — the tail tie-breaker keeps page boundaries stable
     # when two rows share the primary sort value. Without it, paginated
@@ -555,9 +555,9 @@ def groups_and_roles(
             .filter(OktaUserGroupMember.user_id == owner.id)
             .filter(OktaUserGroupMember.is_owner.is_(True))
             .filter(
-                _db.or_(
+                or_(
                     OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > _db.func.now(),
+                    OktaUserGroupMember.ended_at > func.now(),
                 )
             )
             .all()
@@ -579,7 +579,7 @@ def groups_and_roles(
         ]
         if q_args.app_owner is True:
             query = query.filter(
-                _db.or_(
+                or_(
                     RoleGroupMap.group_id.in_(owner_group_ids),
                     RoleGroupMap.group_id.in_(app_groups_owned_ids),
                 )
@@ -592,16 +592,16 @@ def groups_and_roles(
                 .filter(OktaUserGroupMember.user_id != owner.id)
                 .filter(OktaUserGroupMember.is_owner.is_(True))
                 .filter(
-                    _db.or_(
+                    or_(
                         OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > _db.func.now(),
+                        OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
                 .all()
             ]
             visible_app_groups = set(app_groups_owned_ids) - set(directly_owned_by_others_ids)
             query = query.filter(
-                _db.or_(
+                or_(
                     RoleGroupMap.group_id.in_(owner_group_ids),
                     RoleGroupMap.group_id.in_(visible_app_groups),
                 )
@@ -614,9 +614,9 @@ def groups_and_roles(
             .filter(OktaUserGroupMember.user_id == role_owner.id)
             .filter(OktaUserGroupMember.is_owner.is_(True))
             .filter(
-                _db.or_(
+                or_(
                     OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > _db.func.now(),
+                    OktaUserGroupMember.ended_at > func.now(),
                 )
             )
             .all()
@@ -628,11 +628,11 @@ def groups_and_roles(
             owners_subquery = (
                 db.query(OktaUserGroupMember.group_id)
                 .filter(
-                    _db.and_(
+                    and_(
                         OktaUserGroupMember.is_owner.is_(True),
-                        _db.or_(
+                        or_(
                             OktaUserGroupMember.ended_at.is_(None),
-                            OktaUserGroupMember.ended_at > _db.func.now(),
+                            OktaUserGroupMember.ended_at > func.now(),
                         ),
                     )
                 )
@@ -641,11 +641,11 @@ def groups_and_roles(
             unowned_admin_role_ids = [
                 rg.id
                 for rg in db.query(RoleGroup)
-                .filter(_db.and_(RoleGroup.deleted_at.is_(None), ~RoleGroup.id.in_(owners_subquery)))
+                .filter(and_(RoleGroup.deleted_at.is_(None), ~RoleGroup.id.in_(owners_subquery)))
                 .all()
             ]
         query = query.filter(
-            _db.or_(
+            or_(
                 RoleGroupMap.role_group_id.in_(role_owner_role_ids),
                 RoleGroupMap.role_group_id.in_(unowned_admin_role_ids),
             )
@@ -656,16 +656,16 @@ def groups_and_roles(
 
     if q_args.active is True:
         query = query.filter(
-            _db.or_(
+            or_(
                 RoleGroupMap.ended_at.is_(None),
-                RoleGroupMap.ended_at > _db.func.now(),
+                RoleGroupMap.ended_at > func.now(),
             )
         )
     elif q_args.active is False:
         query = query.filter(
-            _db.and_(
+            and_(
                 RoleGroupMap.ended_at.is_not(None),
-                RoleGroupMap.ended_at < _db.func.now(),
+                RoleGroupMap.ended_at < func.now(),
             )
         )
 
@@ -677,7 +677,7 @@ def groups_and_roles(
 
     if q_args.start_date is not None and q_args.end_date is not None:
         query = query.filter(
-            _db.and_(
+            and_(
                 RoleGroupMap.ended_at.is_not(None),
                 RoleGroupMap.ended_at > _unix_to_utc_naive(q_args.start_date),
                 RoleGroupMap.ended_at < _unix_to_utc_naive(q_args.end_date),
@@ -701,11 +701,11 @@ def groups_and_roles(
             group_alias.description.ilike(like),
         )
         if group is not None:
-            query = query.filter(_db.or_(*role_cols))
+            query = query.filter(or_(*role_cols))
         if role is not None:
-            query = query.filter(_db.or_(*group_cols))
+            query = query.filter(or_(*group_cols))
         if owner is not None or (group is None and role is None):
-            query = query.filter(_db.or_(*role_cols, *group_cols))
+            query = query.filter(or_(*role_cols, *group_cols))
 
     # Compound order_by — the tail tie-breaker keeps page boundaries stable.
     # Primary column depends on context: when `group_id` is pinned, the

--- a/api/routers/group_requests.py
+++ b/api/routers/group_requests.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query
-from sqlalchemy import String, cast
+from sqlalchemy import String, and_, cast, or_
 from sqlalchemy.orm import aliased, joinedload
 from starlette.requests import Request
 
 from api.auth.dependencies import CurrentUserId
 from api.database import DbSession
-from api.extensions import db as _db
 from api.models import AccessRequestStatus, App, GroupRequest, OktaUser, Tag
 from api.operations import ApproveGroupRequest, CreateGroupRequest, RejectGroupRequest
 from api.pagination import paginate
@@ -58,7 +57,7 @@ def list_group_requests(
         else:
             requester_alias = aliased(OktaUser)
             query = query.join(GroupRequest.requester.of_type(requester_alias)).filter(
-                _db.or_(
+                or_(
                     GroupRequest.requester_user_id == q_args.requester_user_id,
                     requester_alias.email.ilike(q_args.requester_user_id),
                 )
@@ -77,7 +76,7 @@ def list_group_requests(
         assignee_user_id = current_user_id if q_args.assignee_user_id == "@me" else q_args.assignee_user_id
         assignee_user = (
             db.query(OktaUser)
-            .filter(_db.or_(OktaUser.id == assignee_user_id, OktaUser.email.ilike(assignee_user_id)))
+            .filter(or_(OktaUser.id == assignee_user_id, OktaUser.email.ilike(assignee_user_id)))
             .first()
         )
         if assignee_user is not None:
@@ -89,7 +88,7 @@ def list_group_requests(
                         owned_app_ids.append(app.id)
                 if owned_app_ids:
                     query = query.filter(
-                        _db.and_(
+                        and_(
                             GroupRequest.requested_app_id.in_(owned_app_ids),
                             GroupRequest.requested_group_type == "app_group",
                         )
@@ -106,7 +105,7 @@ def list_group_requests(
         else:
             resolver_alias = aliased(OktaUser)
             query = query.outerjoin(GroupRequest.resolver.of_type(resolver_alias)).filter(
-                _db.or_(
+                or_(
                     GroupRequest.resolver_user_id == q_args.resolver_user_id,
                     resolver_alias.email.ilike(q_args.resolver_user_id),
                 )
@@ -122,7 +121,7 @@ def list_group_requests(
             query.join(GroupRequest.requester.of_type(q_requester_alias))
             .outerjoin(GroupRequest.resolver.of_type(q_resolver_alias))
             .filter(
-                _db.or_(
+                or_(
                     GroupRequest.id.like(f"{q_args.q}%"),
                     cast(GroupRequest.status, String).ilike(like),
                     q_requester_alias.email.ilike(like),

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -17,7 +17,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import RedirectResponse
 from pydantic import TypeAdapter
-from sqlalchemy import func, nullsfirst
+from sqlalchemy import func, nullsfirst, or_
 from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload, with_polymorphic
 from starlette.requests import Request
 
@@ -28,7 +28,6 @@ from api.auth.permissions import (
     is_app_owner_group_owner,
 )
 from api.database import DbSession
-from api.extensions import db as _db
 from api.models import AppGroup, OktaGroup, OktaUserGroupMember, RoleGroup
 from api.operations import (
     CreateGroup,
@@ -91,7 +90,7 @@ def _load_group_with_options(db: DbSession, group_id: str) -> OktaGroup | None:
     return (
         db.query(OktaGroup)
         .options(*DEFAULT_LOAD_OPTIONS)
-        .filter(_db.or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
+        .filter(or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
         .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
         .first()
     )
@@ -120,7 +119,7 @@ def list_groups(
     )
     if q_args.q:
         like = f"%{q_args.q}%"
-        query = query.filter(_db.or_(OktaGroup.name.ilike(like), OktaGroup.description.ilike(like)))
+        query = query.filter(or_(OktaGroup.name.ilike(like), OktaGroup.description.ilike(like)))
     if q_args.managed is not None:
         query = query.filter(OktaGroup.is_managed == q_args.managed)
 
@@ -407,7 +406,7 @@ def get_group_members(group_id: str, db: DbSession, current_user_id: CurrentUser
     group = (
         db.query(OktaGroup)
         .filter(OktaGroup.deleted_at.is_(None))
-        .filter(_db.or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
+        .filter(or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
         .first()
     )
     if group is None:
@@ -417,9 +416,9 @@ def get_group_members(group_id: str, db: DbSession, current_user_id: CurrentUser
         db.query(OktaUserGroupMember)
         .with_entities(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
         .filter(
-            _db.or_(
+            or_(
                 OktaUserGroupMember.ended_at.is_(None),
-                OktaUserGroupMember.ended_at > _db.func.now(),
+                OktaUserGroupMember.ended_at > func.now(),
             )
         )
         .filter(OktaUserGroupMember.group_id == group.id)
@@ -442,7 +441,7 @@ def put_group_members(
     group = (
         db.query(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
         .filter(OktaGroup.deleted_at.is_(None))
-        .filter(_db.or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
+        .filter(or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
         .first()
     )
     if group is None:

--- a/api/routers/role_requests.py
+++ b/api/routers/role_requests.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query
-from sqlalchemy import String, cast
+from sqlalchemy import String, and_, cast, not_, or_
 from sqlalchemy.orm import aliased, joinedload, selectinload
 from starlette.requests import Request
 
 from api.auth.dependencies import CurrentUserId
 from api.database import DbSession
-from api.extensions import db as _db
 from api.models import (
     AccessRequestStatus,
     App,
@@ -102,7 +101,7 @@ def list_role_requests(
         else:
             requester_alias = aliased(OktaUser)
             query = query.join(RoleRequest.requester.of_type(requester_alias)).filter(
-                _db.or_(
+                or_(
                     RoleRequest.requester_user_id == q_args.requester_user_id,
                     requester_alias.email.ilike(q_args.requester_user_id),
                 )
@@ -110,7 +109,7 @@ def list_role_requests(
 
     if q_args.requester_role_id:
         query = query.join(RoleRequest.requester_role).filter(
-            _db.or_(
+            or_(
                 RoleRequest.requester_role_id == q_args.requester_role_id,
                 RoleGroup.name.ilike(q_args.requester_role_id),
             )
@@ -118,7 +117,7 @@ def list_role_requests(
 
     if q_args.requested_group_id:
         query = query.join(RoleRequest.requested_group).filter(
-            _db.or_(
+            or_(
                 RoleRequest.requested_group_id == q_args.requested_group_id,
                 OktaGroup.name.ilike(q_args.requested_group_id),
             )
@@ -134,7 +133,7 @@ def list_role_requests(
         assignee_user_id = current_user_id if q_args.assignee_user_id == "@me" else q_args.assignee_user_id
         assignee_user = (
             db.query(OktaUser)
-            .filter(_db.or_(OktaUser.id == assignee_user_id, OktaUser.email.ilike(assignee_user_id)))
+            .filter(or_(OktaUser.id == assignee_user_id, OktaUser.email.ilike(assignee_user_id)))
             .first()
         )
         if assignee_user is not None:
@@ -218,7 +217,7 @@ def list_role_requests(
                         blocked_request_ids.append(req.id)
 
                 query = query.join(RoleRequest.requested_group).filter(
-                    _db.or_(
+                    or_(
                         OktaGroup.id.in_(groups_owned_subquery),
                         OktaGroup.id.in_(app_groups_owned_subquery),
                         RoleRequest.id.in_(blocked_request_ids),
@@ -226,7 +225,7 @@ def list_role_requests(
                 )
             else:
                 query = query.join(RoleRequest.requested_group).filter(
-                    _db.or_(
+                    or_(
                         OktaGroup.id.in_(groups_owned_subquery),
                         OktaGroup.id.in_(app_groups_owned_subquery),
                     )
@@ -236,7 +235,7 @@ def list_role_requests(
                     db.query(OktaGroup)
                     .options(joinedload(OktaGroup.active_group_tags))
                     .filter(
-                        _db.or_(
+                        or_(
                             OktaGroup.id.in_(groups_owned_subquery),
                             OktaGroup.id.in_(app_groups_owned_subquery),
                         )
@@ -265,14 +264,14 @@ def list_role_requests(
                     if assignee_user.id in [m.user_id for m in rg.active_user_memberships]
                 ]
                 query = query.filter(
-                    _db.not_(
-                        _db.or_(
-                            _db.and_(
+                    not_(
+                        or_(
+                            and_(
                                 RoleRequest.requested_group_id.in_(owned_groups_no_self_owner),
                                 RoleRequest.requester_role_id.in_(role_membership_ids),
                                 RoleRequest.request_ownership.is_(True),
                             ),
-                            _db.and_(
+                            and_(
                                 RoleRequest.requested_group_id.in_(owned_groups_no_self_member),
                                 RoleRequest.requester_role_id.in_(role_membership_ids),
                                 RoleRequest.request_ownership.is_(False),
@@ -291,7 +290,7 @@ def list_role_requests(
         else:
             resolver_alias = aliased(OktaUser)
             query = query.outerjoin(RoleRequest.resolver.of_type(resolver_alias)).filter(
-                _db.or_(
+                or_(
                     RoleRequest.resolver_user_id == q_args.resolver_user_id,
                     resolver_alias.email.ilike(q_args.resolver_user_id),
                 )
@@ -311,7 +310,7 @@ def list_role_requests(
             .join(RoleRequest.requested_group.of_type(q_group_alias))
             .outerjoin(RoleRequest.resolver.of_type(q_resolver_alias))
             .filter(
-                _db.or_(
+                or_(
                     RoleRequest.id.like(f"{q_args.q}%"),
                     cast(RoleRequest.status, String).ilike(like),
                     q_requester_alias.email.ilike(like),

--- a/api/routers/roles.py
+++ b/api/routers/roles.py
@@ -10,13 +10,12 @@ from typing import Annotated, Any
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import RedirectResponse
 from pydantic import TypeAdapter
-from sqlalchemy import func, nullsfirst
+from sqlalchemy import func, nullsfirst, or_
 from starlette.requests import Request
 
 from api.auth import permissions as _perms
 from api.auth.dependencies import CurrentUserId
 from api.database import DbSession
-from api.extensions import db as _db
 from api.models import OktaGroup, OktaUser, OktaUserGroupMember, RoleGroup, RoleGroupMap
 from api.operations import ModifyRoleGroups
 from api.pagination import paginate
@@ -54,7 +53,7 @@ def list_roles(
         owner_id = current_user_id if q_args.owner_id == "@me" else q_args.owner_id
         owner = (
             db.query(OktaUser)
-            .filter(_db.or_(OktaUser.id == owner_id, OktaUser.email.ilike(owner_id)))
+            .filter(or_(OktaUser.id == owner_id, OktaUser.email.ilike(owner_id)))
             .order_by(nullsfirst(OktaUser.deleted_at.desc()))
             .first()
         )
@@ -66,9 +65,9 @@ def list_roles(
             .filter(OktaUserGroupMember.user_id == owner.id)
             .filter(OktaUserGroupMember.is_owner.is_(True))
             .filter(
-                _db.or_(
+                or_(
                     OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > _db.func.now(),
+                    OktaUserGroupMember.ended_at > func.now(),
                 )
             )
             .all()
@@ -77,7 +76,7 @@ def list_roles(
 
     if q_args.q:
         like = f"%{q_args.q}%"
-        query = query.filter(_db.or_(RoleGroup.name.ilike(like), RoleGroup.description.ilike(like)))
+        query = query.filter(or_(RoleGroup.name.ilike(like), RoleGroup.description.ilike(like)))
     return paginate(request, query, RolePagination, extract=lambda: (q_args.page, q_args.per_page))
 
 
@@ -86,7 +85,7 @@ def get_role(role_id: str, db: DbSession, current_user_id: CurrentUserId) -> Gro
     role = (
         db.query(RoleGroup)
         .options(*_GROUP_LOAD_OPTIONS)
-        .filter(_db.or_(RoleGroup.id == role_id, RoleGroup.name == role_id))
+        .filter(or_(RoleGroup.id == role_id, RoleGroup.name == role_id))
         .order_by(nullsfirst(RoleGroup.deleted_at.desc()))
         .first()
     )
@@ -109,7 +108,7 @@ def get_role_members(role_id: str, db: DbSession, current_user_id: CurrentUserId
     role = (
         db.query(RoleGroup)
         .filter(RoleGroup.deleted_at.is_(None))
-        .filter(_db.or_(RoleGroup.id == role_id, RoleGroup.name == role_id))
+        .filter(or_(RoleGroup.id == role_id, RoleGroup.name == role_id))
         .first()
     )
     if role is None:
@@ -117,7 +116,7 @@ def get_role_members(role_id: str, db: DbSession, current_user_id: CurrentUserId
     mappings = (
         db.query(RoleGroupMap)
         .filter(RoleGroupMap.role_group_id == role.id)
-        .filter(_db.or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > _db.func.now()))
+        .filter(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
         .all()
     )
     return RoleMembersSummary(
@@ -141,7 +140,7 @@ def put_role_members(
     role = (
         db.query(RoleGroup)
         .filter(RoleGroup.deleted_at.is_(None))
-        .filter(_db.or_(RoleGroup.id == role_id, RoleGroup.name == role_id))
+        .filter(or_(RoleGroup.id == role_id, RoleGroup.name == role_id))
         .first()
     )
     if role is None:
@@ -204,7 +203,7 @@ def put_role_members(
     affected_ids = body.groups_to_add + body.owner_groups_to_add + body.groups_to_remove + body.owner_groups_to_remove
     if affected_ids:
         unmanaged_count = (
-            db.query(_db.func.count(OktaGroup.id))
+            db.query(func.count(OktaGroup.id))
             .filter(OktaGroup.id.in_(affected_ids))
             .filter(OktaGroup.deleted_at.is_(None))
             .filter(OktaGroup.is_managed.is_(False))
@@ -217,7 +216,7 @@ def put_role_members(
     add_ids = body.groups_to_add + body.owner_groups_to_add
     if add_ids:
         role_in_add_count = (
-            db.query(_db.func.count(OktaGroup.id))
+            db.query(func.count(OktaGroup.id))
             .filter(OktaGroup.id.in_(add_ids))
             .filter(OktaGroup.deleted_at.is_(None))
             .filter(OktaGroup.type == RoleGroup.__mapper_args__["polymorphic_identity"])

--- a/api/routers/tags.py
+++ b/api/routers/tags.py
@@ -6,7 +6,7 @@ import logging
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import func, nullsfirst
+from sqlalchemy import func, nullsfirst, or_
 from sqlalchemy.orm import joinedload, selectinload
 from starlette.requests import Request
 
@@ -14,7 +14,6 @@ from api.auth.dependencies import CurrentUserId
 from api.auth.permissions import require_access_admin
 from api.context import get_request_context
 from api.database import DbSession
-from api.extensions import db as _db
 from api.models import AppTagMap, OktaUser, Tag
 from api.operations import CreateTag, DeleteTag
 from api.pagination import paginate
@@ -52,7 +51,7 @@ def list_tags(
     query = db.query(Tag).filter(Tag.deleted_at.is_(None)).order_by(func.lower(Tag.name))
     if q_args.q:
         like = f"%{q_args.q}%"
-        query = query.filter(_db.or_(Tag.name.ilike(like), Tag.description.ilike(like)))
+        query = query.filter(or_(Tag.name.ilike(like), Tag.description.ilike(like)))
     return paginate(request, query, TagPagination, extract=lambda: (q_args.page, q_args.per_page))
 
 
@@ -64,7 +63,7 @@ def get_tag(tag_id: str, db: DbSession, current_user_id: CurrentUserId) -> TagDe
     tag = (
         db.query(Tag)
         .options(*_TAG_LOAD_OPTIONS)
-        .filter(_db.or_(Tag.id == tag_id, Tag.name == tag_id))
+        .filter(or_(Tag.id == tag_id, Tag.name == tag_id))
         .order_by(nullsfirst(Tag.deleted_at.desc()))
         .first()
     )
@@ -112,7 +111,7 @@ def put_tag(
 
     from api.operations import ModifyGroupsTimeLimit
 
-    tag = db.query(Tag).filter(Tag.deleted_at.is_(None)).filter(_db.or_(Tag.id == tag_id, Tag.name == tag_id)).first()
+    tag = db.query(Tag).filter(Tag.deleted_at.is_(None)).filter(or_(Tag.id == tag_id, Tag.name == tag_id)).first()
     if tag is None:
         raise HTTPException(404, "Not Found")
     payload = body.model_dump(exclude_unset=True)
@@ -187,7 +186,7 @@ def delete_tag(
     _admin: str = Depends(require_access_admin),
     current_user_id: CurrentUserId = None,  # type: ignore[assignment]
 ) -> DeleteMessage:
-    tag = db.query(Tag).filter(Tag.deleted_at.is_(None)).filter(_db.or_(Tag.id == tag_id, Tag.name == tag_id)).first()
+    tag = db.query(Tag).filter(Tag.deleted_at.is_(None)).filter(or_(Tag.id == tag_id, Tag.name == tag_id)).first()
     if tag is None:
         raise HTTPException(404, "Not Found")
     DeleteTag(tag=tag, current_user_id=current_user_id).execute()

--- a/api/routers/users.py
+++ b/api/routers/users.py
@@ -12,7 +12,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import RedirectResponse
-from sqlalchemy import func, nullsfirst
+from sqlalchemy import cast, func, nullsfirst, or_
 from sqlalchemy.orm import joinedload, selectinload, with_polymorphic
 from sqlalchemy.sql import sqltypes
 from starlette.requests import Request
@@ -66,7 +66,7 @@ def list_users(
             search_jsonpath = f"strict $ ? ({' || '.join(attr_query)})"
             format_params = [query_regex_quote_escaped] * len(search_attributes)
             query = query.filter(
-                _db.or_(
+                or_(
                     OktaUser.email.ilike(like),
                     OktaUser.first_name.ilike(like),
                     OktaUser.last_name.ilike(like),
@@ -77,7 +77,7 @@ def list_users(
                     # FORMAT() at execution time. The regex is escaped above.
                     func.jsonb_path_exists(
                         OktaUser.profile,
-                        _db.cast(func.format(search_jsonpath, *format_params), sqltypes.JSON.JSONPathType),
+                        cast(func.format(search_jsonpath, *format_params), sqltypes.JSON.JSONPathType),
                         func.jsonb_build_object(),
                         True,
                     ),
@@ -86,7 +86,7 @@ def list_users(
         else:
             # Naive search of JSON field (matches both keys and values).
             query = query.filter(
-                _db.or_(
+                or_(
                     OktaUser.email.ilike(like),
                     OktaUser.first_name.ilike(like),
                     OktaUser.last_name.ilike(like),
@@ -111,7 +111,7 @@ def get_user(user_id: str, db: DbSession, current_user_id: CurrentUserId) -> Okt
             selectinload(OktaUser.active_group_ownerships).options(*user_group_member_options()),
             joinedload(OktaUser.manager),
         )
-        .filter(_db.or_(OktaUser.id == user_id, OktaUser.email.ilike(user_id)))
+        .filter(or_(OktaUser.id == user_id, OktaUser.email.ilike(user_id)))
         .order_by(nullsfirst(OktaUser.deleted_at.desc()))
         .first()
     )

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from datetime import date, datetime, timedelta, timezone
 from typing import List
 
+from sqlalchemy import and_, func, or_
 from api.config import settings
 from sqlalchemy.orm import (
     aliased,
@@ -48,7 +49,7 @@ def sync_users() -> None:
 
     # Hydrate all users into sql alchemy context at once
     # to avoid a roundtrip for each user
-    _ = OktaUser.query.all()
+    _ = db.session.query(OktaUser).all()
 
     for user in users:
         logger.info(f"Syncing user {user.id}")
@@ -74,29 +75,33 @@ def sync_users() -> None:
     deleted_user_ids = [u.id for u in filter(lambda u: u.get_deleted_at() is not None, users)]
 
     users_to_delete = (
-        OktaUser.query.filter(OktaUser.id.in_(deleted_user_ids)).filter(OktaUser.deleted_at.is_(None)).all()
+        db.session.query(OktaUser).filter(OktaUser.id.in_(deleted_user_ids)).filter(OktaUser.deleted_at.is_(None)).all()
     )
 
-    for user in users_to_delete:
-        logger.info(f"Deleting user in DB {user.id} that was suspended/deactivated in Okta")
-        DeleteUser(user=user.id).execute()
+    for db_user in users_to_delete:
+        logger.info(f"Deleting user in DB {db_user.id} that was suspended/deactivated in Okta")
+        DeleteUser(user=db_user.id).execute()
 
     # Delete users and end all group memberships in the DB for users that are deleted in Okta
     active_user_ids = [u.id for u in filter(lambda u: u.get_deleted_at() is None, users)]
 
     more_users_to_delete = (
-        OktaUser.query.filter(OktaUser.id.not_in(active_user_ids)).filter(OktaUser.deleted_at.is_(None)).all()
+        db.session.query(OktaUser)
+        .filter(OktaUser.id.not_in(active_user_ids))
+        .filter(OktaUser.deleted_at.is_(None))
+        .all()
     )
 
-    for user in more_users_to_delete:
-        logger.info(f"Deleting user in DB {user.id} that was deleted in Okta")
-        DeleteUser(user=user.id, sync_to_okta=False).execute()
+    for db_user in more_users_to_delete:
+        logger.info(f"Deleting user in DB {db_user.id} that was deleted in Okta")
+        DeleteUser(user=db_user.id, sync_to_okta=False).execute()
 
     # End all active group memberships in the DB for users that were previously deleted
     db_deleted_users_with_access = (
-        OktaUserGroupMember.query.join(OktaUserGroupMember.user)
+        db.session.query(OktaUserGroupMember)
+        .join(OktaUserGroupMember.user)
         .filter(OktaUser.deleted_at.isnot(None))
-        .filter(db.or_(OktaUserGroupMember.ended_at.is_(None), OktaUserGroupMember.ended_at > db.func.now()))
+        .filter(or_(OktaUserGroupMember.ended_at.is_(None), OktaUserGroupMember.ended_at > func.now()))
         .all()
     )
     for user_id in set([u.user_id for u in db_deleted_users_with_access]):
@@ -109,6 +114,10 @@ def sync_users() -> None:
     }
     for user in users:
         db_user = db.session.get(OktaUser, user.id)
+        if db_user is None:
+            # The user iteration just upserted this row, so a None here
+            # would only happen if Okta returned a duplicate id mid-iteration.
+            continue
         manager = users_by_employee_number.get(user.profile.manager_id, None)
         db_user.manager_id = getattr(manager, "id", None)
 
@@ -203,9 +212,9 @@ def sync_group_memberships(act_as_authority: bool) -> None:
                 ).filter(
                     OktaUserGroupMember.group_id == group.id,
                     OktaUserGroupMember.is_owner.is_(False),
-                    db.or_(
+                    or_(
                         OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > db.func.now(),
+                        OktaUserGroupMember.ended_at > func.now(),
                     ),
                 )
             }
@@ -291,9 +300,9 @@ def sync_group_ownerships(act_as_authority: bool) -> None:
                 ).filter(
                     OktaUserGroupMember.group_id == group.id,
                     OktaUserGroupMember.is_owner.is_(True),
-                    db.or_(
+                    or_(
                         OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > db.func.now(),
+                        OktaUserGroupMember.ended_at > func.now(),
                     ),
                 )
             }
@@ -302,7 +311,8 @@ def sync_group_ownerships(act_as_authority: bool) -> None:
             # check to see if it's an AppGroup and if so, add the app owners as owners in Okta
             if act_authoritatively and len(db_all_group_owners) == 0:
                 app_group = (
-                    AppGroup.query.options(
+                    db.session.query(AppGroup)
+                    .options(
                         joinedload(AppGroup.app).options(selectinload(App.active_owner_app_groups)),
                     )
                     .filter(AppGroup.deleted_at.is_(None))
@@ -320,9 +330,9 @@ def sync_group_ownerships(act_as_authority: bool) -> None:
                         ).filter(
                             OktaUserGroupMember.group_id.in_(app_owner_group_ids),
                             OktaUserGroupMember.is_owner.is_(True),
-                            db.or_(
+                            or_(
                                 OktaUserGroupMember.ended_at.is_(None),
-                                OktaUserGroupMember.ended_at > db.func.now(),
+                                OktaUserGroupMember.ended_at > func.now(),
                             ),
                         )
                     }
@@ -385,7 +395,8 @@ def expire_access_requests() -> None:
     MAX_ACCESS_REQUEST_AGE_SECONDS = settings.MAX_ACCESS_REQUEST_AGE_SECONDS
 
     older_than_max = (
-        AccessRequest.query.filter(AccessRequest.status == AccessRequestStatus.PENDING)
+        db.session.query(AccessRequest)
+        .filter(AccessRequest.status == AccessRequestStatus.PENDING)
         .filter(AccessRequest.resolved_at.is_(None))
         .filter(
             AccessRequest.created_at < datetime.now(timezone.utc) - timedelta(seconds=MAX_ACCESS_REQUEST_AGE_SECONDS)
@@ -399,9 +410,10 @@ def expire_access_requests() -> None:
         ).execute()
 
     older_than_request = (
-        AccessRequest.query.filter(AccessRequest.status == AccessRequestStatus.PENDING)
+        db.session.query(AccessRequest)
+        .filter(AccessRequest.status == AccessRequestStatus.PENDING)
         .filter(AccessRequest.resolved_at.is_(None))
-        .filter(AccessRequest.request_ending_at < db.func.now())
+        .filter(AccessRequest.request_ending_at < func.now())
         .all()
     )
     for access_request in older_than_request:
@@ -425,13 +437,12 @@ def expiring_access_notifications_user() -> None:
         weekend_notif_tomorrow = True
 
     db_memberships_expiring_tomorrow = (
-        OktaUserGroupMember.query.options(
-            joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group)
-        )
+        db.session.query(OktaUserGroupMember)
+        .options(joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group))
         .join(OktaUserGroupMember.active_user)
         .join(OktaUserGroupMember.active_group)
         .filter(OktaGroup.is_managed.is_(True))
-        .filter(db.and_(OktaUserGroupMember.ended_at >= day, OktaUserGroupMember.ended_at < next_day))
+        .filter(and_(OktaUserGroupMember.ended_at >= day, OktaUserGroupMember.ended_at < next_day))
         .filter(OktaUserGroupMember.role_group_map_id.is_(None))
         .filter(OktaUserGroupMember.should_expire.is_(False))
         .all()
@@ -439,9 +450,8 @@ def expiring_access_notifications_user() -> None:
 
     # remove OktaUserGroupMembers from the list where there's a role that grants the same access
     db_memberships_roles = (
-        OktaUserGroupMember.query.options(
-            joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group)
-        )
+        db.session.query(OktaUserGroupMember)
+        .options(joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group))
         .join(OktaUserGroupMember.active_user)
         .join(OktaUserGroupMember.active_group)
         .filter(OktaUserGroupMember.role_group_map_id.is_not(None))
@@ -473,13 +483,12 @@ def expiring_access_notifications_user() -> None:
         weekend_notif_week = True
 
     db_memberships_expiring_next_week = (
-        OktaUserGroupMember.query.options(
-            joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group)
-        )
+        db.session.query(OktaUserGroupMember)
+        .options(joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group))
         .join(OktaUserGroupMember.active_user)
         .join(OktaUserGroupMember.active_group)
         .filter(OktaGroup.is_managed.is_(True))
-        .filter(db.and_(OktaUserGroupMember.ended_at >= day, OktaUserGroupMember.ended_at < next_day))
+        .filter(and_(OktaUserGroupMember.ended_at >= day, OktaUserGroupMember.ended_at < next_day))
         .filter(OktaUserGroupMember.role_group_map_id.is_(None))
         .filter(OktaUserGroupMember.should_expire.is_(False))
         .all()
@@ -550,13 +559,12 @@ def expiring_access_notifications_owner() -> None:
 
     # Expiring groups
     db_memberships_expiring_this_week = (
-        OktaUserGroupMember.query.options(
-            joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group)
-        )
+        db.session.query(OktaUserGroupMember)
+        .options(joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group))
         .join(OktaUserGroupMember.active_user)
         .join(OktaUserGroupMember.active_group)
         .filter(OktaGroup.is_managed.is_(True))
-        .filter(db.and_(OktaUserGroupMember.ended_at >= day, OktaUserGroupMember.ended_at < next_week))
+        .filter(and_(OktaUserGroupMember.ended_at >= day, OktaUserGroupMember.ended_at < next_week))
         .filter(OktaUserGroupMember.role_group_map_id.is_(None))
         .filter(OktaUserGroupMember.should_expire.is_(False))
         .all()
@@ -611,13 +619,12 @@ def expiring_access_notifications_owner() -> None:
     two_weeks = one_week + timedelta(weeks=1)
 
     db_memberships_expiring_next_week = (
-        OktaUserGroupMember.query.options(
-            joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group)
-        )
+        db.session.query(OktaUserGroupMember)
+        .options(joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group))
         .join(OktaUserGroupMember.active_user)
         .join(OktaUserGroupMember.active_group)
         .filter(OktaGroup.is_managed.is_(True))
-        .filter(db.and_(OktaUserGroupMember.ended_at >= one_week, OktaUserGroupMember.ended_at < two_weeks))
+        .filter(and_(OktaUserGroupMember.ended_at >= one_week, OktaUserGroupMember.ended_at < two_weeks))
         .filter(OktaUserGroupMember.role_group_map_id.is_(None))
         .filter(OktaUserGroupMember.should_expire.is_(False))
         .all()
@@ -715,13 +722,14 @@ def expiring_access_notifications_owner() -> None:
     next_week = day + timedelta(weeks=1)
 
     db_roles_expiring_this_week = (
-        RoleGroupMap.query.options(
+        db.session.query(RoleGroupMap)
+        .options(
             joinedload(RoleGroupMap.active_role_group), joinedload(RoleGroupMap.active_group.of_type(all_group_types))
         )
         .join(RoleGroupMap.active_role_group.of_type(role_group_alias))
         .join(RoleGroupMap.active_group)
         .filter(OktaGroup.is_managed.is_(True))
-        .filter(db.and_(RoleGroupMap.ended_at >= day, RoleGroupMap.ended_at < next_week))
+        .filter(and_(RoleGroupMap.ended_at >= day, RoleGroupMap.ended_at < next_week))
         .filter(RoleGroupMap.should_expire.is_(False))
         .all()
     )
@@ -766,13 +774,14 @@ def expiring_access_notifications_owner() -> None:
     two_weeks = one_week + timedelta(weeks=1)
 
     db_roles_expiring_next_week = (
-        RoleGroupMap.query.options(
+        db.session.query(RoleGroupMap)
+        .options(
             joinedload(RoleGroupMap.active_role_group), joinedload(RoleGroupMap.active_group.of_type(all_group_types))
         )
         .join(RoleGroupMap.active_role_group.of_type(role_group_alias))
         .join(RoleGroupMap.active_group)
         .filter(OktaGroup.is_managed.is_(True))
-        .filter(db.and_(RoleGroupMap.ended_at >= one_week, RoleGroupMap.ended_at < two_weeks))
+        .filter(and_(RoleGroupMap.ended_at >= one_week, RoleGroupMap.ended_at < two_weeks))
         .filter(RoleGroupMap.should_expire.is_(False))
         .all()
     )
@@ -874,13 +883,14 @@ def expiring_access_notifications_role_owner() -> None:
         weekend_notif_tomorrow = True
 
     db_roles_expiring_tomorrow = (
-        RoleGroupMap.query.options(
+        db.session.query(RoleGroupMap)
+        .options(
             joinedload(RoleGroupMap.active_role_group), joinedload(RoleGroupMap.active_group.of_type(all_group_types))
         )
         .join(RoleGroupMap.active_role_group.of_type(role_group_alias))
         .join(RoleGroupMap.active_group)
         .filter(OktaGroup.is_managed.is_(True))
-        .filter(db.and_(RoleGroupMap.ended_at >= day, RoleGroupMap.ended_at < next_day))
+        .filter(and_(RoleGroupMap.ended_at >= day, RoleGroupMap.ended_at < next_day))
         .filter(RoleGroupMap.should_expire.is_(False))
         .all()
     )
@@ -904,13 +914,14 @@ def expiring_access_notifications_role_owner() -> None:
         weekend_notif_week = True
 
     db_roles_expiring_next_week = (
-        RoleGroupMap.query.options(
+        db.session.query(RoleGroupMap)
+        .options(
             joinedload(RoleGroupMap.active_role_group), joinedload(RoleGroupMap.active_group.of_type(all_group_types))
         )
         .join(RoleGroupMap.active_role_group.of_type(role_group_alias))
         .join(RoleGroupMap.active_group)
         .filter(OktaGroup.is_managed.is_(True))
-        .filter(db.and_(RoleGroupMap.ended_at >= day, RoleGroupMap.ended_at < next_day))
+        .filter(and_(RoleGroupMap.ended_at >= day, RoleGroupMap.ended_at < next_day))
         .filter(RoleGroupMap.should_expire.is_(False))
         .all()
     )

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -11,6 +11,7 @@ from okta.models.user_profile import UserProfile
 from okta.models.user_schema import UserSchema
 from sqlalchemy.orm import joinedload
 
+from api.extensions import db
 from api.models import (
     AccessRequest,
     AccessRequestStatus,
@@ -57,7 +58,9 @@ class GroupFactory(factory.Factory[Group]):
 
     @staticmethod
     def create_access_owner_group() -> Group:
-        access_app = App.query.options(joinedload(App.active_owner_app_groups)).filter(App.name == "Access").first()
+        access_app = (
+            db.session.query(App).options(joinedload(App.active_owner_app_groups)).filter(App.name == "Access").first()
+        )
         access_owner_group = access_app.active_owner_app_groups[0]
         okta_access_owner_group = GroupFactory.build()
         okta_access_owner_group.profile.name = access_owner_group.name

--- a/tests/test_access_request.py
+++ b/tests/test_access_request.py
@@ -90,7 +90,7 @@ def test_get_access_request(
     assert data["request_reason"] == okta_group_access_request.request_reason
     assert data["request_ownership"] == okta_group_access_request.request_ownership
 
-    access_owner = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
     add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
@@ -128,7 +128,7 @@ def test_get_access_request(
     assert data["request_reason"] == role_group_access_request.request_reason
     assert data["request_ownership"] == role_group_access_request.request_ownership
 
-    access_owner = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
     add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
@@ -193,7 +193,7 @@ def test_put_access_request(
     assert add_user_to_group_spy.call_count == 1
     assert add_owner_to_group_spy.call_count == 0
 
-    access_owner = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     data = rep.json()
     assert data["requester"]["email"] == user.email
@@ -205,7 +205,7 @@ def test_put_access_request(
     assert data["resolver"]["email"] == access_owner.email
     assert data["resolution_reason"] == access_request.resolution_reason
 
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 2
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 2
 
     access_request2 = CreateAccessRequest(
         requester_user=user,
@@ -226,7 +226,7 @@ def test_put_access_request(
     assert add_user_to_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
 
-    access_owner = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     data = rep.json()
     assert data["requester"]["email"] == user.email
@@ -238,7 +238,7 @@ def test_put_access_request(
     assert data["resolver"]["email"] == access_owner.email
     assert data["resolution_reason"] == access_request.resolution_reason
 
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 2
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 2
 
 
 def test_put_access_request_by_non_owner(
@@ -251,7 +251,7 @@ def test_put_access_request_by_non_owner(
     db.session.commit()
 
     access_request_by_owner = CreateAccessRequest(
-        requester_user=OktaUser.query.filter(OktaUser.email == access_owner).first(),
+        requester_user=db.session.query(OktaUser).filter(OktaUser.email == access_owner).first(),
         requested_group=okta_group,
         request_ownership=False,
         request_reason="test reason",
@@ -266,7 +266,7 @@ def test_put_access_request_by_non_owner(
 
     db.session.commit()
 
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
 
     assert access_request_by_owner is not None
     assert access_request_by_owner.status == AccessRequestStatus.PENDING
@@ -287,7 +287,7 @@ def test_put_access_request_by_non_owner(
     assert access_request_by_non_owner.resolved_at is None
     assert access_request_by_non_owner.resolver_user_id is None
 
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
 
     data = {"approved": False, "reason": "test rejection"}
 
@@ -298,7 +298,7 @@ def test_put_access_request_by_non_owner(
     assert access_request_by_non_owner.resolved_at is None
     assert access_request_by_non_owner.resolver_user_id is None
 
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
 
     access_request_url = url_for(
         "api-access-requests.access_request_by_id", access_request_id=access_request_by_non_owner.id
@@ -312,7 +312,7 @@ def test_put_access_request_by_non_owner(
     assert access_request_by_non_owner.resolved_at is None
     assert access_request_by_non_owner.resolver_user_id is None
 
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
 
     data = {"approved": False, "reason": "test rejection"}
 
@@ -331,7 +331,7 @@ def test_put_access_request_by_non_owner(
     assert access_request_by_non_owner.resolved_at is not None
     assert access_request_by_non_owner.resolver_user_id == user.id
 
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
 
 
 def test_create_access_request(app: FastAPI, client: TestClient, db: Db, okta_group: OktaGroup, url_for: Any) -> None:
@@ -355,7 +355,7 @@ def test_create_access_request(app: FastAPI, client: TestClient, db: Db, okta_gr
 
     data = rep.json()
     access_request = db.session.get(AccessRequest, data["id"])
-    access_owner = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     assert data["requester"]["email"] == access_owner.email
     assert data["requested_group"]["name"] == okta_group.name
@@ -445,7 +445,7 @@ def test_create_access_request_notification(
     assert access_request is not None
     assert request_created_notification_spy.call_count == 1
 
-    access_owner = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     ApproveAccessRequest(access_request=access_request, approver_user=access_owner).execute()
 
@@ -517,7 +517,7 @@ def test_create_app_access_request_notification(
     assert kwargs["group"] == app_group
     assert kwargs["requester"] == user
 
-    access_owner = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     ApproveAccessRequest(access_request=access_request, approver_user=access_owner).execute()
 
@@ -546,7 +546,7 @@ def test_create_app_access_request_notification(
 
 
 def test_get_all_possible_request_approvers(app: FastAPI, mocker: MockerFixture, db: Db) -> None:
-    access_admin = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     users = OktaUserFactory.build_batch(3)
     db.session.add_all(users)
@@ -578,7 +578,7 @@ def test_get_all_possible_request_approvers(app: FastAPI, mocker: MockerFixture,
 def test_resolve_app_access_request_notification(
     app: FastAPI, db: Db, access_app: App, app_group: AppGroup, user: OktaUser, mocker: MockerFixture
 ) -> None:
-    access_admin = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     app_owner_user1 = OktaUserFactory.build()
     app_owner_user2 = OktaUserFactory.build()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -138,8 +138,8 @@ def test_put_app(
         db.session.get(AppGroup, old_app_group_id).name
         == f"{AppGroup.APP_GROUP_NAME_PREFIX}Updated{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}group"
     )
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
-    assert AppTagMap.query.filter(AppTagMap.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
+    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 1
 
     update_group_spy.reset_mock()
 
@@ -152,8 +152,8 @@ def test_put_app(
     assert data["name"] == "Updated"
     assert data["description"] == "new description"
     assert data["id"] == access_app.id
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
-    assert AppTagMap.query.filter(AppTagMap.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
+    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 1
 
     update_group_spy.reset_mock()
 
@@ -166,14 +166,14 @@ def test_put_app(
     assert data["name"] == "Updated"
     assert data["description"] == "new description"
     assert data["id"] == access_app.id
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
-    assert AppTagMap.query.filter(AppTagMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 0
 
     # Updating the name of the built-in Access app should fail
-    builtin_access_app = App.query.filter(App.name == App.ACCESS_APP_RESERVED_NAME).first()
-    builtin_access_owners_group = AppGroup.query.filter(
-        AppGroup.app_id == builtin_access_app.id, AppGroup.is_owner.is_(True)
-    ).first()
+    builtin_access_app = db.session.query(App).filter(App.name == App.ACCESS_APP_RESERVED_NAME).first()
+    builtin_access_owners_group = (
+        db.session.query(AppGroup).filter(AppGroup.app_id == builtin_access_app.id, AppGroup.is_owner.is_(True)).first()
+    )
     app_url = url_for("api-apps.app_by_id", app_id=builtin_access_app.id)
     data = {"name": "UpdatedAccess"}
     rep = client.put(app_url, json=data)
@@ -195,8 +195,8 @@ def test_put_app(
         == f"{AppGroup.APP_GROUP_NAME_PREFIX}{App.ACCESS_APP_RESERVED_NAME}"
         + f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
     )
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
-    assert AppTagMap.query.filter(AppTagMap.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
+    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 1
 
     data = {"name": "UpdatedAccess", "description": "new description", "tags_to_remove": [tag.id]}
     update_group_spy.reset_mock()
@@ -213,8 +213,8 @@ def test_put_app(
         == f"{AppGroup.APP_GROUP_NAME_PREFIX}{App.ACCESS_APP_RESERVED_NAME}"
         + f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
     )
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
-    assert AppTagMap.query.filter(AppTagMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 0
 
 
 def test_delete_app(client: TestClient, db: Db, mocker: MockerFixture, access_app: App, tag: Tag, url_for: Any) -> None:
@@ -248,8 +248,8 @@ def test_delete_app(client: TestClient, db: Db, mocker: MockerFixture, access_ap
     assert delete_group_spy.call_count == 3
     assert db.session.get(App, app_id).deleted_at is not None
     assert db.session.get(AppGroup, app_group_id).deleted_at is not None
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
-    assert AppTagMap.query.filter(AppTagMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 0
 
 
 def test_get_app_excludes_soft_deleted(
@@ -315,12 +315,14 @@ def test_create_app(
     assert data["description"] == ""
     assert data["active_app_tags"][0]["active_tag"]["id"] == tag.id
 
-    app_groups = AppGroup.query.filter(AppGroup.app_id == data["id"]).all()
+    app_groups = db.session.query(AppGroup).filter(AppGroup.app_id == data["id"]).all()
     assert len(app_groups) == 1
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
-    assert AppTagMap.query.filter(AppTagMap.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
+    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 1
 
-    test_app_group = AppGroup.query.filter(AppGroup.name == "App-Created-Owners", AppGroup.app_id == data["id"]).first()
+    test_app_group = (
+        db.session.query(AppGroup).filter(AppGroup.name == "App-Created-Owners", AppGroup.app_id == data["id"]).first()
+    )
     assert test_app_group is not None
     assert test_app_group.is_owner is True
 
@@ -359,22 +361,26 @@ def test_create_app_with_initial_owners(
     assert data["name"] == "Created"
     assert data["description"] == ""
 
-    app_groups = AppGroup.query.filter(AppGroup.app_id == data["id"]).all()
+    app_groups = db.session.query(AppGroup).filter(AppGroup.app_id == data["id"]).all()
     assert len(app_groups) == 1
 
-    test_app_group = AppGroup.query.filter(AppGroup.name == "App-Created-Owners", AppGroup.app_id == data["id"]).first()
+    test_app_group = (
+        db.session.query(AppGroup).filter(AppGroup.name == "App-Created-Owners", AppGroup.app_id == data["id"]).first()
+    )
     assert test_app_group is not None
     assert test_app_group.is_owner is True
 
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == test_app_group.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == test_app_group.id)
         .filter(OktaUserGroupMember.user_id == user.id)
         .filter(OktaUserGroupMember.ended_at.is_(None))
         .count()
         == 2
     )
     assert (
-        RoleGroupMap.query.filter(RoleGroupMap.group_id == test_app_group.id)
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.group_id == test_app_group.id)
         .filter(RoleGroupMap.role_group_id == role_group.id)
         .filter(RoleGroupMap.ended_at.is_(None))
         .count()
@@ -445,14 +451,18 @@ def test_create_app_with_additional_groups(
     assert data["name"] == "Created"
     assert data["description"] == ""
 
-    app_groups = AppGroup.query.filter(AppGroup.app_id == data["id"]).all()
+    app_groups = db.session.query(AppGroup).filter(AppGroup.app_id == data["id"]).all()
     assert len(app_groups) == 3
 
-    test_app_group = AppGroup.query.filter(AppGroup.name == "App-Created-Owners", AppGroup.app_id == data["id"]).first()
+    test_app_group = (
+        db.session.query(AppGroup).filter(AppGroup.name == "App-Created-Owners", AppGroup.app_id == data["id"]).first()
+    )
     assert test_app_group is not None
     assert test_app_group.is_owner is True
 
-    test_app_group = AppGroup.query.filter(AppGroup.name == "App-Created-Test", AppGroup.app_id == data["id"]).first()
+    test_app_group = (
+        db.session.query(AppGroup).filter(AppGroup.name == "App-Created-Test", AppGroup.app_id == data["id"]).first()
+    )
     assert test_app_group is not None
     assert test_app_group.description == "test"
     assert test_app_group.is_owner is False
@@ -496,11 +506,11 @@ def test_create_app_with_name_collision(
     assert data["name"] == "Test"
 
     # Make sure new app doesn't end up with additional app groups from name collision
-    app_groups = AppGroup.query.filter(AppGroup.app_id == data["id"]).all()
+    app_groups = db.session.query(AppGroup).filter(AppGroup.app_id == data["id"]).all()
     assert len(app_groups) == 1
 
     # Make sure original app still has its app group
-    app_groups = AppGroup.query.filter(AppGroup.app_id == app.id).all()
+    app_groups = db.session.query(AppGroup).filter(AppGroup.app_id == app.id).all()
     assert len(app_groups) == 1
 
 
@@ -679,7 +689,7 @@ def test_create_app_fails_when_preexisting_owner_group_is_occupied(
     rep = client.post(apps_url, json={"name": "Payments"})
     assert rep.status_code == 409
 
-    assert App.query.filter(App.name == "Payments").filter(App.deleted_at.is_(None)).first() is None
+    assert db.session.query(App).filter(App.name == "Payments").filter(App.deleted_at.is_(None)).first() is None
 
 
 def test_create_app_succeeds_with_empty_preexisting_owner_group(
@@ -709,7 +719,7 @@ def test_create_app_succeeds_with_empty_preexisting_owner_group(
 
     data = rep.json()
     assert data["name"] == "Payments"
-    assert App.query.filter(App.name == "Payments").filter(App.deleted_at.is_(None)).first() is not None
+    assert db.session.query(App).filter(App.name == "Payments").filter(App.deleted_at.is_(None)).first() is not None
 
 
 def test_create_app_succeeds_with_members_only_preexisting_owner_group(
@@ -745,7 +755,7 @@ def test_create_app_succeeds_with_members_only_preexisting_owner_group(
 
     data = rep.json()
     assert data["name"] == "Payments"
-    assert App.query.filter(App.name == "Payments").filter(App.deleted_at.is_(None)).first() is not None
+    assert db.session.query(App).filter(App.name == "Payments").filter(App.deleted_at.is_(None)).first() is not None
 
 
 def test_delete_reserved_access_app_blocked(client: TestClient, db: Db, url_for: Any) -> None:

--- a/tests/test_disallow_self_add_constraint.py
+++ b/tests/test_disallow_self_add_constraint.py
@@ -101,15 +101,15 @@ def test_disallow_self_add_modify_group_users(
 
     # Establish a baseline of user memberships/ownerships
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
 
@@ -125,15 +125,15 @@ def test_disallow_self_add_modify_group_users(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
 
@@ -148,15 +148,15 @@ def test_disallow_self_add_modify_group_users(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
 
@@ -179,15 +179,15 @@ def test_disallow_self_add_modify_group_users(
     assert len(data["owners"]) == 2
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
 
@@ -219,15 +219,15 @@ def test_disallow_self_add_modify_group_users(
     assert len(data["owners"]) == 1
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
 
@@ -247,15 +247,15 @@ def test_disallow_self_add_modify_group_users(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
 
@@ -270,15 +270,15 @@ def test_disallow_self_add_modify_group_users(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
 
@@ -301,15 +301,15 @@ def test_disallow_self_add_modify_group_users(
     assert len(data["owners"]) == 2
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
 
@@ -333,15 +333,15 @@ def test_disallow_self_add_modify_group_users(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 5
     )
 
@@ -356,15 +356,15 @@ def test_disallow_self_add_modify_group_users(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 5
     )
 
@@ -387,15 +387,15 @@ def test_disallow_self_add_modify_group_users(
     assert len(data["owners"]) == 2
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 7
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 8
     )
 
@@ -469,19 +469,25 @@ def test_disallow_self_add_modify_role_groups(
 
     # Establish a baseline of user memberships/ownerships
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 0
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 0
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 0
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 0
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 0
+    )
 
     # Add current_user as owner of role_groups[0]
     ModifyGroupUsers(group=okta_group, owners_to_add=[current_user.id], sync_to_okta=False).execute()
@@ -498,19 +504,25 @@ def test_disallow_self_add_modify_role_groups(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 0
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 0
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 0
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 0
+    )
 
     # Add the current user role group as a owner to the okta group
     data = {
@@ -527,19 +539,25 @@ def test_disallow_self_add_modify_role_groups(
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 0
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 1
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 0
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 1
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -557,19 +575,25 @@ def test_disallow_self_add_modify_role_groups(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 0
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 1
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 0
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 1
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -593,19 +617,25 @@ def test_disallow_self_add_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 1
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 1
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 1
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 1
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -628,19 +658,25 @@ def test_disallow_self_add_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 1
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 1
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 2
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -663,19 +699,25 @@ def test_disallow_self_add_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 1
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 1
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 2
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -700,19 +742,25 @@ def test_disallow_self_add_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 5
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 2
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 2
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 2
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -730,19 +778,25 @@ def test_disallow_self_add_modify_role_groups(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 5
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 2
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 2
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 2
+    )
 
     # Add the current user role group as a member and owner to the app group
     data = {
@@ -755,19 +809,25 @@ def test_disallow_self_add_modify_role_groups(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 5
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 2
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 2
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 2
+    )
 
     # Add the user role group as a member to the app group
     data = {
@@ -785,19 +845,25 @@ def test_disallow_self_add_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 6
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 3
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 3
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 2
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -820,19 +886,25 @@ def test_disallow_self_add_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 6
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 5
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 3
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 3
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 3
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 3
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -855,19 +927,25 @@ def test_disallow_self_add_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 6
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 5
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 3
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 3
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 3
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 3
+    )
 
 
 # Admin should be allowed to bypass the constraints in all cases
@@ -883,7 +961,7 @@ def test_disallow_self_add_admin_modify_group_users(
     user: OktaUser,
     url_for: Any,
 ) -> None:
-    current_user = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    current_user = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     tags = TagFactory.create_batch(
         3,
@@ -943,15 +1021,15 @@ def test_disallow_self_add_admin_modify_group_users(
 
     # Establish a baseline of user memberships/ownerships
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 0
     )
 
@@ -967,15 +1045,15 @@ def test_disallow_self_add_admin_modify_group_users(
     assert rep.status_code == 200
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 0
     )
 
@@ -998,15 +1076,15 @@ def test_disallow_self_add_admin_modify_group_users(
     assert len(data["owners"]) == 1
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
 
@@ -1030,15 +1108,15 @@ def test_disallow_self_add_admin_modify_group_users(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
 
@@ -1066,15 +1144,15 @@ def test_disallow_self_add_admin_modify_group_users(
     assert len(data["owners"]) == 2
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
 
@@ -1103,15 +1181,15 @@ def test_disallow_self_add_admin_modify_group_users(
     assert len(data["owners"]) == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
 
@@ -1135,15 +1213,15 @@ def test_disallow_self_add_admin_modify_group_users(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
 
@@ -1167,15 +1245,15 @@ def test_disallow_self_add_admin_modify_group_users(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
 
@@ -1203,15 +1281,15 @@ def test_disallow_self_add_admin_modify_group_users(
     assert len(data["owners"]) == 2
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 5
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
 
@@ -1236,15 +1314,15 @@ def test_disallow_self_add_admin_modify_group_users(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 8
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 6
     )
 
@@ -1272,15 +1350,15 @@ def test_disallow_self_add_admin_modify_group_users(
     assert len(data["owners"]) == 1
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 8
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 7
     )
 
@@ -1304,15 +1382,15 @@ def test_disallow_self_add_admin_modify_group_users(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 8
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 7
     )
 
@@ -1340,15 +1418,15 @@ def test_disallow_self_add_admin_modify_group_users(
     assert len(data["owners"]) == 2
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 11
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 10
     )
 
@@ -1365,7 +1443,7 @@ def test_disallow_self_add_admin_modify_role_groups(
     user: OktaUser,
     url_for: Any,
 ) -> None:
-    current_user = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    current_user = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     role_groups = RoleGroupFactory.create_batch(2)
 
@@ -1421,19 +1499,25 @@ def test_disallow_self_add_admin_modify_role_groups(
 
     # Establish a baseline of user memberships/ownerships
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 0
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 0
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 0
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 0
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 0
+    )
 
     # Add the current user role group as a member to the okta group
     data: dict[str, Any] = {
@@ -1451,19 +1535,25 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 0
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 1
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 0
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 1
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 0
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -1485,19 +1575,25 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 1
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 1
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 1
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 1
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -1515,19 +1611,25 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert rep.status_code == 200
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 1
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 1
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 1
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 1
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -1551,19 +1653,25 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 5
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 2
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 1
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 2
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 1
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -1586,19 +1694,25 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 5
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 2
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 2
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 2
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -1621,19 +1735,25 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 5
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 2
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 2
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 2
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -1655,19 +1775,25 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 6
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 3
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 3
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 2
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -1689,19 +1815,25 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 6
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 3
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 3
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 3
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 3
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -1723,19 +1855,25 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 6
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 3
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 3
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 3
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 3
+    )
 
     # Add the user role group as a member to the app group
     data = {
@@ -1753,19 +1891,25 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 7
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 4
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 3
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 4
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 3
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -1788,19 +1932,25 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 7
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 4
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 4
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 4
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 4
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -1823,16 +1973,22 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 7
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count() == 4
-    assert RoleGroupMap.query.filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count() == 4
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        == 4
+    )
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        == 4
+    )

--- a/tests/test_expiring_access_notifications.py
+++ b/tests/test_expiring_access_notifications.py
@@ -36,12 +36,14 @@ def test_individual_expiring_access_notifications(
     ).execute()
 
     membership1 = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.user_id == user.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.user_id == user.id)
         .filter(OktaUserGroupMember.group_id == okta_group.id)
         .first()
     )
     membership2 = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.user_id == user.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.user_id == user.id)
         .filter(OktaUserGroupMember.group_id == role_group.id)
         .first()
     )
@@ -87,12 +89,14 @@ def test_individual_expiring_access_notifications_week(
     ).execute()
 
     membership1 = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.user_id == user.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.user_id == user.id)
         .filter(OktaUserGroupMember.group_id == okta_group.id)
         .first()
     )
     membership2 = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.user_id == user.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.user_id == user.id)
         .filter(OktaUserGroupMember.group_id == role_group.id)
         .first()
     )
@@ -201,12 +205,14 @@ def test_owner_expiring_access_notifications(db: Db, mocker: MockerFixture) -> N
     ModifyGroupUsers(group=group2, owners_to_add=[owner.id], sync_to_okta=False).execute()
 
     membership1 = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == group1.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == group1.id)
         .filter(OktaUserGroupMember.user_id == user1.id)
         .first()
     )
     membership2 = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == group2.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == group2.id)
         .filter(OktaUserGroupMember.user_id == user2.id)
         .first()
     )
@@ -282,17 +288,20 @@ def test_owner_expiring_access_notifications_owner_member(db: Db, mocker: Mocker
     ModifyGroupUsers(group=group2, owners_to_add=[owner.id], sync_to_okta=False).execute()
 
     membership1 = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == group1.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == group1.id)
         .filter(OktaUserGroupMember.user_id == user1.id)
         .first()
     )
     membership2 = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == group1.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == group1.id)
         .filter(OktaUserGroupMember.user_id == owner.id)
         .first()
     )
     membership3 = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == group2.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == group2.id)
         .filter(OktaUserGroupMember.user_id == user2.id)
         .first()
     )
@@ -345,12 +354,14 @@ def test_owner_expiring_access_notifications_week(db: Db, mocker: MockerFixture)
     ModifyGroupUsers(group=group2, owners_to_add=[owner.id], sync_to_okta=False).execute()
 
     membership1 = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == group1.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == group1.id)
         .filter(OktaUserGroupMember.user_id == user1.id)
         .first()
     )
     membership2 = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == group2.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == group2.id)
         .filter(OktaUserGroupMember.user_id == user2.id)
         .first()
     )
@@ -426,17 +437,20 @@ def test_owner_expiring_access_notifications_owner_member_week(db: Db, mocker: M
     ModifyGroupUsers(group=group2, owners_to_add=[owner.id], sync_to_okta=False).execute()
 
     membership1 = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == group1.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == group1.id)
         .filter(OktaUserGroupMember.user_id == user1.id)
         .first()
     )
     membership2 = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == group1.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == group1.id)
         .filter(OktaUserGroupMember.user_id == owner.id)
         .first()
     )
     membership3 = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == group2.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == group2.id)
         .filter(OktaUserGroupMember.user_id == user2.id)
         .first()
     )
@@ -484,7 +498,8 @@ def test_owner_expiring_access_notifications_role(db: Db, mocker: MockerFixture)
     ).execute()
 
     membership1 = (
-        RoleGroupMap.query.filter(RoleGroupMap.group_id == group2.id)
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.group_id == group2.id)
         .filter(RoleGroupMap.role_group_id == group1.id)
         .first()
     )
@@ -533,12 +548,14 @@ def test_owner_expiring_access_notifications_role_week(db: Db, mocker: MockerFix
     ).execute()
 
     membership1 = (
-        RoleGroupMap.query.filter(RoleGroupMap.group_id == group1.id)
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.group_id == group1.id)
         .filter(RoleGroupMap.role_group_id == role.id)
         .first()
     )
     membership2 = (
-        RoleGroupMap.query.filter(RoleGroupMap.group_id == group2.id)
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.group_id == group2.id)
         .filter(RoleGroupMap.role_group_id == role.id)
         .first()
     )
@@ -583,10 +600,12 @@ def test_individual_do_not_renew_notification_behavior(
 
     # Get the OktaUserGroupMember for the user's membership to role_group
     membership = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.user_id == user.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.user_id == user.id)
         .filter(OktaUserGroupMember.group_id == role_group.id)
         .first()
     )
+    assert membership is not None
 
     # Mark one membership as 'should_expire'
     ModifyGroupUsers(group=role_group, members_should_expire=[membership.id], sync_to_okta=False).execute()
@@ -637,16 +656,20 @@ def test_owner_role_do_not_renew_notification_behavior(
 
     # Get the OktaUserGroupMember for the user's membership to role_group
     membership = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.user_id == user1.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.user_id == user1.id)
         .filter(OktaUserGroupMember.group_id == role_group.id)
         .first()
     )
+    assert membership is not None
     # Get RoleGroupMap
     role_membership = (
-        RoleGroupMap.query.filter(RoleGroupMap.role_group_id == role_group.id)
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.role_group_id == role_group.id)
         .filter(RoleGroupMap.group_id == okta_group.id)
         .first()
     )
+    assert role_membership is not None
 
     # Mark user as do not renew
     ModifyGroupUsers(group=role_group, members_should_expire=[membership.id], sync_to_okta=False).execute()
@@ -688,12 +711,14 @@ def test_role_owner_expiring_access_notifications_role_tomorrow(db: Db, mocker: 
     ).execute()
 
     membership1 = (
-        RoleGroupMap.query.filter(RoleGroupMap.role_group_id == role1.id)
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.role_group_id == role1.id)
         .filter(RoleGroupMap.group_id == group.id)
         .first()
     )
     membership2 = (
-        RoleGroupMap.query.filter(RoleGroupMap.role_group_id == role2.id)
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.role_group_id == role2.id)
         .filter(RoleGroupMap.group_id == group.id)
         .first()
     )
@@ -747,17 +772,20 @@ def test_role_owner_expiring_access_notifications_role_multiple_dates(db: Db, mo
     ).execute()
 
     membership1 = (
-        RoleGroupMap.query.filter(RoleGroupMap.role_group_id == role1.id)
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.role_group_id == role1.id)
         .filter(RoleGroupMap.group_id == group1.id)
         .first()
     )
     membership2 = (
-        RoleGroupMap.query.filter(RoleGroupMap.role_group_id == role2.id)
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.role_group_id == role2.id)
         .filter(RoleGroupMap.group_id == group1.id)
         .first()
     )
     membership3 = (
-        RoleGroupMap.query.filter(RoleGroupMap.role_group_id == role2.id)
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.role_group_id == role2.id)
         .filter(RoleGroupMap.group_id == group2.id)
         .first()
     )
@@ -785,7 +813,7 @@ def test_owner_expiring_access_notifications_managed_group_admin(db: Db, app: Fa
     group2 = OktaGroupFactory.create()
 
     user = OktaUserFactory.create()
-    access_owner = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     expiration_datetime = datetime.now() + timedelta(days=2)
 
@@ -802,7 +830,8 @@ def test_owner_expiring_access_notifications_managed_group_admin(db: Db, app: Fa
     ).execute()
 
     membership = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == group2.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == group2.id)
         .filter(OktaUserGroupMember.user_id == user.id)
         .first()
     )

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -9,8 +9,9 @@ from okta.models.group import Group
 from pytest_mock import MockerFixture
 from fastapi import FastAPI
 
+from sqlalchemy import func, or_
 from api.auth import permissions as AuthorizationHelpers
-from api.extensions import Db
+from api.extensions import Db, db
 from api.config import settings
 from api.models import (
     AccessRequest,
@@ -237,9 +238,9 @@ def test_put_group(
         f"{AppGroup.APP_GROUP_NAME_PREFIX}{App.ACCESS_APP_RESERVED_NAME}"
         + f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
     )
-    builtin_access_owners_group = AppGroup.query.filter(
-        AppGroup.name == builtin_access_owners_group_name, AppGroup.is_owner
-    ).first()
+    builtin_access_owners_group = (
+        db.session.query(AppGroup).filter(AppGroup.name == builtin_access_owners_group_name, AppGroup.is_owner).first()
+    )
     update_group_spy.reset_mock()
 
     data: dict[str, Any] = {
@@ -270,7 +271,7 @@ def test_put_group(
     assert ret_data["name"] == builtin_access_owners_group_name
     assert ret_data["description"] != "new description"
     assert ret_data["id"] == group_id
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
 
     update_group_spy.reset_mock()
     data.update(
@@ -289,7 +290,7 @@ def test_put_group(
     assert ret_data["name"] == builtin_access_owners_group_name
     assert ret_data["description"] != "new description"
     assert ret_data["id"] == group_id
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
 
 
 def _update_group_type(
@@ -322,8 +323,8 @@ def _update_group_type(
     assert ret_data["name"] == data["name"]
     assert ret_data["description"] == f"new description {group_type}"
     assert ret_data["id"] == group_id
-    assert AppTagMap.query.filter(AppTagMap.ended_at.is_(None)).count() == 1
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == expected_tags_count
+    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == expected_tags_count
 
 
 def test_put_app_group_rebind_authorization(
@@ -360,7 +361,7 @@ def test_put_app_group_rebind_authorization(
     target_app_name = target_app.name
     target_app_owner_group_id = target_app_owner_group.id
 
-    access_owner = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
     ModifyGroupUsers(group=app_group, owners_to_add=[access_owner.id], sync_to_okta=False).execute()
 
     mocker.patch.object(okta, "update_group")
@@ -695,7 +696,7 @@ def test_delete_group(
     assert rep.status_code == 200
     assert delete_group_spy.call_count == 1
     assert db.session.get(OktaGroup, group_id).deleted_at is not None
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
 
     db.session.add(user)
     db.session.add(access_app)
@@ -729,8 +730,8 @@ def test_delete_group(
     assert db.session.get(OktaGroup, group_id).deleted_at is not None
     assert access_request is not None
     assert db.session.get(AccessRequest, access_request.id).status == AccessRequestStatus.REJECTED
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
-    assert AppTagMap.query.filter(AppTagMap.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 1
 
 
 def test_delete_group_as_app_group_deleter(
@@ -800,7 +801,7 @@ def test_create_group(
     assert data["name"] == "Created"
     assert data["description"] == ""
     assert data["active_group_tags"][0]["active_tag"]["id"] == tag.id
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
 
 
 def test_create_app_group(
@@ -828,7 +829,7 @@ def test_create_app_group(
         okta, "create_group", return_value=Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
 
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
 
     app_group_name = f"{AppGroup.APP_GROUP_NAME_PREFIX}{access_app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}Created"
     data = {"type": "app_group", "app_id": access_app.id, "name": app_group_name, "description": ""}
@@ -841,7 +842,7 @@ def test_create_app_group(
     assert data["name"] == app_group_name
     assert data["description"] == ""
     assert data["active_group_tags"][0]["active_tag"]["id"] == tag.id
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
 
 
 def test_get_all_group(client: TestClient, db: Db, access_app: App, url_for: Any) -> None:
@@ -897,7 +898,7 @@ def test_do_not_renew(
     ).execute()
 
     # need the OktaUserGroupMember id to pass in later
-    membership_user2 = OktaUserGroupMember.query.filter(OktaUserGroupMember.user_id == user2.id).first()
+    membership_user2 = db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.user_id == user2.id).first()
 
     # test non-owner/admin perms
     mocker.patch.object(AuthorizationHelpers, "can_manage_group", return_value=False)
@@ -957,10 +958,11 @@ def test_do_not_renew(
 
     # get OktaUserGroupMembers, check expiration dates and should_expire
     membership_user1 = (
-        OktaUserGroupMember.query.filter(
-            db.or_(
+        db.session.query(OktaUserGroupMember)
+        .filter(
+            or_(
                 OktaUserGroupMember.ended_at.is_(None),
-                OktaUserGroupMember.ended_at > db.func.now(),
+                OktaUserGroupMember.ended_at > func.now(),
             )
         )
         .filter(OktaUserGroupMember.user_id == user.id)
@@ -971,20 +973,21 @@ def test_do_not_renew(
     assert membership_user1[0].ended_at is None
     assert membership_user1[0].should_expire is False
 
-    membership_user2 = (
-        OktaUserGroupMember.query.filter(
-            db.or_(
+    memberships_user2 = (
+        db.session.query(OktaUserGroupMember)
+        .filter(
+            or_(
                 OktaUserGroupMember.ended_at.is_(None),
-                OktaUserGroupMember.ended_at > db.func.now(),
+                OktaUserGroupMember.ended_at > func.now(),
             )
         )
         .filter(OktaUserGroupMember.user_id == user2.id)
         .all()
     )
 
-    assert len(membership_user2) == 1
-    assert membership_user2[0].ended_at == expiration_datetime
-    assert membership_user2[0].should_expire is True
+    assert len(memberships_user2) == 1
+    assert memberships_user2[0].ended_at == expiration_datetime
+    assert memberships_user2[0].should_expire is True
 
 
 def test_do_not_renew_scoped_to_route_group(
@@ -1014,7 +1017,9 @@ def test_do_not_renew_scoped_to_route_group(
         sync_to_okta=False,
     ).execute()
 
-    victim_membership = OktaUserGroupMember.query.filter(OktaUserGroupMember.user_id == victim_user.id).first()
+    victim_membership = (
+        db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.user_id == victim_user.id).first()
+    )
     assert victim_membership is not None
 
     mocker.patch.object(AuthorizationHelpers, "can_manage_group", return_value=True)

--- a/tests/test_group_membership_sync.py
+++ b/tests/test_group_membership_sync.py
@@ -340,7 +340,7 @@ def run_sync(
     user_membership_func: Callable[[str], list[User]],
     act_as_authority: bool,
     groups_with_rules: set[str] = set(),
-) -> list[OktaGroup]:
+) -> list[OktaUserGroupMember]:
     with Session(db.engine) as session:
         mocker.patch.object(okta, "list_groups", return_value=okta_groups)
 

--- a/tests/test_group_ownership_sync.py
+++ b/tests/test_group_ownership_sync.py
@@ -395,7 +395,7 @@ def run_sync(
     user_ownership_func: Callable[[str], list[User]],
     act_as_authority: bool,
     groups_with_rules: set[str] = set(),
-) -> list[OktaGroup]:
+) -> list[OktaUserGroupMember]:
     with Session(db.engine) as session:
         mocker.patch.object(okta, "list_groups", return_value=okta_groups)
 

--- a/tests/test_group_request.py
+++ b/tests/test_group_request.py
@@ -7,6 +7,7 @@ from okta.models import Group
 from pytest_mock import MockerFixture
 from fastapi import FastAPI
 
+from sqlalchemy import func, or_
 from api.config import settings
 from api.extensions import Db
 from api.models import (
@@ -266,7 +267,7 @@ def test_approve_group_request_creates_group(
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    admin = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     db.session.add(user)
     db.session.commit()
@@ -305,7 +306,8 @@ def test_approve_group_request_creates_group(
     assert created_group.description == "New group description"
 
     ownerships = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == created_group.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == created_group.id)
         .filter(OktaUserGroupMember.user_id == user.id)
         .filter(OktaUserGroupMember.is_owner.is_(True))
         .all()
@@ -322,7 +324,7 @@ def test_approve_group_request_sets_owner_with_ending_time(
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    admin = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     db.session.add(user)
     db.session.commit()
@@ -359,7 +361,8 @@ def test_approve_group_request_sets_owner_with_ending_time(
 
     # Check that the requester is an owner with the correct ending time
     ownerships = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == created_group.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == created_group.id)
         .filter(OktaUserGroupMember.user_id == user.id)
         .filter(OktaUserGroupMember.is_owner.is_(True))
         .all()
@@ -385,7 +388,7 @@ def test_approve_group_request_tag_limits_owner_ending_time(
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    admin = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     db.session.add(user)
     db.session.commit()
@@ -436,7 +439,8 @@ def test_approve_group_request_tag_limits_owner_ending_time(
 
     # Check that requester is an owner
     ownerships = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == created_group.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == created_group.id)
         .filter(OktaUserGroupMember.user_id == user.id)
         .filter(OktaUserGroupMember.is_owner.is_(True))
         .all()
@@ -474,7 +478,7 @@ def test_approve_group_request_applies_tags(
     user: OktaUser,
     tag: Tag,
 ) -> None:
-    admin = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     db.session.add(user)
     db.session.add(tag)
@@ -513,12 +517,13 @@ def test_approve_group_request_applies_tags(
 
     # Check that the tag was applied
     tag_mappings = (
-        OktaGroupTagMap.query.filter(OktaGroupTagMap.group_id == created_group.id)
+        db.session.query(OktaGroupTagMap)
+        .filter(OktaGroupTagMap.group_id == created_group.id)
         .filter(OktaGroupTagMap.tag_id == tag.id)
         .filter(
-            db.or_(
+            or_(
                 OktaGroupTagMap.ended_at.is_(None),
-                OktaGroupTagMap.ended_at > db.func.now(),
+                OktaGroupTagMap.ended_at > func.now(),
             )
         )
         .all()
@@ -534,7 +539,7 @@ def test_approve_group_request_sets_name(
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    admin = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     db.session.add(user)
     db.session.commit()
@@ -576,7 +581,7 @@ def test_approve_group_request_sets_type(
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    admin = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
     app_obj = AppFactory.create()
 
     db.session.add(user)
@@ -875,7 +880,7 @@ def test_admin_can_reject_request(
     db: Db,
     user: OktaUser,
 ) -> None:
-    admin = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     db.session.add(user)
     db.session.add(admin)
@@ -1008,7 +1013,7 @@ def test_approver_can_modify_group_details(
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    admin = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
     tag = TagFactory.create(enabled=True)
     other_tag = TagFactory.create(enabled=True)
 
@@ -1056,11 +1061,12 @@ def test_approver_can_modify_group_details(
 
     # Check tags
     tag_mappings = (
-        OktaGroupTagMap.query.filter(OktaGroupTagMap.group_id == created_group.id)
+        db.session.query(OktaGroupTagMap)
+        .filter(OktaGroupTagMap.group_id == created_group.id)
         .filter(
-            db.or_(
+            or_(
                 OktaGroupTagMap.ended_at.is_(None),
-                OktaGroupTagMap.ended_at > db.func.now(),
+                OktaGroupTagMap.ended_at > func.now(),
             )
         )
         .all()
@@ -1155,7 +1161,7 @@ def test_cannot_approve_deleted_requester(
     assert group_request is not None
 
     # Delete the requester
-    user.deleted_at = db.func.now()
+    user.deleted_at = func.now()
     db.session.commit()
 
     # Try to approve
@@ -1240,7 +1246,8 @@ def test_app_owner_auto_approves_own_app_group_request(
 
     # Verify the requester (app owner) is set as the group owner
     ownerships = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == created_group.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == created_group.id)
         .filter(OktaUserGroupMember.user_id == app_owner.id)
         .filter(OktaUserGroupMember.is_owner.is_(True))
         .all()
@@ -1327,7 +1334,8 @@ def test_app_owner_auto_approves_own_app_group_request_tagged(
 
     # Verify the app owner is *not* set as the group owner due to tags (will own implicitly via app ownership)
     ownerships = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == created_group.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == created_group.id)
         .filter(OktaUserGroupMember.user_id == app_owner.id)
         .filter(OktaUserGroupMember.is_owner.is_(True))
         .all()
@@ -1338,12 +1346,13 @@ def test_app_owner_auto_approves_own_app_group_request_tagged(
     tag_mappings = {
         tag_map.tag_id
         for tag_map in (
-            OktaGroupTagMap.query.filter(OktaGroupTagMap.group_id == created_group.id)
+            db.session.query(OktaGroupTagMap)
+            .filter(OktaGroupTagMap.group_id == created_group.id)
             .filter(OktaGroupTagMap.tag_id == tag.id)
             .filter(
-                db.or_(
+                or_(
                     OktaGroupTagMap.ended_at.is_(None),
-                    OktaGroupTagMap.ended_at > db.func.now(),
+                    OktaGroupTagMap.ended_at > func.now(),
                 )
             )
             .all()
@@ -1461,7 +1470,8 @@ def test_app_owner_cannot_hijack_cross_app_group_via_resolved_name(
     assert group_request.resolved_at is None
 
     hijacked_ownership = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == sensitive_group.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == sensitive_group.id)
         .filter(OktaUserGroupMember.user_id == user.id)
         .filter(OktaUserGroupMember.is_owner.is_(True))
         .filter(OktaUserGroupMember.ended_at.is_(None))
@@ -1533,7 +1543,8 @@ def test_app_owner_cannot_hijack_okta_group_via_resolved_name(
     assert group_request.resolved_at is None
 
     hijacked_ownership = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == existing_okta_group.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == existing_okta_group.id)
         .filter(OktaUserGroupMember.user_id == user.id)
         .filter(OktaUserGroupMember.is_owner.is_(True))
         .filter(OktaUserGroupMember.ended_at.is_(None))
@@ -1605,7 +1616,8 @@ def test_app_owner_cannot_hijack_role_group_via_resolved_name(
     assert group_request.resolved_at is None
 
     hijacked_ownership = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == existing_role_group.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == existing_role_group.id)
         .filter(OktaUserGroupMember.user_id == user.id)
         .filter(OktaUserGroupMember.is_owner.is_(True))
         .filter(OktaUserGroupMember.ended_at.is_(None))
@@ -1678,7 +1690,8 @@ def test_app_owner_cannot_hijack_group_via_resolved_name_case_insensitive(
     assert group_request.resolved_at is None
 
     hijacked_ownership = (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == sensitive_group.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == sensitive_group.id)
         .filter(OktaUserGroupMember.user_id == user.id)
         .filter(OktaUserGroupMember.is_owner.is_(True))
         .filter(OktaUserGroupMember.ended_at.is_(None))
@@ -1747,7 +1760,10 @@ def test_cannot_approve_okta_group_with_reserved_app_owners_name(
     assert group_request.resolved_at is None
 
     assert (
-        OktaGroup.query.filter(OktaGroup.name == "App-Payments-Owners").filter(OktaGroup.deleted_at.is_(None)).first()
+        db.session.query(OktaGroup)
+        .filter(OktaGroup.name == "App-Payments-Owners")
+        .filter(OktaGroup.deleted_at.is_(None))
+        .first()
         is None
     )
 
@@ -1812,7 +1828,10 @@ def test_cannot_approve_role_group_with_reserved_app_owners_name(
     assert group_request.resolved_at is None
 
     assert (
-        OktaGroup.query.filter(OktaGroup.name == "App-Payments-Owners").filter(OktaGroup.deleted_at.is_(None)).first()
+        db.session.query(OktaGroup)
+        .filter(OktaGroup.name == "App-Payments-Owners")
+        .filter(OktaGroup.deleted_at.is_(None))
+        .first()
         is None
     )
 
@@ -1878,7 +1897,10 @@ def test_cannot_approve_okta_group_with_any_reserved_app_prefix(
     assert group_request.resolved_at is None
 
     assert (
-        OktaGroup.query.filter(OktaGroup.name == "App-Payments-Members").filter(OktaGroup.deleted_at.is_(None)).first()
+        db.session.query(OktaGroup)
+        .filter(OktaGroup.name == "App-Payments-Members")
+        .filter(OktaGroup.deleted_at.is_(None))
+        .first()
         is None
     )
 
@@ -1947,7 +1969,8 @@ def test_cannot_approve_app_group_request_with_owners_group_name(
     assert group_request.resolved_at is None
 
     assert (
-        OktaGroup.query.filter(OktaGroup.name == owners_group_name)
+        db.session.query(OktaGroup)
+        .filter(OktaGroup.name == owners_group_name)
         .filter(OktaGroup.deleted_at.is_(None))
         .filter(OktaGroup.id != owner_group.id)
         .first()

--- a/tests/test_require_reason_constraint.py
+++ b/tests/test_require_reason_constraint.py
@@ -90,15 +90,15 @@ def test_require_reason_modify_group_users(
 
     # Establish a baseline of user memberships/ownerships with a created reason
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 0
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
 
@@ -114,15 +114,15 @@ def test_require_reason_modify_group_users(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 0
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
 
@@ -145,15 +145,15 @@ def test_require_reason_modify_group_users(
     assert len(data["owners"]) == 1
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 0
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
 
@@ -173,15 +173,15 @@ def test_require_reason_modify_group_users(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 0
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
 
@@ -205,15 +205,15 @@ def test_require_reason_modify_group_users(
     assert len(data["owners"]) == 1
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
 
@@ -242,15 +242,15 @@ def test_require_reason_modify_group_users(
     assert len(data["owners"]) == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
 
@@ -270,15 +270,15 @@ def test_require_reason_modify_group_users(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
 
@@ -293,15 +293,15 @@ def test_require_reason_modify_group_users(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
 
@@ -325,15 +325,15 @@ def test_require_reason_modify_group_users(
     assert len(data["owners"]) == 1
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
 
@@ -354,15 +354,15 @@ def test_require_reason_modify_group_users(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
 
@@ -385,15 +385,15 @@ def test_require_reason_modify_group_users(
     assert len(data["owners"]) == 1
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
 
@@ -413,15 +413,15 @@ def test_require_reason_modify_group_users(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
 
@@ -445,15 +445,15 @@ def test_require_reason_modify_group_users(
     assert len(data["owners"]) == 1
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 10
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
 
@@ -516,19 +516,29 @@ def test_require_reason_modify_role_groups(
 
     # Establish a baseline of user memberships/ownerships with a created reason
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 0
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None)).count() == 0
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None)).count() == 0
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 0
+    )
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 0
+    )
 
     # Add the role group as a member to the okta group without a reason
     data: dict[str, Any] = {
@@ -542,19 +552,29 @@ def test_require_reason_modify_role_groups(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 0
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None)).count() == 0
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None)).count() == 0
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 0
+    )
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 0
+    )
 
     # Add the role group as a owner to the okta group without a reason
     data = {
@@ -571,19 +591,29 @@ def test_require_reason_modify_role_groups(
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 0
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None)).count() == 0
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None)).count() == 1
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 0
+    )
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 1
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -601,19 +631,29 @@ def test_require_reason_modify_role_groups(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 0
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None)).count() == 0
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None)).count() == 1
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 0
+    )
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 1
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -637,19 +677,29 @@ def test_require_reason_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None)).count() == 1
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None)).count() == 1
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 1
+    )
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 1
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -673,19 +723,29 @@ def test_require_reason_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None)).count() == 2
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None)).count() == 0
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 2
+    )
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 0
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -709,19 +769,29 @@ def test_require_reason_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None)).count() == 2
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None)).count() == 0
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 2
+    )
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 0
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -743,19 +813,29 @@ def test_require_reason_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None)).count() == 2
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None)).count() == 1
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 2
+    )
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 1
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -773,19 +853,29 @@ def test_require_reason_modify_role_groups(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None)).count() == 2
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None)).count() == 1
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 2
+    )
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 1
+    )
 
     # Add the role group as a member and owner to the app group without a reason
     data = {
@@ -798,19 +888,29 @@ def test_require_reason_modify_role_groups(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None)).count() == 2
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None)).count() == 1
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 2
+    )
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 1
+    )
 
     # Add the role group as a member to the app group with a reason
     data = {
@@ -829,19 +929,29 @@ def test_require_reason_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None)).count() == 3
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None)).count() == 0
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 3
+    )
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 0
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -865,19 +975,29 @@ def test_require_reason_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None)).count() == 4
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None)).count() == 0
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 4
+    )
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 0
+    )
 
     add_user_to_group_spy.reset_mock()
     remove_user_from_group_spy.reset_mock()
@@ -901,19 +1021,29 @@ def test_require_reason_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None)).count() == 4
-    assert RoleGroupMap.query.filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None)).count() == 0
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 4
+    )
+    assert (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        .count()
+        == 0
+    )
 
 
 def test_require_reason_approve_access_request(
@@ -985,15 +1115,15 @@ def test_require_reason_approve_access_request(
 
     # Establish a baseline of user memberships/ownerships with a created reason
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 0
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
 
@@ -1013,15 +1143,15 @@ def test_require_reason_approve_access_request(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 0
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
 
@@ -1043,15 +1173,15 @@ def test_require_reason_approve_access_request(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 0
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
 
@@ -1080,15 +1210,15 @@ def test_require_reason_approve_access_request(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
 
@@ -1115,15 +1245,15 @@ def test_require_reason_approve_access_request(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
 
@@ -1152,15 +1282,15 @@ def test_require_reason_approve_access_request(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
 
@@ -1183,15 +1313,15 @@ def test_require_reason_approve_access_request(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
 
@@ -1215,15 +1345,15 @@ def test_require_reason_approve_access_request(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 3
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
 
@@ -1250,15 +1380,15 @@ def test_require_reason_approve_access_request(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
 
@@ -1283,15 +1413,15 @@ def test_require_reason_approve_access_request(
     assert rep.status_code == 400
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )
 
@@ -1313,15 +1443,15 @@ def test_require_reason_approve_access_request(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
 
@@ -1350,15 +1480,15 @@ def test_require_reason_approve_access_request(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 9
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 2
     )
 
@@ -1385,14 +1515,14 @@ def test_require_reason_approve_access_request(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 10
     )
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
-        ).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
+        .count()
         == 1
     )

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -4,6 +4,7 @@ from typing import Any
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 
+from sqlalchemy import func, or_
 from api.extensions import Db
 from api.models import (
     AccessRequestStatus,
@@ -409,7 +410,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 2
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 2
 
     data = rep.json()
     assert len(data["members"]) == 1
@@ -433,7 +434,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
 
     data = rep.json()
     assert len(data["members"]) == 1
@@ -458,7 +459,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
 
     data = rep.json()
     assert len(data["groups_in_role"]) == 1
@@ -484,7 +485,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
 
     data = rep.json()
     assert len(data["groups_in_role"]) == 0
@@ -508,7 +509,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
 
     data = rep.json()
     assert len(data["groups_in_role"]) == 1
@@ -535,7 +536,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 1
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 2
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 2
 
     data = rep.json()
     assert len(data["members"]) == 0
@@ -559,7 +560,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
 
     data = rep.json()
     assert len(data["members"]) == 1
@@ -584,7 +585,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
 
     data = rep.json()
     assert len(data["members"]) == 1
@@ -609,7 +610,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 6
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 6
 
     data = rep.json()
     assert len(data["members"]) == 1
@@ -635,7 +636,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 7
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 7
 
     data = rep.json()
     assert len(data["groups_in_role"]) == 1
@@ -662,7 +663,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 6
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 6
 
     data = rep.json()
     assert len(data["groups_in_role"]) == 1
@@ -687,7 +688,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 7
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 7
 
     data = rep.json()
     assert len(data["groups_in_role"]) == 1
@@ -713,7 +714,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 1
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 6
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 6
 
     data = rep.json()
     assert len(data["members"]) == 1
@@ -738,7 +739,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 7
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 7
 
     data = rep.json()
     assert len(data["members"]) == 1
@@ -766,7 +767,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 1
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
 
     data = rep.json()
     assert len(data["members"]) == 0
@@ -791,7 +792,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 7
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 7
 
     data = rep.json()
     assert len(data["members"]) == 1
@@ -823,7 +824,7 @@ def test_complex_role_modifications(
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
     assert update_group_spy.call_count == 1
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
 
     data = rep.json()
     assert data["type"] == "app_group"
@@ -857,7 +858,7 @@ def test_complex_role_modifications(
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
     assert update_group_spy.call_count == 1
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
 
     data = rep.json()
     assert data["type"] == "role_group"
@@ -887,8 +888,8 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at > db.func.now()).count() == 2
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at > func.now()).count() == 2
 
     data = rep.json()
     assert len(data["groups_in_role"]) == 1
@@ -916,20 +917,24 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
     # User should only be added for the length of their membership to the role group
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.ended_at > db.func.now(),
+        db.session.query(OktaUserGroupMember)
+        .filter(
+            OktaUserGroupMember.ended_at > func.now(),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=2)),
-        ).count()
+        )
+        .count()
         == 3
     )
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 0
     )
 
@@ -953,21 +958,25 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
     # User should be added for the length of the okta group membership to the role group
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 2
     )
     # User should only be added for the length of their membership to the role group
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
-        ).count()
+        )
+        .count()
         == 1
     )
 
@@ -995,13 +1004,15 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
     # User should only be in associated groups for the length of their membership to the role group
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
-        ).count()
+        )
+        .count()
         == 3
     )
 
@@ -1030,13 +1041,15 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
     # User should only be in associated groups for the length of their membership to the role group
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=4)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=6)),
-        ).count()
+        )
+        .count()
         == 3
     )
 
@@ -1066,13 +1079,15 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
     # User should only be in associated groups for the length of their membership to the role group
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=4)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=6)),
-        ).count()
+        )
+        .count()
         == 3
     )
 
@@ -1102,21 +1117,25 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
     # User should only be in associated groups for the length of their membership to the role group
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=4)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=6)),
-        ).count()
+        )
+        .count()
         == 1
     )
     # User should be added for the length of the okta group membership to the role group
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 2
     )
 
@@ -1144,13 +1163,15 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
     # User should only be in associated groups for the length of their membership to the role group
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 2
     )
 
@@ -1178,7 +1199,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 7
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 7
 
     data = rep.json()
     assert len(data["groups_in_role"]) == 1
@@ -1204,7 +1225,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
 
     data = rep.json()
     assert len(data["members"]) == 1
@@ -1234,7 +1255,7 @@ def test_complex_role_modifications(
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
     assert update_group_spy.call_count == 1
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
 
     data = rep.json()
     assert data["type"] == "role_group"
@@ -1264,7 +1285,7 @@ def test_complex_role_modifications(
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
     assert update_group_spy.call_count == 1
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
 
     data = rep.json()
     assert data["type"] == "okta_group"
@@ -1290,7 +1311,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 7
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 7
 
     data = rep.json()
     assert len(data["groups_in_role"]) == 1
@@ -1316,7 +1337,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
 
     data = rep.json()
     assert len(data["members"]) == 1
@@ -1340,7 +1361,7 @@ def test_complex_role_modifications(
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 1
     assert delete_group_spy.call_count == 1
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
     assert db.session.get(OktaGroup, group_id).deleted_at is not None
 
 
@@ -1373,7 +1394,7 @@ def test_do_not_renew(
     ).execute()
 
     # need the RoleGroupMap id to pass in later
-    role_group_map = RoleGroupMap.query.filter(RoleGroupMap.role_group_id == role_group.id).first()
+    role_group_map = db.session.query(RoleGroupMap).filter(RoleGroupMap.role_group_id == role_group.id).first()
 
     # set one user to renew and one do not renew
     add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
@@ -1404,10 +1425,11 @@ def test_do_not_renew(
 
     # get OktaUserGroupMembers, check expiration dates and should_expire
     membership_role = (
-        RoleGroupMap.query.filter(
-            db.or_(
+        db.session.query(RoleGroupMap)
+        .filter(
+            or_(
                 RoleGroupMap.ended_at.is_(None),
-                RoleGroupMap.ended_at > db.func.now(),
+                RoleGroupMap.ended_at > func.now(),
             )
         )
         .filter(RoleGroupMap.role_group_id == role_group.id)
@@ -1454,7 +1476,7 @@ def test_do_not_renew_scoped_to_route_role(
         sync_to_okta=False,
     ).execute()
 
-    victim_map = RoleGroupMap.query.filter(RoleGroupMap.role_group_id == victim_role.id).first()
+    victim_map = db.session.query(RoleGroupMap).filter(RoleGroupMap.role_group_id == victim_role.id).first()
     assert victim_map is not None
 
     data: dict[str, Any] = {
@@ -1499,7 +1521,7 @@ def test_do_not_renew_requires_group_ownership(
         sync_to_okta=False,
     ).execute()
 
-    role_group_map = RoleGroupMap.query.filter(RoleGroupMap.role_group_id == role_group.id).first()
+    role_group_map = db.session.query(RoleGroupMap).filter(RoleGroupMap.role_group_id == role_group.id).first()
     assert role_group_map is not None
 
     # User is not an admin and not an owner of the group in the mapping

--- a/tests/test_role_memberships_fix.py
+++ b/tests/test_role_memberships_fix.py
@@ -30,13 +30,15 @@ def test_missing_user_from_group_membership(
     assert add_ownership_spy.call_count == 1
 
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
         .filter(OktaUserGroupMember.ended_at.is_(None))
         .count()
         == 1
     )
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
         .filter(OktaUserGroupMember.ended_at.is_(None))
         .count()
         == 1
@@ -67,7 +69,8 @@ def test_missing_user_from_group_membership_with_expiring_role_membership(
     assert add_ownership_spy.call_count == 1
 
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
         .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=1)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=3)),
@@ -76,7 +79,8 @@ def test_missing_user_from_group_membership_with_expiring_role_membership(
         == 1
     )
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
         .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=1)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=3)),
@@ -85,13 +89,15 @@ def test_missing_user_from_group_membership_with_expiring_role_membership(
         == 1
     )
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
         .filter(OktaUserGroupMember.ended_at.is_(None))
         .count()
         == 0
     )
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
         .filter(OktaUserGroupMember.ended_at.is_(None))
         .count()
         == 0
@@ -132,7 +138,8 @@ def test_missing_user_from_group_membership_with_expiring_role_assignment(
     assert add_ownership_spy.call_count == 1
 
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
         .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=1)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=3)),
@@ -141,7 +148,8 @@ def test_missing_user_from_group_membership_with_expiring_role_assignment(
         == 1
     )
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
         .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=3)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=5)),
@@ -150,13 +158,15 @@ def test_missing_user_from_group_membership_with_expiring_role_assignment(
         == 1
     )
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
         .filter(OktaUserGroupMember.ended_at.is_(None))
         .count()
         == 0
     )
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
         .filter(OktaUserGroupMember.ended_at.is_(None))
         .count()
         == 0
@@ -195,7 +205,8 @@ def test_missing_user_from_group_membership_with_both_expiring(
     assert add_ownership_spy.call_count == 1
 
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
         .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=1)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=3)),
@@ -204,7 +215,8 @@ def test_missing_user_from_group_membership_with_both_expiring(
         == 1
     )
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
         .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=3)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=5)),
@@ -213,13 +225,15 @@ def test_missing_user_from_group_membership_with_both_expiring(
         == 1
     )
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
         .filter(OktaUserGroupMember.ended_at.is_(None))
         .count()
         == 0
     )
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
         .filter(OktaUserGroupMember.ended_at.is_(None))
         .count()
         == 0
@@ -264,19 +278,22 @@ def test_extra_user_from_role_membership(
     assert remove_ownership_spy.call_count == 1
 
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
         .filter(OktaUserGroupMember.ended_at.is_(None))
         .count()
         == 0
     )
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
         .filter(OktaUserGroupMember.ended_at.is_(None))
         .count()
         == 0
     )
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == okta_group.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == okta_group.id)
         .filter(OktaUserGroupMember.ended_at.is_(None))
         .count()
         == 0
@@ -334,19 +351,22 @@ def test_extra_user_from_role_membership_with_direct(
     assert remove_ownership_spy.call_count == 0
 
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
         .filter(OktaUserGroupMember.ended_at.is_(None))
         .count()
         == 0
     )
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
         .filter(OktaUserGroupMember.ended_at.is_(None))
         .count()
         == 0
     )
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.group_id == okta_group.id)
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.group_id == okta_group.id)
         .filter(OktaUserGroupMember.ended_at.is_(None))
         .count()
         == 2

--- a/tests/test_role_request.py
+++ b/tests/test_role_request.py
@@ -103,7 +103,7 @@ def test_get_role_request(
     assert len(data["groups_in_role"]) == 0
     assert len(data["groups_owned_by_role"]) == 0
 
-    access_owner = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
     add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
@@ -228,9 +228,9 @@ def test_put_role_request(
     add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
     add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
 
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 0
     # The Access owner plus the role membership and ownership added above
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
 
     data = {"approved": True, "reason": "test reason"}
 
@@ -239,7 +239,7 @@ def test_put_role_request(
     assert add_user_to_group_spy.call_count == 1
     assert add_owner_to_group_spy.call_count == 0
 
-    access_owner = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     data = rep.json()
     assert data["requester"]["email"] == user.email
@@ -252,8 +252,8 @@ def test_put_role_request(
     assert data["resolver"]["email"] == access_owner.email
     assert data["resolution_reason"] == role_request.resolution_reason
 
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at.is_(None)).count() == 1
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
 
     role_request2 = CreateRoleRequest(
         requester_user=user,
@@ -275,7 +275,7 @@ def test_put_role_request(
     assert add_user_to_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
 
-    access_owner = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     data = rep.json()
     assert data["requester"]["email"] == user.email
@@ -288,8 +288,8 @@ def test_put_role_request(
     assert data["resolver"]["email"] == access_owner.email
     assert data["resolution_reason"] == role_request.resolution_reason
 
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at.is_(None)).count() == 1
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
 
 
 def test_put_role_request_by_non_owner(
@@ -301,7 +301,7 @@ def test_put_role_request_by_non_owner(
     user: OktaUser,
     url_for: Any,
 ) -> None:
-    access_owner = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     db.session.add(user)
     db.session.add(role_group)
@@ -333,7 +333,7 @@ def test_put_role_request_by_non_owner(
 
     db.session.commit()
 
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
 
     assert role_request_by_owner is not None
     assert role_request_by_owner.status == AccessRequestStatus.PENDING
@@ -352,7 +352,7 @@ def test_put_role_request_by_non_owner(
     assert role_request_by_owner.resolved_at is None
     assert role_request_by_owner.resolver_user_id is None
 
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
 
     data = {"approved": False, "reason": "test rejection"}
 
@@ -363,7 +363,7 @@ def test_put_role_request_by_non_owner(
     assert role_request_by_owner.resolved_at is None
     assert role_request_by_owner.resolver_user_id is None
 
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
 
     role_request_url = url_for("api-role-requests.role_request_by_id", role_request_id=role_request_by_non_owner.id)
 
@@ -375,7 +375,7 @@ def test_put_role_request_by_non_owner(
     assert role_request_by_non_owner.resolved_at is None
     assert role_request_by_non_owner.resolver_user_id is None
 
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
 
     data = {"approved": False, "reason": "test rejection"}
 
@@ -395,7 +395,7 @@ def test_put_role_request_by_non_owner(
     assert role_request_by_non_owner.resolved_at is not None
     assert role_request_by_non_owner.resolver_user_id == user.id
 
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
 
 
 def test_create_role_request(
@@ -423,7 +423,7 @@ def test_create_role_request(
 
     data = rep.json()
     role_request = db.session.get(RoleRequest, data["id"])
-    access_owner = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     assert data["requester"]["email"] == access_owner.email
     assert data["requester_role"]["name"] == role_group.name
@@ -560,7 +560,7 @@ def test_create_role_request_notification(
     assert role_request is not None
     assert request_created_notification_spy.call_count == 1
 
-    access_owner = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     ApproveRoleRequest(role_request=role_request, approver_user=access_owner).execute()
 
@@ -646,7 +646,7 @@ def test_create_app_role_request_notification(
     assert kwargs["group"] == app_group
     assert kwargs["requester"] == user
 
-    access_owner = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     ApproveRoleRequest(role_request=role_request, approver_user=access_owner).execute()
 
@@ -677,7 +677,7 @@ def test_create_app_role_request_notification(
 
 
 def test_get_all_possible_role_request_approvers(app: FastAPI, mocker: MockerFixture, db: Db) -> None:
-    access_admin = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     users = OktaUserFactory.build_batch(3)
     db.session.add_all(users)
@@ -770,7 +770,7 @@ def test_resolve_app_role_request_notification(
     user: OktaUser,
     mocker: MockerFixture,
 ) -> None:
-    access_admin = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     app_owner_user1 = OktaUserFactory.build()
     app_owner_user2 = OktaUserFactory.build()
@@ -1082,7 +1082,7 @@ def test_time_limit_constraint_tag(
     tag: Tag,
     mocker: MockerFixture,
 ) -> None:
-    access_owner = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     # Add App
     db.session.add(access_app)
@@ -1143,7 +1143,7 @@ def test_time_limit_constraint_tag(
     ).execute()
 
     # Should only be approved for time limit if approved time is higher
-    approval = RoleGroupMap.query.filter(RoleGroupMap.role_group == role_group).first()
+    approval = db.session.query(RoleGroupMap).filter(RoleGroupMap.role_group == role_group).first()
     # Make sure approval time is correct (could be a couple milliseconds off from calculated which is okay)
     approval_time = approval.ended_at.replace(tzinfo=timezone.utc)
     expected_approval_time = datetime.now(timezone.utc) + timedelta(seconds=THREE_DAYS_IN_SECONDS)
@@ -1161,7 +1161,7 @@ def test_owner_cant_add_self_constraint_tag(
     tag: Tag,
     mocker: MockerFixture,
 ) -> None:
-    access_owner = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     # Add App
     db.session.add(access_app)
@@ -1278,7 +1278,7 @@ def test_role_request_approval_via_direct_add(
     assert role_request is not None
     assert request_created_notification_spy.call_count == 1
 
-    access_owner = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     ModifyRoleGroups(
         role_group=role_group, groups_to_add=[okta_group.id], sync_to_okta=False, created_reason="test"
@@ -1315,7 +1315,7 @@ def test_role_request_approval_via_direct_add(
     assert role_request is not None
     assert request_created_notification_spy.call_count == 1
 
-    access_owner = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
 
     ModifyRoleGroups(
         role_group=role_group, owner_groups_to_add=[okta_group2.id], sync_to_okta=False, created_reason="test"

--- a/tests/test_time_limit_constraint.py
+++ b/tests/test_time_limit_constraint.py
@@ -4,6 +4,7 @@ from typing import Any
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 
+from sqlalchemy import func, or_
 from api.extensions import Db
 from api.models import (
     App,
@@ -82,10 +83,12 @@ def test_time_limit_modify_group_users(
 
     # Establish a baseline where a user shouldn't be expiring in the next 8 days
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.ended_at > db.func.now(),
+        db.session.query(OktaUserGroupMember)
+        .filter(
+            OktaUserGroupMember.ended_at > func.now(),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
-        ).count()
+        )
+        .count()
         == 0
     )
 
@@ -111,17 +114,21 @@ def test_time_limit_modify_group_users(
 
     # user should only be added to the app group for 3 days (time limit constraint)
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 2
     )
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
-        ).count()
+        )
+        .count()
         == 0
     )
 
@@ -151,17 +158,21 @@ def test_time_limit_modify_group_users(
 
     # user should only be added to the app group group for 1 days (less than time limit constraint)
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.ended_at > db.func.now(),
+        db.session.query(OktaUserGroupMember)
+        .filter(
+            OktaUserGroupMember.ended_at > func.now(),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=2)),
-        ).count()
+        )
+        .count()
         == 2
     )
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 0
     )
 
@@ -206,7 +217,7 @@ def test_time_limit_modify_group_users(
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
 
     data = rep.json()
     assert len(data["groups_in_role"]) == 1
@@ -236,17 +247,21 @@ def test_time_limit_modify_group_users(
 
     # user should only be added to the role and okta group for 3 days (time limit constraint)
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
-        ).count()
+        )
+        .count()
         == 0
     )
 
@@ -276,17 +291,21 @@ def test_time_limit_modify_group_users(
 
     # user should only be added to the role and okta group for 1 days (less than time limit constraint)
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.ended_at > db.func.now(),
+        db.session.query(OktaUserGroupMember)
+        .filter(
+            OktaUserGroupMember.ended_at > func.now(),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=2)),
-        ).count()
+        )
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 0
     )
 
@@ -350,17 +369,19 @@ def test_time_limit_modify_role_groups(
 
     # Establish a base line of tag, user, and role mappings
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 2
     )
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
     assert (
-        RoleGroupMap.query.filter(
-            db.or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > db.func.now())
-        ).count()
+        db.session.query(RoleGroupMap)
+        .filter(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
+        .count()
         == 0
     )
 
@@ -379,21 +400,25 @@ def test_time_limit_modify_role_groups(
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 4
     )
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
     assert (
-        RoleGroupMap.query.filter(
+        db.session.query(RoleGroupMap)
+        .filter(
             RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 0
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 2
 
     # Add the role group as a member and owner of the app group, for an unlimited time
     add_user_to_group_spy.reset_mock()
@@ -414,21 +439,25 @@ def test_time_limit_modify_role_groups(
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 6
     )
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
     assert (
-        RoleGroupMap.query.filter(
+        db.session.query(RoleGroupMap)
+        .filter(
             RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 2
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 2
 
 
 def test_time_limit_modify_group_type(
@@ -486,17 +515,19 @@ def test_time_limit_modify_group_type(
     role_group_id = role_group.id
 
     # Establish a base line of tag, user, and role mappings
-    assert AppTagMap.query.filter(AppTagMap.ended_at.is_(None)).count() == 3
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 2
+    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 3
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 2
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 4
     )
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 2
 
     update_group_spy = mocker.patch.object(okta, "update_group")
 
@@ -518,24 +549,28 @@ def test_time_limit_modify_group_type(
     assert ret_data["name"] == data["name"]
     assert ret_data["description"] == data["description"]
     assert ret_data["id"] == okta_group_id
-    assert AppTagMap.query.filter(AppTagMap.ended_at.is_(None)).count() == 3
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 5
+    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 3
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 5
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 6
     )
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
     assert (
-        RoleGroupMap.query.filter(
+        db.session.query(RoleGroupMap)
+        .filter(
             RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 2
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 0
 
     # Update the role group to be an app group which should affect and also limit it's role group mapping
     update_group_spy.reset_mock()
@@ -551,20 +586,22 @@ def test_time_limit_modify_group_type(
     assert ret_data["name"] == data["name"]
     assert ret_data["description"] == data["description"]
     assert ret_data["id"] == role_group_id
-    assert AppTagMap.query.filter(AppTagMap.ended_at.is_(None)).count() == 3
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 8
+    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 3
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 8
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 4
     )
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
     assert (
-        RoleGroupMap.query.filter(
-            db.or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > db.func.now())
-        ).count()
+        db.session.query(RoleGroupMap)
+        .filter(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
+        .count()
         == 0
     )
 
@@ -630,20 +667,24 @@ def test_time_limit_modify_group_tags(
     ).execute()
 
     # Establish a baseline of user and role mappings
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
-        ).count()
+        )
+        .count()
         == 6
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 2
     assert (
-        RoleGroupMap.query.filter(
+        db.session.query(RoleGroupMap)
+        .filter(
             RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=6)),
             RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=8)),
-        ).count()
+        )
+        .count()
         == 2
     )
 
@@ -672,34 +713,42 @@ def test_time_limit_modify_group_tags(
     assert data["id"] == tags[0].id
 
     # The primary tag should reduce the user and role mappings to three days
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 6
     )
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
-        ).count()
+        )
+        .count()
         == 0
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 2
     assert (
-        RoleGroupMap.query.filter(
+        db.session.query(RoleGroupMap)
+        .filter(
             RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 2
     )
     assert (
-        RoleGroupMap.query.filter(
+        db.session.query(RoleGroupMap)
+        .filter(
             RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=6)),
             RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=8)),
-        ).count()
+        )
+        .count()
         == 0
     )
 
@@ -728,26 +777,33 @@ def test_time_limit_modify_group_tags(
     assert data["id"] == tags[2].id
 
     # The enabled tag should reduce the user and role mappings to one day
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.ended_at > db.func.now(),
+        db.session.query(OktaUserGroupMember)
+        .filter(
+            OktaUserGroupMember.ended_at > func.now(),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=2)),
-        ).count()
+        )
+        .count()
         == 6
     )
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2))).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)))
+        .count()
         == 0
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 2
     assert (
-        RoleGroupMap.query.filter(
-            RoleGroupMap.ended_at > db.func.now(), RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=2))
-        ).count()
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.ended_at > func.now(), RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=2)))
+        .count()
         == 2
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2))).count() == 0
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2))).count()
+        == 0
+    )
 
     # Update the last tag to be disabled
     data = {
@@ -774,26 +830,33 @@ def test_time_limit_modify_group_tags(
     assert data["id"] == tags[2].id
 
     # The disabled tag should have no effect on the user and role mappings
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
     assert (
-        OktaUserGroupMember.query.filter(
-            OktaUserGroupMember.ended_at > db.func.now(),
+        db.session.query(OktaUserGroupMember)
+        .filter(
+            OktaUserGroupMember.ended_at > func.now(),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=2)),
-        ).count()
+        )
+        .count()
         == 6
     )
     assert (
-        OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2))).count()
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)))
+        .count()
         == 0
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 2
     assert (
-        RoleGroupMap.query.filter(
-            RoleGroupMap.ended_at > db.func.now(), RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=2))
-        ).count()
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.ended_at > func.now(), RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=2)))
+        .count()
         == 2
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2))).count() == 0
+    assert (
+        db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2))).count()
+        == 0
+    )
 
 
 def test_time_limit_add_group_tags(
@@ -844,12 +907,12 @@ def test_time_limit_add_group_tags(
     ).execute()
 
     # Establish a base line of tag, user, and role mappings
-    assert AppTagMap.query.filter(AppTagMap.ended_at.is_(None)).count() == 0
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at > db.func.now()).count() == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 9
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at > db.func.now()).count() == 0
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at.is_(None)).count() == 4
+    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at > func.now()).count() == 0
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 9
+    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at > func.now()).count() == 0
+    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 4
 
     update_group_spy = mocker.patch.object(okta, "update_group")
 
@@ -865,25 +928,29 @@ def test_time_limit_add_group_tags(
     assert rep.status_code == 200
     assert update_group_spy.call_count == 1
 
-    assert AppTagMap.query.filter(AppTagMap.ended_at.is_(None)).count() == 0
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 2
+    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 2
 
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 4
     )
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
     assert (
-        RoleGroupMap.query.filter(
+        db.session.query(RoleGroupMap)
+        .filter(
             RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 2
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 2
 
     update_group_spy.reset_mock()
 
@@ -899,39 +966,47 @@ def test_time_limit_add_group_tags(
     assert rep.status_code == 200
     assert update_group_spy.call_count == 1
 
-    assert AppTagMap.query.filter(AppTagMap.ended_at.is_(None)).count() == 0
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 4
+    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 4
 
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
-        ).count()
+        )
+        .count()
         == 4
     )
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
     assert (
-        RoleGroupMap.query.filter(
+        db.session.query(RoleGroupMap)
+        .filter(
             RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 2
     )
     assert (
-        RoleGroupMap.query.filter(
+        db.session.query(RoleGroupMap)
+        .filter(
             RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=6)),
             RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=8)),
-        ).count()
+        )
+        .count()
         == 0
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 2
 
     update_group_spy.reset_mock()
 
@@ -948,39 +1023,47 @@ def test_time_limit_add_group_tags(
     assert rep.status_code == 200
     assert update_group_spy.call_count == 1
 
-    assert AppTagMap.query.filter(AppTagMap.ended_at.is_(None)).count() == 0
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 6
+    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 6
 
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 4
     )
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
-        ).count()
+        )
+        .count()
         == 4
     )
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
     assert (
-        RoleGroupMap.query.filter(
+        db.session.query(RoleGroupMap)
+        .filter(
             RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 2
     )
     assert (
-        RoleGroupMap.query.filter(
+        db.session.query(RoleGroupMap)
+        .filter(
             RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=6)),
             RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=8)),
-        ).count()
+        )
+        .count()
         == 2
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 0
 
 
 def test_time_limit_add_app_tags(
@@ -1026,12 +1109,12 @@ def test_time_limit_add_app_tags(
     ).execute()
 
     # Establish a base line of tag, user, and role mappings
-    assert AppTagMap.query.filter(AppTagMap.ended_at.is_(None)).count() == 0
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at > db.func.now()).count() == 0
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 7
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at > db.func.now()).count() == 0
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at > func.now()).count() == 0
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 7
+    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at > func.now()).count() == 0
+    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 2
 
     update_group_spy = mocker.patch.object(okta, "update_group")
 
@@ -1043,24 +1126,28 @@ def test_time_limit_add_app_tags(
     assert rep.status_code == 200
     assert update_group_spy.call_count == 1
 
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 2
-    assert AppTagMap.query.filter(AppTagMap.ended_at.is_(None)).count() == 2
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 2
+    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 2
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 4
     )
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
     assert (
-        RoleGroupMap.query.filter(
+        db.session.query(RoleGroupMap)
+        .filter(
             RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 2
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 0
 
     update_group_spy.reset_mock()
 
@@ -1077,21 +1164,25 @@ def test_time_limit_add_app_tags(
     assert rep.status_code == 200
     assert update_group_spy.call_count == 0
 
-    assert OktaGroupTagMap.query.filter(OktaGroupTagMap.ended_at.is_(None)).count() == 2
-    assert AppTagMap.query.filter(AppTagMap.ended_at.is_(None)).count() == 2
+    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 2
+    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 2
     assert (
-        OktaUserGroupMember.query.filter(
+        db.session.query(OktaUserGroupMember)
+        .filter(
             OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 4
     )
-    assert OktaUserGroupMember.query.filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
     assert (
-        RoleGroupMap.query.filter(
+        db.session.query(RoleGroupMap)
+        .filter(
             RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
             RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
-        ).count()
+        )
+        .count()
         == 2
     )
-    assert RoleGroupMap.query.filter(RoleGroupMap.ended_at.is_(None)).count() == 0
+    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 0

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -23,7 +23,7 @@ def test_get_user_at_me_includes_group_memberships(
     OktaUserDetail originally dropped these lists."""
     db.session.add(okta_group)
     db.session.commit()
-    access_user = OktaUser.query.filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_user = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
     ModifyGroupUsers(
         group=okta_group,
         members_to_add=[access_user.id],

--- a/tests/test_user_sync.py
+++ b/tests/test_user_sync.py
@@ -3,6 +3,7 @@ from typing import List
 from pytest_mock import MockerFixture
 from sqlalchemy.orm import Session
 
+from sqlalchemy import func
 from api.models import AccessRequest, AccessRequestStatus, OktaGroup, OktaUser, OktaUserGroupMember, RoleGroup
 from api.extensions import Db
 from api.operations import CreateAccessRequest
@@ -177,7 +178,7 @@ def test_user_sync_ends_memberships_for_previously_deleted_user(
     seed_db(db, initial_users_in_okta)
 
     # Mark the user as deleted in Access
-    db.session.get(OktaUser, initial_users_in_okta[0].id).deleted_at = db.func.now()
+    db.session.get(OktaUser, initial_users_in_okta[0].id).deleted_at = func.now()
 
     # Add a managed group membership and ownership to the user to be deleted
     db.session.add(okta_group)


### PR DESCRIPTION
## Summary
- Drop the Flask-SQLAlchemy emulation surface (`db.Model` / `db.Column` / `db.relationship` / `db.func` / `db.or_` / `db.and_` / `db.not_`, the `Model.query` descriptor with `first_or_404` / `get_or_404` / `paginate`) in `api/extensions.py`. `db.session` survives as a slim session/engine facade so `db.session.query(Model).filter(...)` keeps working.
- Move all six model files in `api/models/` to direct `from sqlalchemy import ...` with `Mapped[T]` annotations on `mapped_column` — idiomatic SQLAlchemy 2.0.
- Mechanically swap `Model.query.X` to `db.session.query(Model).X` across 28 operation files, the 9 routers, `api/syncer.py`, `api/integrity.py`, `api/auth/permissions.py`, and the test suite.
- Tick item `#1` off [POST_MIGRATION_TODO.md](POST_MIGRATION_TODO.md).

Follow-up to [#425](https://github.com/discord/access/pull/425) — the migration kept the shim alive so the diff could focus on the Flask→FastAPI plumbing.

## Test plan
- [x] `pytest tests/` — 426 passed locally (no flakes/skips related to this change)
- [x] `alembic upgrade head` against a fresh SQLite DB applies cleanly — no schema drift from the `Column` → `mapped_column` move
- [x] App boots: `python -c "from api.app import create_app; create_app(testing=True)"` returns clean
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)