### PR TITLE
[async 1/7] deps: prepare for async SQLAlchemy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,10 +12,12 @@ pydantic>=2.7,<3
 pydantic-settings>=2.6,<3
 
 # Database
-SQLAlchemy==2.0.36
+SQLAlchemy[asyncio]==2.0.50
 alembic==1.18.4
 sqlalchemy-json==0.7.0
-cloud-sql-python-connector==1.14.0
+asyncpg==0.31.0
+aiosqlite==0.22.1
+cloud-sql-python-connector[asyncpg]==1.20.3
 pg8000==1.31.5
 
 # HTTP


### PR DESCRIPTION
First PR of the async-SQLAlchemy migration stack (POST_MIGRATION_TODO items 2, 3, 11, 15).

- `SQLAlchemy==2.0.36` → `SQLAlchemy[asyncio]==2.0.50` — the `asyncio` extra guarantees greenlet on all platforms, and the patch bump lands separately from the async flip so any library regression bisects cleanly
- add `asyncpg==0.31.0` and `aiosqlite==0.22.1` (async drivers for the upcoming `create_async_engine` switch; inert until then)
- `cloud-sql-python-connector==1.14.0` → `cloud-sql-python-connector[asyncpg]==1.20.3` for `connect_async` support

No code changes. `pg8000` stays until the flip PR (#480) moves alembic to the async engine.

## PR stack

Merge bottom-up; each PR is based on the branch of the one before it (retarget to `main` as predecessors merge).

1. #475 — async dependency prep (SQLAlchemy[asyncio] 2.0.50, asyncpg, aiosqlite) ⬅️ **this PR**
2. #476 — legacy Query API -> 2.0-style statements (~350 sites)
3. #477 — eliminate lazy loading and commit-expiration from the ORM layer
4. #478 — operation DB resolution out of `__init__` into `_resolve()`
5. #479 — keep `db.session` access out of spawned notification tasks
6. #480 — **the async flip** (production + tests + docs)
7. #481 — surface failed Okta/notification fan-out tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)


