### PR TITLE
Observability metrics fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,4 +65,4 @@ ENV SENTRY_RELEASE=$SENTRY_RELEASE
 
 EXPOSE 3000
 
-CMD ["gunicorn", "-w", "4", "-t", "600", "-b", ":3000", "-k", "uvicorn.workers.UvicornWorker", "--access-logfile", "-", "--logger-class", "api.log_filters.RedactingGunicornLogger", "api.asgi:app"]
+CMD ["gunicorn", "-w", "4", "-t", "600", "-b", ":3000", "-k", "uvicorn.workers.UvicornWorker", "--access-logfile", "-", "api.asgi:app"]

--- a/api/app.py
+++ b/api/app.py
@@ -21,7 +21,7 @@ from api import exception_handlers, middleware
 from api.config import settings
 from api.database import build_engine
 from api.extensions import db
-from api.log_filters import TokenSanitizingFilter
+from api.log_filters import RedactingUvicornLogger, TokenSanitizingFilter
 from api.services import okta
 
 logger = logging.getLogger(__name__)
@@ -35,6 +35,7 @@ def _configure_logging() -> None:
     token_filter = TokenSanitizingFilter()
     logging.getLogger("authlib").addFilter(token_filter)
     logging.getLogger("uvicorn.access").addFilter(token_filter)
+    logging.getLogger("uvicorn.access").addFilter(RedactingUvicornLogger())
     logging.root.addFilter(token_filter)
 
 
@@ -183,6 +184,7 @@ def create_app(testing: Optional[bool] = False) -> FastAPI:
     app.add_middleware(middleware.SecurityHeadersMiddleware)
     app.add_middleware(middleware.RequestContextMiddleware)
     app.add_middleware(middleware.RequestIdMiddleware)
+    app.add_middleware(middleware.RequestObservabilityMiddleware)
 
     exception_handlers.install(app)
 

--- a/api/app.py
+++ b/api/app.py
@@ -178,8 +178,9 @@ def create_app(testing: Optional[bool] = False) -> FastAPI:
             allow_credentials=True,
         )
 
-    # Order: outer-most last. RequestId outermost so request_id is on state
-    # for inner middleware and dependencies.
+    # Order: outer-most last. RequestObservability outermost so it times the
+    # full request; RequestId next so request_id is on state for inner
+    # middleware and dependencies.
     app.add_middleware(middleware.CacheControlMiddleware)
     app.add_middleware(middleware.SecurityHeadersMiddleware)
     app.add_middleware(middleware.RequestContextMiddleware)

--- a/api/log_filters.py
+++ b/api/log_filters.py
@@ -1,16 +1,9 @@
 import logging
 import re
-from typing import Any, Dict
-
-from gunicorn.glogging import Logger as GunicornLogger
 
 
 class TokenSanitizingFilter(logging.Filter):
-    """Filter that redacts sensitive token information from application logs.
-
-    Note: This filter handles internal application logs. For HTTP access logs,
-    see RedactingGunicornLogger below for specialized handling.
-    """
+    """Filter that redacts sensitive token information from application logs."""
 
     def filter(self, record: logging.LogRecord) -> bool:
         if hasattr(record, "msg") and isinstance(record.msg, str):
@@ -21,7 +14,6 @@ class TokenSanitizingFilter(logging.Filter):
             if "Could not refresh token" in msg and "{" in msg:
                 msg = re.sub(r"Could not refresh token (\{.*?\})", "Could not refresh token {REDACTED_TOKEN_DATA}", msg)
 
-            # This provides defense-in-depth alongside the Gunicorn logger
             if "code=" in msg:
                 msg = re.sub(r'(code=)[^&"\s]*([&"\s]|$)', r"\1[REDACTED_AUTH_CODE]\2", msg)
 
@@ -30,22 +22,18 @@ class TokenSanitizingFilter(logging.Filter):
         return True
 
 
-# Ignore mypy error as GunicornLogger lacks proper type annotations in gunicorn stubs
-class RedactingGunicornLogger(GunicornLogger):  # type: ignore[misc]
-    """
-    Gunicorn logger that strips query strings from /oidc/authorize access logs.
-    """
+class RedactingUvicornLogger(logging.Filter):
+    """Strip the query string from /oidc/authorize* access logs."""
 
