### PR TITLE
ci: scope push trigger to main for test/lint workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: Test Python
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   python-test:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,10 @@
 name: Linting and formatting checks
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   node-lint:


### PR DESCRIPTION
## What

Scope the `push` trigger to `main` on the **Python test** (`ci.yml`) and **lint** (`lint.yml`) workflows:

```yaml
on:
  push:
    branches:
      - main
  pull_request:
```

## Why

Both workflows used `on: [push, pull_request]`. When a branch has an open PR in this repo, **every push fires both** the `push` event (on the branch) and the `pull_request` `synchronize` event, so each workflow runs **twice per push** — duplicate jobs, duplicate status checks, ~2× the CI minutes.

Scoping `push` to `main` gives:
- **PRs validated once** via `pull_request` (including PRs from forks, run against the merge result), and
- **`main` still gets a post-merge run** — `pull_request` never fires on a direct push/merge to the default branch, so `push: main` keeps the default branch covered.

## Notes for reviewers

- Pushes to feature branches **without** an open PR will no longer trigger these workflows. For a PR-based flow that's the intended behavior; flag if anyone relies on pre-PR branch CI.
- Branch-protection required checks keep working — the check *names* are unchanged, only the trigger.
- `docker-image.yml` (`push: main`) and `semgrep.yml` (`push: main` + schedule + dispatch) already scope their triggers and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
