### PR TITLE
ci: add a workflow that verifies database migrations work

### DIFF
--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -1,8 +1,10 @@
 name: Database migrations
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   migrations:

--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -81,7 +81,10 @@ jobs:
         # `make db-revision msg="..."` (alembic revision --autogenerate).
         run: alembic check
 
-      - name: Verify migrations are reversible (downgrade to base, then re-upgrade)
+      - name: Verify the latest migration is reversible (downgrade one step, then re-upgrade)
+        # Rolls back just the most recent migration — the one a PR typically
+        # adds — and re-applies it, so every new migration ships with a
+        # working downgrade.
         run: |
-          alembic downgrade base
+          alembic downgrade -1
           alembic upgrade head

--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -1,0 +1,87 @@
+name: Database migrations
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  migrations:
+    # Exercise the migrations against both databases Access supports:
+    # PostgreSQL in production and SQLite for local development. Nothing
+    # else in CI runs the migrations — the test suite builds its schema
+    # straight from the models via create_all().
+    name: migrations (${{ matrix.database }})
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: "3.13"
+            database: postgresql
+            database-uri: postgresql+pg8000://postgres:postgres@localhost:5432/postgres
+          - python-version: "3.13"
+            database: sqlite
+            database-uri: sqlite:///migrations_ci.db
+
+    services:
+      postgres:
+        # Docker Hub image. Started for every leg of the matrix; the SQLite
+        # leg simply doesn't connect to it.
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+
+    # `migrations/env.py` reads the SQLAlchemy URL from DATABASE_URI.
+    env:
+      DATABASE_URI: ${{ matrix.database-uri }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install -e .
+
+      - name: Check for a single migration head
+        # Two migrations that branch from the same parent produce divergent
+        # heads that won't apply cleanly. Fail loudly so they get merged.
+        run: |
+          heads="$(alembic heads)"
+          echo "$heads"
+          count="$(printf '%s\n' "$heads" | grep -c '(head)')"
+          if [ "$count" -ne 1 ]; then
+            echo "::error::Expected exactly one migration head but found $count. Two migrations likely branched from the same parent; reconcile them with 'alembic merge'."
+            exit 1
+          fi
+
+      - name: Apply all migrations (alembic upgrade head)
+        run: alembic upgrade head
+
+      - name: Verify models and migrations are in sync (alembic check)
+        # `alembic check` autogenerates a diff between the SQLAlchemy models
+        # and the migrated schema. A non-empty diff means a model changed
+        # without a matching migration — generate one with
+        # `make db-revision msg="..."` (alembic revision --autogenerate).
+        run: alembic check
+
+      - name: Verify migrations are reversible (downgrade to base, then re-upgrade)
+        run: |
+          alembic downgrade base
+          alembic upgrade head

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -6,6 +6,7 @@ import logging
 from logging.config import fileConfig
 
 from alembic import context
+from sqlalchemy import JSON
 
 from api.config import settings
 from api.database import build_engine
@@ -34,6 +35,20 @@ def run_migrations_offline() -> None:
         context.run_migrations()
 
 
+def compare_type(context, inspected_column, metadata_column, inspected_type, metadata_type):
+    """Suppress spurious JSON type-change diffs during autogenerate/check.
+
+    Postgres reflects JSON columns with an explicit ``astext_type`` that the
+    models' ``JSON`` (and the ``JSONB`` variant, a subclass) don't carry, so
+    `alembic check` reports a phantom type change. Treat any JSON-family pair
+    as equal; fall back to Alembic's default comparison for everything else
+    by returning ``None``.
+    """
+    if isinstance(inspected_type, JSON) and isinstance(metadata_type, JSON):
+        return False
+    return None
+
+
 def run_migrations_online() -> None:
     def process_revision_directives(context, revision, directives):
         if getattr(config.cmd_opts, "autogenerate", False):
@@ -48,6 +63,7 @@ def run_migrations_online() -> None:
             connection=connection,
             target_metadata=target_metadata,
             process_revision_directives=process_revision_directives,
+            compare_type=compare_type,
             render_as_batch=connection.dialect.name == "sqlite",
         )
         with context.begin_transaction():