-    def access(self, resp: Any, req: Any, environ: Dict[str, Any], request_time: float) -> None:
-        path = environ.get("PATH_INFO", "")
-        query = environ.get("QUERY_STRING", "")
-
-        if path.startswith("/oidc/authorize"):
-            # Override WSGI variable used by Gunicorn's access log formatter
-            environ["RAW_URI"] = f"{path}?[REDACTED]"
-        else:
-            # Optional: Set RAW_URI for other paths to preserve default behavior
-            # so Gunicorn doesn't construct it from PATH_INFO + QUERY_STRING
-            environ["RAW_URI"] = f"{path}?{query}" if query else path
-
-        super().access(resp, req, environ, request_time)
+    def filter(self, record: logging.LogRecord) -> bool:
+        args = record.args
+        if not isinstance(args, tuple) or len(args) < 3:
+            return True
+        full_path = args[2]
+        if not isinstance(full_path, str) or "?" not in full_path:
+            return True
+        path, _, _ = full_path.partition("?")
+        if not path.startswith("/oidc/authorize"):
+            return True
+        record.args = (args[0], args[1], f"{path}?[REDACTED]", *args[3:])
+        return True

--- a/api/middleware.py
+++ b/api/middleware.py
@@ -27,7 +27,7 @@ from typing import Awaitable, Callable
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from api.config import settings
 from api.context import RequestContext, reset_request_context, set_request_context
@@ -173,7 +173,7 @@ class RequestObservabilityMiddleware:
         start = time.perf_counter()
         status_code = 500
 
-        async def _send(message: dict) -> None:
+        async def _send(message: Message) -> None:
             nonlocal status_code
             if message["type"] == "http.response.start":
                 status_code = message["status"]

--- a/api/middleware.py
+++ b/api/middleware.py
@@ -19,16 +19,20 @@ FastAPI route, which also runs through the app-wide dependency.
 
 from __future__ import annotations
 
+import logging
+import time
 import uuid
 from typing import Awaitable, Callable
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from api.config import settings
 from api.context import RequestContext, reset_request_context, set_request_context
 from api.extensions import _session_scope, db
+from api.plugins.metrics_reporter import get_metrics_reporter_hook
 
 CSP = (
     "default-src 'self'; "
@@ -151,3 +155,45 @@ class CacheControlMiddleware(BaseHTTPMiddleware):
             response.headers["Pragma"] = "no-cache"
             response.headers["Expires"] = "0"
         return response
+
+
+class RequestObservabilityMiddleware:
+    """Emit per-request counter and duration histogram via the metrics_reporter hook."""
+
+    _logger = logging.getLogger(__name__)
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        start = time.perf_counter()
+        status_code = 500
+
+        async def _send(message: dict) -> None:
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = message["status"]
+            await send(message)
+
+        try:
+            await self.app(scope, receive, _send)
+        finally:
+            duration_ms = (time.perf_counter() - start) * 1000.0
+            self._record(scope.get("method", ""), status_code, duration_ms)
+
+    def _record(self, method: str, status_code: int, duration_ms: float) -> None:
+        try:
+            hook = get_metrics_reporter_hook()
+        except Exception:
+            self._logger.exception("metrics_reporter hook unavailable; skipping emit")
+            return
+        tags = {"method": method, "status": str(status_code)}
+        try:
+            hook.record_counter(metric_name="requests", value=1, tags=tags)
+            hook.record_histogram(metric_name="request.duration", value=duration_ms, tags={**tags, "unit": "ms"})
+        except Exception:
+            self._logger.exception("metrics_reporter emit failed; continuing")

--- a/api/plugins/metrics_reporter.py
+++ b/api/plugins/metrics_reporter.py
@@ -18,8 +18,8 @@ class MetricsReporterPluginSpec:
     def record_counter(
         self,
         metric_name: str,
-        value: float = 1.0,
-        tags: Optional[Dict[str, str]] = None,
+        value: float,
+        tags: Optional[Dict[str, str]],
         monotonic: bool = True,
     ) -> None:
         """
@@ -27,9 +27,15 @@ class MetricsReporterPluginSpec:
 
         Args:
             metric_name: The metric name
-            value: The value to add (default 1.0)
-            tags: Optional tags
+            value: The value to add
+            tags: Optional tags (pass {} or None for no tags)
             monotonic: If True, counter only increases. If False, can decrease.
+
+        Note: pluggy 1.5+ does not forward caller kwargs that correspond to
+        impl parameters with default values. `metric_name`, `value`, and `tags`
+        are declared as required here so they reach implementations.
+        Implementations must mirror this since there are no defaults on these
+        three params.
         """
 
     @hookspec
@@ -46,7 +52,7 @@ class MetricsReporterPluginSpec:
         self,
         metric_name: str,
         value: float,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[Dict[str, str]],
         buckets: Optional[List[float]] = None,
     ) -> None:
         """
@@ -55,8 +61,10 @@ class MetricsReporterPluginSpec:
         Args:
             metric_name: The metric name
             value: The value to record
-            tags: Optional tags
+            tags: Tags (pass {} or None for no tags)
             buckets: Optional bucket boundaries for the histogram
+
+        Note: see record_counter `tags` is required so pluggy forwards it.
         """
 
     @hookspec

