### PR TITLE
Approve/reject operations silently no-op on stale state; no row-level       locking

### DIFF
--- a/api/exception_handlers.py
+++ b/api/exception_handlers.py
@@ -29,6 +29,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.requests import Request
 
 from api.auth.dependencies import OIDCRedirectRequired
+from api.exceptions import AccessException
 from api.plugins.app_group_lifecycle import PluginNotFoundError
 
 logger = logging.getLogger(__name__)
@@ -167,6 +168,12 @@ async def plugin_not_found_handler(request: Request, exc: PluginNotFoundError) -
     return JSONResponse({"error": f"Plugin '{exc.plugin_id}' not found"}, status_code=404)
 
 
+async def access_exception_handler(request: Request, exc: AccessException) -> JSONResponse:
+    # Domain errors raised by the operations layer. Mapped to the shared RFC
+    # 9457 envelope using the status code the exception carries.
+    return _problem(status_code=exc.status_code, detail=exc.detail)
+
+
 async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse | HTMLResponse:
     logger.exception("Unhandled exception", exc_info=exc)
     if _is_api(request):
@@ -186,4 +193,5 @@ def install(app: FastAPI) -> None:
     app.add_exception_handler(ValidationError, pydantic_validation_handler)  # type: ignore[arg-type]
     app.add_exception_handler(OIDCRedirectRequired, oidc_redirect_handler)  # type: ignore[arg-type]
     app.add_exception_handler(PluginNotFoundError, plugin_not_found_handler)  # type: ignore[arg-type]
+    app.add_exception_handler(AccessException, access_exception_handler)  # type: ignore[arg-type]
     app.add_exception_handler(Exception, unhandled_exception_handler)

--- a/api/exceptions.py
+++ b/api/exceptions.py
@@ -1,0 +1,46 @@
+"""Domain exceptions raised by the operations layer.
+
+Operations are decoupled from the FastAPI/HTTP stack, so they raise these
+instead of `HTTPException`. `api.exception_handlers` maps any `AccessException`
+to the RFC 9457 problem-detail response via its `status_code`. Callers outside
+an HTTP request (the syncer, CLI commands) can catch `AccessException` directly.
+"""
+
+from __future__ import annotations
+
+
+class AccessException(Exception):
+    """Base class for operation-layer domain errors.
+
+    `status_code` is the HTTP status the exception handler emits when this
+    propagates out of an API request. Subclasses pin a default; the constructor
+    can override it for one-off cases.
+    """
+
+    status_code: int = 400
+
+    def __init__(self, detail: str, *, status_code: int | None = None) -> None:
+        self.detail = detail
+        if status_code is not None:
+            self.status_code = status_code
+        super().__init__(detail)
+
+
+class ConflictError(AccessException):
+    """The resource's current state conflicts with the requested action
+    (e.g. a request that has already been resolved)."""
+
+    status_code = 409
+
+
+class ResourceGoneError(AccessException):
+    """A resource the action depends on no longer exists (soft-deleted)."""
+
+    status_code = 410
+
+
+class InvalidRequestError(AccessException):
+    """The action is invalid for the resource's current configuration
+    (e.g. a group that is not managed by Access)."""
+
+    status_code = 400

--- a/api/operations/approve_access_request.py
+++ b/api/operations/approve_access_request.py
@@ -4,6 +4,7 @@ from typing import Optional
 import logging
 
 from api.context import get_request_context
+from fastapi import HTTPException
 from sqlalchemy.orm import joinedload, selectin_polymorphic
 
 from api.extensions import db
@@ -24,10 +25,16 @@ class ApproveAccessRequest:
         ending_at: Optional[datetime] = None,
         notify: bool = True,
     ):
+        # Lock the request row for the duration of the transaction so two
+        # concurrent approvers can't both pass the pending-state guard below
+        # and double-grant. `of=AccessRequest` keeps FOR UPDATE off the
+        # joinedload's nullable outer-join side (Postgres rejects that); it's
+        # a no-op on SQLite.
         self.access_request = (
             db.session.query(AccessRequest)
             .options(joinedload(AccessRequest.active_requested_group))
             .filter(AccessRequest.id == (access_request if isinstance(access_request, str) else access_request.id))
+            .with_for_update(of=AccessRequest)
             .first()
         )
 
@@ -51,9 +58,11 @@ class ApproveAccessRequest:
         self.notification_hook = get_notification_hook()
 
     def execute(self) -> AccessRequest:
-        # Don't allow approving a request that is already resolved
+        # Don't allow approving a request that is already resolved. Raise
+        # rather than silently no-op so a stale/concurrent approval surfaces
+        # as a conflict instead of looking like a success.
         if self.access_request.status != AccessRequestStatus.PENDING or self.access_request.resolved_at is not None:
-            return self.access_request
+            raise HTTPException(409, "Access request is no longer pending")
 
         # Don't allow requester to approve their own request
         if self.access_request.requester_user_id == self.approver_id:
@@ -72,13 +81,13 @@ class ApproveAccessRequest:
         # Don't allow approving a request if the requester is deleted
         requester = db.session.get(OktaUser, self.access_request.requester_user_id)
         if requester is None or requester.deleted_at is not None:
-            return self.access_request
+            raise HTTPException(410, "The requester no longer exists")
 
-        # Don't allow approving a request for an a deleted or unmanaged group
+        # Don't allow approving a request for a deleted or unmanaged group
         if self.access_request.active_requested_group is None:
