### PR TITLE
Adopt RFC 9457 problem-detail error format

### DIFF
--- a/POST_MIGRATION_TODO.md
+++ b/POST_MIGRATION_TODO.md
@@ -61,13 +61,6 @@ Pydantic emits `None` fields as `"key": null` by default. Switch responses
 to `model_dump(exclude_none=True)` and update the frontend to handle missing
 keys as None.
 
-### 7. Adopt RFC 9457 problem-detail error format
-
-Today: `{"message": "..."}` (matches the legacy Flask envelope).
-Future: `{"type": "...", "title": "...", "status": 400, "detail": "..."}`
-(FastAPI / RFC 9457 standard). Update `api/exception_handlers.py` and the
-frontend.
-
 ### 8. Replace `paginate()` with `fastapi-pagination`
 
 Drop the hand-rolled `{total, pages, next, prev, results}` envelope in

--- a/api/exception_handlers.py
+++ b/api/exception_handlers.py
@@ -1,12 +1,21 @@
-"""FastAPI exception handlers — emit the `{"message": ...}` envelope used
-by the React frontend. FastAPI's default is `{"detail": ...}`; we override
-across `HTTPException`, `RequestValidationError`, and the catch-all
-`Exception` handler so the wire shape stays consistent. Adopting the
-RFC 9457 problem-detail format is a follow-up (POST_MIGRATION_TODO #7)."""
+"""FastAPI exception handlers — emit the RFC 9457 problem-detail envelope.
+
+All HTTP errors cross the wire as
+`{"type": "about:blank", "title": "<reason>", "status": <code>, "detail": "<message>"}`
+with `Content-Type: application/problem+json`. Validation errors include a
+non-standard `errors:` extension with the full FastAPI/Pydantic error list
+for clients that want it.
+
+`PluginNotFoundError` is the lone outlier: it emits `{"error": ...}` because
+the React plugin-admin page reads `error` (not `detail`). Migrating that page
+to RFC 9457 is a separate, frontend-coupled change.
+"""
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
+from http import HTTPStatus
 from pathlib import Path
 from typing import Any
 
@@ -26,12 +35,44 @@ logger = logging.getLogger(__name__)
 
 INDEX_HTML = Path(__file__).resolve().parent.parent / "build" / "index.html"
 
+PROBLEM_JSON = "application/problem+json"
+
 
 def _is_api(request: Request) -> bool:
     return request.url.path.startswith("/api/") or request.url.path == "/api"
 
 
-def _format_validation_error(exc: RequestValidationError | ValidationError) -> str:
+def _problem(
+    *,
+    status_code: int,
+    detail: str,
+    title: str | None = None,
+    extras: dict[str, Any] | None = None,
+    headers: Mapping[str, str] | None = None,
+) -> JSONResponse:
+    """Build a `JSONResponse` with the RFC 9457 problem-detail envelope.
+
+    `type` defaults to `"about:blank"` — we'll grow a typed URI scheme later if
+    a specific error class needs it.
+    """
+    body: dict[str, Any] = {
+        "type": "about:blank",
+        "title": title or HTTPStatus(status_code).phrase,
+        "status": status_code,
+        "detail": detail,
+    }
+    if extras:
+        body.update(extras)
+    return JSONResponse(
+        body,
+        status_code=status_code,
+        media_type=PROBLEM_JSON,
+        headers=headers,
+    )
+
+
+def _format_validation_detail(exc: RequestValidationError | ValidationError) -> str:
+    """First-error human-readable summary, kept short for UI surfaces."""
     errors = exc.errors()
     if not errors:
         return "Validation error"
@@ -43,28 +84,74 @@ def _format_validation_error(exc: RequestValidationError | ValidationError) -> s
     return str(msg)
 
 
+def _validation_errors(exc: RequestValidationError | ValidationError) -> list[dict[str, Any]]:
+    """Sanitize FastAPI/Pydantic's `.errors()` for the wire.
+
+    Drops the bound `input` value because it may include caller data we don't
+    want to echo. `ctx` can contain non-JSON-serializable values (e.g. a raw
+    `ValueError` instance) — stringify those.
+    """
+    out: list[dict[str, Any]] = []
+    for err in exc.errors():
+        clean: dict[str, Any] = {}
+        for k, v in err.items():
+            if k == "input":
+                continue
+            if k == "ctx" and isinstance(v, dict):
+                clean["ctx"] = {ck: str(cv) for ck, cv in v.items()}
+            else:
+                clean[k] = v
+        out.append(clean)
+    return out
+
+
 async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse | HTMLResponse:
     detail = exc.detail
     # Cloudflare and other 404s for non-/api/ paths should serve the SPA.
     if exc.status_code == 404 and not _is_api(request):
         if INDEX_HTML.exists():
             return HTMLResponse(INDEX_HTML.read_text(), status_code=200)
