### PR TITLE
Enforce App- name prefix for app groups server-side

### DIFF
--- a/api/models/core_models.py
+++ b/api/models/core_models.py
@@ -21,7 +21,7 @@ from sqlalchemy.sql import expression
 from sqlalchemy_json import mutable_json_type
 
 from api import config
-from api.extensions import Base, db
+from api.extensions import Base
 
 
 class OktaUserGroupMember(Base):
@@ -629,20 +629,10 @@ class AppGroup(OktaGroup):
         "polymorphic_identity": "app_group",
     }
 
-    @validates("name")
-    def validate_group(self, key: str, name: str) -> str:
-        app = db.session.query(App).filter(App.id == self.app_id).filter(App.deleted_at.is_(None)).first()
-        if app is None:
-            raise ValueError(f"Specified App with app_id: {self.app_id} does not exist")
-        # app_groups should have app name prepended always
-        app_group_name_prefix = f"{AppGroup.APP_GROUP_NAME_PREFIX}{app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}"
-        if not name.startswith(app_group_name_prefix):
-            raise ValueError(
-                'App Group name "{}" should be prefixed with App name. For example: "{}"'.format(
-                    name, app_group_name_prefix
-                )
-            )
-        return name
+    # NOTE: do not add an @validates("name") hook here — `name` is mapped on the
+    # OktaGroup base mapper, so with joined-table inheritance a subclass validator
+    # never fires. The "App-{app name}-" prefix rule is enforced in the operations
+    # layer instead (CreateGroup and ModifyGroupDetails).
 
 
 class App(Base):

--- a/api/operations/create_group.py
+++ b/api/operations/create_group.py
@@ -49,13 +49,23 @@ class CreateGroup:
         if existing_group is not None:
             return existing_group
 
-        # Make sure the app exists if we're creating an app group
-        if (
-            type(self.group) is AppGroup
-            and db.session.query(App).filter(App.id == self.group.app_id).filter(App.deleted_at.is_(None)).first()
-            is None
-        ):
-            raise ValueError("App for AppGroup does not exist")
+        # Make sure the app exists if we're creating an app group, and that the
+        # group name carries the "App-{app name}-" prefix. The prefix convention
+        # is load-bearing: app renames rewrite group names by prefix substitution
+        # and group request approval reasons about reserved prefixes.
+        if type(self.group) is AppGroup:
+            app = db.session.query(App).filter(App.id == self.group.app_id).filter(App.deleted_at.is_(None)).first()
+            if app is None:
+                raise ValueError("App for AppGroup does not exist")
+            app_group_name_prefix = (
+                f"{AppGroup.APP_GROUP_NAME_PREFIX}{app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}"
+            )
+            if not self.group.name.startswith(app_group_name_prefix):
+                raise ValueError(
+                    'App Group name "{}" should be prefixed with App name. For example: "{}"'.format(
+                        self.group.name, app_group_name_prefix
+                    )
+                )
 
         okta_group = okta.create_group(self.group.name, self.group.description)
         if okta_group is None:

--- a/api/operations/modify_group_details.py
+++ b/api/operations/modify_group_details.py
@@ -5,7 +5,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import with_polymorphic
 
 from api.extensions import db
-from api.models import AppGroup, OktaGroup, OktaUser, RoleGroup
+from api.models import App, AppGroup, OktaGroup, OktaUser, RoleGroup
 from api.plugins.app_group_lifecycle import get_app_group_lifecycle_hook, get_app_group_lifecycle_plugin_to_invoke
 from api.services import okta
 from api.schemas import AuditLogSchema, EventType
@@ -21,11 +21,17 @@ class ModifyGroupDetails:
         name: str | None = None,
         description: str | None = None,
         current_user_id: str | None = None,
+        validate_app_group_prefix: bool = True,
     ):
         self.group = group
         self.name = name
         self.description = description
         self.current_user_id = current_user_id