-            return self.access_request
+            raise HTTPException(410, "The requested group no longer exists")
         if not self.access_request.active_requested_group.is_managed:
-            return self.access_request
+            raise HTTPException(400, "Groups not managed by Access cannot be modified")
 
         # Now handled inside ModifyGroupUsers
         # self.access_request.status = AccessRequestStatus.APPROVED

--- a/api/operations/approve_access_request.py
+++ b/api/operations/approve_access_request.py
@@ -4,8 +4,9 @@ from typing import Optional
 import logging
 
 from api.context import get_request_context
-from fastapi import HTTPException
 from sqlalchemy.orm import joinedload, selectin_polymorphic
+
+from api.exceptions import ConflictError, InvalidRequestError, ResourceGoneError
 
 from api.extensions import db
 from api.models import AccessRequest, AccessRequestStatus, AppGroup, OktaGroup, OktaUser, RoleGroup
@@ -62,7 +63,7 @@ class ApproveAccessRequest:
         # rather than silently no-op so a stale/concurrent approval surfaces
         # as a conflict instead of looking like a success.
         if self.access_request.status != AccessRequestStatus.PENDING or self.access_request.resolved_at is not None:
-            raise HTTPException(409, "Access request is no longer pending")
+            raise ConflictError("Access request is no longer pending")
 
         # Don't allow requester to approve their own request
         if self.access_request.requester_user_id == self.approver_id:
@@ -81,13 +82,13 @@ class ApproveAccessRequest:
         # Don't allow approving a request if the requester is deleted
         requester = db.session.get(OktaUser, self.access_request.requester_user_id)
         if requester is None or requester.deleted_at is not None:
-            raise HTTPException(410, "The requester no longer exists")
+            raise ResourceGoneError("The requester no longer exists")
 
         # Don't allow approving a request for a deleted or unmanaged group
         if self.access_request.active_requested_group is None:
-            raise HTTPException(410, "The requested group no longer exists")
+            raise ResourceGoneError("The requested group no longer exists")
         if not self.access_request.active_requested_group.is_managed:
-            raise HTTPException(400, "Groups not managed by Access cannot be modified")
+            raise InvalidRequestError("Groups not managed by Access cannot be modified")
 
         # Now handled inside ModifyGroupUsers
         # self.access_request.status = AccessRequestStatus.APPROVED

--- a/api/operations/approve_group_request.py
+++ b/api/operations/approve_group_request.py
@@ -3,6 +3,7 @@ from typing import Optional
 import logging
 
 from api.context import get_request_context
+from fastapi import HTTPException
 from sqlalchemy import func
 from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload, with_polymorphic
 
@@ -38,10 +39,15 @@ class ApproveGroupRequest:
         notify: bool = True,
         bypass_self_approval: bool = False,
     ):
+        # Lock the request row for the transaction so concurrent approvers
+        # can't both pass the pending-state guard and double-create the group.
+        # `of=` keeps FOR UPDATE off the joinedload's nullable outer-join side
+        # (Postgres rejects that); no-op on SQLite.
         self.group_request = (
             db.session.query(GroupRequest)
             .options(joinedload(GroupRequest.active_requester))
             .filter(GroupRequest.id == (group_request if isinstance(group_request, str) else group_request.id))
+            .with_for_update(of=GroupRequest)
             .first()
         )
 
@@ -66,15 +72,20 @@ class ApproveGroupRequest:
         if self.group_request is None:
             return None
 
-        # Don't allow approving a request that is already resolved
+        # Don't allow approving a request that is already resolved. Raise
+        # rather than silently no-op so a stale/concurrent approval surfaces
+        # as a conflict instead of looking like a success.
         if self.group_request.status != AccessRequestStatus.PENDING or self.group_request.resolved_at is not None:
-            return self.group_request
+            raise HTTPException(409, "Group request is no longer pending")
 
         # Don't allow requester to approve their own request
         if self.group_request.requester_user_id == self.approver_id and not self.bypass_self_approval:
             return self.group_request
 
-        # Don't allow approving a request if the requester is deleted
+        # Don't allow approving a request if the requester is deleted. (Note:
+        # a deleted requester usually can't even load above — active_requester
+        # is an inner join filtering deleted_at — so this is a belt-and-braces
+        # check that mirrors the historical no-op rather than a 4xx path.)
         requester = db.session.get(OktaUser, self.group_request.requester_user_id)
         if requester is None or requester.deleted_at is not None:
             return self.group_request

--- a/api/operations/approve_group_request.py
+++ b/api/operations/approve_group_request.py
@@ -3,10 +3,10 @@ from typing import Optional
 import logging
 
 from api.context import get_request_context
-from fastapi import HTTPException
 from sqlalchemy import func
 from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload, with_polymorphic
 
+from api.exceptions import ConflictError
 from api.extensions import db
 from api.models import (
     AccessRequestStatus,
@@ -76,7 +76,7 @@ class ApproveGroupRequest:
         # rather than silently no-op so a stale/concurrent approval surfaces
         # as a conflict instead of looking like a success.
         if self.group_request.status != AccessRequestStatus.PENDING or self.group_request.resolved_at is not None:
-            raise HTTPException(409, "Group request is no longer pending")
+            raise ConflictError("Group request is no longer pending")
 
         # Don't allow requester to approve their own request
         if self.group_request.requester_user_id == self.approver_id and not self.bypass_self_approval:

--- a/api/operations/approve_role_request.py
+++ b/api/operations/approve_role_request.py
@@ -4,6 +4,7 @@ from typing import Optional
 import logging
 
 from api.context import get_request_context
+from fastapi import HTTPException
 from sqlalchemy.orm import joinedload, selectin_polymorphic
 
 from api.extensions import db
@@ -24,10 +25,15 @@ class ApproveRoleRequest:
         ending_at: Optional[datetime] = None,
         notify: bool = True,
     ):