--- a/migrations/versions/dc768a8ce1ad_align_postgres_enum_and_json_column_.py
+++ b/migrations/versions/dc768a8ce1ad_align_postgres_enum_and_json_column_.py
@@ -1,0 +1,48 @@
+"""align postgres enum and json column types with models
+
+Revision ID: dc768a8ce1ad
+Revises: 11a0117dabea
+Create Date: 2026-06-11 12:28:16.771725
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "dc768a8ce1ad"
+down_revision = "11a0117dabea"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        # On SQLite the status column is a CHECK-constrained VARCHAR and
+        # plugin_data is plain TEXT/JSON, so there is no distinct named type
+        # to reconcile.
+        return
+
+    # The initial migration created `access_request.status` with the enum
+    # type named `accessrequeststate`, but the models and every other request
+    # table (`role_request`, `group_request`) use `accessrequeststatus`. Move
+    # the column onto the canonical type and drop the now-unused one.
+    op.execute(
+        "ALTER TABLE access_request "
+        "ALTER COLUMN status TYPE accessrequeststatus "
+        "USING status::text::accessrequeststatus"
+    )
+    op.execute("DROP TYPE accessrequeststate")
+
+
+def downgrade():
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+
+    op.execute("CREATE TYPE accessrequeststate AS ENUM ('PENDING', 'APPROVED', 'REJECTED')")
+    op.execute(
+        "ALTER TABLE access_request "
+        "ALTER COLUMN status TYPE accessrequeststate "
+        "USING status::text::accessrequeststate"
+    )


### PR DESCRIPTION
## What

Adds a new **Database migrations** GitHub Actions workflow (`.github/workflows/db-migrations.yml`) that exercises the Alembic migrations on every push and pull request, and fixes a pre-existing schema drift the new check surfaced.

## Why

Nothing in CI currently runs the migrations. The test suite builds its schema straight from the SQLAlchemy models via `create_all()` (see `tests/conftest.py`), so a migration that fails to apply — or that has drifted from the models — wouldn't surface until deploy time.

## The workflow

Runs against **both** databases Access supports — PostgreSQL (production) and SQLite (local dev) — via a matrix, and for each:

- **Single migration head** — fails if two migrations branched from the same parent (divergent heads that won't apply cleanly).
- **`alembic upgrade head`** — all migrations apply cleanly from an empty database.
- **`alembic check`** — the models and the migrations are in sync; catches a model change made without a matching migration (`make db-revision msg="..."`).
- **Reversibility** — `alembic downgrade -1` followed by `alembic upgrade head` confirms the newest migration (the one a PR typically adds) rolls back cleanly.

It reuses the same `postgres` service container and Python setup as the existing `Test Python` workflow. `migrations/env.py` reads the database URL from `DATABASE_URI`, which the workflow sets per matrix leg.

## Drift the new check caught (and this PR fixes)

`alembic check` immediately flagged a real, pre-existing inconsistency on PostgreSQL:

- The initial migration created `access_request.status` with the enum type named `accessrequeststate`, while the models and every other request table (`role_request`, `group_request`) use `accessrequeststatus` — so production carried two enum types and that column never matched the model. A new migration moves the column onto the canonical `accessrequeststatus` type and drops the unused one (PostgreSQL only; on SQLite the column is a CHECK-constrained `VARCHAR` with no named type, so it's a no-op).
- A `compare_type` callback in `migrations/env.py` suppresses a spurious JSON type-change diff: Postgres reflects JSON columns with an explicit `astext_type` the models don't carry, which `alembic check` otherwise reports as a phantom change.

## Testing

All four steps pass on both engines in CI (`migrations (postgresql)` and `migrations (sqlite)`), alongside the existing lint, type-check, and test workflows. Also verified locally that `alembic check` fails (exit non-zero, `New upgrade operations detected`) when a column is added to a model without a migration — confirming the drift check actually catches drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