--- a/api/plugins/metrics_reporter.py
+++ b/api/plugins/metrics_reporter.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import sys
 from typing import ContextManager, Dict, List, Optional
@@ -9,6 +10,12 @@ hookspec = pluggy.HookspecMarker(metrics_reporter_plugin_name)
 hookimpl = pluggy.HookimplMarker(metrics_reporter_plugin_name)
 
 _cached_metrics_reporter_hook: Optional[pluggy.HookRelay] = None
+
+# Hooks whose value/tags carry per-call data. pluggy only forwards a caller
+# argument to an implementation when that parameter has no default, so an impl
+# that defaults value or tags silently discards the caller's metric data.
+_TAG_FORWARDING_HOOKS = ("record_counter", "record_gauge", "record_histogram", "record_summary")
+_MUST_NOT_DEFAULT = ("value", "tags")
 
 logger = logging.getLogger(__name__)
 
@@ -28,14 +35,11 @@ class MetricsReporterPluginSpec:
         Args:
             metric_name: The metric name
             value: The value to add
-            tags: Optional tags (pass {} or None for no tags)
+            tags: Tags for the metric (pass {} or None for no tags)
             monotonic: If True, counter only increases. If False, can decrease.
 
-        Note: pluggy 1.5+ does not forward caller kwargs that correspond to
-        impl parameters with default values. `metric_name`, `value`, and `tags`
-        are declared as required here so they reach implementations.
-        Implementations must mirror this since there are no defaults on these
-        three params.
+        Implementations must declare value and tags without defaults, or pluggy
+        silently drops the caller's values (see _verify_tag_forwarding).
         """
 
     @hookspec
@@ -43,7 +47,7 @@ class MetricsReporterPluginSpec:
         self,
         metric_name: str,
         value: float,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[Dict[str, str]],
     ) -> None:
         """Record a gauge metric value (snapshot/current value)."""
 
@@ -64,7 +68,7 @@ class MetricsReporterPluginSpec:
             tags: Tags (pass {} or None for no tags)
             buckets: Optional bucket boundaries for the histogram
 
-        Note: see record_counter `tags` is required so pluggy forwards it.
+        Note: see record_counter; tags is required so pluggy forwards it.
         """
 
     @hookspec
@@ -72,11 +76,13 @@ class MetricsReporterPluginSpec:
         self,
         metric_name: str,
         value: float,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[Dict[str, str]],
     ) -> None:
         """
         Record a value for summary statistics (percentiles, min, max, etc).
         This is similar to histogram but may be implemented differently by backends.
+
+        Note: see record_counter; tags is required so pluggy forwards it.
         """
 
     @hookspec
@@ -89,9 +95,9 @@ class MetricsReporterPluginSpec:
 
         Example:
             with metrics.batch_metrics():