+        # Lock the request row for the transaction so concurrent approvers
+        # can't both pass the pending-state guard and double-grant. `of=` keeps
+        # FOR UPDATE off the joinedloads' nullable outer-join sides (Postgres
+        # rejects that); no-op on SQLite.
         self.role_request = (
             db.session.query(RoleRequest)
             .options(joinedload(RoleRequest.active_requested_group), joinedload(RoleRequest.active_requester_role))
             .filter(RoleRequest.id == (role_request if isinstance(role_request, str) else role_request.id))
+            .with_for_update(of=RoleRequest)
             .first()
         )
 
@@ -51,9 +57,11 @@ class ApproveRoleRequest:
         self.notification_hook = get_notification_hook()
 
     def execute(self) -> RoleRequest:
-        # Don't allow approving a request that is already resolved
+        # Don't allow approving a request that is already resolved. Raise
+        # rather than silently no-op so a stale/concurrent approval surfaces
+        # as a conflict instead of looking like a success.
         if self.role_request.status != AccessRequestStatus.PENDING or self.role_request.resolved_at is not None:
-            return self.role_request
+            raise HTTPException(409, "Role request is no longer pending")
 
         # Don't allow requester to approve their own request
         if self.role_request.requester_user_id == self.approver_id:
@@ -72,13 +80,13 @@ class ApproveRoleRequest:
         # Don't allow approving a request if the requester role is deleted
         requester = db.session.get(RoleGroup, self.role_request.requester_role_id)
         if requester is None or requester.deleted_at is not None:
-            return self.role_request
+            raise HTTPException(410, "The requester role no longer exists")
 
-        # Don't allow approving a request for an a deleted or unmanaged group
+        # Don't allow approving a request for a deleted or unmanaged group
         if self.role_request.active_requested_group is None:
-            return self.role_request
+            raise HTTPException(410, "The requested group no longer exists")
         if not self.role_request.active_requested_group.is_managed:
-            return self.role_request
+            raise HTTPException(400, "Groups not managed by Access cannot be modified")
 
         db.session.commit()
 

--- a/api/operations/approve_role_request.py
+++ b/api/operations/approve_role_request.py
@@ -4,8 +4,9 @@ from typing import Optional
 import logging
 
 from api.context import get_request_context
-from fastapi import HTTPException
 from sqlalchemy.orm import joinedload, selectin_polymorphic
+
+from api.exceptions import ConflictError, InvalidRequestError, ResourceGoneError
 
 from api.extensions import db
 from api.models import AccessRequestStatus, AppGroup, OktaGroup, OktaUser, RoleGroup, RoleRequest
@@ -61,7 +62,7 @@ class ApproveRoleRequest:
         # rather than silently no-op so a stale/concurrent approval surfaces
         # as a conflict instead of looking like a success.
         if self.role_request.status != AccessRequestStatus.PENDING or self.role_request.resolved_at is not None:
-            raise HTTPException(409, "Role request is no longer pending")
+            raise ConflictError("Role request is no longer pending")
 
         # Don't allow requester to approve their own request
         if self.role_request.requester_user_id == self.approver_id:
@@ -80,13 +81,13 @@ class ApproveRoleRequest:
         # Don't allow approving a request if the requester role is deleted
         requester = db.session.get(RoleGroup, self.role_request.requester_role_id)
         if requester is None or requester.deleted_at is not None:
-            raise HTTPException(410, "The requester role no longer exists")
+            raise ResourceGoneError("The requester role no longer exists")
 
         # Don't allow approving a request for a deleted or unmanaged group
         if self.role_request.active_requested_group is None:
-            raise HTTPException(410, "The requested group no longer exists")
+            raise ResourceGoneError("The requested group no longer exists")
         if not self.role_request.active_requested_group.is_managed:
-            raise HTTPException(400, "Groups not managed by Access cannot be modified")
+            raise InvalidRequestError("Groups not managed by Access cannot be modified")
 
         db.session.commit()
 

--- a/api/operations/reject_access_request.py
+++ b/api/operations/reject_access_request.py
@@ -3,6 +3,7 @@ from typing import Optional
 import logging
 
 from api.context import get_request_context
+from fastapi import HTTPException
 from sqlalchemy import func, nullsfirst
 from sqlalchemy.orm import joinedload, selectin_polymorphic
 
@@ -23,10 +24,13 @@ class RejectAccessRequest:
         notify_requester: bool = True,
         current_user_id: Optional[str | OktaUser] = None,
     ):
-        if isinstance(access_request, str):
-            self.access_request = db.session.get(AccessRequest, access_request)
-        else:
-            self.access_request = access_request
+        # Lock the request row so a reject can't race a concurrent approve/
+        # reject; both serialize on this row and the loser hits the resolved
+        # guard. No-op on SQLite.
+        request_id = access_request if isinstance(access_request, str) else access_request.id
+        self.access_request = (
+            db.session.query(AccessRequest).filter(AccessRequest.id == request_id).with_for_update().first()
+        )
 
         if current_user_id is None:
             self.rejecter_id = None