-        return JSONResponse({"message": "Not Found"}, status_code=404)
-    if isinstance(detail, (str, type(None))):
-        body: dict[str, Any] = {"message": detail or ""}
-    elif isinstance(detail, dict):
-        body = detail
+        return _problem(status_code=404, detail="Not Found", headers=exc.headers or None)
+    # When the handler raises `HTTPException(detail={...})` it's already
+    # supplying a structured body — pass it through as the problem-detail
+    # `detail` field instead of stringifying it.
+    extras: dict[str, Any] | None = None
+    if isinstance(detail, dict):
+        detail_str = detail.get("detail") or detail.get("message") or ""
+        extras = {k: v for k, v in detail.items() if k not in ("detail", "message")}
+        return _problem(
+            status_code=exc.status_code,
+            detail=str(detail_str),
+            extras=extras or None,
+            headers=exc.headers or None,
+        )
+    if detail is None:
+        detail_str = ""
     else:
-        body = {"message": str(detail)}
-    return JSONResponse(body, status_code=exc.status_code, headers=exc.headers or None)
+        detail_str = str(detail)
+    return _problem(
+        status_code=exc.status_code,
+        detail=detail_str,
+        headers=exc.headers or None,
+    )
 
 
 async def request_validation_handler(request: Request, exc: RequestValidationError) -> JSONResponse:
-    return JSONResponse({"message": _format_validation_error(exc)}, status_code=400)
+    return _problem(
+        status_code=400,
+        title="Bad Request",
+        detail=_format_validation_detail(exc),
+        extras={"errors": _validation_errors(exc)},
+    )
 
 
 async def pydantic_validation_handler(request: Request, exc: ValidationError) -> JSONResponse:
-    return JSONResponse({"message": _format_validation_error(exc)}, status_code=400)
+    return _problem(
+        status_code=400,
+        title="Bad Request",
+        detail=_format_validation_detail(exc),
+        extras={"errors": _validation_errors(exc)},
+    )
 
 
 async def oidc_redirect_handler(request: Request, exc: OIDCRedirectRequired) -> RedirectResponse:
@@ -73,8 +160,10 @@ async def oidc_redirect_handler(request: Request, exc: OIDCRedirectRequired) -> 
 
 
 async def plugin_not_found_handler(request: Request, exc: PluginNotFoundError) -> JSONResponse:
-    # The React client reads `error` (not `message`) from these endpoints,
-    # so this handler diverges from the shared `{"message": ...}` envelope.
+    # The React plugin-admin client reads `error` (not `detail`) from these
+    # endpoints, so this handler diverges from the shared RFC 9457 envelope.
+    # Migrating it requires a coordinated frontend change — tracked as future
+    # follow-up; out of scope for the RFC 9457 conversion.
     return JSONResponse({"error": f"Plugin '{exc.plugin_id}' not found"}, status_code=404)
 
 
@@ -84,10 +173,10 @@ async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONR
         # Return a static body — `str(exc)` for SQLAlchemy errors leaks the
         # full SQL statement, table/column names, and bound parameters.
         # Diagnostics already go to the log pipeline via logger.exception.
-        return JSONResponse({"message": "Internal Server Error"}, status_code=500)
+        return _problem(status_code=500, detail="Internal Server Error")
     if INDEX_HTML.exists():
         return HTMLResponse(INDEX_HTML.read_text(), status_code=200)
-    return JSONResponse({"message": "Internal Server Error"}, status_code=500)
+    return _problem(status_code=500, detail="Internal Server Error")
 
 
 def install(app: FastAPI) -> None:

--- a/src/api/apiFetcher.ts
+++ b/src/api/apiFetcher.ts
@@ -4,8 +4,20 @@ const baseUrl = import.meta.env.VITE_API_SERVER_URL;
 
 export type ErrorWrapper<TError> = TError | {status: 'unknown'; payload: string};
 