+        # Renaming an app group must keep the "App-{app name}-" prefix, except
+        # when the rename is part of a group type conversion: converting away
+        # from an app group legitimately drops the prefix (ModifyGroupType
+        # requires it gone before it will convert).
+        self.validate_app_group_prefix = validate_app_group_prefix
 
     def execute(self) -> OktaGroup:
         old_name = self.group.name
@@ -41,6 +47,28 @@ class ModifyGroupDetails:
             )
             if existing_group is not None:
                 raise ValueError("Group already exists with the same name")
+
+        # Enforce the "App-{app name}-" prefix on app group renames. Unchanged
+        # names are tolerated so description-only edits of legacy non-conforming
+        # groups keep working.
+        if (
+            self.validate_app_group_prefix
+            and self.name is not None
+            and self.name != old_name
+            and type(self.group) is AppGroup
+        ):
+            app = db.session.query(App).filter(App.id == self.group.app_id).filter(App.deleted_at.is_(None)).first()
+            if app is None:
+                raise ValueError("App for AppGroup does not exist")
+            app_group_name_prefix = (
+                f"{AppGroup.APP_GROUP_NAME_PREFIX}{app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}"
+            )
+            if not self.name.startswith(app_group_name_prefix):
+                raise ValueError(
+                    'App Group name "{}" should be prefixed with App name. For example: "{}"'.format(
+                        self.name, app_group_name_prefix
+                    )
+                )
 
         if self.name is not None:
             self.group.name = self.name