@@ -49,9 +53,11 @@ class RejectAccessRequest:
         self.notification_hook = get_notification_hook()
 
     def execute(self) -> AccessRequest:
-        # Don't allow approving a request that is already resolved
+        # Don't allow rejecting a request that is already resolved. Raise
+        # rather than silently no-op so a stale/concurrent rejection surfaces
+        # as a conflict instead of looking like a success.
         if self.access_request.status != AccessRequestStatus.PENDING or self.access_request.resolved_at is not None:
-            return self.access_request
+            raise HTTPException(409, "Access request is no longer pending")
 
         self.access_request.status = AccessRequestStatus.REJECTED
         self.access_request.resolved_at = func.now()

--- a/api/operations/reject_access_request.py
+++ b/api/operations/reject_access_request.py
@@ -3,10 +3,10 @@ from typing import Optional
 import logging
 
 from api.context import get_request_context
-from fastapi import HTTPException
 from sqlalchemy import func, nullsfirst
 from sqlalchemy.orm import joinedload, selectin_polymorphic
 
+from api.exceptions import ConflictError
 from api.extensions import db
 from api.models import AccessRequest, AccessRequestStatus, AppGroup, OktaGroup, OktaUser, RoleGroup
 from api.models.access_request import get_all_possible_request_approvers
@@ -57,7 +57,7 @@ class RejectAccessRequest:
         # rather than silently no-op so a stale/concurrent rejection surfaces
         # as a conflict instead of looking like a success.
         if self.access_request.status != AccessRequestStatus.PENDING or self.access_request.resolved_at is not None:
-            raise HTTPException(409, "Access request is no longer pending")
+            raise ConflictError("Access request is no longer pending")
 
         self.access_request.status = AccessRequestStatus.REJECTED
         self.access_request.resolved_at = func.now()

--- a/api/operations/reject_group_request.py
+++ b/api/operations/reject_group_request.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import logging
 
+from fastapi import HTTPException
 from sqlalchemy import func
 from api.context import get_request_context
 
@@ -23,10 +24,13 @@ class RejectGroupRequest:
         notify_requester: bool = True,
         current_user_id: Optional[str | OktaUser] = None,
     ):
-        if isinstance(group_request, str):
-            self.group_request = db.session.get(GroupRequest, group_request)
-        else:
-            self.group_request = group_request
+        # Lock the request row so a reject can't race a concurrent approve/
+        # reject; both serialize on this row and the loser hits the resolved
+        # guard. No-op on SQLite.
+        request_id = group_request if isinstance(group_request, str) else group_request.id
+        self.group_request = (
+            db.session.query(GroupRequest).filter(GroupRequest.id == request_id).with_for_update().first()
+        )
 
         if current_user_id is None:
             self.rejecter_id = None
@@ -48,9 +52,10 @@ class RejectGroupRequest:
         self.notification_hook = get_notification_hook()
 
     def execute(self) -> GroupRequest:
-        # Already resolved
+        # Already resolved — raise rather than silently no-op so a stale/
+        # concurrent rejection surfaces as a conflict instead of a success.
         if self.group_request.status != AccessRequestStatus.PENDING or self.group_request.resolved_at is not None:
