### PR TITLE
Rename resolution_reason → reason on ResolveGroupRequestBody

### DIFF
--- a/POST_MIGRATION_TODO.md
+++ b/POST_MIGRATION_TODO.md
@@ -76,24 +76,6 @@ Drop the hand-rolled `{total, pages, next, prev, results}` envelope in
 and consistent shape across endpoints for free. Wire shape changes; coordinate
 with frontend.
 
-### 22. Rename `resolution_reason` → `reason` on `ResolveGroupRequestBody`
-
-`PUT /api/group-requests/{id}` accepts `resolution_reason` while
-`PUT /api/access-requests/{id}` and `PUT /api/role-requests/{id}` both
-accept `reason`. Align on `reason` for the group-request resolve body
-to make the three resolve endpoints consistent.
-
-**Touches:**
-- `api/schemas/requests_schemas.py` — rename the field on
-  `ResolveGroupRequestBody`.
-- `api/routers/group_requests.py` — update the handler to read
-  `body.reason`.
-- Frontend client(s) posting to `PUT /api/group-requests/{id}` — switch
-  the body key.
-- Tests in `tests/test_group_request.py` that exercise the resolve PUT.
-
-Coordinate with frontend; this is a breaking wire-shape change.
-
 ---
 
 ## Auth

--- a/api/routers/group_requests.py
+++ b/api/routers/group_requests.py
@@ -274,7 +274,7 @@ def put_group_request(
 
     db.commit()
 
-    resolution_reason = body.resolution_reason or ""
+    resolution_reason = body.reason or ""
     if body.approved:
         ApproveGroupRequest(
             group_request=gr,

--- a/api/schemas/requests_schemas.py
+++ b/api/schemas/requests_schemas.py
@@ -346,7 +346,7 @@ CreateGroupRequestBody = Annotated[
 class ResolveGroupRequestBody(BaseModel):
     model_config = ConfigDict(extra="ignore")
     approved: StrictBool
-    resolution_reason: Optional[str] = ""
+    reason: Optional[str] = ""
     resolved_group_name: Optional[str] = None
     resolved_group_description: Optional[str] = None
     resolved_group_type: Optional[str] = None

--- a/src/api/apiSchemas.ts
+++ b/src/api/apiSchemas.ts
@@ -424,6 +424,10 @@ export type ResolveRoleRequest = {
 export type ResolveGroupRequest = {
   approved: boolean;
   /**
+   * @maxLength 1024
+   */
+  reason?: string;
+  /**
    * @maxLength 255
    */
   resolved_group_name?: string;
@@ -445,10 +449,6 @@ export type ResolveGroupRequest = {
    */
   resolved_ownership_ending_at?: string;
   resolved_group_tags?: string[];
-  /**
-   * @maxLength 1024
-   */
-  resolution_reason?: string;
 };
 
 export type GroupRoleAuditPagination = {

--- a/src/pages/group_requests/Read.tsx
+++ b/src/pages/group_requests/Read.tsx
@@ -166,7 +166,7 @@ interface ResolveRequestForm {
   resolved_app?: App;
   resolved_ownership_ending_at?: string;
   resolved_ownership_ending_at_custom?: string;
-  resolution_reason?: string;
+  reason?: string;
 }
 
 export default function ReadGroupRequest() {
@@ -441,7 +441,7 @@ export default function ReadGroupRequest() {
         })()
       : 'indefinite',
     resolved_ownership_ending_at_custom: groupRequest.requested_ownership_ending_at ?? undefined,
-    resolution_reason: '',
+    reason: '',
   };
 
   const submit = (responseForm: ResolveRequestForm) => {
@@ -466,7 +466,7 @@ export default function ReadGroupRequest() {
       resolved_app_id:
         responseForm.resolved_group_type === 'app_group' ? responseForm.resolved_app?.id ?? '' : undefined,
       resolved_group_tags: selectedTags.map((t) => t.id),
-      resolution_reason: responseForm.resolution_reason ?? '',
+      reason: responseForm.reason ?? '',
     };
 
     switch (responseForm.resolved_ownership_ending_at) {
@@ -924,7 +924,7 @@ export default function ReadGroupRequest() {
                                     ? 'Why? (provide a reason)'
                                     : 'Why is this group creation approved or rejected? (provide a reason)'
                                 }
-                                name="resolution_reason"
+                                name="reason"
                                 multiline
                                 rows={4}
                                 validation={{maxLength: 1024}}

--- a/tests/test_group_request.py
+++ b/tests/test_group_request.py
@@ -2223,12 +2223,13 @@ def test_post_group_request_tag_ids_must_be_undeleted(
     assert "tags not found" in rep.text
 
 
-def test_put_group_request_ignores_unknown_reason_alias_via_http(
+def test_put_group_request_ignores_legacy_resolution_reason_alias_via_http(
     client: TestClient, db: Db, user: OktaUser, url_for: Any
 ) -> None:
-    """PUT /api/group-requests/{id} only reads `resolution_reason` from the
-    body — an undocumented `reason` key must be silently dropped, leaving
-    the persisted resolution_reason empty."""
+    """PUT /api/group-requests/{id} reads `reason` from the body (matching
+    the access-request and role-request resolve endpoints). The legacy
+    `resolution_reason` key is silently dropped, leaving the persisted
+    resolution_reason empty."""
     db.session.add(user)
     db.session.commit()
 
@@ -2242,7 +2243,7 @@ def test_put_group_request_ignores_unknown_reason_alias_via_http(
     assert group_request is not None
 
     resolve_url = url_for("api-group-requests.group_request_by_id_put", group_request_id=group_request.id)
-    rep = client.put(resolve_url, json={"approved": False, "reason": "should be dropped"})
+    rep = client.put(resolve_url, json={"approved": False, "resolution_reason": "should be dropped"})
     assert rep.status_code == 200
 
     db.session.refresh(group_request)
@@ -2250,25 +2251,24 @@ def test_put_group_request_ignores_unknown_reason_alias_via_http(
     assert group_request.resolution_reason == ""
 
 
-def test_put_group_request_persists_resolution_reason_via_http(
-    client: TestClient, db: Db, user: OktaUser, url_for: Any
-) -> None:
-    """PUT /api/group-requests/{id} stores the body's `resolution_reason`
-    verbatim on the resolved request."""
+def test_put_group_request_persists_reason_via_http(client: TestClient, db: Db, user: OktaUser, url_for: Any) -> None:
+    """PUT /api/group-requests/{id} stores the body's `reason` verbatim on
+    the resolved request's `resolution_reason` column (the DB column name
+    is preserved; only the request-body key was renamed)."""
     db.session.add(user)
     db.session.commit()
 
     group_request = CreateGroupRequest(
         requester_user=user,
         requested_group_name="ResolveResolutionReasonOktaGroup",
-        requested_group_description="resolution_reason test",
+        requested_group_description="reason test",
         requested_group_type="okta_group",
         request_reason="please",
     ).execute()
     assert group_request is not None
 
     resolve_url = url_for("api-group-requests.group_request_by_id_put", group_request_id=group_request.id)
-    rep = client.put(resolve_url, json={"approved": False, "resolution_reason": "duplicate work"})
+    rep = client.put(resolve_url, json={"approved": False, "reason": "duplicate work"})
     assert rep.status_code == 200
 
     db.session.refresh(group_request)


### PR DESCRIPTION
## Summary
One of four PRs splitting the original combined wire-shape change into focused, independently reviewable pieces (this PR *was* the original combined #454, now scoped down to just item 22). Targets `main`.

Aligns the group-request resolve body with the access-request and role-request resolve endpoints, which both already accept `reason`. `PUT /api/group-requests/{id}` previously accepted `resolution_reason`.

- `api/schemas/requests_schemas.py` — `ResolveGroupRequestBody.resolution_reason` → `reason`.
- `api/routers/group_requests.py` — handler reads `body.reason`.
- The `resolution_reason` DB column and all **response** fields keep their name — only the request-body key changes.
- Frontend: `ResolveGroupRequest` type + `group_requests/Read.tsx` resolve form field.

This is a **breaking** wire-shape change for clients posting to `PUT /api/group-requests/{id}`.

Closes POST_MIGRATION_TODO.md item #22.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy .` — no new errors
- [x] `pytest tests/test_group_request.py` — 45 passed
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## ⚠️ Cross-dependency with the sibling split PRs
This is one of four independent PRs splitting the original combined wire-shape change, all branched off `main` (not stacked, so they can merge in any order — but they **overlap on shared files** and will conflict on merge):

- #463 — RFC 9457 error format (item 7)
- #464 — ISO 8601 datetimes (item 5)
- #465 — exclude_none + fastapi-pagination (items 6 & 8)

Files this PR shares with siblings (expect a rebase for whichever merges second):
- `POST_MIGRATION_TODO.md` — every split PR deletes its own item section (conflicts with all three).
- `api/schemas/requests_schemas.py` — also edited by #464 (datetime types) and #465 (docstring).
- `api/routers/group_requests.py` — also edited by #465 (route_class + pagination).
- `src/api/apiSchemas.ts` — also edited by #465 (pagination types).
- `src/pages/group_requests/Read.tsx` — also edited by #464 and #465.

After any sibling merges, rebase this branch and re-resolve those files.