--- a/api/routers/group_requests.py
+++ b/api/routers/group_requests.py
@@ -276,11 +276,14 @@ def put_group_request(
 
     resolution_reason = body.reason or ""
     if body.approved:
-        ApproveGroupRequest(
-            group_request=gr,
-            approver_user=current_user_id,
-            approval_reason=resolution_reason,
-        ).execute()
+        try:
+            ApproveGroupRequest(
+                group_request=gr,
+                approver_user=current_user_id,
+                approval_reason=resolution_reason,
+            ).execute()
+        except ValueError as e:
+            raise HTTPException(400, str(e)) from e
     else:
         RejectGroupRequest(
             group_request=gr,

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -29,7 +29,7 @@ from api.auth.permissions import (
     is_app_owner_group_owner,
 )
 from api.database import DbSession
-from api.models import AppGroup, OktaGroup, OktaUserGroupMember, RoleGroup
+from api.models import App, AppGroup, OktaGroup, OktaUserGroupMember, RoleGroup
 from api.operations import (
     CreateGroup,
     DeleteGroup,
@@ -190,7 +190,10 @@ def post_group(
             400, "App owner groups cannot be created directly. They are created automatically when an app is created."
         )
 
-    created = CreateGroup(group=group, tags=body.tags_to_add or [], current_user_id=current_user_id).execute()
+    try:
+        created = CreateGroup(group=group, tags=body.tags_to_add or [], current_user_id=current_user_id).execute()
+    except ValueError as e:
+        raise HTTPException(400, str(e)) from e
     refreshed = _load_group_with_options(db, created.id)
     return _group_adapter.validate_python(refreshed, from_attributes=True)
 
@@ -261,8 +264,6 @@ def put_group(
         and "app_id" in fields_set
         and body.app_id != group.app_id
     ):
-        from api.models import App
-
         target_app = db.query(App).filter(App.id == body.app_id).filter(App.deleted_at.is_(None)).first()
         if target_app is None:
             raise HTTPException(404, "Not Found")
@@ -308,11 +309,41 @@ def put_group(
                 400, "The Role- prefix cannot be used for non-role groups. Please choose a different group name."
             )
 
+    # Converting a group to an app group must yield a name carrying the target
+    # app's "App-{app name}-" prefix, whether or not the request also renames.
+    # Same-type renames are enforced in ModifyGroupDetails; conversions are
+    # checked here because the rename runs while the group is still its old
+    # type. Validating before ModifyGroupDetails also keeps an invalid
+    # conversion from committing the rename.
+    if body.type == "app_group" and type(group) is not AppGroup:
+        final_name = body.name if "name" in fields_set and body.name is not None else group.name
+        target_app_id = (
+            body.app_id
+            if isinstance(body, _AppGroupUpdateBody) and "app_id" in fields_set
+            else getattr(group, "app_id", None)
+        )
+        conversion_app = db.query(App).filter(App.id == target_app_id).filter(App.deleted_at.is_(None)).first()
+        if conversion_app is None:
+            raise HTTPException(400, "App for AppGroup does not exist")
+        app_group_name_prefix = (
+            f"{AppGroup.APP_GROUP_NAME_PREFIX}{conversion_app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}"
+        )
+        if not final_name.startswith(app_group_name_prefix):
+            raise HTTPException(
+                400,
+                'App Group name "{}" should be prefixed with App name. For example: "{}"'.format(
+                    final_name, app_group_name_prefix
+                ),
+            )
+
     try:
         ModifyGroupDetails(
             group=group,
             name=body.name if "name" in fields_set else None,
             description=description,
+            # A type conversion legitimately renames away from the App- prefix;
+            # the final-state name rules are enforced above and by ModifyGroupType.
+            validate_app_group_prefix=body.type == group.type,
         ).execute()
     except ValueError as e:
         raise HTTPException(400, str(e)) from e

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1298,6 +1298,195 @@ def test_cannot_create_group_with_reserved_app_prefix(
     assert rep.status_code == 201
 
 
+def test_create_app_group_requires_app_name_prefix(
+    client: TestClient,
+    db: Db,
+    mocker: MockerFixture,
+    faker: Faker,  # type: ignore[type-arg]
+    access_app: App,
+    url_for: Any,
+) -> None:
+    mocker.patch.object(
+        okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
+    )
+
+    db.session.add(access_app)
+    db.session.commit()
+    app_name = access_app.name
+
+    groups_url = url_for("api-groups.groups")
+    expected_prefix = f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}"
+
+    # app_group with no App- prefix at all is blocked
+    rep = client.post(
+        groups_url, json={"type": "app_group", "app_id": access_app.id, "name": "Whatever", "description": ""}
+    )
+    assert rep.status_code == 400
+    assert rep.json()["detail"] == (
+        f'App Group name "Whatever" should be prefixed with App name. For example: "{expected_prefix}"'
+    )
+
+    # app_group prefixed with a different app's name is blocked
+    wrong_app_name = f"{AppGroup.APP_GROUP_NAME_PREFIX}NotTheApp{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}Group"
+    rep = client.post(
+        groups_url, json={"type": "app_group", "app_id": access_app.id, "name": wrong_app_name, "description": ""}
+    )
+    assert rep.status_code == 400
+
+    # app_group referencing a non-existent app is a 400, not a 500
+    conforming_name = f"{expected_prefix}Group"
+    rep = client.post(
+        groups_url, json={"type": "app_group", "app_id": "nonexistent-app", "name": conforming_name, "description": ""}
+    )
+    assert rep.status_code == 400
+    assert rep.json()["detail"] == "App for AppGroup does not exist"
+
+    # conforming name is allowed
+    rep = client.post(
+        groups_url, json={"type": "app_group", "app_id": access_app.id, "name": conforming_name, "description": ""}
+    )
+    assert rep.status_code == 201
+    assert rep.json()["name"] == conforming_name
+
+
+def test_cannot_rename_app_group_to_non_conforming_name(
+    client: TestClient,
+    db: Db,
+    mocker: MockerFixture,
+    url_for: Any,
+) -> None:
+    mocker.patch.object(okta, "update_group")
+
+    target_app = AppFactory.create()
+    app_group = AppGroupFactory.create(
+        app_id=target_app.id,
+        name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{target_app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}Conforming",
+    )
+    db.session.add_all([target_app, app_group])
+    db.session.commit()
+    app_name = target_app.name
+    app_id = target_app.id
+
+    group_url = url_for("api-groups.group_by_id", group_id=app_group.id)
+    expected_prefix = f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}"
+
+    # Renaming an app group to a name without the app prefix is blocked
+    rep = client.put(group_url, json={"type": "app_group", "app_id": app_id, "name": "Renamed", "description": ""})
+    assert rep.status_code == 400
+    assert rep.json()["detail"] == (
+        f'App Group name "Renamed" should be prefixed with App name. For example: "{expected_prefix}"'
+    )
+
+    # Renaming to a different app's prefix is blocked
+    wrong_prefix_name = f"{AppGroup.APP_GROUP_NAME_PREFIX}OtherApp{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}Renamed"
+    rep = client.put(
+        group_url, json={"type": "app_group", "app_id": app_id, "name": wrong_prefix_name, "description": ""}
+    )
+    assert rep.status_code == 400
+
+    # Renaming within the app's prefix is allowed
+    rep = client.put(
+        group_url,
+        json={"type": "app_group", "app_id": app_id, "name": f"{expected_prefix}Renamed", "description": ""},
+    )
+    assert rep.status_code == 200
+    assert rep.json()["name"] == f"{expected_prefix}Renamed"
+
+
+def test_convert_to_app_group_requires_app_name_prefix(
+    client: TestClient,
+    db: Db,
+    mocker: MockerFixture,
+    access_app: App,
+    url_for: Any,
+) -> None:
+    mocker.patch.object(okta, "update_group")
+
+    okta_group = OktaGroupFactory.create(name="PlainGroup")
+    db.session.add_all([access_app, okta_group])
+    db.session.commit()
+    app_name = access_app.name
+    app_id = access_app.id
+    group_name = okta_group.name
+
+    group_url = url_for("api-groups.group_by_id", group_id=okta_group.id)
+    expected_prefix = f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}"
+
+    # Converting with a rename to a non-conforming name is blocked
+    rep = client.put(
+        group_url, json={"type": "app_group", "app_id": app_id, "name": "NonConforming", "description": ""}
+    )
+    assert rep.status_code == 400
+    assert rep.json()["detail"] == (
+        f'App Group name "NonConforming" should be prefixed with App name. For example: "{expected_prefix}"'
+    )
+
+    # Converting without a rename is blocked when the current name doesn't conform
+    rep = client.put(group_url, json={"type": "app_group", "app_id": app_id})
+    assert rep.status_code == 400
+    assert rep.json()["detail"] == (
+        f'App Group name "{group_name}" should be prefixed with App name. For example: "{expected_prefix}"'
+    )
+
+    # Converting against a non-existent app is a 400, not a rename + 500
+    rep = client.put(
+        group_url,
+        json={"type": "app_group", "app_id": "nonexistent-app", "name": f"{expected_prefix}Members", "description": ""},
+    )
+    assert rep.status_code == 400
+    assert rep.json()["detail"] == "App for AppGroup does not exist"
+
+    # Nothing above should have renamed or converted the group
+    db.session.expire_all()
+    unchanged = db.session.get(OktaGroup, okta_group.id)
+    assert unchanged.name == group_name
+    assert unchanged.type == "okta_group"
+
+    # Converting with a conforming name succeeds
+    rep = client.put(
+        group_url,
+        json={"type": "app_group", "app_id": app_id, "name": f"{expected_prefix}Members", "description": ""},
+    )
+    assert rep.status_code == 200
+    assert rep.json()["type"] == "app_group"
+    assert rep.json()["name"] == f"{expected_prefix}Members"
+
+
+def test_legacy_non_conforming_app_group_tolerates_unchanged_name(
+    client: TestClient,
+    db: Db,
+    mocker: MockerFixture,
+    url_for: Any,
+) -> None:
+    """Pre-enforcement rows may carry non-conforming names; edits that resend
+    the unchanged name (the frontend always sends `name`) must keep working."""
+    mocker.patch.object(okta, "update_group")
+
+    target_app = AppFactory.create()
+    legacy_group = AppGroupFactory.create(app_id=target_app.id, name="App-SomethingElse-Group")
+    db.session.add_all([target_app, legacy_group])
+    db.session.commit()
+    legacy_name = legacy_group.name
+
+    group_url = url_for("api-groups.group_by_id", group_id=legacy_group.id)
+
+    # Description-only edit resending the same name succeeds
+    rep = client.put(
+        group_url,
+        json={"type": "app_group", "app_id": target_app.id, "name": legacy_name, "description": "updated"},
+    )
+    assert rep.status_code == 200
+    assert rep.json()["name"] == legacy_name
+    assert rep.json()["description"] == "updated"
+
+    # But an actual rename must conform
+    rep = client.put(
+        group_url,
+        json={"type": "app_group", "app_id": target_app.id, "name": "App-SomethingElse-Renamed", "description": ""},
+    )
+    assert rep.status_code == 400
+
+
 def test_cannot_rename_non_app_group_to_app_prefix(
     client: TestClient,
     db: Db,

--- a/tests/test_group_request.py
+++ b/tests/test_group_request.py
@@ -14,6 +14,7 @@ from api.models import (
     AccessRequestStatus,
     AppGroup,
     AppTagMap,
+    GroupRequest,
     OktaGroup,
     OktaUser,
     OktaUserGroupMember,
@@ -2554,6 +2555,10 @@ def test_approve_app_group_request_with_non_conforming_resolved_name_is_rejected
     assert rep.status_code == 200
 
     db.session.refresh(group_request)
-    assert group_request.status == AccessRequestStatus.APPROVED
-    created_group = db.session.get(OktaGroup, group_request.approved_group_id)
+    # Re-fetch instead of reusing `group_request` — mypy narrows `status` to
+    # PENDING after the assert above and doesn't know refresh() mutates it.
+    approved_request = db.session.get(GroupRequest, group_request.id)
+    assert approved_request is not None
+    assert approved_request.status == AccessRequestStatus.APPROVED
+    created_group = db.session.get(OktaGroup, approved_request.approved_group_id)
     assert created_group.name == f"App-{app_name}-RenamedGroup"

--- a/tests/test_group_request.py
+++ b/tests/test_group_request.py
@@ -2502,3 +2502,58 @@ def test_approve_group_request_op_blocks_type_mismatch_for_non_admin(
     assert group_request.approved_group_id is None
     role_evil = db.session.query(RoleGroup).filter(func.lower(OktaGroup.name) == func.lower("Role-evil")).first()
     assert role_evil is None
+
+
+def test_approve_app_group_request_with_non_conforming_resolved_name_is_rejected(
+    client: TestClient,
+    db: Db,
+    mocker: MockerFixture,
+    faker: Faker,  # type: ignore[type-arg]
+    user: OktaUser,
+    url_for: Any,
+) -> None:
+    """Approving an app group request whose resolved name lacks the
+    "App-{app name}-" prefix is a 400 and leaves the request pending."""
+    app_obj = AppFactory.create()
+    db.session.add_all([user, app_obj])
+    db.session.commit()
+    app_name = app_obj.name
+
+    mocker.patch.object(
+        okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
+    )
+    mocker.patch.object(okta, "async_add_user_to_group")
+    mocker.patch.object(okta, "async_add_owner_to_group")
+
+    group_request = CreateGroupRequest(
+        requester_user=user,
+        requested_group_name=f"App-{app_name}-NewGroup",
+        requested_group_description="New group",
+        requested_group_type="app_group",
+        requested_app_id=app_obj.id,
+        request_reason="Need a new group",
+    ).execute()
+    assert group_request is not None
+
+    resolve_url = url_for("api-group-requests.group_request_by_id_put", group_request_id=group_request.id)
+    rep = client.put(resolve_url, json={"approved": True, "reason": "ok", "resolved_group_name": "Whatever"})
+    assert rep.status_code == 400
+    assert rep.json()["detail"] == (
+        f'App Group name "Whatever" should be prefixed with App name. For example: "App-{app_name}-"'
+    )
+
+    db.session.refresh(group_request)
+    assert group_request.status == AccessRequestStatus.PENDING
+    assert group_request.approved_group_id is None
+
+    # A conforming resolved name approves cleanly
+    rep = client.put(
+        resolve_url,
+        json={"approved": True, "reason": "ok", "resolved_group_name": f"App-{app_name}-RenamedGroup"},
+    )
+    assert rep.status_code == 200
+
+    db.session.refresh(group_request)
+    assert group_request.status == AccessRequestStatus.APPROVED
+    created_group = db.session.get(OktaGroup, group_request.approved_group_id)
+    assert created_group.name == f"App-{app_name}-RenamedGroup"


### PR DESCRIPTION
## What

Server-side enforcement of the `App-{app name}-` naming rule for app groups, replacing a model-level validator that never ran.

- **`CreateGroup`** now validates the prefix alongside the existing app-existence check — covers `POST /api/groups`, group request approval, and app creation.
- **`ModifyGroupDetails`** validates renames of app groups. Unchanged names are tolerated, so description-only edits of legacy non-conforming rows keep working. A `validate_app_group_prefix` flag lets `put_group` skip the check when the rename is part of a type conversion — converting away from an app group legitimately drops the prefix, and `ModifyGroupType` already requires it gone before converting (blind enforcement would deadlock conversions).
- **`put_group`** validates conversions **to** `app_group` against the target app — whether or not the request also renames — before anything commits. (The conversion rename runs while the group is still its old type, so the operation-layer check can't see it.)
- The dead `@validates("name")` hook on `AppGroup` is removed, with a NOTE comment explaining why a model-level validator can't work there.

## Why

`AppGroup`'s `@validates("name")` was provably dead code: with joined-table inheritance, `name` is mapped on the `OktaGroup` base mapper, so a subclass validator never gets wired to the attribute's `set` event — the AppGroup mapper records it in `mapper.validators` but never installs a listener (verified empirically: construction and reassignment both skip it).

That left the prefix rule unenforced on every path, while other code depends on it: app renames rewrite group names by prefix substitution (`api/routers/apps.py`), and group request approval reasons about reserved prefixes. `POST /api/groups` and `PUT /api/groups/{id}` only checked the inverse rules (non-app groups must not use `App-`).

## Also fixed along the way

- `POST /api/groups` with a bogus `app_id` returned a **500** (the operation's `ValueError` was never caught); now a 400 with `"App for AppGroup does not exist"`. Group request approval had the same unwrapped path.
- Converting a group to `app_group` without an `app_id` committed the rename and then died on an IntegrityError (500, with the rename left applied). Now a clean 400 before any mutation.

## Reviewer notes

- **Behavioral change for direct API clients**: non-conforming app group names were previously silently accepted; they now get a 400 with a copy-pasteable example prefix (same message the old validator intended: `App Group name "{name}" should be prefixed with App name. For example: "{prefix}"`). The frontend is unaffected — all three surfaces (group create/update, request creation, approval) compose the prefix client-side and users only type the suffix. Deployments can check for pre-existing non-conforming rows with:
  ```sql
  SELECT og.name FROM app_group ag
  JOIN okta_group og ON og.id = ag.id
  JOIN app ON app.id = ag.app_id
  WHERE og.name NOT LIKE 'App-' || app.name || '-%' AND og.deleted_at IS NULL;
  ```
  Such rows remain fully usable; only an actual rename forces conformance.
- `ModifyGroupType` is deliberately left unchanged: `CreateApp` adopts pre-existing prefix-matched groups case-insensitively (`ilike`), so a strict check inside `ModifyGroupType` would break app creation for case-mismatched adoptees. Conversions via the API are enforced in the router instead.
- Tests cover: POST with non-conforming name / wrong app's prefix / bogus app_id, PUT rename to non-conforming names, legacy-row leniency, conversion to `app_group` (with and without rename, plus state-untouched assertions after each 400), and approval with a non-conforming resolved name (request stays pending, then approves cleanly with a conforming one).

`pytest` (520 passed), `ruff check`, `ruff format`, and `mypy` are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
