### PR TITLE
Hidden app owner groups bug

### DIFF
--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -149,7 +149,7 @@ def post_group(
             name=body.name,
             description=description,
             app_id=body.app_id,
-            is_owner=body.is_owner,
+            is_owner=False,
             plugin_data=body.plugin_data or {},
         )
     elif isinstance(body, _RoleGroupCreateBody):
@@ -324,7 +324,7 @@ def put_group(
             setattr(new_group, k, getattr(group, k, None))
         if isinstance(new_group, AppGroup) and isinstance(body, _AppGroupUpdateBody):
             new_group.app_id = body.app_id if "app_id" in fields_set else getattr(group, "app_id", None)
-            new_group.is_owner = bool(body.is_owner) if body.is_owner is not None else False
+            new_group.is_owner = False
         try:
             group = ModifyGroupType(group=group, group_changes=new_group, current_user_id=current_user_id).execute()
         except ValueError as e:

--- a/api/schemas/requests_schemas.py
+++ b/api/schemas/requests_schemas.py
@@ -526,7 +526,6 @@ class _RoleGroupCreateBody(_GroupCreateBodyShared):
 class _AppGroupCreateBody(_GroupCreateBodyShared):
     type: Literal["app_group"]
     app_id: Optional[str] = None
-    is_owner: bool = False
     plugin_data: Optional[dict[str, Any]] = None
 
 
@@ -570,7 +569,6 @@ class _RoleGroupUpdateBody(_GroupUpdateBodyShared):
 class _AppGroupUpdateBody(_GroupUpdateBodyShared):
     type: Literal["app_group"]
     app_id: Optional[str] = None
-    is_owner: Optional[bool] = None
     plugin_data: Optional[dict[str, Any]] = None
 
 

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -845,6 +845,60 @@ def test_create_app_group(
     assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
 
 
+def test_create_app_group_cannot_set_is_owner_shadow_escalation(
+    app: FastAPI,
+    client: TestClient,
+    db: Db,
+    mocker: MockerFixture,
+    faker: Faker,  # type: ignore[type-arg]
+    url_for: Any,
+) -> None:
+    """A non-admin app owner must not be able to create a *second* owner-group
+    by setting `is_owner=True` on POST /api/groups. Such a "shadow" owner-group
+    silently turns anyone added as its owner into an app owner — without them
+    ever appearing in the App-<app>-Owners member list.
+    """
+    # App "Foo" with its owner group, owned by non-admin Alice
+    foo = AppFactory.create()
+    owners_group = AppGroupFactory.create(
+        app_id=foo.id,
+        is_owner=True,
+        name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{foo.name}"
+        f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
+    )
+    alice = OktaUserFactory.create()
+    db.session.add_all([foo, owners_group, alice])
+    db.session.commit()
+    foo_id = foo.id
+    foo_name = foo.name
+
+    ModifyGroupUsers(group=owners_group, owners_to_add=[alice.id], sync_to_okta=False).execute()
+
+    mocker.patch.object(okta, "create_group", return_value=Group({"id": cast(FakerWithPyStr, faker).pystr()}))
+
+    # act as Alice — a plain app owner, NOT an Access admin.
+    app.state.current_user_email = alice.email
+    assert not AuthorizationHelpers.is_access_admin(db.session, alice.id)
+
+    shadow_name = f"{AppGroup.APP_GROUP_NAME_PREFIX}{foo_name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}shadow"
+    rep = client.post(
+        url_for("api-groups.groups"),
+        json={"type": "app_group", "app_id": foo_id, "name": shadow_name, "is_owner": True, "description": ""},
+    )
+    assert rep.status_code == 201
+
+    # privilege flag should be ignored, so the new group is an
+    # ordinary (non-owner) app group and Foo still has exactly one owner group.
+    created = db.session.get(AppGroup, rep.json()["id"])
+    assert not created.is_owner
+    owner_groups = (
+        db.session.query(AppGroup)
+        .filter(AppGroup.app_id == foo_id, AppGroup.is_owner.is_(True), AppGroup.deleted_at.is_(None))
+        .all()
+    )
+    assert [g.id for g in owner_groups] == [owners_group.id]
+
+
 def test_get_all_group(client: TestClient, db: Db, access_app: App, url_for: Any) -> None:
     groups_url = url_for("api-groups.groups")
 


### PR DESCRIPTION
POST /api/groups accepts submitting a value for is_owner on app-group create bodies and writes it verbatim. The router only checks the name doesn't end in -Owners. is_app_owner_group_owner considers any AppGroup.is_owner=True for an app as an owner-group. This allows for a group to be set as and behave as an owner group without it being clearly marked as one, potentially allowing for hidden persistent access

Since app groups are only set as owner groups at app creation time, removed is_owner from request bodies and defaulted to setting is_owner to False when creating a new app group