### PR TITLE
Healthz leaking data

### DIFF
--- a/api/routers/health.py
+++ b/api/routers/health.py
@@ -2,17 +2,21 @@
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 from sqlalchemy import text
 
 from api.database import DbSession
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api/healthz", tags=["health"])
 
 
 # Returns a `JSONResponse` directly because the success and failure paths
-# emit different JSON shapes (`{"status":"ok"}` vs `{"status":"error","error":"..."}`)
+# emit different JSON shapes (`{"status":"ok"}` vs `{"status":"error"}`)
 # at different status codes. FastAPI's `response_model` filtering is silently
 # skipped when the handler returns a `Response` subclass, so we don't declare
 # one here — adding it would be misleading. Refactoring to a single
@@ -21,6 +25,9 @@ router = APIRouter(prefix="/api/healthz", tags=["health"])
 def health_check(db: DbSession) -> JSONResponse:
     try:
         db.execute(text("SELECT 1"))
-    except Exception as e:
-        return JSONResponse({"status": "error", "error": str(e)}, status_code=500)
+    except Exception:
+        # Log server-side only — the exception text carries driver/connection
+        # detail (host, db name, user) and this endpoint is unauthenticated.
+        logger.exception("Health check DB query failed")
+        return JSONResponse({"status": "error"}, status_code=500)
     return JSONResponse({"status": "ok"}, status_code=200)

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from pytest_mock import MockerFixture
 
 from api.extensions import Db
 
@@ -14,3 +15,20 @@ def test_health_check(app: FastAPI, client: TestClient, db: Db, url_for: Any) ->
     health_check_url = url_for("api-health-check.health_check")
     rep = client.get(health_check_url)
     assert rep.status_code == 200
+
+
+def test_health_check_does_not_leak_db_error(
+    app: FastAPI, client: TestClient, db: Db, mocker: MockerFixture, url_for: Any
+) -> None:
+    # /api/healthz is unauthenticated (in AUTH_ALLOWLIST_PREFIXES), so its
+    # error path must not expose driver/connection details to the caller.
+    app.state.current_user_email = "Unauthenticated"
+
+    secret = "could not connect: host=db.internal dbname=access user=access_admin password=hunter2"
+    mocker.patch.object(db.session, "execute", side_effect=Exception(secret))
+
+    rep = client.get(url_for("api-health-check.health_check"))
+    assert rep.status_code == 500
+    # The raw exception text must not reach an unauthenticated client.
+    assert secret not in rep.text
+    assert rep.json() == {"status": "error"}


### PR DESCRIPTION
On a transient DB outage, an unauthenticated attacker scraping /api/healthz gets the SQLAlchemy/psycopg2 error string — typically including connection target, database name, user, and driver-level details.

Changed it so the error message is logged server-side and only an error status is exposed