### PR TITLE
Bug: Zombie RoleRequests

### DIFF
--- a/api/operations/delete_group.py
+++ b/api/operations/delete_group.py
@@ -236,9 +236,7 @@ class DeleteGroup:
             ).execute()
 
         # Reject all pending role requests touching this group, either as the
-        # requested target or as the requester role. Left pending, they would
-        # silently no-op in ApproveRoleRequest now but become approvable again
-        # if the group is later resurrected by the syncer (same id).
+        # requested target or as the requester role.
         obsolete_role_requests = (
             db.session.query(RoleRequest)
             .filter(

--- a/api/operations/delete_group.py
+++ b/api/operations/delete_group.py
@@ -19,8 +19,10 @@ from api.models import (
     OktaUserGroupMember,
     RoleGroup,
     RoleGroupMap,
+    RoleRequest,
 )
 from api.operations.reject_access_request import RejectAccessRequest
+from api.operations.reject_role_request import RejectRoleRequest
 from api.plugins.app_group_lifecycle import get_app_group_lifecycle_hook, get_app_group_lifecycle_plugin_to_invoke
 from api.services import okta
 from api.schemas import AuditLogSchema, EventType
@@ -230,6 +232,29 @@ class DeleteGroup:
             RejectAccessRequest(
                 access_request=obsolete_access_request,
                 rejection_reason="Closed because the requested group was deleted",
+                current_user_id=self.current_user_id,
+            ).execute()
+
+        # Reject all pending role requests touching this group, either as the
+        # requested target or as the requester role. Left pending, they would
+        # silently no-op in ApproveRoleRequest now but become approvable again
+        # if the group is later resurrected by the syncer (same id).
+        obsolete_role_requests = (
+            db.session.query(RoleRequest)
+            .filter(
+                or_(
+                    RoleRequest.requested_group_id == self.group.id,
+                    RoleRequest.requester_role_id == self.group.id,
+                )
+            )
+            .filter(RoleRequest.status == AccessRequestStatus.PENDING)
+            .filter(RoleRequest.resolved_at.is_(None))
+            .all()
+        )
+        for obsolete_role_request in obsolete_role_requests:
+            RejectRoleRequest(
+                role_request=obsolete_role_request,
+                rejection_reason="Closed because a group in this role request was deleted",
                 current_user_id=self.current_user_id,
             ).execute()
 

--- a/api/operations/unmanage_group.py
+++ b/api/operations/unmanage_group.py
@@ -14,8 +14,10 @@ from api.models import (
     OktaUserGroupMember,
     RoleGroup,
     RoleGroupMap,
+    RoleRequest,
 )
 from api.operations.reject_access_request import RejectAccessRequest
+from api.operations.reject_role_request import RejectRoleRequest
 
 logger = logging.getLogger(__name__)
 
@@ -109,5 +111,32 @@ class UnmanageGroup:
                 RejectAccessRequest(
                     access_request=obsolete_access_request,
                     rejection_reason="Closed because the requested group is no longer managed by Access",
+                    current_user_id=self.current_user_id,
+                ).execute()
+
+        # Reject all pending role requests touching this group, either as the
+        # requested target or as the requester role. Left pending, they would
+        # silently no-op in ApproveRoleRequest now but become approvable again
+        # if the group is later re-managed by the syncer.
+        obsolete_role_requests = (
+            db.session.query(RoleRequest)
+            .filter(
+                or_(
+                    RoleRequest.requested_group_id == self.group.id,
+                    RoleRequest.requester_role_id == self.group.id,
+                )
+            )
+            .filter(RoleRequest.status == AccessRequestStatus.PENDING)
+            .filter(RoleRequest.resolved_at.is_(None))
+            .all()
+        )
+        for obsolete_role_request in obsolete_role_requests:
+            logger.info(
+                f"Rejecting obsolete role request {obsolete_role_request.id} for unmanaged group {self.group.id}"
+            )
+            if not dry_run:
+                RejectRoleRequest(
+                    role_request=obsolete_role_request,
+                    rejection_reason="Closed because a group in this role request is no longer managed by Access",
                     current_user_id=self.current_user_id,
                 ).execute()

--- a/api/operations/unmanage_group.py
+++ b/api/operations/unmanage_group.py
@@ -115,9 +115,7 @@ class UnmanageGroup:
                 ).execute()
 
         # Reject all pending role requests touching this group, either as the
-        # requested target or as the requester role. Left pending, they would
-        # silently no-op in ApproveRoleRequest now but become approvable again
-        # if the group is later re-managed by the syncer.
+        # requested target or as the requester role.
         obsolete_role_requests = (
             db.session.query(RoleRequest)
             .filter(

--- a/tests/test_zombie_role_requests.py
+++ b/tests/test_zombie_role_requests.py
@@ -1,0 +1,128 @@
+"""Spec tests: unmanage_group / delete_group must reject pending RoleRequests.
+
+Both operations reject pending AccessRequests for the affected group but ignore
+pending RoleRequests, leaving them PENDING. ApproveRoleRequest then silently
+no-ops while the group is unmanaged/deleted, but the syncer can re-manage a
+group (update_okta_group re-derives is_managed) or resurrect a soft-deleted one
+(clears deleted_at on the same id), at which point the leftover RoleRequest
+becomes approvable under whatever tag/constraint state exists at that later
+moment.
+
+These encode the fix contract: pending RoleRequests touching the group must be
+rejected, both where the group is the requested target and (when the group is a
+role) where it is the requester role. RED until the rejection loop is added.
+"""
+
+import pytest
+from pytest_mock import MockerFixture
+
+from api.config import settings
+from api.extensions import Db
+from api.models import AccessRequestStatus, OktaGroup, OktaUser, RoleGroup
+from api.operations import CreateRoleRequest, DeleteGroup, ModifyGroupUsers, UnmanageGroup
+from api.services import okta
+
+
+@pytest.fixture(autouse=True)
+def _mock_okta(mocker: MockerFixture) -> None:
+    # Keep the operations off the network. patch.object auto-detects the async
+    # functions and substitutes AsyncMocks.
+    mocker.patch.object(okta, "async_add_user_to_group")
+    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "async_remove_user_from_group")
+    mocker.patch.object(okta, "async_remove_owner_from_group")
+    mocker.patch.object(okta, "async_delete_group")
+
+
+def _access_owner(db: Db) -> OktaUser:
+    owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    assert owner is not None
+    return owner
+
+
+def _pending_role_request(db: Db, *, requester_role: RoleGroup, requested_group: OktaGroup, requester_user: OktaUser):
+    # Requester must own the role to file a role request for it.
+    ModifyGroupUsers(group=requester_role, owners_to_add=[requester_user.id], sync_to_okta=False).execute()
+    role_request = CreateRoleRequest(
+        requester_user=requester_user,
+        requester_role=requester_role,
+        requested_group=requested_group,
+        request_reason="role needs this group",
+    ).execute()
+    assert role_request is not None
+    assert role_request.status == AccessRequestStatus.PENDING
+    return role_request
+
+
+# ---------------------------------------------------------------------------
+# Group is the requested target of the RoleRequest
+# ---------------------------------------------------------------------------
+
+
+def test_unmanage_group_rejects_pending_role_request_for_group(
+    db: Db, user: OktaUser, role_group: RoleGroup, okta_group: OktaGroup
+) -> None:
+    db.session.add_all([user, role_group, okta_group])
+    db.session.commit()
+    role_request = _pending_role_request(db, requester_role=role_group, requested_group=okta_group, requester_user=user)
+
+    # Group transitions to unmanaged (as the syncer does before UnmanageGroup).
+    okta_group.is_managed = False
+    db.session.commit()
+
+    UnmanageGroup(group=okta_group, current_user_id=_access_owner(db).id).execute()
+
+    db.session.refresh(role_request)
+    assert role_request.status == AccessRequestStatus.REJECTED
+    assert role_request.resolved_at is not None
+
+
+def test_delete_group_rejects_pending_role_request_for_group(
+    db: Db, user: OktaUser, role_group: RoleGroup, okta_group: OktaGroup
+) -> None:
+    db.session.add_all([user, role_group, okta_group])
+    db.session.commit()
+    role_request = _pending_role_request(db, requester_role=role_group, requested_group=okta_group, requester_user=user)
+
+    DeleteGroup(group=okta_group, sync_to_okta=False, current_user_id=_access_owner(db).id).execute()
+
+    db.session.refresh(role_request)
+    assert role_request.status == AccessRequestStatus.REJECTED
+    assert role_request.resolved_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Group is the requester role of the RoleRequest
+# ---------------------------------------------------------------------------
+
+
+def test_unmanage_group_rejects_pending_role_request_where_group_is_requester_role(
+    db: Db, user: OktaUser, role_group: RoleGroup, okta_group: OktaGroup
+) -> None:
+    db.session.add_all([user, role_group, okta_group])
+    db.session.commit()
+    # role_group is the requester; okta_group is the requested target.
+    role_request = _pending_role_request(db, requester_role=role_group, requested_group=okta_group, requester_user=user)
+
+    role_group.is_managed = False
+    db.session.commit()
+
+    UnmanageGroup(group=role_group, current_user_id=_access_owner(db).id).execute()
+
+    db.session.refresh(role_request)
+    assert role_request.status == AccessRequestStatus.REJECTED
+    assert role_request.resolved_at is not None
+
+
+def test_delete_group_rejects_pending_role_request_where_group_is_requester_role(
+    db: Db, user: OktaUser, role_group: RoleGroup, okta_group: OktaGroup
+) -> None:
+    db.session.add_all([user, role_group, okta_group])
+    db.session.commit()
+    role_request = _pending_role_request(db, requester_role=role_group, requested_group=okta_group, requester_user=user)
+
+    DeleteGroup(group=role_group, sync_to_okta=False, current_user_id=_access_owner(db).id).execute()
+
+    db.session.refresh(role_request)
+    assert role_request.status == AccessRequestStatus.REJECTED
+    assert role_request.resolved_at is not None

--- a/tests/test_zombie_role_requests.py
+++ b/tests/test_zombie_role_requests.py
@@ -1,16 +1,14 @@
-"""Spec tests: unmanage_group / delete_group must reject pending RoleRequests.
+"""unmanage_group / delete_group must reject pending RoleRequests for the group.
 
-Both operations reject pending AccessRequests for the affected group but ignore
-pending RoleRequests, leaving them PENDING. ApproveRoleRequest then silently
-no-ops while the group is unmanaged/deleted, but the syncer can re-manage a
-group (update_okta_group re-derives is_managed) or resurrect a soft-deleted one
-(clears deleted_at on the same id), at which point the leftover RoleRequest
-becomes approvable under whatever tag/constraint state exists at that later
-moment.
+Guards against a leftover RoleRequest surviving the operation in PENDING. If one
+did, it would be invisible until the syncer re-managed the group (re-derives
+is_managed) or resurrected a soft-deleted one (clears deleted_at on the same
+id), at which point it would become approvable under whatever tag/constraint
+state existed at that later moment.
 
-These encode the fix contract: pending RoleRequests touching the group must be
-rejected, both where the group is the requested target and (when the group is a
-role) where it is the requester role. RED until the rejection loop is added.
+These assert that pending RoleRequests touching the group are resolved at
+unmanage/delete time, both where the group is the requested target and (when the
+group is a role) where it is the requester role.
 """
 
 import pytest


### PR DESCRIPTION
Issue
- unmanage_group and delete_group rejected pending AccessRequests for group but ignored pending RoleRequests
- those RoleRequests lingered in PENDING, ApproveRoleRequest silently no-ops while the group is unmanaged or deleted
- syncer can re-manage a group (re-derives is_managed=True) or resurrect a soft-deleted one (clears deleted_at on the same id) at which point the leftover request becomes approvable again under whatever tag and constraint state exists then, bypassing the constraints in force when it was filed

Fix
- added a RoleRequest rejection loop to both operations, mirroring the existing AccessRequest loop
- rejects pending RoleRequests where the group is the requested target (requested_group_id) or the requester role (requester_role_id)
- uses RejectRoleRequest with a close reason matching the existing AccessRequest wording
- unmanage loop honors the existing dry_run flag, delete rejects directly like its AccessRequest loop