-            return self.group_request
+            raise HTTPException(409, "Group request is no longer pending")
 
         resolved_app_id = (
             self.group_request.resolved_app_id

--- a/api/operations/reject_group_request.py
+++ b/api/operations/reject_group_request.py
@@ -2,10 +2,10 @@ from typing import Optional
 
 import logging
 
-from fastapi import HTTPException
 from sqlalchemy import func
 from api.context import get_request_context
 
+from api.exceptions import ConflictError
 from api.extensions import db
 from api.models import AccessRequestStatus, AppGroup, GroupRequest, OktaUser, OktaUserGroupMember
 from api.models.access_request import get_all_possible_request_approvers
@@ -55,7 +55,7 @@ class RejectGroupRequest:
         # Already resolved — raise rather than silently no-op so a stale/
         # concurrent rejection surfaces as a conflict instead of a success.
         if self.group_request.status != AccessRequestStatus.PENDING or self.group_request.resolved_at is not None:
-            raise HTTPException(409, "Group request is no longer pending")
+            raise ConflictError("Group request is no longer pending")
 
         resolved_app_id = (
             self.group_request.resolved_app_id

--- a/api/operations/reject_role_request.py
+++ b/api/operations/reject_role_request.py
@@ -3,10 +3,10 @@ from typing import Optional
 import logging
 
 from api.context import get_request_context
-from fastapi import HTTPException
 from sqlalchemy import func, nullsfirst
 from sqlalchemy.orm import joinedload, selectin_polymorphic
 
+from api.exceptions import ConflictError
 from api.extensions import db
 from api.models import AccessRequestStatus, AppGroup, OktaGroup, OktaUser, RoleRequest
 from api.models.access_request import get_all_possible_request_approvers
@@ -55,7 +55,7 @@ class RejectRoleRequest:
         # rather than silently no-op so a stale/concurrent rejection surfaces
         # as a conflict instead of looking like a success.
         if self.role_request.status != AccessRequestStatus.PENDING or self.role_request.resolved_at is not None:
-            raise HTTPException(409, "Role request is no longer pending")
+            raise ConflictError("Role request is no longer pending")
 
         self.role_request.status = AccessRequestStatus.REJECTED
         self.role_request.resolved_at = func.now()

--- a/api/operations/reject_role_request.py
+++ b/api/operations/reject_role_request.py
@@ -3,6 +3,7 @@ from typing import Optional
 import logging
 
 from api.context import get_request_context
+from fastapi import HTTPException
 from sqlalchemy import func, nullsfirst
 from sqlalchemy.orm import joinedload, selectin_polymorphic
 
@@ -23,10 +24,11 @@ class RejectRoleRequest:
         notify_requester: bool = True,
         current_user_id: Optional[str | OktaUser] = None,
     ):
-        if isinstance(role_request, str):
-            self.role_request = db.session.get(RoleRequest, role_request)
-        else:
-            self.role_request = role_request
+        # Lock the request row so a reject can't race a concurrent approve/
+        # reject; both serialize on this row and the loser hits the resolved
+        # guard. No-op on SQLite.
+        request_id = role_request if isinstance(role_request, str) else role_request.id
+        self.role_request = db.session.query(RoleRequest).filter(RoleRequest.id == request_id).with_for_update().first()
 
         if current_user_id is None:
             self.rejecter_id = None
@@ -49,9 +51,11 @@ class RejectRoleRequest:
         self.notification_hook = get_notification_hook()
 
     def execute(self) -> RoleRequest:
-        # Don't allow approving a request that is already resolved
+        # Don't allow rejecting a request that is already resolved. Raise
+        # rather than silently no-op so a stale/concurrent rejection surfaces
+        # as a conflict instead of looking like a success.
         if self.role_request.status != AccessRequestStatus.PENDING or self.role_request.resolved_at is not None:
-            return self.role_request
+            raise HTTPException(409, "Role request is no longer pending")
 
         self.role_request.status = AccessRequestStatus.REJECTED
         self.role_request.resolved_at = func.now()

--- a/api/routers/access_requests.py
+++ b/api/routers/access_requests.py
@@ -289,7 +289,7 @@ def put_access_request(
             raise HTTPException(400, err_message)
 
     if ar.status != AccessRequestStatus.PENDING or ar.resolved_at is not None:
-        raise HTTPException(400, "Access request is not pending")
+        raise HTTPException(409, "Access request is not pending")
 
     if body.approved:
         if not ar.requested_group.is_managed:

--- a/api/routers/group_requests.py
+++ b/api/routers/group_requests.py
@@ -247,7 +247,7 @@ def put_group_request(
             raise HTTPException(403, "Current user is not allowed to perform this action")
 
     if gr.status != AccessRequestStatus.PENDING or gr.resolved_at is not None:
-        raise HTTPException(400, "Group request is not pending")
+        raise HTTPException(409, "Group request is not pending")
 
     if body.approved and not is_access_admin(db, current_user_id):
         type_changed = body.resolved_group_type is not None and body.resolved_group_type != gr.requested_group_type

--- a/api/routers/role_requests.py
+++ b/api/routers/role_requests.py
@@ -430,7 +430,7 @@ def put_role_request(
             raise HTTPException(400, err_message)
 
     if rr.status != AccessRequestStatus.PENDING or rr.resolved_at is not None:
-        raise HTTPException(400, "Role request is not pending")
+        raise HTTPException(409, "Role request is not pending")
     if body.approved:
         if not rr.requested_group.is_managed:
             raise HTTPException(400, "Groups not managed by Access cannot be modified")

--- a/tests/test_approve_reject_stale_state.py
+++ b/tests/test_approve_reject_stale_state.py
@@ -6,27 +6,31 @@ return the request object unchanged with no error and, for several guards, no
 status flip. This both confuses callers and (under concurrency) lets a stale
 approval slip a second grant past the router's pre-check.
 
-These tests encode the agreed contract for the fix:
-  - already-resolved approve/reject  -> HTTPException 409 (Conflict)
-  - deleted requester / deleted-or-unmanaged target -> HTTPException 400/410
+These tests encode the contract for the fix. Operations raise `AccessException`
+subclasses (decoupled from FastAPI; mapped to HTTP by api.exception_handlers):
+  - already-resolved approve/reject  -> ConflictError (409)
+  - deleted requester / deleted-or-unmanaged target -> 410 / 400
   - a stale approval (request resolved between load and execute) must conflict
     and must NOT create a grant.
 
-They are RED until the fix lands (the operations currently raise nothing). The
-true two-connection duplicate-row race can only be reproduced against Postgres;
-the single-connection sqlite harness shares one connection, so these simulate
-the stale/already-resolved state deterministically instead.
+The true two-connection duplicate-row race can only be reproduced against
+Postgres; the single-connection sqlite harness shares one connection, so these
+simulate the stale/already-resolved state deterministically instead.
 """
 
+import asyncio
 import uuid
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI
 from okta.models import Group
 from pytest_mock import MockerFixture
 from sqlalchemy import func, or_
+from starlette.requests import Request
 
 from api.config import settings
+from api.exception_handlers import access_exception_handler
+from api.exceptions import AccessException, ConflictError, InvalidRequestError, ResourceGoneError
 from api.extensions import Db
 from api.models import (
     AccessRequest,
@@ -102,7 +106,7 @@ def test_approve_already_resolved_access_request_conflicts(db: Db, user: OktaUse
     assert _active_direct_member_count(db, user_id=user.id, group_id=okta_group.id) == 1
 
     # A second approval of the now-APPROVED request must conflict, not no-op.
-    with pytest.raises(HTTPException) as exc:
+    with pytest.raises(AccessException) as exc:
         ApproveAccessRequest(access_request=request.id, approver_user=owner, approval_reason="again").execute()
     assert exc.value.status_code == 409
 
@@ -127,7 +131,7 @@ def test_reject_already_resolved_access_request_conflicts(db: Db, user: OktaUser
     ApproveAccessRequest(access_request=request.id, approver_user=owner, approval_reason="ok").execute()
 
     # Rejecting an already-approved request must conflict, not silently no-op.
-    with pytest.raises(HTTPException) as exc:
+    with pytest.raises(AccessException) as exc:
         RejectAccessRequest(
             access_request=request.id,
             rejection_reason="too late",
@@ -154,7 +158,7 @@ def test_approve_access_request_with_deleted_requester_errors(db: Db, user: Okta
     user.deleted_at = func.now()
     db.session.commit()
 
-    with pytest.raises(HTTPException) as exc:
+    with pytest.raises(AccessException) as exc:
         ApproveAccessRequest(access_request=request.id, approver_user=owner, approval_reason="ok").execute()
     assert exc.value.status_code in (400, 410)
 
@@ -185,7 +189,7 @@ def test_approve_access_request_with_unmanaged_group_errors(db: Db, user: OktaUs
     okta_group.is_managed = False
     db.session.commit()
 
-    with pytest.raises(HTTPException) as exc:
+    with pytest.raises(AccessException) as exc:
         ApproveAccessRequest(access_request=request.id, approver_user=owner, approval_reason="ok").execute()
     assert exc.value.status_code in (400, 410)
     assert _active_direct_member_count(db, user_id=user.id, group_id=okta_group.id) == 0
@@ -220,7 +224,7 @@ def test_stale_resolution_then_approve_conflicts_without_granting(
     )
     db.session.commit()
 
-    with pytest.raises(HTTPException) as exc:
+    with pytest.raises(AccessException) as exc:
         op.execute()
     assert exc.value.status_code == 409
 
@@ -265,7 +269,7 @@ def test_approve_already_resolved_role_request_conflicts(
     )
     assert active_maps == 1
 
-    with pytest.raises(HTTPException) as exc:
+    with pytest.raises(AccessException) as exc:
         ApproveRoleRequest(role_request=request.id, approver_user=owner, approval_reason="again").execute()
     assert exc.value.status_code == 409
 
@@ -291,6 +295,30 @@ def test_approve_already_resolved_group_request_conflicts(db: Db, user: OktaUser
 
     ApproveGroupRequest(group_request=request.id, approver_user=owner, approval_reason="ok").execute()
 
-    with pytest.raises(HTTPException) as exc:
+    with pytest.raises(AccessException) as exc:
         ApproveGroupRequest(group_request=request.id, approver_user=owner, approval_reason="again").execute()
     assert exc.value.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# AccessException -> HTTP mapping
+# ---------------------------------------------------------------------------
+
+
+def test_access_exception_handler_maps_status_and_envelope() -> None:
+    req = Request({"type": "http", "method": "GET", "path": "/api/x", "headers": [], "query_string": b""})
+    cases = [
+        (ConflictError("nope"), 409),
+        (ResourceGoneError("gone"), 410),
+        (InvalidRequestError("bad"), 400),
+        (AccessException("teapot", status_code=418), 418),  # constructor override
+    ]
+    for exc, expected in cases:
+        resp = asyncio.run(access_exception_handler(req, exc))
+        assert resp.status_code == expected
+        assert resp.media_type == "application/problem+json"
+
+
+def test_access_exception_handler_is_registered(app: FastAPI) -> None:
+    # Guards against the handler silently falling through to the 500 catch-all.
+    assert app.exception_handlers.get(AccessException) is access_exception_handler

--- a/tests/test_approve_reject_stale_state.py
+++ b/tests/test_approve_reject_stale_state.py
@@ -1,0 +1,296 @@
+"""Spec tests for the approve/reject stale-state bug.
+
+Today the approve/reject operations *silently no-op* when they hit a guard
+(already-resolved request, deleted requester/target, unmanaged group): they
+return the request object unchanged with no error and, for several guards, no
+status flip. This both confuses callers and (under concurrency) lets a stale
+approval slip a second grant past the router's pre-check.
+
+These tests encode the agreed contract for the fix:
+  - already-resolved approve/reject  -> HTTPException 409 (Conflict)
+  - deleted requester / deleted-or-unmanaged target -> HTTPException 400/410
+  - a stale approval (request resolved between load and execute) must conflict
+    and must NOT create a grant.
+
+They are RED until the fix lands (the operations currently raise nothing). The
+true two-connection duplicate-row race can only be reproduced against Postgres;
+the single-connection sqlite harness shares one connection, so these simulate
+the stale/already-resolved state deterministically instead.
+"""
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from okta.models import Group
+from pytest_mock import MockerFixture
+from sqlalchemy import func, or_
+
+from api.config import settings
+from api.extensions import Db
+from api.models import (
+    AccessRequest,
+    AccessRequestStatus,
+    OktaGroup,
+    OktaUser,
+    OktaUserGroupMember,
+    RoleGroup,
+    RoleGroupMap,
+)
+from api.operations import (
+    ApproveAccessRequest,
+    ApproveGroupRequest,
+    ApproveRoleRequest,
+    CreateAccessRequest,
+    CreateGroupRequest,
+    CreateRoleRequest,
+    ModifyGroupUsers,
+    RejectAccessRequest,
+)
+from api.services import okta
+
+
+@pytest.fixture(autouse=True)
+def _mock_okta(mocker: MockerFixture) -> None:
+    # The approve path pushes membership to Okta via ModifyGroupUsers; stub it
+    # so these tests never hit the network. patch.object auto-detects the async
+    # functions and substitutes AsyncMocks.
+    mocker.patch.object(okta, "async_add_user_to_group")
+    mocker.patch.object(okta, "async_add_owner_to_group")
+    # Group-request approval creates a group in Okta; stub it.
+    mocker.patch.object(okta, "create_group", side_effect=lambda name, desc: Group({"id": uuid.uuid4().hex}))
+
+
+def _access_owner(db: Db) -> OktaUser:
+    owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    assert owner is not None
+    return owner
+
+
+def _active_direct_member_count(db: Db, *, user_id: str, group_id: str, is_owner: bool = False) -> int:
+    return (
+        db.session.query(OktaUserGroupMember)
+        .filter(OktaUserGroupMember.user_id == user_id)
+        .filter(OktaUserGroupMember.group_id == group_id)
+        .filter(OktaUserGroupMember.is_owner.is_(is_owner))
+        .filter(OktaUserGroupMember.role_group_map_id.is_(None))
+        .filter(or_(OktaUserGroupMember.ended_at.is_(None), OktaUserGroupMember.ended_at > func.now()))
+        .count()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Access requests
+# ---------------------------------------------------------------------------
+
+
+def test_approve_already_resolved_access_request_conflicts(db: Db, user: OktaUser, okta_group: OktaGroup) -> None:
+    db.session.add(user)
+    db.session.add(okta_group)
+    db.session.commit()
+    owner = _access_owner(db)
+
+    request = CreateAccessRequest(
+        requester_user=user,
+        requested_group=okta_group,
+        request_ownership=False,
+        request_reason="need access",
+    ).execute()
+    assert request is not None
+
+    ApproveAccessRequest(access_request=request.id, approver_user=owner, approval_reason="ok").execute()
+    assert _active_direct_member_count(db, user_id=user.id, group_id=okta_group.id) == 1
+
+    # A second approval of the now-APPROVED request must conflict, not no-op.
+    with pytest.raises(HTTPException) as exc:
+        ApproveAccessRequest(access_request=request.id, approver_user=owner, approval_reason="again").execute()
+    assert exc.value.status_code == 409
+
+    # And it must not have created a duplicate grant.
+    assert _active_direct_member_count(db, user_id=user.id, group_id=okta_group.id) == 1
+
+
+def test_reject_already_resolved_access_request_conflicts(db: Db, user: OktaUser, okta_group: OktaGroup) -> None:
+    db.session.add(user)
+    db.session.add(okta_group)
+    db.session.commit()
+    owner = _access_owner(db)
+
+    request = CreateAccessRequest(
+        requester_user=user,
+        requested_group=okta_group,
+        request_ownership=False,
+        request_reason="need access",
+    ).execute()
+    assert request is not None
+
+    ApproveAccessRequest(access_request=request.id, approver_user=owner, approval_reason="ok").execute()
+
+    # Rejecting an already-approved request must conflict, not silently no-op.
+    with pytest.raises(HTTPException) as exc:
+        RejectAccessRequest(
+            access_request=request.id,
+            rejection_reason="too late",
+            current_user_id=owner.id,
+        ).execute()
+    assert exc.value.status_code == 409
+
+
+def test_approve_access_request_with_deleted_requester_errors(db: Db, user: OktaUser, okta_group: OktaGroup) -> None:
+    db.session.add(user)
+    db.session.add(okta_group)
+    db.session.commit()
+    owner = _access_owner(db)
+
+    request = CreateAccessRequest(
+        requester_user=user,
+        requested_group=okta_group,
+        request_ownership=False,
+        request_reason="need access",
+    ).execute()
+    assert request is not None
+
+    # Requester is soft-deleted before the approval is processed.
+    user.deleted_at = func.now()
+    db.session.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        ApproveAccessRequest(access_request=request.id, approver_user=owner, approval_reason="ok").execute()
+    assert exc.value.status_code in (400, 410)
+
+    # The error is surfaced (not a silent success) and no grant is created.
+    # The request stays PENDING — the approver gets a clear 4xx rather than the
+    # operation quietly resolving a request it can't fulfil.
+    assert _active_direct_member_count(db, user_id=user.id, group_id=okta_group.id) == 0
+    refreshed = db.session.get(AccessRequest, request.id)
+    assert refreshed is not None
+    assert refreshed.status == AccessRequestStatus.PENDING
+
+
+def test_approve_access_request_with_unmanaged_group_errors(db: Db, user: OktaUser, okta_group: OktaGroup) -> None:
+    db.session.add(user)
+    db.session.add(okta_group)
+    db.session.commit()
+    owner = _access_owner(db)
+
+    request = CreateAccessRequest(
+        requester_user=user,
+        requested_group=okta_group,
+        request_ownership=False,
+        request_reason="need access",
+    ).execute()
+    assert request is not None
+
+    # Target group becomes externally managed before the approval is processed.
+    okta_group.is_managed = False
+    db.session.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        ApproveAccessRequest(access_request=request.id, approver_user=owner, approval_reason="ok").execute()
+    assert exc.value.status_code in (400, 410)
+    assert _active_direct_member_count(db, user_id=user.id, group_id=okta_group.id) == 0
+
+
+def test_stale_resolution_then_approve_conflicts_without_granting(
+    db: Db, user: OktaUser, okta_group: OktaGroup
+) -> None:
+    """Approver loads a PENDING request; another actor resolves it; the
+    approver's execute() must conflict (409) and grant nothing."""
+    db.session.add(user)
+    db.session.add(okta_group)
+    db.session.commit()
+    owner = _access_owner(db)
+
+    request = CreateAccessRequest(
+        requester_user=user,
+        requested_group=okta_group,
+        request_ownership=False,
+        request_reason="need access",
+    ).execute()
+    assert request is not None
+
+    # Operation loads the request while it is still PENDING.
+    op = ApproveAccessRequest(access_request=request.id, approver_user=owner, approval_reason="ok")
+
+    # A concurrent actor resolves the request out from under it (direct DB flip
+    # mirrors the row another approver's transaction would have committed).
+    db.session.query(AccessRequest).filter(AccessRequest.id == request.id).update(
+        {AccessRequest.status: AccessRequestStatus.APPROVED, AccessRequest.resolved_at: func.now()},
+        synchronize_session=False,
+    )
+    db.session.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        op.execute()
+    assert exc.value.status_code == 409
+
+    # The stale approver must not have slipped in a grant.
+    assert _active_direct_member_count(db, user_id=user.id, group_id=okta_group.id) == 0
+
+
+# ---------------------------------------------------------------------------
+# Role requests
+# ---------------------------------------------------------------------------
+
+
+def test_approve_already_resolved_role_request_conflicts(
+    db: Db, user: OktaUser, okta_group: OktaGroup, role_group: RoleGroup
+) -> None:
+    db.session.add(user)
+    db.session.add(okta_group)
+    db.session.add(role_group)
+    db.session.commit()
+    owner = _access_owner(db)
+
+    # Requester must own the role to file a role request for it.
+    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
+
+    request = CreateRoleRequest(
+        requester_user=user,
+        requester_role=role_group,
+        requested_group=okta_group,
+        request_ownership=False,
+        request_reason="role needs this group",
+    ).execute()
+    assert request is not None
+
+    ApproveRoleRequest(role_request=request.id, approver_user=owner, approval_reason="ok").execute()
+
+    active_maps = (
+        db.session.query(RoleGroupMap)
+        .filter(RoleGroupMap.role_group_id == role_group.id)
+        .filter(RoleGroupMap.group_id == okta_group.id)
+        .filter(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
+        .count()
+    )
+    assert active_maps == 1
+
+    with pytest.raises(HTTPException) as exc:
+        ApproveRoleRequest(role_request=request.id, approver_user=owner, approval_reason="again").execute()
+    assert exc.value.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# Group requests
+# ---------------------------------------------------------------------------
+
+
+def test_approve_already_resolved_group_request_conflicts(db: Db, user: OktaUser) -> None:
+    db.session.add(user)
+    db.session.commit()
+    owner = _access_owner(db)
+
+    request = CreateGroupRequest(
+        requester_user=user,
+        requested_group_name="Test Group",
+        requested_group_description="Test Description",
+        requested_group_type="okta_group",
+        request_reason="need a group",
+    ).execute()
+    assert request is not None
+
+    ApproveGroupRequest(group_request=request.id, approver_user=owner, approval_reason="ok").execute()
+
+    with pytest.raises(HTTPException) as exc:
+        ApproveGroupRequest(group_request=request.id, approver_user=owner, approval_reason="again").execute()
+    assert exc.value.status_code == 409

--- a/tests/test_role_request.py
+++ b/tests/test_role_request.py
@@ -1487,5 +1487,5 @@ def test_put_role_request_pending_check_includes_resolved_at(
 
     put_url = url_for("api-role-requests.role_request_by_id_put", role_request_id=rr.id)
     rep = client.put(put_url, json={"approved": False, "reason": "no"})
-    assert rep.status_code == 400
+    assert rep.status_code == 409
     assert "is not pending" in rep.text


### PR DESCRIPTION
Original issue
- Approve/reject operations silently no-op'd on stale state (already-resolved request, deleted requester, deleted or unmanaged target group), returning the request unchanged with no error and no status flip
- No row-level locking on the request load (no SELECT FOR UPDATE)
- Two concurrent approvers could both pass the pending check and double-grant creating duplicate OktaUserGroupMember rows
- Stale approvals looked like successes to the caller masking the problem

Changes
- Converted silent guards to typed HTTPExceptions across approve and reject operations:
  - already-resolved, now 409
  - deleted requester (access, role), now 410
  - deleted requested group (access, role), now 410
  - unmanaged target group (access, role), now 400
- Added row-level locking on each operation's request load, with_for_update(of=...) on approve (keeps FOR UPDATE off the joinedload's nullable outer-join side, Postgres-safe), plain with_for_update() on reject, no-op on SQLite, so concurrent resolvers serialize on the row and the loser hits the resolved guard
- Updated the not-pending pre-check in all 3 resolve routers from 400 to 409, so the HTTP contract matches the operations
- Left unchanged on purpose (authorization and validation, mirror router checks): self-approval, reason, app-owner/admin authz, name-prefix/collision
- Group-request deleted-requester left silent, its active_requester is an inner join filtering deleted_at, so a deleted requester fails to load and hits the existing not-found guard before reaching that check