-                metrics.record_counter("requests", 1)
-                metrics.record_gauge("queue_size", 42)
-                metrics.record_histogram("response_time", 0.123)
+                metrics.record_counter("requests", 1, tags={"method": "GET"})
+                metrics.record_gauge("queue_size", 42, tags=None)
+                metrics.record_histogram("response_time", 0.123, tags={"route": "/api"})
             # All metrics sent in one batch here
         """
         return NotImplemented
@@ -108,6 +114,35 @@ class MetricsReporterPluginSpec:
         """Force flush any buffered metrics to the backend."""
 
 
+def _verify_tag_forwarding(pm: pluggy.PluginManager) -> None:
+    """Fail fast if a registered implementation would make pluggy silently drop
+    a metric's value or tags.
+
+    pluggy forwards a caller argument to an implementation only when that
+    parameter has no default. An impl that defaults value or tags therefore
+    discards the caller's data without error. Raise so an org that upgrades
+    Access without updating its plugin sees the problem at startup.
+    """
+    offenders = []
+    for hook_name in _TAG_FORWARDING_HOOKS:
+        caller = getattr(pm.hook, hook_name, None)
+        if caller is None:
+            continue
+        for impl in caller.get_hookimpls():
+            params = inspect.signature(impl.function).parameters
+            defaulted = [
+                arg for arg in _MUST_NOT_DEFAULT if arg in params and params[arg].default is not inspect.Parameter.empty
+            ]
+            if defaulted:
+                offenders.append(f"{pm.get_name(impl.plugin)}.{hook_name} (defaults: {', '.join(defaulted)})")
+    if offenders:
+        raise RuntimeError(
+            "metrics_reporter implementations declare defaults for arguments that "
+            "pluggy then silently drops, discarding the metric's value/tags. Remove "
+            "the defaults from these implementation parameters: " + "; ".join(offenders)
+        )
+
+
 def get_metrics_reporter_hook() -> pluggy.HookRelay:
     global _cached_metrics_reporter_hook
 
@@ -122,6 +157,7 @@ def get_metrics_reporter_hook() -> pluggy.HookRelay:
 
     count = pm.load_setuptools_entrypoints(metrics_reporter_plugin_name)
     logger.debug(f"Count of loaded metrics reporter plugins: {count}")
+    _verify_tag_forwarding(pm)
     _cached_metrics_reporter_hook = pm.hook
 
     return _cached_metrics_reporter_hook

--- a/api/plugins/notifications.py
+++ b/api/plugins/notifications.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 import sys
-from typing import Generator, Optional
+from typing import Dict, Generator, Optional
 
 import pluggy
 
@@ -15,6 +15,7 @@ from api.models import (
     RoleGroupMap,
     RoleRequest,
 )
+from api.plugins.metrics_reporter import get_metrics_reporter_hook
 
 notification_plugin_name = "access_notifications"
 hookspec = pluggy.HookspecMarker(notification_plugin_name)
@@ -23,6 +24,13 @@ hookimpl = pluggy.HookimplMarker(notification_plugin_name)
 _cached_notification_hook: pluggy.HookRelay | None = None
 
 logger = logging.getLogger(__name__)
+
+
+def _record_sent(metric_name: str, tags: Optional[Dict[str, str]] = None) -> None:
+    try:
+        get_metrics_reporter_hook().record_counter(metric_name=metric_name, value=1, tags=tags)
+    except Exception:
+        logger.exception("Failed to record %s metric", metric_name)
 
 
 class NotificationPluginSpec:
@@ -146,12 +154,15 @@ def access_request_created(
     access_request: AccessRequest, group: OktaGroup, requester: OktaUser, approvers: list[OktaUser]
 ) -> Generator[None, None, None]:
     try:
-        return (yield)
+        result = yield
     except Exception:
         # Log and do not raise since notification failures should not
         # break the flow. Users can still manually ping approvers
         # to process their request from the UI
         logger.exception("Failed to execute access request created notification callback")
+        return
+    _record_sent("notifications.access_request_created.sent")
+    return result
 
 
 @hookimpl(wrapper=True)
@@ -163,12 +174,15 @@ def access_request_completed(
     notify_requester: bool,
 ) -> Generator[None, None, None]:
     try:
-        return (yield)
+        result = yield
     except Exception:
         # Log and do not raise since notification failures should not
         # break the flow. Users can still manually ping approvers
         # to process their request from the UI
         logger.exception("Failed to execute access request completed notification callback")
+        return
+    _record_sent("notifications.access_request_completed.sent")
+    return result
 
 
 @hookimpl(wrapper=True)
@@ -179,12 +193,15 @@ def access_expiring_user(
     okta_user_group_members: Optional[list[OktaUserGroupMember]],
 ) -> Generator[None, None, None]:
     try:
-        return (yield)
+        result = yield
     except Exception:
         # Log and do not raise since notification failures should not
         # break the flow. Users can still manually ping approvers
         # to process their request from the UI
         logger.exception("Failed to execute access expiring for user notification callback")
+        return
+    _record_sent("notifications.expiring_access.sent", tags={"kind": "user"})
+    return result
 
 
 @hookimpl(wrapper=True)
@@ -198,12 +215,15 @@ def access_expiring_owner(
     role_group_associations: Optional[list[RoleGroupMap]],
 ) -> Generator[None, None, None]:
     try:
-        return (yield)
+        result = yield
     except Exception:
         # Log and do not raise since notification failures should not
         # break the flow. Users can still manually ping approvers
         # to process their request from the UI
         logger.exception("Failed to execute access expiring for owner notification callback")
+        return
+    _record_sent("notifications.expiring_access.sent", tags={"kind": "owner"})
+    return result
 
 
 @hookimpl(wrapper=True)
@@ -213,12 +233,15 @@ def access_expiring_role_owner(
     expiration_datetime: datetime.datetime,
 ) -> Generator[None, None, None]:
     try:
-        return (yield)
+        result = yield
     except Exception:
         # Log and do not raise since notification failures should not
         # break the flow. Users can still manually ping approvers
         # to process their request from the UI
         logger.exception("Failed to execute access expiring for role owner notification callback")
+        return
+    _record_sent("notifications.expiring_access.sent", tags={"kind": "role_owner"})
+    return result
 
 
 @hookimpl(wrapper=True)
@@ -230,12 +253,15 @@ def access_role_request_created(
     approvers: list[OktaUser],
 ) -> Generator[None, None, None]:
     try:
-        return (yield)
+        result = yield
     except Exception:
         # Log and do not raise since notification failures should not
         # break the flow. Users can still manually ping approvers
         # to process their request from the UI
         logger.exception("Failed to execute role request created notification callback")
+        return
+    _record_sent("notifications.role_request_created.sent")
+    return result
 
 
 @hookimpl(wrapper=True)
@@ -248,12 +274,15 @@ def access_role_request_completed(
     notify_requester: bool,
 ) -> Generator[None, None, None]:
     try:
-        return (yield)
+        result = yield
     except Exception:
         # Log and do not raise since notification failures should not
         # break the flow. Users can still manually ping approvers
         # to process their request from the UI
         logger.exception("Failed to execute role request completed notification callback")
+        return
+    _record_sent("notifications.role_request_completed.sent")
+    return result
 
 
 @hookimpl(wrapper=True)
@@ -263,12 +292,15 @@ def access_group_request_created(
     approvers: list[OktaUser],
 ) -> Generator[None, None, None]:
     try:
-        return (yield)
+        result = yield
     except Exception:
         # Log and do not raise since notification failures should not
         # break the flow. Users can still manually ping approvers
         # to process their request from the UI
         logger.exception("Failed to execute group request created notification callback")
+        return
+    _record_sent("notifications.group_request_created.sent")
+    return result
 
 
 @hookimpl(wrapper=True)
@@ -280,12 +312,15 @@ def access_group_request_completed(
     notify_requester: bool,
 ) -> Generator[None, None, None]:
     try:
-        return (yield)
+        result = yield
     except Exception:
         # Log and do not raise since notification failures should not
         # break the flow. Users can still manually ping approvers
         # to process their request from the UI
         logger.exception("Failed to execute group request completed notification callback")
+        return
+    _record_sent("notifications.group_request_completed.sent")
+    return result
 
 
 def get_notification_hook() -> pluggy.HookRelay:

--- a/examples/plugins/datadog_metrics_reporter/metrics_reporter.py
+++ b/examples/plugins/datadog_metrics_reporter/metrics_reporter.py
@@ -77,7 +77,7 @@ class DatadogMetricsReporter:
 
     @metrics_reporter_hookimpl
     def record_counter(
-        self, metric_name: str, value: float = 1.0, tags: Optional[Dict[str, str]] = None, monotonic: bool = True
+        self, metric_name: str, value: float, tags: Optional[Dict[str, str]], monotonic: bool = True
     ) -> None:
         if not self.client:
             return
@@ -118,7 +118,7 @@ class DatadogMetricsReporter:
         self,
         metric_name: str,
         value: float,
-        tags: Optional[Dict[str, str]] = None,
+        tags: Optional[Dict[str, str]],
         buckets: Optional[List[float]] = None,
     ) -> None:
         if not self.client:

--- a/examples/plugins/datadog_metrics_reporter/metrics_reporter.py
+++ b/examples/plugins/datadog_metrics_reporter/metrics_reporter.py
@@ -99,7 +99,7 @@ class DatadogMetricsReporter:
             self.client.increment(metric_name, value=value, tags=formatted_tags)
 
     @metrics_reporter_hookimpl
-    def record_gauge(self, metric_name: str, value: float, tags: Optional[Dict[str, str]] = None) -> None:
+    def record_gauge(self, metric_name: str, value: float, tags: Optional[Dict[str, str]]) -> None:
         if not self.client:
             return
 
@@ -140,7 +140,7 @@ class DatadogMetricsReporter:
             self.client.histogram(metric_name, value=value, tags=formatted_tags)
 
     @metrics_reporter_hookimpl
-    def record_summary(self, metric_name: str, value: float, tags: Optional[Dict[str, str]] = None) -> None:
+    def record_summary(self, metric_name: str, value: float, tags: Optional[Dict[str, str]]) -> None:
         if not self.client:
             return
 

--- a/examples/plugins/datadog_metrics_reporter/setup.py
+++ b/examples/plugins/datadog_metrics_reporter/setup.py
@@ -5,6 +5,6 @@ setup(
     install_requires=["pluggy==1.5.0", "datadog>=0.49.0"],
     py_modules=["metrics_reporter"],
     entry_points={
-        "access_metrics_reporter": ["metrics_reporter = metrics_reporter"],
+        "access_metrics_reporter": ["metrics_reporter = metrics_reporter:datadog_metrics_plugin"],
     },
 )

--- a/tests/test_log_filters.py
+++ b/tests/test_log_filters.py
@@ -42,7 +42,5 @@ def test_passes_through_paths_without_query() -> None:
 
 
 def test_ignores_unexpected_record_shape() -> None:
-    record = logging.LogRecord(
-        name="x", level=logging.INFO, pathname="", lineno=0, msg="msg", args=(), exc_info=None
-    )
+    record = logging.LogRecord(name="x", level=logging.INFO, pathname="", lineno=0, msg="msg", args=(), exc_info=None)
     assert RedactingUvicornLogger().filter(record) is True

--- a/tests/test_log_filters.py
+++ b/tests/test_log_filters.py
@@ -5,7 +5,7 @@ import logging
 from api.log_filters import RedactingUvicornLogger
 
 
-def _record(args: tuple) -> logging.LogRecord:
+def _record(args: tuple[object, ...]) -> logging.LogRecord:
     return logging.LogRecord(
         name="uvicorn.access",
         level=logging.INFO,
@@ -20,25 +20,25 @@ def _record(args: tuple) -> logging.LogRecord:
 def test_redacts_oidc_authorize_query() -> None:
     record = _record(("1.2.3.4", "GET", "/oidc/authorize?code=secret&state=xyz", "1.1", 302))
     assert RedactingUvicornLogger().filter(record) is True
-    assert record.args[2] == "/oidc/authorize?[REDACTED]"
+    assert isinstance(record.args, tuple) and record.args[2] == "/oidc/authorize?[REDACTED]"
 
 
 def test_redacts_oidc_authorize_subpaths() -> None:
     record = _record(("1.2.3.4", "GET", "/oidc/authorize-callback?code=secret", "1.1", 302))
     assert RedactingUvicornLogger().filter(record) is True
-    assert record.args[2] == "/oidc/authorize-callback?[REDACTED]"
+    assert isinstance(record.args, tuple) and record.args[2] == "/oidc/authorize-callback?[REDACTED]"
 
 
 def test_passes_through_non_oidc_paths_with_query() -> None:
     record = _record(("1.2.3.4", "GET", "/api/users?page=0&per_page=20", "1.1", 200))
     assert RedactingUvicornLogger().filter(record) is True
-    assert record.args[2] == "/api/users?page=0&per_page=20"
+    assert isinstance(record.args, tuple) and record.args[2] == "/api/users?page=0&per_page=20"
 
 
 def test_passes_through_paths_without_query() -> None:
     record = _record(("1.2.3.4", "GET", "/api/users", "1.1", 200))
     assert RedactingUvicornLogger().filter(record) is True
-    assert record.args[2] == "/api/users"
+    assert isinstance(record.args, tuple) and record.args[2] == "/api/users"
 
 
 def test_ignores_unexpected_record_shape() -> None:

--- a/tests/test_log_filters.py
+++ b/tests/test_log_filters.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import logging
+
+from api.log_filters import RedactingUvicornLogger
+
+
+def _record(args: tuple) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg='%s - "%s %s HTTP/%s" %d',
+        args=args,
+        exc_info=None,
+    )
+
+
+def test_redacts_oidc_authorize_query() -> None:
+    record = _record(("1.2.3.4", "GET", "/oidc/authorize?code=secret&state=xyz", "1.1", 302))
+    assert RedactingUvicornLogger().filter(record) is True
+    assert record.args[2] == "/oidc/authorize?[REDACTED]"
+
+
+def test_redacts_oidc_authorize_subpaths() -> None:
+    record = _record(("1.2.3.4", "GET", "/oidc/authorize-callback?code=secret", "1.1", 302))
+    assert RedactingUvicornLogger().filter(record) is True
+    assert record.args[2] == "/oidc/authorize-callback?[REDACTED]"
+
+
+def test_passes_through_non_oidc_paths_with_query() -> None:
+    record = _record(("1.2.3.4", "GET", "/api/users?page=0&per_page=20", "1.1", 200))
+    assert RedactingUvicornLogger().filter(record) is True
+    assert record.args[2] == "/api/users?page=0&per_page=20"
+
+
+def test_passes_through_paths_without_query() -> None:
+    record = _record(("1.2.3.4", "GET", "/api/users", "1.1", 200))
+    assert RedactingUvicornLogger().filter(record) is True
+    assert record.args[2] == "/api/users"
+
+
+def test_ignores_unexpected_record_shape() -> None:
+    record = logging.LogRecord(
+        name="x", level=logging.INFO, pathname="", lineno=0, msg="msg", args=(), exc_info=None
+    )
+    assert RedactingUvicornLogger().filter(record) is True

--- a/tests/test_metrics_reporter_validation.py
+++ b/tests/test_metrics_reporter_validation.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import pluggy
+import pytest
+
+from api.plugins.metrics_reporter import (
+    MetricsReporterPluginSpec,
+    _verify_tag_forwarding,
+    hookimpl,
+    metrics_reporter_plugin_name,
+)
+
+
+def _manager_with(plugin: object) -> pluggy.PluginManager:
+    pm = pluggy.PluginManager(metrics_reporter_plugin_name)
+    pm.add_hookspecs(MetricsReporterPluginSpec)
+    pm.register(plugin)
+    return pm
+
+
+def test_accepts_impl_without_defaults() -> None:
+    class GoodPlugin:
+        @hookimpl
+        def record_counter(
+            self, metric_name: str, value: float, tags: Optional[dict[str, str]], monotonic: bool = True
+        ) -> None:
+            pass
+
+    _verify_tag_forwarding(_manager_with(GoodPlugin()))
+
+
+def test_raises_when_tags_has_default() -> None:
+    class BadPlugin:
+        @hookimpl
+        def record_counter(
+            self, metric_name: str, value: float, tags: Optional[dict[str, str]] = None, monotonic: bool = True
+        ) -> None:
+            pass
+
+    with pytest.raises(RuntimeError, match="record_counter"):
+        _verify_tag_forwarding(_manager_with(BadPlugin()))

--- a/tests/test_notification_metrics.py
+++ b/tests/test_notification_metrics.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import inspect
+from typing import Any, Callable, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+import api.plugins.notifications as notifications_module
+from api.plugins import notifications
+
+WRAPPERS: list[tuple[str, str, Optional[dict[str, str]]]] = [
+    ("access_request_created", "notifications.access_request_created.sent", None),
+    ("access_request_completed", "notifications.access_request_completed.sent", None),
+    ("access_expiring_user", "notifications.expiring_access.sent", {"kind": "user"}),
+    ("access_expiring_owner", "notifications.expiring_access.sent", {"kind": "owner"}),
+    ("access_expiring_role_owner", "notifications.expiring_access.sent", {"kind": "role_owner"}),
+    ("access_role_request_created", "notifications.role_request_created.sent", None),
+    ("access_role_request_completed", "notifications.role_request_completed.sent", None),
+    ("access_group_request_created", "notifications.group_request_created.sent", None),
+    ("access_group_request_completed", "notifications.group_request_completed.sent", None),
+]
+
+
+def _kwargs_for(wrapper_fn: Callable[..., Any]) -> dict[str, Any]:
+    sig = inspect.signature(wrapper_fn)
+    return {name: True if name == "notify_requester" else None for name in sig.parameters}
+
+
+def _drive_success(wrapper_fn: Callable[..., Any]) -> None:
+    gen = wrapper_fn(**_kwargs_for(wrapper_fn))
+    next(gen)
+    with pytest.raises(StopIteration):
+        gen.send(None)
+
+
+def _drive_failure(wrapper_fn: Callable[..., Any], exc: BaseException) -> None:
+    gen = wrapper_fn(**_kwargs_for(wrapper_fn))
+    next(gen)
+    with pytest.raises(StopIteration):
+        gen.throw(exc)
+
+
+@pytest.fixture
+def fake_hook(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    fake = MagicMock()
+    monkeypatch.setattr(notifications_module, "get_metrics_reporter_hook", lambda: fake)
+    return fake
+
+
+@pytest.mark.parametrize("wrapper_name,metric,tags", WRAPPERS)
+def test_wrapper_emits_counter_on_success(
+    fake_hook: MagicMock, wrapper_name: str, metric: str, tags: Optional[dict[str, str]]
+) -> None:
+    _drive_success(getattr(notifications, wrapper_name))
+    fake_hook.record_counter.assert_called_once_with(metric_name=metric, value=1, tags=tags)
+
+
+@pytest.mark.parametrize("wrapper_name", [w[0] for w in WRAPPERS])
+def test_wrapper_does_not_emit_counter_on_failure(fake_hook: MagicMock, wrapper_name: str) -> None:
+    _drive_failure(getattr(notifications, wrapper_name), RuntimeError("inner plugin blew up"))
+    fake_hook.record_counter.assert_not_called()
+
+
+def test_metric_emit_failure_does_not_break_wrapper(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom() -> Any:
+        raise RuntimeError("metrics_reporter unavailable")
+
+    monkeypatch.setattr(notifications_module, "get_metrics_reporter_hook", boom)
+    _drive_success(notifications.access_request_created)

--- a/tests/test_request_observability_middleware.py
+++ b/tests/test_request_observability_middleware.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.middleware as middleware_module
+
+
+@pytest.fixture
+def fake_hook(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    fake = MagicMock()
+    monkeypatch.setattr(middleware_module, "get_metrics_reporter_hook", lambda: fake)
+    return fake
+
+
+def test_emits_counter_and_histogram_per_request(
+    app: FastAPI, client: TestClient, db: Any, fake_hook: MagicMock
+) -> None:
+    rep = client.get("/api/healthz")
+    assert rep.status_code == 200
+
+    fake_hook.record_counter.assert_called_once()
+    counter_kwargs = fake_hook.record_counter.call_args.kwargs
+    assert counter_kwargs == {"metric_name": "requests", "value": 1, "tags": {"method": "GET", "status": "200"}}
+
+    fake_hook.record_histogram.assert_called_once()
+    hist_kwargs = fake_hook.record_histogram.call_args.kwargs
+    assert hist_kwargs["metric_name"] == "request.duration"
+    assert isinstance(hist_kwargs["value"], float) and hist_kwargs["value"] >= 0
+    assert hist_kwargs["tags"] == {"method": "GET", "status": "200", "unit": "ms"}
+
+
+def test_tags_record_non_2xx_status(
+    app: FastAPI, client: TestClient, db: Any, fake_hook: MagicMock
+) -> None:
+    rep = client.get("/api/this-route-does-not-exist")
+    assert rep.status_code == 404
+    assert fake_hook.record_counter.call_args.kwargs["tags"]["status"] == "404"
+    assert fake_hook.record_histogram.call_args.kwargs["tags"]["status"] == "404"
+
+
+def test_does_not_emit_an_access_log_line(
+    app: FastAPI, client: TestClient, db: Any, fake_hook: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.INFO)
+    client.get("/api/healthz")
+    assert [r for r in caplog.records if r.name.startswith("api.middleware")] == []
+
+
+def test_request_survives_plugin_hook_failure(
+    app: FastAPI, client: TestClient, db: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def boom() -> Any:
+        raise RuntimeError("plugin manager not initialised")
+
+    monkeypatch.setattr(middleware_module, "get_metrics_reporter_hook", boom)
+    rep = client.get("/api/healthz")
+    assert rep.status_code == 200

--- a/tests/test_request_observability_middleware.py
+++ b/tests/test_request_observability_middleware.py
@@ -35,9 +35,7 @@ def test_emits_counter_and_histogram_per_request(
     assert hist_kwargs["tags"] == {"method": "GET", "status": "200", "unit": "ms"}
 
 
-def test_tags_record_non_2xx_status(
-    app: FastAPI, client: TestClient, db: Any, fake_hook: MagicMock
-) -> None:
+def test_tags_record_non_2xx_status(app: FastAPI, client: TestClient, db: Any, fake_hook: MagicMock) -> None:
     rep = client.get("/api/this-route-does-not-exist")
     assert rep.status_code == 404
     assert fake_hook.record_counter.call_args.kwargs["tags"]["status"] == "404"


### PR DESCRIPTION
# Summary

Before the migration to FastAPI, Flask ran directly under gunicorn, and gunicorn's built-in statsd integration emitted `access.gunicorn.requests` and `access.gunicorn.request.duration.*` because gunicorn handled every HTTP request. After the migration to `gunicorn -k uvicorn.workers.UvicornWorker`, uvicorn handles HTTP and gunicorn only spawns workers. The notification metrics were a separate gap of the same shape

As a result, nothing inside gunicorn ever calls into statsd per request so emission stopped entirely.

## What this PR does
- New ASGI middleware emits `access.requests` and `access.request.duration` per request via the existing `metrics_reporter` plugin hook.
- Each notification wrapper emits `access.notifications.{event}.sent` on successful delivery (with `kind:` tag on the three expiring-access variants).
- OIDC query-string redaction moved from the dead `RedactingGunicornLogger` to a `logging.Filter` on `uvicorn.access`.