+// RFC 9457 problem-detail envelope. `detail` is the human-readable message
+// the React client surfaces; `title`, `status`, `type` are RFC standard.
+// Validation errors carry an extra non-standard `errors[]` list.
 export type ErrorMessage = {
-  message: string;
+  type?: string;
+  title?: string;
+  status?: number;
+  detail?: string;
+  errors?: Array<{
+    type?: string;
+    loc?: Array<string | number>;
+    msg?: string;
+    ctx?: Record<string, unknown>;
+  }>;
 };
 
 export type ApiFetcherOptions<TBody, THeaders, TQueryParams, TPathParams> = {
@@ -70,9 +82,11 @@ export async function apiFetch<
       payload:
         e instanceof Error
           ? `Network error (${e.message})`
-          : (e as ErrorMessage).message != null
-            ? (e as ErrorMessage).message
-            : 'Network error',
+          : (e as ErrorMessage).detail != null
+            ? (e as ErrorMessage).detail!
+            : (e as ErrorMessage).title != null
+              ? (e as ErrorMessage).title!
+              : 'Network error',
     };
   }
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -796,12 +796,14 @@ def test_put_app_logs_audit_on_rename(
 def test_post_app_validation_via_http(client: TestClient, db: Db, url_for: Any) -> None:
     """Body validation enforced at the HTTP layer (not just Pydantic-level).
     The project's request_validation_handler converts 422 → 400 with the
-    `{"message": ...}` envelope."""
+    RFC 9457 problem-detail envelope."""
     apps_url = url_for("api-apps.apps")
 
     rep = client.post(apps_url, json={"name": ""})
     assert rep.status_code == 400
-    assert "message" in rep.json()
+    body = rep.json()
+    assert body["status"] == 400
+    assert "detail" in body
 
     rep = client.post(apps_url, json={"name": "MyApp", "description": "x" * 1025})
     assert rep.status_code == 400

--- a/tests/test_app_group_lifecycle_plugin.py
+++ b/tests/test_app_group_lifecycle_plugin.py
@@ -315,8 +315,8 @@ class TestPluginAPIEndpoints:
         `{"error": "..."}` (the React client reads the `error` field).
         The plugin router raises `PluginNotFoundError`, which the
         exception handler in `api/exception_handlers.py` serializes with
-        the `error` envelope — distinct from the global `{"message": ...}`
-        shape used by every other HTTPException."""
+        the `error` envelope — distinct from the global RFC 9457
+        problem-detail envelope used by every other HTTPException."""
         for endpoint in (
             "api-plugins.app_group_lifecycle_plugin_app_config_props",
             "api-plugins.app_group_lifecycle_plugin_group_config_props",


### PR DESCRIPTION
## Summary
One of four PRs splitting the original combined wire-shape change ([#454](https://github.com/discord/access/pull/454)) into focused, independently reviewable pieces. Each targets `main` directly.

Replaces the legacy `{"message": "..."}` Flask error envelope with the [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457) problem-detail shape — `{"type", "title", "status", "detail"}` served as `application/problem+json`. Validation errors include a non-standard `errors` extension carrying the full FastAPI/Pydantic error list.

- `api/exception_handlers.py` rewritten around a `_problem()` helper covering `HTTPException`, `RequestValidationError`, `ValidationError`, and the catch-all `Exception` handler.
- `PluginNotFoundError` keeps its `{"error": ...}` envelope (the React plugin-admin page reads `error`) — converting it needs a coordinated frontend change, out of scope here.
- Frontend `apiFetcher.ts` reads `body.detail` / `body.title` instead of `body.message`.

This is a **breaking** wire-shape change for API clients.

Closes POST_MIGRATION_TODO.md item #7.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy .` — no new errors (the 22 pre-existing `api/mcp/tools.py` errors are on `main` already)
- [x] `pytest tests/test_app.py tests/test_app_group_lifecycle_plugin.py` — 81 passed
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ⚠️ Cross-dependency with the sibling split PRs
This is one of four independent PRs splitting the original combined wire-shape change, all branched off `main` (not stacked, so they can merge in any order — but a couple of files overlap and will conflict on merge):

- #454 — rename `resolution_reason` → `reason` (item 22)
- #464 — ISO 8601 datetimes (item 5)
- #465 — exclude_none + fastapi-pagination (items 6 & 8)

This PR is the most isolated of the four (it owns `api/exception_handlers.py` + `apiFetcher.ts`). Its only shared files:
- `POST_MIGRATION_TODO.md` — every split PR deletes its own item section (conflicts with all three).
- `tests/test_app.py` — also edited by #465 (`results`→`items`); this PR changes the validation-error assertion.

After any sibling merges, rebase this branch and re-resolve those two files.
