### PR TITLE
[async 2/7] refactor: modernize the legacy Query API to 2.0-style statements

### DIFF
--- a/api/auth/dependencies.py
+++ b/api/auth/dependencies.py
@@ -18,7 +18,7 @@ from typing import Annotated
 
 from fastapi import Depends, HTTPException
 from sentry_sdk import set_user
-from sqlalchemy import func
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 from starlette.requests import Request
 
@@ -31,12 +31,9 @@ logger = logging.getLogger(__name__)
 
 
 def _lookup_user_by_email(db: Session, email: str) -> OktaUser:
-    user = (
-        db.query(OktaUser)
-        .filter(func.lower(OktaUser.email) == func.lower(email))
-        .filter(OktaUser.deleted_at.is_(None))
-        .first()
-    )
+    user = db.scalars(
+        select(OktaUser).where(func.lower(OktaUser.email) == func.lower(email)).where(OktaUser.deleted_at.is_(None))
+    ).first()
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
     return user
@@ -111,7 +108,9 @@ def get_current_user(
     db: DbSession,
     current_user_id: Annotated[str, Depends(get_current_user_id)],
 ) -> OktaUser:
-    user = db.query(OktaUser).filter(OktaUser.id == current_user_id).filter(OktaUser.deleted_at.is_(None)).first()
+    user = db.scalars(
+        select(OktaUser).where(OktaUser.id == current_user_id).where(OktaUser.deleted_at.is_(None))
+    ).first()
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
     return user

--- a/api/auth/permissions.py
+++ b/api/auth/permissions.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from typing import Annotated, Optional
 
 from fastapi import Depends, HTTPException
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session, selectinload
 
 from api.auth.dependencies import CurrentUserId
@@ -21,20 +21,19 @@ from api.models import App, AppGroup, OktaGroup, OktaUserGroupMember
 
 
 def is_group_owner(db: Session, current_user_id: str, group: OktaGroup) -> bool:
-    return (
-        db.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == group.id)
-        .filter(OktaUserGroupMember.user_id == current_user_id)
-        .filter(OktaUserGroupMember.is_owner.is_(True))
-        .filter(
+    stmt = (
+        select(OktaUserGroupMember)
+        .where(OktaUserGroupMember.group_id == group.id)
+        .where(OktaUserGroupMember.user_id == current_user_id)
+        .where(OktaUserGroupMember.is_owner.is_(True))
+        .where(
             or_(
                 OktaUserGroupMember.ended_at.is_(None),
                 OktaUserGroupMember.ended_at > func.now(),
             )
         )
-        .count()
-        > 0
     )
+    return (db.scalar(select(func.count()).select_from(stmt.subquery())) or 0) > 0
 
 
 def is_app_owner_group_owner(
@@ -51,55 +50,52 @@ def is_app_owner_group_owner(
     else:
         return False
 
-    owner_app_groups = (
-        db.query(AppGroup)
-        .filter(OktaGroup.deleted_at.is_(None))
-        .filter(AppGroup.app_id == app_id)
-        .filter(AppGroup.is_owner.is_(True))
+    owner_app_groups_stmt = (
+        select(AppGroup)
+        .where(OktaGroup.deleted_at.is_(None))
+        .where(AppGroup.app_id == app_id)
+        .where(AppGroup.is_owner.is_(True))
     )
-    if owner_app_groups.count() == 0:
+    if (db.scalar(select(func.count()).select_from(owner_app_groups_stmt.subquery())) or 0) == 0:
         return False
 
-    return (
-        db.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id.in_([ag.id for ag in owner_app_groups]))
-        .filter(OktaUserGroupMember.user_id == current_user_id)
-        .filter(OktaUserGroupMember.is_owner.is_(True))
-        .filter(
+    stmt = (
+        select(OktaUserGroupMember)
+        .where(OktaUserGroupMember.group_id.in_([ag.id for ag in db.scalars(owner_app_groups_stmt)]))
+        .where(OktaUserGroupMember.user_id == current_user_id)
+        .where(OktaUserGroupMember.is_owner.is_(True))
+        .where(
             or_(
                 OktaUserGroupMember.ended_at.is_(None),
                 OktaUserGroupMember.ended_at > func.now(),
             )
         )
-        .count()
-        > 0
     )
+    return (db.scalar(select(func.count()).select_from(stmt.subquery())) or 0) > 0
 
 
 def is_access_admin(db: Session, current_user_id: str) -> bool:
-    access_app = (
-        db.query(App)
+    access_app = db.scalars(
+        select(App)
         .options(selectinload(App.active_owner_app_groups))
-        .filter(App.deleted_at.is_(None))
-        .filter(App.name == App.ACCESS_APP_RESERVED_NAME)
-        .first()
-    )
+        .where(App.deleted_at.is_(None))
+        .where(App.name == App.ACCESS_APP_RESERVED_NAME)
+    ).first()
     if access_app is None or len(access_app.active_owner_app_groups) == 0:
         return False
-    return (
-        db.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id.in_([ag.id for ag in access_app.active_owner_app_groups]))
-        .filter(OktaUserGroupMember.user_id == current_user_id)
-        .filter(OktaUserGroupMember.is_owner.is_(False))
-        .filter(
+    stmt = (
+        select(OktaUserGroupMember)
+        .where(OktaUserGroupMember.group_id.in_([ag.id for ag in access_app.active_owner_app_groups]))
+        .where(OktaUserGroupMember.user_id == current_user_id)
+        .where(OktaUserGroupMember.is_owner.is_(False))
+        .where(
             or_(
                 OktaUserGroupMember.ended_at.is_(None),
                 OktaUserGroupMember.ended_at > func.now(),
             )
         )
-        .count()
-        > 0
     )
+    return (db.scalar(select(func.count()).select_from(stmt.subquery())) or 0) > 0
 
 
 def can_manage_group(db: Session, current_user_id: str, group: OktaGroup) -> bool:
@@ -146,7 +142,9 @@ def require_app_owner_or_access_admin_for_app(
     db: DbSession,
     current_user_id: CurrentUserId,
 ) -> App:
-    app_obj = db.query(App).filter(App.deleted_at.is_(None)).filter(or_(App.id == app_id, App.name == app_id)).first()
+    app_obj = db.scalars(
+        select(App).where(App.deleted_at.is_(None)).where(or_(App.id == app_id, App.name == app_id))
+    ).first()
     if app_obj is None:
         raise HTTPException(status_code=404, detail="Not Found")
     if is_app_owner_group_owner(db, current_user_id, app=app_obj):

--- a/api/integrity.py
+++ b/api/integrity.py
@@ -1,6 +1,6 @@
 import logging
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select, update
 from api.extensions import db
 from api.models import OktaGroup, OktaUserGroupMember, RoleGroupMap
 from api.operations import UnmanageGroup
@@ -10,49 +10,46 @@ logger = logging.getLogger(__name__)
 
 
 def verify_and_fix_unmanaged_groups(dry_run: bool = False) -> None:
-    active_unmanaged_groups = (
-        db.session.query(OktaGroup).filter(OktaGroup.is_managed.is_(False)).filter(OktaGroup.deleted_at.is_(None)).all()
-    )
+    active_unmanaged_groups = db.session.scalars(
+        select(OktaGroup).where(OktaGroup.is_managed.is_(False)).where(OktaGroup.deleted_at.is_(None))
+    ).all()
     for group in active_unmanaged_groups:
         UnmanageGroup(group=group.id).execute(dry_run=dry_run)
 
 
 def verify_and_fix_role_memberships(dry_run: bool = False) -> None:
-    active_role_group_maps = (
-        db.session.query(RoleGroupMap)
-        .filter(
+    active_role_group_maps = db.session.scalars(
+        select(RoleGroupMap).where(
             or_(
                 RoleGroupMap.ended_at.is_(None),
                 RoleGroupMap.ended_at > func.now(),
             )
         )
-        .all()
-    )
+    ).all()
     for active_role_group_map in active_role_group_maps:
         active_role_group_members_query = (
-            db.session.query(OktaUserGroupMember)
-            .filter(OktaUserGroupMember.group_id == active_role_group_map.role_group_id)
-            .filter(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == active_role_group_map.role_group_id)
+            .where(
                 or_(
                     OktaUserGroupMember.ended_at.is_(None),
                     OktaUserGroupMember.ended_at > func.now(),
                 )
             )
-            .filter(OktaUserGroupMember.is_owner.is_(False))
+            .where(OktaUserGroupMember.is_owner.is_(False))
         )
-        active_role_group_members_ids = [m.user_id for m in active_role_group_members_query.all()]
+        active_role_group_members_ids = [m.user_id for m in db.session.scalars(active_role_group_members_query).all()]
 
-        active_group_users_for_role = (
-            db.session.query(OktaUserGroupMember)
-            .filter(
+        active_group_users_for_role = db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(
                 or_(
                     OktaUserGroupMember.ended_at.is_(None),
                     OktaUserGroupMember.ended_at > func.now(),
                 )
             )
-            .filter(OktaUserGroupMember.role_group_map_id == active_role_group_map.id)
-            .all()
-        )
+            .where(OktaUserGroupMember.role_group_map_id == active_role_group_map.id)
+        ).all()
         active_group_users_for_role_ids = [m.user_id for m in active_group_users_for_role]
 
         # Fix missing group memberships/ownerships for the role by adding the user to the group
@@ -65,8 +62,8 @@ def verify_and_fix_role_memberships(dry_run: bool = False) -> None:
             )
             if not dry_run:
                 for member in list(missing_group_users_for_role):
-                    role_group_membership = active_role_group_members_query.filter(
-                        OktaUserGroupMember.user_id == member
+                    role_group_membership = db.session.scalars(
+                        active_role_group_members_query.where(OktaUserGroupMember.user_id == member)
                     ).first()
                     # `member` came out of `active_role_group_members_ids` which we
                     # just built from this same query, so the filter must return a
@@ -115,35 +112,36 @@ def verify_and_fix_role_memberships(dry_run: bool = False) -> None:
             )
             if not dry_run:
                 # End all extra OktaUserGroupMembers the users not members of the role group
-                db.session.query(OktaUserGroupMember).filter(
-                    or_(
-                        OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > func.now(),
+                db.session.execute(
+                    update(OktaUserGroupMember)
+                    .where(
+                        or_(
+                            OktaUserGroupMember.ended_at.is_(None),
+                            OktaUserGroupMember.ended_at > func.now(),
+                        )
                     )
-                ).filter(OktaUserGroupMember.role_group_map_id == active_role_group_map.id).filter(
-                    OktaUserGroupMember.user_id.in_(extra_group_users_for_role)
-                ).update(
-                    {OktaUserGroupMember.ended_at: func.now()},
-                    synchronize_session="fetch",
+                    .where(OktaUserGroupMember.role_group_map_id == active_role_group_map.id)
+                    .where(OktaUserGroupMember.user_id.in_(extra_group_users_for_role))
+                    .values({OktaUserGroupMember.ended_at: func.now()})
+                    .execution_options(synchronize_session="fetch")
                 )
                 db.session.commit()
 
                 # Check if there are other OktaUserGroupMembers for this user/group
                 # combination before removing membership, there can be multiple role groups
                 # which allow group access for this user
-                removed_users_with_other_access = (
-                    db.session.query(OktaUserGroupMember)
-                    .filter(
+                removed_users_with_other_access = db.session.scalars(
+                    select(OktaUserGroupMember)
+                    .where(
                         or_(
                             OktaUserGroupMember.ended_at.is_(None),
                             OktaUserGroupMember.ended_at > func.now(),
                         )
                     )
-                    .filter(OktaUserGroupMember.is_owner == active_role_group_map.is_owner)
-                    .filter(OktaUserGroupMember.group_id == active_role_group_map.group_id)
-                    .filter(OktaUserGroupMember.user_id.in_(extra_group_users_for_role))
-                    .all()
-                )
+                    .where(OktaUserGroupMember.is_owner == active_role_group_map.is_owner)
+                    .where(OktaUserGroupMember.group_id == active_role_group_map.group_id)
+                    .where(OktaUserGroupMember.user_id.in_(extra_group_users_for_role))
+                ).all()
                 removed_users_with_other_access_ids = [m.user_id for m in removed_users_with_other_access]
                 okta_users_to_remove_ids = set(extra_group_users_for_role) - set(removed_users_with_other_access_ids)
                 for user_id in okta_users_to_remove_ids:

--- a/api/manage.py
+++ b/api/manage.py
@@ -17,7 +17,7 @@ import uuid
 from typing import Any, Callable, List, TypeVar
 
 import click
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select
 
 F = TypeVar("F", bound=Callable[..., Any])
 
@@ -119,7 +119,7 @@ def _import_from_okta() -> None:
     from api.services import okta
 
     click.echo("Starting Okta Import")
-    if db.session.query(func.count(OktaUser.id)).scalar() > 0:
+    if (db.session.scalar(select(func.count(OktaUser.id))) or 0) > 0:
         click.echo("Skipping import of Okta Users as they were previously imported")
     else:
         click.echo("Importing Okta Users")
@@ -138,7 +138,7 @@ def _import_from_okta() -> None:
 
         db.session.commit()
 
-    if db.session.query(func.count(OktaGroup.id)).scalar() > 0:
+    if (db.session.scalar(select(func.count(OktaGroup.id))) or 0) > 0:
         click.echo("Skipping import of Okta Groups as they were previously imported")
     else:
         click.echo("Importing Okta Groups")
@@ -150,7 +150,7 @@ def _import_from_okta() -> None:
             db.session.add(group.update_okta_group(OktaGroup(), group_ids_with_group_rules))
         db.session.commit()
 
-    if db.session.query(func.count(OktaUserGroupMember.id)).scalar() > 0:
+    if (db.session.scalar(select(func.count(OktaUserGroupMember.id))) or 0) > 0:
         click.echo("Skipping import of Okta Group Memberships as they were previously imported")
     else:
         click.echo("Importing Okta Group Memberships")
@@ -177,24 +177,23 @@ def _init_builtin_apps(admin_okta_user_email: str) -> None:
     from api.models import App, OktaUser
     from api.operations import CreateApp
 
-    existing_app = (
-        db.session.query(App).filter(App.name == App.ACCESS_APP_RESERVED_NAME).filter(App.deleted_at.is_(None)).first()
-    )
+    existing_app = db.session.scalars(
+        select(App).where(App.name == App.ACCESS_APP_RESERVED_NAME).where(App.deleted_at.is_(None))
+    ).first()
     if existing_app is not None:
         click.echo("Access app and groups already exist, skipping init of built-in apps")
         return
 
-    admin_okta_user = (
-        db.session.query(OktaUser)
-        .filter(OktaUser.deleted_at.is_(None))
-        .filter(
+    admin_okta_user = db.session.scalars(
+        select(OktaUser)
+        .where(OktaUser.deleted_at.is_(None))
+        .where(
             or_(
                 OktaUser.id == admin_okta_user_email,
                 OktaUser.email.ilike(admin_okta_user_email),
             )
         )
-        .first()
-    )
+    ).first()
 
     if admin_okta_user is None:
         click.echo(f"Admin Okta user not found with email or id {admin_okta_user_email}")
@@ -319,8 +318,10 @@ def sync_app_group_memberships() -> None:
 
     click.echo("Starting app group lifecycle plugin sync")
 
-    apps: List[App] = (
-        db.session.query(App).filter(App.deleted_at.is_(None)).filter(App.app_group_lifecycle_plugin.isnot(None)).all()
+    apps: List[App] = list(
+        db.session.scalars(
+            select(App).where(App.deleted_at.is_(None)).where(App.app_group_lifecycle_plugin.isnot(None))
+        ).all()
     )
 
     if len(apps) == 0:

--- a/api/mcp/auth/cloudflare.py
+++ b/api/mcp/auth/cloudflare.py
@@ -45,7 +45,7 @@ from typing import Optional
 
 import jwt
 from fastapi import HTTPException
-from sqlalchemy import func
+from sqlalchemy import func, select
 from starlette.types import Scope
 
 from api.auth.cloudflare import verify_cloudflare_token
@@ -157,12 +157,11 @@ def resolve_identity(scope: Scope) -> Optional[MCPIdentity]:
     if "email" not in payload:
         logger.warning("CF Access JWT verified but carries no 'email' claim")
         return None
-    user = (
-        db.query(OktaUser)
-        .filter(func.lower(OktaUser.email) == func.lower(payload["email"]))
-        .filter(OktaUser.deleted_at.is_(None))
-        .first()
-    )
+    user = db.scalars(
+        select(OktaUser)
+        .where(func.lower(OktaUser.email) == func.lower(payload["email"]))
+        .where(OktaUser.deleted_at.is_(None))
+    ).first()
     if user is None:
         logger.warning(f"CF Access JWT verified for email={payload['email']!r} but no matching active OktaUser exists")
         return None

--- a/api/mcp/auth/dev.py
+++ b/api/mcp/auth/dev.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from sqlalchemy import func
+from sqlalchemy import func, select
 from starlette.types import Scope
 
 from api.config import settings
@@ -37,12 +37,9 @@ def resolve_identity(scope: Scope) -> Optional[MCPIdentity]:
         return None
 
     db = _db_shim.session
-    user = (
-        db.query(OktaUser)
-        .filter(func.lower(OktaUser.email) == func.lower(email))
-        .filter(OktaUser.deleted_at.is_(None))
-        .first()
-    )
+    user = db.scalars(
+        select(OktaUser).where(func.lower(OktaUser.email) == func.lower(email)).where(OktaUser.deleted_at.is_(None))
+    ).first()
     if user is None:
         logger.warning(
             f"Dev MCP auth provider: CURRENT_OKTA_USER_EMAIL={email!r} has no matching active OktaUser; deferring"

--- a/api/mcp/auth/oidc.py
+++ b/api/mcp/auth/oidc.py
@@ -34,7 +34,7 @@ from typing import Any, Optional
 
 import httpx
 import jwt
-from sqlalchemy import func
+from sqlalchemy import func, select
 from starlette.types import Scope
 
 from api.config import settings
@@ -144,12 +144,9 @@ def resolve_identity(scope: Scope) -> Optional[MCPIdentity]:
         return None
 
     db = _db_shim.session
-    user = (
-        db.query(OktaUser)
-        .filter(func.lower(OktaUser.email) == func.lower(email))
-        .filter(OktaUser.deleted_at.is_(None))
-        .first()
-    )
+    user = db.scalars(
+        select(OktaUser).where(func.lower(OktaUser.email) == func.lower(email)).where(OktaUser.deleted_at.is_(None))
+    ).first()
     if user is None:
         logger.warning(f"OIDC token verified for email={email!r} but no matching active OktaUser exists")
         return None

--- a/api/mcp/tools.py
+++ b/api/mcp/tools.py
@@ -58,8 +58,8 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from mcp.types import ToolAnnotations
 from pydantic import TypeAdapter, ValidationError
-from sqlalchemy import func, nullsfirst, or_
-from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload
+from sqlalchemy import func, nullsfirst, or_, select
+from sqlalchemy.orm import joinedload, noload, selectin_polymorphic, selectinload
 
 from api.auth.permissions import can_manage_group
 from api.context import get_request_context
@@ -189,12 +189,12 @@ def _clamp_pagination(page: int, size: int) -> tuple[int, int, Optional[str]]:
     return page, size, None
 
 
-def _paginate_query(query: Any, page: int, size: int) -> dict[str, Any]:
+def _paginate_query(db: Any, query: Any, page: int, size: int) -> dict[str, Any]:
     """Run ``query`` and return the standard envelope. ``page`` is
     zero-indexed."""
-    total = query.order_by(None).count()
+    total = db.scalar(select(func.count()).select_from(query.order_by(None).options(noload("*")).subquery())) or 0
     pages = max(1, (total + size - 1) // size)
-    items = query.limit(size).offset(page * size).all()
+    items = db.scalars(query.limit(size).offset(page * size)).all()
     return {"total": total, "pages": pages, "page": page, "size": size, "items": items}
 
 
@@ -383,7 +383,7 @@ def _register_group_tools(mcp: "FastMCP") -> None:
             return _error(err)
         db = _db_shim.session
         query = (
-            db.query(OktaGroup)
+            select(OktaGroup)
             .options(
                 selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
                 selectinload(OktaGroup.active_group_tags).options(*group_tag_map_options()),
@@ -391,16 +391,16 @@ def _register_group_tools(mcp: "FastMCP") -> None:
                 selectinload(RoleGroup.active_role_associated_group_owner_mappings).options(*role_group_map_options()),
                 joinedload(AppGroup.app),
             )
-            .filter(OktaGroup.deleted_at.is_(None))
+            .where(OktaGroup.deleted_at.is_(None))
             .order_by(func.lower(OktaGroup.name))
         )
         if q:
             like = f"%{q}%"
-            query = query.filter(or_(OktaGroup.name.ilike(like), OktaGroup.description.ilike(like)))
+            query = query.where(or_(OktaGroup.name.ilike(like), OktaGroup.description.ilike(like)))
         if managed is not None:
-            query = query.filter(OktaGroup.is_managed == managed)
+            query = query.where(OktaGroup.is_managed == managed)
 
-        page_data = _paginate_query(query, page, size)
+        page_data = _paginate_query(db, query, page, size)
         adapter: TypeAdapter[Any] = TypeAdapter(GroupSummary)
         results = [_serialize_model(adapter.validate_python(row, from_attributes=True)) for row in page_data["items"]]
         return json.dumps(
@@ -437,13 +437,12 @@ def _register_group_tools(mcp: "FastMCP") -> None:
     @requires_scope(MCP_SCOPE_READ_ALL)
     def get_group(group_id_or_name: str) -> str:
         db = _db_shim.session
-        group = (
-            db.query(OktaGroup)
+        group = db.scalars(
+            select(OktaGroup)
             .options(*_group_load_options())
-            .filter(or_(OktaGroup.id == group_id_or_name, OktaGroup.name == group_id_or_name))
+            .where(or_(OktaGroup.id == group_id_or_name, OktaGroup.name == group_id_or_name))
             .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
-            .first()
-        )
+        ).first()
         if group is None:
             return _error("Group not found")
         validated = _group_adapter.validate_python(group, from_attributes=True)
@@ -463,27 +462,24 @@ def _register_group_tools(mcp: "FastMCP") -> None:
     @requires_scope(MCP_SCOPE_READ_ALL)
     def list_group_memberships(group_id_or_name: str) -> str:
         db = _db_shim.session
-        group = (
-            db.query(OktaGroup)
-            .filter(OktaGroup.deleted_at.is_(None))
-            .filter(or_(OktaGroup.id == group_id_or_name, OktaGroup.name == group_id_or_name))
-            .first()
-        )
+        group = db.scalars(
+            select(OktaGroup)
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(or_(OktaGroup.id == group_id_or_name, OktaGroup.name == group_id_or_name))
+        ).first()
         if group is None:
             return _error("Group not found")
-        rows = (
-            db.query(OktaUserGroupMember)
-            .with_entities(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
-            .filter(
+        rows = db.execute(
+            select(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
+            .where(
                 or_(
                     OktaUserGroupMember.ended_at.is_(None),
                     OktaUserGroupMember.ended_at > func.now(),
                 )
             )
-            .filter(OktaUserGroupMember.group_id == group.id)
+            .where(OktaUserGroupMember.group_id == group.id)
             .group_by(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
-            .all()
-        )
+        ).all()
         result = GroupMembersSummary(
             members=[r.user_id for r in rows if not r.is_owner],
             owners=[r.user_id for r in rows if r.is_owner],
@@ -512,34 +508,31 @@ def _register_role_tools(mcp: "FastMCP") -> None:
         if err:
             return _error(err)
         db = _db_shim.session
-        query = db.query(RoleGroup).filter(RoleGroup.deleted_at.is_(None)).order_by(func.lower(RoleGroup.name))
+        query = select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).order_by(func.lower(RoleGroup.name))
         if owner_id:
-            owner = (
-                db.query(OktaUser)
-                .filter(or_(OktaUser.id == owner_id, OktaUser.email.ilike(owner_id)))
+            owner = db.scalars(
+                select(OktaUser)
+                .where(or_(OktaUser.id == owner_id, OktaUser.email.ilike(owner_id)))
                 .order_by(nullsfirst(OktaUser.deleted_at.desc()))
-                .first()
-            )
+            ).first()
             if owner is None:
                 return _error(f"Owner not found: {owner_id}")
-            owned_role_ids = [
-                row.group_id
-                for row in db.query(OktaUserGroupMember.group_id)
-                .filter(OktaUserGroupMember.user_id == owner.id)
-                .filter(OktaUserGroupMember.is_owner.is_(True))
-                .filter(
+            owned_role_ids = db.scalars(
+                select(OktaUserGroupMember.group_id)
+                .where(OktaUserGroupMember.user_id == owner.id)
+                .where(OktaUserGroupMember.is_owner.is_(True))
+                .where(
                     or_(
                         OktaUserGroupMember.ended_at.is_(None),
                         OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
-                .all()
-            ]
-            query = query.filter(RoleGroup.id.in_(owned_role_ids))
+            ).all()
+            query = query.where(RoleGroup.id.in_(owned_role_ids))
         if q:
             like = f"%{q}%"
-            query = query.filter(or_(RoleGroup.name.ilike(like), RoleGroup.description.ilike(like)))
-        page_data = _paginate_query(query, page, size)
+            query = query.where(or_(RoleGroup.name.ilike(like), RoleGroup.description.ilike(like)))
+        page_data = _paginate_query(db, query, page, size)
         adapter: TypeAdapter[Any] = TypeAdapter(RoleGroupListItem)
         results = [_serialize_model(adapter.validate_python(row, from_attributes=True)) for row in page_data["items"]]
         return json.dumps(
@@ -569,13 +562,12 @@ def _register_role_tools(mcp: "FastMCP") -> None:
     @requires_scope(MCP_SCOPE_READ_ALL)
     def get_role(role_id_or_name: str) -> str:
         db = _db_shim.session
-        role = (
-            db.query(RoleGroup)
+        role = db.scalars(
+            select(RoleGroup)
             .options(*_group_load_options())
-            .filter(or_(RoleGroup.id == role_id_or_name, RoleGroup.name == role_id_or_name))
+            .where(or_(RoleGroup.id == role_id_or_name, RoleGroup.name == role_id_or_name))
             .order_by(nullsfirst(RoleGroup.deleted_at.desc()))
-            .first()
-        )
+        ).first()
         if role is None:
             return _error("Role not found")
         return _group_adapter.dump_json(_group_adapter.validate_python(role, from_attributes=True)).decode()
@@ -602,11 +594,11 @@ def _register_app_tools(mcp: "FastMCP") -> None:
         if err:
             return _error(err)
         db = _db_shim.session
-        query = db.query(App).filter(App.deleted_at.is_(None)).order_by(func.lower(App.name))
+        query = select(App).where(App.deleted_at.is_(None)).order_by(func.lower(App.name))
         if q:
             like = f"%{q}%"
-            query = query.filter(or_(App.name.ilike(like), App.description.ilike(like)))
-        page_data = _paginate_query(query, page, size)
+            query = query.where(or_(App.name.ilike(like), App.description.ilike(like)))
+        page_data = _paginate_query(db, query, page, size)
         adapter: TypeAdapter[Any] = TypeAdapter(AppSummary)
         results = [_serialize_model(adapter.validate_python(row, from_attributes=True)) for row in page_data["items"]]
         return json.dumps(
@@ -633,13 +625,12 @@ def _register_app_tools(mcp: "FastMCP") -> None:
     @requires_scope(MCP_SCOPE_READ_ALL)
     def get_app(app_id_or_name: str) -> str:
         db = _db_shim.session
-        app = (
-            db.query(App)
+        app = db.scalars(
+            select(App)
             .options(*_app_load_options())
-            .filter(App.deleted_at.is_(None))
-            .filter(or_(App.id == app_id_or_name, App.name == app_id_or_name))
-            .first()
-        )
+            .where(App.deleted_at.is_(None))
+            .where(or_(App.id == app_id_or_name, App.name == app_id_or_name))
+        ).first()
         if app is None:
             return _error("App not found")
         return AppDetail.model_validate(app, from_attributes=True).model_dump_json()
@@ -665,10 +656,10 @@ def _register_user_tools(mcp: "FastMCP") -> None:
         if err:
             return _error(err)
         db = _db_shim.session
-        query = db.query(OktaUser).filter(OktaUser.deleted_at.is_(None)).order_by(func.lower(OktaUser.email))
+        query = select(OktaUser).where(OktaUser.deleted_at.is_(None)).order_by(func.lower(OktaUser.email))
         if q:
             like = f"%{q}%"
-            query = query.filter(
+            query = query.where(
                 or_(
                     OktaUser.email.ilike(like),
                     OktaUser.first_name.ilike(like),
@@ -677,7 +668,7 @@ def _register_user_tools(mcp: "FastMCP") -> None:
                     (OktaUser.first_name + " " + OktaUser.last_name).ilike(like),
                 )
             )
-        page_data = _paginate_query(query, page, size)
+        page_data = _paginate_query(db, query, page, size)
         adapter: TypeAdapter[Any] = TypeAdapter(OktaUserSummary)
         results = [_serialize_model(adapter.validate_python(row, from_attributes=True)) for row in page_data["items"]]
         return json.dumps(
@@ -706,17 +697,16 @@ def _register_user_tools(mcp: "FastMCP") -> None:
         if user_id_or_email == "@me":
             user_id_or_email = get_mcp_user_id()
         db = _db_shim.session
-        user = (
-            db.query(OktaUser)
+        user = db.scalars(
+            select(OktaUser)
             .options(
                 selectinload(OktaUser.active_group_memberships).options(*user_group_member_options()),
                 selectinload(OktaUser.active_group_ownerships).options(*user_group_member_options()),
                 joinedload(OktaUser.manager),
             )
-            .filter(or_(OktaUser.id == user_id_or_email, OktaUser.email.ilike(user_id_or_email)))
+            .where(or_(OktaUser.id == user_id_or_email, OktaUser.email.ilike(user_id_or_email)))
             .order_by(nullsfirst(OktaUser.deleted_at.desc()))
-            .first()
-        )
+        ).first()
         if user is None:
             return _error("User not found")
         return OktaUserDetail.model_validate(user, from_attributes=True).model_dump_json()
@@ -744,11 +734,11 @@ def _register_tag_tools(mcp: "FastMCP") -> None:
         if err:
             return _error(err)
         db = _db_shim.session
-        query = db.query(Tag).filter(Tag.deleted_at.is_(None)).order_by(func.lower(Tag.name))
+        query = select(Tag).where(Tag.deleted_at.is_(None)).order_by(func.lower(Tag.name))
         if q:
             like = f"%{q}%"
-            query = query.filter(or_(Tag.name.ilike(like), Tag.description.ilike(like)))
-        page_data = _paginate_query(query, page, size)
+            query = query.where(or_(Tag.name.ilike(like), Tag.description.ilike(like)))
+        page_data = _paginate_query(db, query, page, size)
         adapter: TypeAdapter[Any] = TypeAdapter(TagListItem)
         results = [_serialize_model(adapter.validate_python(row, from_attributes=True)) for row in page_data["items"]]
         return json.dumps(
@@ -768,13 +758,12 @@ def _register_tag_tools(mcp: "FastMCP") -> None:
     @requires_scope(MCP_SCOPE_READ_ALL)
     def get_tag(tag_id_or_name: str) -> str:
         db = _db_shim.session
-        tag = (
-            db.query(Tag)
+        tag = db.scalars(
+            select(Tag)
             .options(*_tag_load_options())
-            .filter(or_(Tag.id == tag_id_or_name, Tag.name == tag_id_or_name))
+            .where(or_(Tag.id == tag_id_or_name, Tag.name == tag_id_or_name))
             .order_by(nullsfirst(Tag.deleted_at.desc()))
-            .first()
-        )
+        ).first()
         if tag is None:
             return _error("Tag not found")
         return TagDetail.model_validate(tag, from_attributes=True).model_dump_json()
@@ -812,33 +801,33 @@ def _register_access_request_tools(mcp: "FastMCP") -> None:
         db = _db_shim.session
         current_user_id = get_mcp_user_id()
         query = (
-            db.query(AccessRequest)
+            select(AccessRequest)
             .options(*_access_request_summary_load_options())
             .order_by(AccessRequest.created_at.desc())
         )
         if status:
-            query = query.filter(AccessRequest.status == status)
+            query = query.where(AccessRequest.status == status)
         if requester_user_id:
             if requester_user_id == "@me":
-                query = query.filter(AccessRequest.requester_user_id == current_user_id)
+                query = query.where(AccessRequest.requester_user_id == current_user_id)
             else:
-                query = query.filter(AccessRequest.requester_user_id == requester_user_id)
+                query = query.where(AccessRequest.requester_user_id == requester_user_id)
         if requested_group_id:
-            query = query.filter(AccessRequest.requested_group_id == requested_group_id)
+            query = query.where(AccessRequest.requested_group_id == requested_group_id)
         if resolver_user_id:
             if resolver_user_id == "@me":
-                query = query.filter(AccessRequest.resolver_user_id == current_user_id)
+                query = query.where(AccessRequest.resolver_user_id == current_user_id)
             else:
-                query = query.filter(AccessRequest.resolver_user_id == resolver_user_id)
+                query = query.where(AccessRequest.resolver_user_id == resolver_user_id)
         if q:
             like = f"%{q}%"
-            query = query.filter(
+            query = query.where(
                 or_(
                     AccessRequest.id.like(f"{q}%"),
                     AccessRequest.request_reason.ilike(like),
                 )
             )
-        page_data = _paginate_query(query, page, size)
+        page_data = _paginate_query(db, query, page, size)
         adapter: TypeAdapter[Any] = TypeAdapter(AccessRequestSummary)
         results = [_serialize_model(adapter.validate_python(row, from_attributes=True)) for row in page_data["items"]]
         return json.dumps(
@@ -859,12 +848,11 @@ def _register_access_request_tools(mcp: "FastMCP") -> None:
     @requires_scope(MCP_SCOPE_READ_ALL)
     def get_access_request(access_request_id: str) -> str:
         db = _db_shim.session
-        ar = (
-            db.query(AccessRequest)
+        ar = db.scalars(
+            select(AccessRequest)
             .options(*_access_request_detail_load_options())
-            .filter(AccessRequest.id == access_request_id)
-            .first()
-        )
+            .where(AccessRequest.id == access_request_id)
+        ).first()
         if ar is None:
             return _error("Access request not found")
         return AccessRequestDetail.model_validate(ar, from_attributes=True).model_dump_json()
@@ -901,23 +889,23 @@ def _register_role_request_tools(mcp: "FastMCP") -> None:
         db = _db_shim.session
         current_user_id = get_mcp_user_id()
         query = (
-            db.query(RoleRequest).options(*_role_request_summary_load_options()).order_by(RoleRequest.created_at.desc())
+            select(RoleRequest).options(*_role_request_summary_load_options()).order_by(RoleRequest.created_at.desc())
         )
         if status:
-            query = query.filter(RoleRequest.status == status)
+            query = query.where(RoleRequest.status == status)
         if requester_user_id:
             if requester_user_id == "@me":
-                query = query.filter(RoleRequest.requester_user_id == current_user_id)
+                query = query.where(RoleRequest.requester_user_id == current_user_id)
             else:
-                query = query.filter(RoleRequest.requester_user_id == requester_user_id)
+                query = query.where(RoleRequest.requester_user_id == requester_user_id)
         if requester_role_id:
-            query = query.filter(RoleRequest.requester_role_id == requester_role_id)
+            query = query.where(RoleRequest.requester_role_id == requester_role_id)
         if requested_group_id:
-            query = query.filter(RoleRequest.requested_group_id == requested_group_id)
+            query = query.where(RoleRequest.requested_group_id == requested_group_id)
         if q:
             like = f"%{q}%"
-            query = query.filter(or_(RoleRequest.id.like(f"{q}%"), RoleRequest.request_reason.ilike(like)))
-        page_data = _paginate_query(query, page, size)
+            query = query.where(or_(RoleRequest.id.like(f"{q}%"), RoleRequest.request_reason.ilike(like)))
+        page_data = _paginate_query(db, query, page, size)
         adapter: TypeAdapter[Any] = TypeAdapter(RoleRequestSummary)
         results = [_serialize_model(adapter.validate_python(row, from_attributes=True)) for row in page_data["items"]]
         return json.dumps(
@@ -937,12 +925,9 @@ def _register_role_request_tools(mcp: "FastMCP") -> None:
     @requires_scope(MCP_SCOPE_READ_ALL)
     def get_role_request(role_request_id: str) -> str:
         db = _db_shim.session
-        rr = (
-            db.query(RoleRequest)
-            .options(*_role_request_detail_load_options())
-            .filter(RoleRequest.id == role_request_id)
-            .first()
-        )
+        rr = db.scalars(
+            select(RoleRequest).options(*_role_request_detail_load_options()).where(RoleRequest.id == role_request_id)
+        ).first()
         if rr is None:
             return _error("Role request not found")
         return RoleRequestDetail.model_validate(rr, from_attributes=True).model_dump_json()
@@ -978,28 +963,28 @@ def _register_group_request_tools(mcp: "FastMCP") -> None:
             return _error(err)
         db = _db_shim.session
         current_user_id = get_mcp_user_id()
-        query = db.query(GroupRequest).options(*_group_request_load_options()).order_by(GroupRequest.created_at.desc())
+        query = select(GroupRequest).options(*_group_request_load_options()).order_by(GroupRequest.created_at.desc())
         if status:
-            query = query.filter(GroupRequest.status == status)
+            query = query.where(GroupRequest.status == status)
         if requester_user_id:
             if requester_user_id == "@me":
-                query = query.filter(GroupRequest.requester_user_id == current_user_id)
+                query = query.where(GroupRequest.requester_user_id == current_user_id)
             else:
-                query = query.filter(GroupRequest.requester_user_id == requester_user_id)
+                query = query.where(GroupRequest.requester_user_id == requester_user_id)
         if requested_group_type:
-            query = query.filter(GroupRequest.requested_group_type == requested_group_type)
+            query = query.where(GroupRequest.requested_group_type == requested_group_type)
         if requested_app_id:
-            query = query.filter(GroupRequest.requested_app_id == requested_app_id)
+            query = query.where(GroupRequest.requested_app_id == requested_app_id)
         if q:
             like = f"%{q}%"
-            query = query.filter(
+            query = query.where(
                 or_(
                     GroupRequest.id.like(f"{q}%"),
                     GroupRequest.requested_group_name.ilike(like),
                     GroupRequest.request_reason.ilike(like),
                 )
             )
-        page_data = _paginate_query(query, page, size)
+        page_data = _paginate_query(db, query, page, size)
         adapter: TypeAdapter[Any] = TypeAdapter(GroupRequestDetail)
         results = [_serialize_model(adapter.validate_python(row, from_attributes=True)) for row in page_data["items"]]
         return json.dumps(
@@ -1015,12 +1000,9 @@ def _register_group_request_tools(mcp: "FastMCP") -> None:
     @requires_scope(MCP_SCOPE_READ_ALL)
     def get_group_request(group_request_id: str) -> str:
         db = _db_shim.session
-        gr = (
-            db.query(GroupRequest)
-            .options(*_group_request_load_options())
-            .filter(GroupRequest.id == group_request_id)
-            .first()
-        )
+        gr = db.scalars(
+            select(GroupRequest).options(*_group_request_load_options()).where(GroupRequest.id == group_request_id)
+        ).first()
         if gr is None:
             return _error("Group request not found")
         return GroupRequestDetail.model_validate(gr, from_attributes=True).model_dump_json()
@@ -1058,37 +1040,35 @@ def _register_audit_tool(mcp: "FastMCP") -> None:
         db = _db_shim.session
         current_user_id = get_mcp_user_id()
 
-        query = db.query(OktaUserGroupMember).order_by(OktaUserGroupMember.created_at.desc())
+        query = select(OktaUserGroupMember).order_by(OktaUserGroupMember.created_at.desc())
 
         if user_id:
             resolved_user_id = current_user_id if user_id == "@me" else user_id
             # Accept email too — match by id or email.
-            user = (
-                db.query(OktaUser)
-                .filter(or_(OktaUser.id == resolved_user_id, OktaUser.email.ilike(resolved_user_id)))
+            user = db.scalars(
+                select(OktaUser)
+                .where(or_(OktaUser.id == resolved_user_id, OktaUser.email.ilike(resolved_user_id)))
                 .order_by(nullsfirst(OktaUser.deleted_at.desc()))
-                .first()
-            )
+            ).first()
             if user is None:
                 return _error(f"User not found: {user_id}")
-            query = query.filter(OktaUserGroupMember.user_id == user.id)
+            query = query.where(OktaUserGroupMember.user_id == user.id)
 
         if group_id:
-            group = (
-                db.query(OktaGroup)
-                .filter(or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
+            group = db.scalars(
+                select(OktaGroup)
+                .where(or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
                 .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
-                .first()
-            )
+            ).first()
             if group is None:
                 return _error(f"Group not found: {group_id}")
-            query = query.filter(OktaUserGroupMember.group_id == group.id)
+            query = query.where(OktaUserGroupMember.group_id == group.id)
 
         if is_owner is not None:
-            query = query.filter(OktaUserGroupMember.is_owner == is_owner)
+            query = query.where(OktaUserGroupMember.is_owner == is_owner)
 
         if active_only:
-            query = query.filter(
+            query = query.where(
                 or_(
                     OktaUserGroupMember.ended_at.is_(None),
                     OktaUserGroupMember.ended_at > func.now(),
@@ -1100,9 +1080,9 @@ def _register_audit_tool(mcp: "FastMCP") -> None:
         # related model. For MCP we keep it simple and return only the
         # scalar columns + user_id / group_id; clients that need richer
         # data can call get_user / get_group on the id values.
-        total = query.order_by(None).count()
+        total = db.scalar(select(func.count()).select_from(query.order_by(None).subquery())) or 0
         pages = max(1, (total + size - 1) // size)
-        items = query.limit(size).offset(page * size).all()
+        items = db.scalars(query.limit(size).offset(page * size)).all()
         results = [
             {
                 "id": m.id,
@@ -1169,33 +1149,32 @@ def _register_write_tools(mcp: "FastMCP") -> None:
         from api.operations import CreateAccessRequest, RejectAccessRequest
 
         with mcp_db_session() as db:
-            requester = (
-                db.query(OktaUser).filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first()
-            )
+            requester = db.scalars(
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+            ).first()
             if requester is None:
                 # No active OktaUser for the resolved id — typically a
                 # service-token request hitting an action that requires
                 # a real human identity. The REST handler returns 403
                 # here; we mirror that.
                 return _error("Current user is not allowed to perform this action")
-            group = (
-                db.query(OktaGroup).filter(OktaGroup.id == body.group_id).filter(OktaGroup.deleted_at.is_(None)).first()
-            )
+            group = db.scalars(
+                select(OktaGroup).where(OktaGroup.id == body.group_id).where(OktaGroup.deleted_at.is_(None))
+            ).first()
             if group is None:
                 return _error("Group not found")
             if not group.is_managed:
                 return _error("Groups not managed by Access cannot be modified")
 
             # Same supersede-prior-pending behavior as POST /api/requests.
-            existing_pending = (
-                db.query(AccessRequest)
-                .filter(AccessRequest.status == AccessRequestStatus.PENDING)
-                .filter(AccessRequest.requester_user_id == requester.id)
-                .filter(AccessRequest.requested_group_id == group.id)
-                .filter(AccessRequest.request_ownership.is_(body.group_owner))
-                .filter(AccessRequest.resolved_at.is_(None))
-                .all()
-            )
+            existing_pending = db.scalars(
+                select(AccessRequest)
+                .where(AccessRequest.status == AccessRequestStatus.PENDING)
+                .where(AccessRequest.requester_user_id == requester.id)
+                .where(AccessRequest.requested_group_id == group.id)
+                .where(AccessRequest.request_ownership.is_(body.group_owner))
+                .where(AccessRequest.resolved_at.is_(None))
+            ).all()
             for prior in existing_pending:
                 RejectAccessRequest(
                     access_request=prior,
@@ -1217,12 +1196,9 @@ def _register_write_tools(mcp: "FastMCP") -> None:
             if ar is None:
                 return _error("Access request could not be created")
 
-            refreshed = (
-                db.query(AccessRequest)
-                .options(*_access_request_summary_load_options())
-                .filter(AccessRequest.id == ar.id)
-                .first()
-            )
+            refreshed = db.scalars(
+                select(AccessRequest).options(*_access_request_summary_load_options()).where(AccessRequest.id == ar.id)
+            ).first()
             # Log the MCP-origin tag onto the audit channel separately
             # from the operation's own audit emission, which already
             # picks up `source="mcp"` from the active RequestContext.
@@ -1276,12 +1252,12 @@ def _register_write_tools(mcp: "FastMCP") -> None:
         from api.operations import CreateRoleRequest, RejectRoleRequest
 
         with mcp_db_session() as db:
-            requester = (
-                db.query(OktaUser).filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first()
-            )
-            role = (
-                db.query(RoleGroup).filter(RoleGroup.deleted_at.is_(None)).filter(RoleGroup.id == body.role_id).first()
-            )
+            requester = db.scalars(
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+            ).first()
+            role = db.scalars(
+                select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == body.role_id)
+            ).first()
             if role is None:
                 return _error("Role not found")
             # Same authorization gate as POST /api/role-requests: the
@@ -1292,9 +1268,9 @@ def _register_write_tools(mcp: "FastMCP") -> None:
             # we surface the same 403 message the REST handler does.
             if requester is None or not can_manage_group(db, current_user_id, role):
                 return _error("Current user is not allowed to perform this action")
-            group = (
-                db.query(OktaGroup).filter(OktaGroup.deleted_at.is_(None)).filter(OktaGroup.id == body.group_id).first()
-            )
+            group = db.scalars(
+                select(OktaGroup).where(OktaGroup.deleted_at.is_(None)).where(OktaGroup.id == body.group_id)
+            ).first()
             if group is None:
                 return _error("Group not found")
             if not group.is_managed:
@@ -1305,16 +1281,15 @@ def _register_write_tools(mcp: "FastMCP") -> None:
                 # error surfaces before we hit the operation.
                 return _error("Role requests may only be made for groups and app groups (not roles).")
 
-            existing = (
-                db.query(RoleRequest)
-                .filter(RoleRequest.requester_user_id == current_user_id)
-                .filter(RoleRequest.requester_role_id == body.role_id)
-                .filter(RoleRequest.requested_group_id == body.group_id)
-                .filter(RoleRequest.request_ownership == body.group_owner)
-                .filter(RoleRequest.status == AccessRequestStatus.PENDING)
-                .filter(RoleRequest.resolved_at.is_(None))
-                .all()
-            )
+            existing = db.scalars(
+                select(RoleRequest)
+                .where(RoleRequest.requester_user_id == current_user_id)
+                .where(RoleRequest.requester_role_id == body.role_id)
+                .where(RoleRequest.requested_group_id == body.group_id)
+                .where(RoleRequest.request_ownership == body.group_owner)
+                .where(RoleRequest.status == AccessRequestStatus.PENDING)
+                .where(RoleRequest.resolved_at.is_(None))
+            ).all()
             for old in existing:
                 RejectRoleRequest(
                     role_request=old,
@@ -1333,12 +1308,9 @@ def _register_write_tools(mcp: "FastMCP") -> None:
             ).execute()
             if rr is None:
                 return _error("Role request could not be created")
-            refreshed = (
-                db.query(RoleRequest)
-                .options(*_role_request_summary_load_options())
-                .filter(RoleRequest.id == rr.id)
-                .first()
-            )
+            refreshed = db.scalars(
+                select(RoleRequest).options(*_role_request_summary_load_options()).where(RoleRequest.id == rr.id)
+            ).first()
             _ctx = get_request_context()
             if _ctx is not None and _ctx.source == "mcp":
                 logger.info(
@@ -1406,9 +1378,9 @@ def _register_write_tools(mcp: "FastMCP") -> None:
             # authenticated can ask Access to create a group; the
             # approval step (not exposed here) is where the gating
             # happens.
-            requester = (
-                db.query(OktaUser).filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first()
-            )
+            requester = db.scalars(
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+            ).first()
             if requester is None:
                 return _error("Current user is not allowed to perform this action")
 
@@ -1416,27 +1388,27 @@ def _register_write_tools(mcp: "FastMCP") -> None:
             if body.requested_group_type == "app_group":
                 if requested_app_id is None:
                     return _error("app_id is required for app group requests")
-                app = db.query(App).filter(App.deleted_at.is_(None)).filter(App.id == requested_app_id).first()
+                app = db.scalars(select(App).where(App.deleted_at.is_(None)).where(App.id == requested_app_id)).first()
                 if app is None:
                     return _error("App not found")
 
             if body.requested_group_tags:
-                tags = (
-                    db.query(Tag).filter(Tag.deleted_at.is_(None)).filter(Tag.id.in_(body.requested_group_tags)).all()
-                )
+                tags = db.scalars(
+                    select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(body.requested_group_tags))
+                ).all()
                 if len(tags) != len(body.requested_group_tags):
                     return _error("One or more tags not found")
 
             existing_query = (
-                db.query(GroupRequest)
-                .filter(GroupRequest.requested_group_name == body.requested_group_name)
-                .filter(GroupRequest.requester_user_id == current_user_id)
-                .filter(GroupRequest.status == AccessRequestStatus.PENDING)
-                .filter(GroupRequest.resolved_at.is_(None))
+                select(GroupRequest)
+                .where(GroupRequest.requested_group_name == body.requested_group_name)
+                .where(GroupRequest.requester_user_id == current_user_id)
+                .where(GroupRequest.status == AccessRequestStatus.PENDING)
+                .where(GroupRequest.resolved_at.is_(None))
             )
             if body.requested_group_type == "app_group":
-                existing_query = existing_query.filter(GroupRequest.requested_app_id == requested_app_id)
-            for prior in existing_query.all():
+                existing_query = existing_query.where(GroupRequest.requested_app_id == requested_app_id)
+            for prior in db.scalars(existing_query).all():
                 RejectGroupRequest(
                     group_request=prior,
                     rejection_reason="Closed due to duplicate group request creation",
@@ -1456,9 +1428,9 @@ def _register_write_tools(mcp: "FastMCP") -> None:
             ).execute()
             if gr is None:
                 return _error("Group request could not be created")
-            refreshed = (
-                db.query(GroupRequest).options(*_group_request_load_options()).filter(GroupRequest.id == gr.id).first()
-            )
+            refreshed = db.scalars(
+                select(GroupRequest).options(*_group_request_load_options()).where(GroupRequest.id == gr.id)
+            ).first()
             _ctx = get_request_context()
             if _ctx is not None and _ctx.source == "mcp":
                 logger.info(

--- a/api/models/app_group.py
+++ b/api/models/app_group.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select
 
 from api.extensions import db
 from api.models.core_models import App, AppGroup, OktaGroup, OktaUser, OktaUserGroupMember
@@ -8,26 +8,27 @@ from api.models.core_models import App, AppGroup, OktaGroup, OktaUser, OktaUserG
 
 def get_app_managers(app_id: str) -> List[OktaUser]:
     """Returns the users that can manage members of the app"""
-    owner_app_groups = (
-        db.session.query(AppGroup)
-        .filter(OktaGroup.deleted_at.is_(None))
-        .filter(AppGroup.app_id == app_id)
-        .filter(AppGroup.is_owner.is_(True))
+    owner_app_groups_stmt = (
+        select(AppGroup)
+        .where(OktaGroup.deleted_at.is_(None))
+        .where(AppGroup.app_id == app_id)
+        .where(AppGroup.is_owner.is_(True))
     )
 
-    if owner_app_groups.count() > 0:
-        return (
-            db.session.query(OktaUser)
-            .join(OktaUser.all_group_memberships_and_ownerships)
-            .filter(OktaUserGroupMember.group_id.in_([ag.id for ag in owner_app_groups]))
-            .filter(OktaUserGroupMember.is_owner.is_(True))
-            .filter(
-                or_(
-                    OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > func.now(),
+    if (db.session.scalar(select(func.count()).select_from(owner_app_groups_stmt.subquery())) or 0) > 0:
+        return list(
+            db.session.scalars(
+                select(OktaUser)
+                .join(OktaUser.all_group_memberships_and_ownerships)
+                .where(OktaUserGroupMember.group_id.in_([ag.id for ag in db.session.scalars(owner_app_groups_stmt)]))
+                .where(OktaUserGroupMember.is_owner.is_(True))
+                .where(
+                    or_(
+                        OktaUserGroupMember.ended_at.is_(None),
+                        OktaUserGroupMember.ended_at > func.now(),
+                    )
                 )
-            )
-            .all()
+            ).all()
         )
 
     return []
@@ -36,33 +37,34 @@ def get_app_managers(app_id: str) -> List[OktaUser]:
 def get_access_owners() -> List[OktaUser]:
     """Returns the access super admins that are members of the owners group"""
 
-    access_app = (
-        db.session.query(App).filter(App.deleted_at.is_(None)).filter(App.name == App.ACCESS_APP_RESERVED_NAME).first()
-    )
+    access_app = db.session.scalars(
+        select(App).where(App.deleted_at.is_(None)).where(App.name == App.ACCESS_APP_RESERVED_NAME)
+    ).first()
 
     if access_app is None:
         return []
 
-    owner_app_groups = (
-        db.session.query(AppGroup)
-        .filter(OktaGroup.deleted_at.is_(None))
-        .filter(AppGroup.app_id == access_app.id)
-        .filter(AppGroup.is_owner.is_(True))
+    owner_app_groups_stmt = (
+        select(AppGroup)
+        .where(OktaGroup.deleted_at.is_(None))
+        .where(AppGroup.app_id == access_app.id)
+        .where(AppGroup.is_owner.is_(True))
     )
 
-    if owner_app_groups.count() > 0:
-        return (
-            db.session.query(OktaUser)
-            .join(OktaUser.all_group_memberships_and_ownerships)
-            .filter(OktaUserGroupMember.group_id.in_([ag.id for ag in owner_app_groups]))
-            .filter(OktaUserGroupMember.is_owner.is_(False))
-            .filter(
-                or_(
-                    OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > func.now(),
+    if (db.session.scalar(select(func.count()).select_from(owner_app_groups_stmt.subquery())) or 0) > 0:
+        return list(
+            db.session.scalars(
+                select(OktaUser)
+                .join(OktaUser.all_group_memberships_and_ownerships)
+                .where(OktaUserGroupMember.group_id.in_([ag.id for ag in db.session.scalars(owner_app_groups_stmt)]))
+                .where(OktaUserGroupMember.is_owner.is_(False))
+                .where(
+                    or_(
+                        OktaUserGroupMember.ended_at.is_(None),
+                        OktaUserGroupMember.ended_at > func.now(),
+                    )
                 )
-            )
-            .all()
+            ).all()
         )
 
     return []

--- a/api/models/okta_group.py
+++ b/api/models/okta_group.py
@@ -1,22 +1,23 @@
 from typing import List
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select
 
 from api.extensions import db
 from api.models.core_models import OktaUser, OktaUserGroupMember
 
 
 def get_group_managers(group_id: str) -> List[OktaUser]:
-    return (
-        db.session.query(OktaUser)
-        .join(OktaUserGroupMember, OktaUser.id == OktaUserGroupMember.user_id)
-        .filter(OktaUserGroupMember.group_id == group_id)
-        .filter(OktaUserGroupMember.is_owner.is_(True))
-        .filter(
-            or_(
-                OktaUserGroupMember.ended_at.is_(None),
-                OktaUserGroupMember.ended_at > func.now(),
+    return list(
+        db.session.scalars(
+            select(OktaUser)
+            .join(OktaUserGroupMember, OktaUser.id == OktaUserGroupMember.user_id)
+            .where(OktaUserGroupMember.group_id == group_id)
+            .where(OktaUserGroupMember.is_owner.is_(True))
+            .where(
+                or_(
+                    OktaUserGroupMember.ended_at.is_(None),
+                    OktaUserGroupMember.ended_at > func.now(),
+                )
             )
-        )
-        .all()
+        ).all()
     )

--- a/api/operations/approve_access_request.py
+++ b/api/operations/approve_access_request.py
@@ -4,6 +4,7 @@ from typing import Optional
 import logging
 
 from api.context import get_request_context
+from sqlalchemy import select
 from sqlalchemy.orm import joinedload, selectin_polymorphic
 
 from api.exceptions import ConflictError, InvalidRequestError, ResourceGoneError
@@ -31,13 +32,12 @@ class ApproveAccessRequest:
         # and double-grant. `of=AccessRequest` keeps FOR UPDATE off the
         # joinedload's nullable outer-join side (Postgres rejects that); it's
         # a no-op on SQLite.
-        self.access_request = (
-            db.session.query(AccessRequest)
+        self.access_request = db.session.scalars(
+            select(AccessRequest)
             .options(joinedload(AccessRequest.active_requested_group))
-            .filter(AccessRequest.id == (access_request if isinstance(access_request, str) else access_request.id))
+            .where(AccessRequest.id == (access_request if isinstance(access_request, str) else access_request.id))
             .with_for_update(of=AccessRequest)
-            .first()
-        )
+        ).first()
 
         if approver_user is None:
             self.approver_id = None
@@ -98,13 +98,12 @@ class ApproveAccessRequest:
         # self.access_request.approval_ending_at = self.ending_at
 
         # Audit logging
-        group = (
-            db.session.query(OktaGroup)
+        group = db.session.scalars(
+            select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
-            .filter(OktaGroup.deleted_at.is_(None))
-            .filter(OktaGroup.id == self.access_request.requested_group_id)
-            .first()
-        )
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(OktaGroup.id == self.access_request.requested_group_id)
+        ).first()
 
         _ctx = get_request_context()
 

--- a/api/operations/approve_group_request.py
+++ b/api/operations/approve_group_request.py
@@ -3,7 +3,7 @@ from typing import Optional
 import logging
 
 from api.context import get_request_context
-from sqlalchemy import func
+from sqlalchemy import func, select
 from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload, with_polymorphic
 
 from api.exceptions import ConflictError
@@ -43,13 +43,12 @@ class ApproveGroupRequest:
         # can't both pass the pending-state guard and double-create the group.
         # `of=` keeps FOR UPDATE off the joinedload's nullable outer-join side
         # (Postgres rejects that); no-op on SQLite.
-        self.group_request = (
-            db.session.query(GroupRequest)
+        self.group_request = db.session.scalars(
+            select(GroupRequest)
             .options(joinedload(GroupRequest.active_requester))
-            .filter(GroupRequest.id == (group_request if isinstance(group_request, str) else group_request.id))
+            .where(GroupRequest.id == (group_request if isinstance(group_request, str) else group_request.id))
             .with_for_update(of=GroupRequest)
-            .first()
-        )
+        ).first()
 
         self.approver_id: str | None = None
         if approver_user is None:
@@ -130,10 +129,10 @@ class ApproveGroupRequest:
         if resolved_app_id is not None:
             # App group request: admins OR owners of that specific app can approve
             if not is_admin:
-                is_app_owner = (
-                    db.session.query(OktaUserGroupMember)
+                is_app_owner = db.session.scalars(
+                    select(OktaUserGroupMember)
                     .join(AppGroup, OktaUserGroupMember.group_id == AppGroup.id)
-                    .filter(
+                    .where(
                         AppGroup.app_id == resolved_app_id,
                         AppGroup.is_owner.is_(True),
                         AppGroup.deleted_at.is_(None),
@@ -141,8 +140,7 @@ class ApproveGroupRequest:
                         OktaUserGroupMember.is_owner.is_(True),
                         OktaUserGroupMember.ended_at.is_(None),
                     )
-                    .first()
-                )
+                ).first()
 
                 if not is_app_owner:
                     return self.group_request
@@ -162,12 +160,11 @@ class ApproveGroupRequest:
         ):
             return self.group_request
 
-        existing_group = (
-            db.session.query(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-            .filter(func.lower(OktaGroup.name) == func.lower(resolved_name))
-            .filter(OktaGroup.deleted_at.is_(None))
-            .first()
-        )
+        existing_group = db.session.scalars(
+            select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+            .where(func.lower(OktaGroup.name) == func.lower(resolved_name))
+            .where(OktaGroup.deleted_at.is_(None))
+        ).first()
         if existing_group is not None:
             return self.group_request
 
@@ -215,16 +212,15 @@ class ApproveGroupRequest:
         ).execute()
 
         # Check tags on created group for ownership length constraints including propagated app tags
-        created_group_with_tags = (
-            db.session.query(OktaGroup)
+        created_group_with_tags = db.session.scalars(
+            select(OktaGroup)
             .options(
                 selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
                 selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
             )
-            .filter(OktaGroup.id == created_group.id)
-            .filter(OktaGroup.deleted_at.is_(None))
-            .first()
-        )
+            .where(OktaGroup.id == created_group.id)
+            .where(OktaGroup.deleted_at.is_(None))
+        ).first()
 
         tags = [tag_map.active_tag for tag_map in created_group_with_tags.active_group_tags]
 

--- a/api/operations/approve_role_request.py
+++ b/api/operations/approve_role_request.py
@@ -4,6 +4,7 @@ from typing import Optional
 import logging
 
 from api.context import get_request_context
+from sqlalchemy import select
 from sqlalchemy.orm import joinedload, selectin_polymorphic
 
 from api.exceptions import ConflictError, InvalidRequestError, ResourceGoneError
@@ -30,13 +31,12 @@ class ApproveRoleRequest:
         # can't both pass the pending-state guard and double-grant. `of=` keeps
         # FOR UPDATE off the joinedloads' nullable outer-join sides (Postgres
         # rejects that); no-op on SQLite.
-        self.role_request = (
-            db.session.query(RoleRequest)
+        self.role_request = db.session.scalars(
+            select(RoleRequest)
             .options(joinedload(RoleRequest.active_requested_group), joinedload(RoleRequest.active_requester_role))
-            .filter(RoleRequest.id == (role_request if isinstance(role_request, str) else role_request.id))
+            .where(RoleRequest.id == (role_request if isinstance(role_request, str) else role_request.id))
             .with_for_update(of=RoleRequest)
-            .first()
-        )
+        ).first()
 
         if approver_user is None:
             self.approver_id = None
@@ -92,13 +92,12 @@ class ApproveRoleRequest:
         db.session.commit()
 
         # Audit logging
-        group = (
-            db.session.query(OktaGroup)
+        group = db.session.scalars(
+            select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup]), joinedload(AppGroup.app))
-            .filter(OktaGroup.deleted_at.is_(None))
-            .filter(OktaGroup.id == self.role_request.requested_group_id)
-            .first()
-        )
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(OktaGroup.id == self.role_request.requested_group_id)
+        ).first()
 
         _ctx = get_request_context()
 

--- a/api/operations/constraints/check_for_reason.py
+++ b/api/operations/constraints/check_for_reason.py
@@ -1,5 +1,6 @@
 from typing import Optional, Tuple
 
+from sqlalchemy import select
 from sqlalchemy.orm import (
     selectin_polymorphic,
     selectinload,
@@ -18,8 +19,8 @@ class CheckForReason:
         members_to_add: list[str] = [],
         owners_to_add: list[str] = [],
     ):
-        self.group = (
-            db.session.query(OktaGroup)
+        self.group = db.session.scalars(
+            select(OktaGroup)
             .options(
                 selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
                 selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
@@ -32,10 +33,9 @@ class CheckForReason:
                 .selectinload(OktaGroup.active_group_tags)
                 .joinedload(OktaGroupTagMap.active_tag),
             )
-            .filter(OktaGroup.deleted_at.is_(None))
-            .filter(OktaGroup.id == (group if isinstance(group, str) else group.id))
-            .first()
-        )
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+        ).first()
 
         self.reason = reason
 
@@ -97,14 +97,13 @@ class CheckForReason:
 
         if self.invalid_reason(self.reason):
             if len(self.members_to_add) > 0:
-                new_member_groups = (
-                    db.session.query(OktaGroup)
+                new_member_groups = db.session.scalars(
+                    select(OktaGroup)
                     .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
-                    .filter(OktaGroup.is_managed.is_(True))
-                    .filter(OktaGroup.id.in_(self.members_to_add))
-                    .filter(OktaGroup.deleted_at.is_(None))
-                    .all()
-                )
+                    .where(OktaGroup.is_managed.is_(True))
+                    .where(OktaGroup.id.in_(self.members_to_add))
+                    .where(OktaGroup.deleted_at.is_(None))
+                ).all()
                 for member_group in new_member_groups:
                     require_member_reason = coalesce_constraints(
                         constraint_key=Tag.REQUIRE_MEMBER_REASON_CONSTRAINT_KEY,
@@ -118,14 +117,13 @@ class CheckForReason:
                         )
 
             if len(self.owners_to_add) > 0:
-                new_owner_groups = (
-                    db.session.query(OktaGroup)
+                new_owner_groups = db.session.scalars(
+                    select(OktaGroup)
                     .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
-                    .filter(OktaGroup.is_managed.is_(True))
-                    .filter(OktaGroup.id.in_(self.owners_to_add))
-                    .filter(OktaGroup.deleted_at.is_(None))
-                    .all()
-                )
+                    .where(OktaGroup.is_managed.is_(True))
+                    .where(OktaGroup.id.in_(self.owners_to_add))
+                    .where(OktaGroup.deleted_at.is_(None))
+                ).all()
                 for owner_group in new_owner_groups:
                     require_owner_reason = coalesce_constraints(
                         constraint_key=Tag.REQUIRE_OWNER_REASON_CONSTRAINT_KEY,

--- a/api/operations/constraints/check_for_self_add.py
+++ b/api/operations/constraints/check_for_self_add.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import (
     selectinload,
 )
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select
 from api.auth.permissions import is_access_admin as _is_access_admin
 from api.extensions import db
 from api.models import AppGroup, OktaGroup, OktaGroupTagMap, OktaUser, OktaUserGroupMember, RoleGroup, RoleGroupMap, Tag
@@ -20,8 +20,8 @@ class CheckForSelfAdd:
         members_to_add: list[str] = [],
         owners_to_add: list[str] = [],
     ):
-        self.group = (
-            db.session.query(OktaGroup)
+        self.group = db.session.scalars(
+            select(OktaGroup)
             .options(
                 selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
                 selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
@@ -34,20 +34,18 @@ class CheckForSelfAdd:
                 .selectinload(OktaGroup.active_group_tags)
                 .joinedload(OktaGroupTagMap.active_tag),
             )
-            .filter(OktaGroup.deleted_at.is_(None))
-            .filter(OktaGroup.id == (group if isinstance(group, str) else group.id))
-            .first()
-        )
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+        ).first()
 
         if current_user is None:
             self.current_user = None
         else:
-            self.current_user = (
-                db.session.query(OktaUser)
-                .filter(OktaUser.deleted_at.is_(None))
-                .filter(OktaUser.id == (current_user if isinstance(current_user, str) else current_user.id))
-                .first()
-            )
+            self.current_user = db.session.scalars(
+                select(OktaUser)
+                .where(OktaUser.deleted_at.is_(None))
+                .where(OktaUser.id == (current_user if isinstance(current_user, str) else current_user.id))
+            ).first()
 
         self.members_to_add = members_to_add
         self.owners_to_add = owners_to_add
@@ -120,28 +118,31 @@ class CheckForSelfAdd:
         # Check to see if the current user is a member of the role,
         # which would grant them access to the newly added groups associated with the role
         if (
-            db.session.query(OktaUserGroupMember)
-            .filter(OktaUserGroupMember.group_id == self.group.id)
-            .filter(OktaUserGroupMember.user_id == self.current_user.id)
-            .filter(OktaUserGroupMember.is_owner.is_(False))
-            .filter(
-                or_(
-                    OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > func.now(),
+            db.session.scalar(
+                select(func.count()).select_from(
+                    select(OktaUserGroupMember)
+                    .where(OktaUserGroupMember.group_id == self.group.id)
+                    .where(OktaUserGroupMember.user_id == self.current_user.id)
+                    .where(OktaUserGroupMember.is_owner.is_(False))
+                    .where(
+                        or_(
+                            OktaUserGroupMember.ended_at.is_(None),
+                            OktaUserGroupMember.ended_at > func.now(),
+                        )
+                    )
+                    .subquery()
                 )
             )
-            .count()
-            > 0
-        ):
+            or 0
+        ) > 0:
             if len(self.members_to_add) > 0:
-                new_member_groups = (
-                    db.session.query(OktaGroup)
+                new_member_groups = db.session.scalars(
+                    select(OktaGroup)
                     .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
-                    .filter(OktaGroup.is_managed.is_(True))
-                    .filter(OktaGroup.id.in_(self.members_to_add))
-                    .filter(OktaGroup.deleted_at.is_(None))
-                    .all()
-                )
+                    .where(OktaGroup.is_managed.is_(True))
+                    .where(OktaGroup.id.in_(self.members_to_add))
+                    .where(OktaGroup.deleted_at.is_(None))
+                ).all()
                 for member_group in new_member_groups:
                     require_member_reason = coalesce_constraints(
                         constraint_key=Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY,
@@ -156,14 +157,13 @@ class CheckForSelfAdd:
                         )
 
             if len(self.owners_to_add) > 0:
-                new_owner_groups = (
-                    db.session.query(OktaGroup)
+                new_owner_groups = db.session.scalars(
+                    select(OktaGroup)
                     .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
-                    .filter(OktaGroup.is_managed.is_(True))
-                    .filter(OktaGroup.id.in_(self.owners_to_add))
-                    .filter(OktaGroup.deleted_at.is_(None))
-                    .all()
-                )
+                    .where(OktaGroup.is_managed.is_(True))
+                    .where(OktaGroup.id.in_(self.owners_to_add))
+                    .where(OktaGroup.deleted_at.is_(None))
+                ).all()
                 for owner_group in new_owner_groups:
                     require_owner_reason = coalesce_constraints(
                         constraint_key=Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY,

--- a/api/operations/create_access_request.py
+++ b/api/operations/create_access_request.py
@@ -6,6 +6,7 @@ from typing import Optional
 import logging
 
 from api.context import get_request_context
+from sqlalchemy import select
 from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload
 
 from api.extensions import db
@@ -43,19 +44,18 @@ class CreateAccessRequest:
         else:
             self.requester = requester_user
 
-        self.requested_group = (
-            db.session.query(OktaGroup)
+        self.requested_group = db.session.scalars(
+            select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
-            .filter(OktaGroup.deleted_at.is_(None))
-            .filter(OktaGroup.id == (requested_group if isinstance(requested_group, str) else requested_group.id))
-            .first()
-        )
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(OktaGroup.id == (requested_group if isinstance(requested_group, str) else requested_group.id))
+        ).first()
 
         self.request_ownership = request_ownership
         self.request_reason = request_reason
         self.request_ending_at = request_ending_at
 
-        self.request_approvers = db.session.query()
+        self.request_approvers = select()
 
         self.conditional_access_hook = get_conditional_access_hook()
         self.notification_hook = get_notification_hook()
@@ -94,8 +94,8 @@ class CreateAccessRequest:
         if len(approvers) == 0 or (len(approvers) == 1 and approvers[0].id == self.requester.id):
             approvers = get_access_owners()
 
-        group = (
-            db.session.query(OktaGroup)
+        group = db.session.scalars(
+            select(OktaGroup)
             .options(
                 selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
                 joinedload(AppGroup.app),
@@ -103,10 +103,9 @@ class CreateAccessRequest:
                     joinedload(OktaGroupTagMap.active_app_tag_mapping), joinedload(OktaGroupTagMap.enabled_active_tag)
                 ),
             )
-            .filter(OktaGroup.deleted_at.is_(None))
-            .filter(OktaGroup.id == self.requested_group.id)
-            .first()
-        )
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(OktaGroup.id == self.requested_group.id)
+        ).first()
 
         # Audit logging
         _ctx = get_request_context()

--- a/api/operations/create_app.py
+++ b/api/operations/create_app.py
@@ -5,7 +5,7 @@ from typing import Optional, TypedDict
 import logging
 
 from api.context import get_request_context
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm import with_polymorphic
 
 from api.extensions import db
@@ -42,22 +42,22 @@ class CreateApp:
             self.app = app
 
         self.tag_ids = [
-            tag.id for tag in db.session.query(Tag).filter(Tag.deleted_at.is_(None)).filter(Tag.id.in_(tags)).all()
+            tag.id
+            for tag in db.session.scalars(select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(tags))).all()
         ]
 
         self.owner_id = getattr(
-            db.session.query(OktaUser).filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == owner_id).first(),
+            db.session.scalars(
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == owner_id)
+            ).first(),
             "id",
             None,
         )
         self.owner_role_ids = None
         if owner_role_ids is not None:
-            self.owner_roles = (
-                db.session.query(RoleGroup)
-                .filter(RoleGroup.id.in_(owner_role_ids))
-                .filter(RoleGroup.deleted_at.is_(None))
-                .all()
-            )
+            self.owner_roles = db.session.scalars(
+                select(RoleGroup).where(RoleGroup.id.in_(owner_role_ids)).where(RoleGroup.deleted_at.is_(None))
+            ).all()
             self.owner_role_ids = [role.id for role in self.owner_roles]
 
         self.app_group_prefix = (
@@ -81,22 +81,18 @@ class CreateApp:
                     continue
                 self.additional_app_groups.append(AppGroup(is_owner=False, name=name, description=description))
         self.current_user_id = getattr(
-            db.session.query(OktaUser)
-            .filter(OktaUser.deleted_at.is_(None))
-            .filter(OktaUser.id == current_user_id)
-            .first(),
+            db.session.scalars(
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+            ).first(),
             "id",
             None,
         )
 
     def execute(self) -> App:
         # Do not allow non-deleted apps with the same name
-        existing_app = (
-            db.session.query(App)
-            .filter(func.lower(App.name) == func.lower(self.app.name))
-            .filter(App.deleted_at.is_(None))
-            .first()
-        )
+        existing_app = db.session.scalars(
+            select(App).where(func.lower(App.name) == func.lower(self.app.name)).where(App.deleted_at.is_(None))
+        ).first()
         if existing_app is not None:
             return existing_app
 
@@ -126,12 +122,11 @@ class CreateApp:
 
         app_id = self.app.id
 
-        existing_owner_group = (
-            db.session.query(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-            .filter(func.lower(OktaGroup.name) == func.lower(self.owner_group_name))
-            .filter(OktaGroup.deleted_at.is_(None))
-            .first()
-        )
+        existing_owner_group = db.session.scalars(
+            select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+            .where(func.lower(OktaGroup.name) == func.lower(self.owner_group_name))
+            .where(OktaGroup.deleted_at.is_(None))
+        ).first()
 
         if existing_owner_group is None:
             owner_app_group = AppGroup(
@@ -149,7 +144,7 @@ class CreateApp:
                     group_changes=AppGroup(app_id=app_id, is_owner=True),
                     current_user_id=self.current_user_id,
                 ).execute()
-            owner_app_group = db.session.query(AppGroup).filter(AppGroup.id == group_id).first()
+            owner_app_group = db.session.scalars(select(AppGroup).where(AppGroup.id == group_id)).first()
             owner_app_group.app_id = app_id
             owner_app_group.is_owner = True
             db.session.commit()
@@ -173,13 +168,12 @@ class CreateApp:
                 ).execute()
 
         # Find other app groups with the same app name prefix and update them
-        other_existing_app_groups = (
-            db.session.query(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-            .filter(OktaGroup.name.ilike(f"{self.app_group_prefix}%"))
-            .filter(func.lower(OktaGroup.name) != func.lower(self.owner_group_name))
-            .filter(OktaGroup.deleted_at.is_(None))
-            .all()
-        )
+        other_existing_app_groups = db.session.scalars(
+            select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+            .where(OktaGroup.name.ilike(f"{self.app_group_prefix}%"))
+            .where(func.lower(OktaGroup.name) != func.lower(self.owner_group_name))
+            .where(OktaGroup.deleted_at.is_(None))
+        ).all()
         existing_app_group_ids_to_update = []
         for existing_app_group in other_existing_app_groups:
             if type(existing_app_group) is not AppGroup:
@@ -197,12 +191,11 @@ class CreateApp:
             for app_group in self.additional_app_groups:
                 app_group.app_id = app_id
 
-                existing_group = (
-                    db.session.query(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-                    .filter(func.lower(OktaGroup.name) == func.lower(app_group.name))
-                    .filter(OktaGroup.deleted_at.is_(None))
-                    .first()
-                )
+                existing_group = db.session.scalars(
+                    select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+                    .where(func.lower(OktaGroup.name) == func.lower(app_group.name))
+                    .where(OktaGroup.deleted_at.is_(None))
+                ).first()
 
                 if existing_group is None:
                     CreateGroup(group=app_group, current_user_id=self.current_user_id).execute()
@@ -214,15 +207,15 @@ class CreateApp:
                             group_changes=AppGroup(app_id=app_id, is_owner=False),
                             current_user_id=self.current_user_id,
                         ).execute()
-                    app_group = db.session.query(AppGroup).filter(AppGroup.id == group_id).first()
+                    app_group = db.session.scalars(select(AppGroup).where(AppGroup.id == group_id)).first()
                     app_group.app_id = app_id
                     app_group.is_owner = False
                     db.session.commit()
 
         if len(self.tag_ids) > 0:
-            all_app_groups = (
-                db.session.query(AppGroup).filter(AppGroup.app_id == app_id).filter(AppGroup.deleted_at.is_(None)).all()
-            )
+            all_app_groups = db.session.scalars(
+                select(AppGroup).where(AppGroup.app_id == app_id).where(AppGroup.deleted_at.is_(None))
+            ).all()
 
             for tag_id in self.tag_ids:
                 db.session.add(
@@ -233,17 +226,16 @@ class CreateApp:
                 )
             db.session.commit()
 
-            new_app_tag_maps = (
-                db.session.query(AppTagMap)
-                .filter(AppTagMap.app_id == app_id)
-                .filter(
+            new_app_tag_maps = db.session.scalars(
+                select(AppTagMap)
+                .where(AppTagMap.app_id == app_id)
+                .where(
                     or_(
                         AppTagMap.ended_at.is_(None),
                         AppTagMap.ended_at > func.now(),
                     )
                 )
-                .all()
-            )
+            ).all()
 
             for app_tag_map in new_app_tag_maps:
                 for app_group in all_app_groups:

--- a/api/operations/create_group.py
+++ b/api/operations/create_group.py
@@ -3,7 +3,7 @@ from typing import Optional, TypedDict, TypeVar
 import logging
 
 from api.context import get_request_context
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm import joinedload, selectin_polymorphic, with_polymorphic
 
 from api.extensions import db
@@ -27,25 +27,23 @@ class CreateGroup:
         else:
             self.group = group
 
-        self.tags = db.session.query(Tag).filter(Tag.deleted_at.is_(None)).filter(Tag.id.in_(tags)).all()
+        self.tags = db.session.scalars(select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(tags))).all()
 
         self.current_user_id = getattr(
-            db.session.query(OktaUser)
-            .filter(OktaUser.deleted_at.is_(None))
-            .filter(OktaUser.id == current_user_id)
-            .first(),
+            db.session.scalars(
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+            ).first(),
             "id",
             None,
         )
 
     def execute(self, *, _group: Optional[T] = None) -> T:
         # Do not allow non-deleted groups with the same name (case-insensitive)
-        existing_group = (
-            db.session.query(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-            .filter(func.lower(OktaGroup.name) == func.lower(self.group.name))
-            .filter(OktaGroup.deleted_at.is_(None))
-            .first()
-        )
+        existing_group = db.session.scalars(
+            select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+            .where(func.lower(OktaGroup.name) == func.lower(self.group.name))
+            .where(OktaGroup.deleted_at.is_(None))
+        ).first()
         if existing_group is not None:
             return existing_group
 
@@ -54,7 +52,9 @@ class CreateGroup:
         # is load-bearing: app renames rewrite group names by prefix substitution
         # and group request approval reasons about reserved prefixes.
         if type(self.group) is AppGroup:
-            app = db.session.query(App).filter(App.id == self.group.app_id).filter(App.deleted_at.is_(None)).first()
+            app = db.session.scalars(
+                select(App).where(App.id == self.group.app_id).where(App.deleted_at.is_(None))
+            ).first()
             if app is None:
                 raise ValueError("App for AppGroup does not exist")
             app_group_name_prefix = (
@@ -76,17 +76,16 @@ class CreateGroup:
 
         # If this is an app group, add any app tags
         if type(self.group) is AppGroup:
-            app_tag_maps = (
-                db.session.query(AppTagMap)
-                .filter(AppTagMap.app_id == self.group.app_id)
-                .filter(
+            app_tag_maps = db.session.scalars(
+                select(AppTagMap)
+                .where(AppTagMap.app_id == self.group.app_id)
+                .where(
                     or_(
                         AppTagMap.ended_at.is_(None),
                         AppTagMap.ended_at > func.now(),
                     )
                 )
-                .all()
-            )
+            ).all()
 
             for app_tag_map in app_tag_maps:
                 db.session.add(
@@ -127,13 +126,12 @@ class CreateGroup:
         if self.current_user_id is not None:
             email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
 
-        group = (
-            db.session.query(OktaGroup)
+        group = db.session.scalars(
+            select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
-            .filter(OktaGroup.deleted_at.is_(None))
-            .filter(OktaGroup.id == self.group.id)
-            .first()
-        )
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(OktaGroup.id == self.group.id)
+        ).first()
 
         _ctx = get_request_context()
 

--- a/api/operations/create_group_request.py
+++ b/api/operations/create_group_request.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 import logging
 
 from api.context import get_request_context
+from sqlalchemy import select
 
 from api.extensions import db
 from api.models import (
@@ -83,14 +84,12 @@ class CreateGroupRequest:
         # Validate app exists if app_id provided and desired group name prefix is correct
         app = None
         if self.requested_app_id is not None:
-            app = (
-                db.session.query(App)
-                .filter(
+            app = db.session.scalars(
+                select(App).where(
                     App.id == self.requested_app_id,
                     App.deleted_at.is_(None),
                 )
-                .first()
-            )
+            ).first()
 
             if app is None:
                 return None
@@ -100,12 +99,9 @@ class CreateGroupRequest:
         # Validate tags exist and load them
         tags = []
         if self.requested_group_tags:
-            tags = (
-                db.session.query(Tag)
-                .filter(Tag.id.in_(self.requested_group_tags))
-                .filter(Tag.deleted_at.is_(None))
-                .all()
-            )
+            tags = db.session.scalars(
+                select(Tag).where(Tag.id.in_(self.requested_group_tags)).where(Tag.deleted_at.is_(None))
+            ).all()
             if len(tags) != len(self.requested_group_tags):
                 return None
 

--- a/api/operations/create_role_request.py
+++ b/api/operations/create_role_request.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import logging
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select
 from api.context import get_request_context
 from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload
 
@@ -49,12 +49,9 @@ class CreateRoleRequest:
             self.requester = requester_user
 
         if isinstance(requester_role, str):
-            self.requester_role = (
-                db.session.query(RoleGroup)
-                .filter(RoleGroup.deleted_at.is_(None))
-                .filter(RoleGroup.id == requester_role)
-                .first()
-            )
+            self.requester_role = db.session.scalars(
+                select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == requester_role)
+            ).first()
             # self.requester_role = (
             #     db.session.query(RoleGroup)
             #     .options(joinedload(OktaUserGroupMember.user))
@@ -65,17 +62,16 @@ class CreateRoleRequest:
         else:
             self.requester_role = requester_role
 
-        self.requested_group = (
-            db.session.query(OktaGroup)
+        self.requested_group = db.session.scalars(
+            select(OktaGroup)
             .options(
                 selectin_polymorphic(OktaGroup, [AppGroup]),
                 joinedload(AppGroup.app),
                 selectinload(OktaGroup.active_group_tags).options(joinedload(OktaGroupTagMap.active_tag)),
             )
-            .filter(OktaGroup.deleted_at.is_(None))
-            .filter(OktaGroup.id == (requested_group if isinstance(requested_group, str) else requested_group.id))
-            .first()
-        )
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(OktaGroup.id == (requested_group if isinstance(requested_group, str) else requested_group.id))
+        ).first()
 
         self.request_ownership = request_ownership
         self.request_reason = request_reason
@@ -114,18 +110,17 @@ class CreateRoleRequest:
 
         role_memberships = [
             u.user_id
-            for u in (
-                db.session.query(OktaUserGroupMember)
-                .filter(OktaUserGroupMember.group_id == self.requester_role.id)
-                .filter(OktaUserGroupMember.is_owner.is_(False))
-                .filter(
+            for u in db.session.scalars(
+                select(OktaUserGroupMember)
+                .where(OktaUserGroupMember.group_id == self.requester_role.id)
+                .where(OktaUserGroupMember.is_owner.is_(False))
+                .where(
                     or_(
                         OktaUserGroupMember.ended_at.is_(None),
                         OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
-                .all()
-            )
+            ).all()
         ]
 
         # If group tagged with disallow self add constraint, filter out approvers who are also members of the role
@@ -157,8 +152,8 @@ class CreateRoleRequest:
         if len(approvers) == 0 or (len(approvers) == 1 and approvers[0].id == self.requester.id):
             approvers = get_access_owners()
 
-        group = (
-            db.session.query(OktaGroup)
+        group = db.session.scalars(
+            select(OktaGroup)
             .options(
                 selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
                 joinedload(AppGroup.app),
@@ -166,10 +161,9 @@ class CreateRoleRequest:
                     joinedload(OktaGroupTagMap.active_app_tag_mapping), joinedload(OktaGroupTagMap.enabled_active_tag)
                 ),
             )
-            .filter(OktaGroup.deleted_at.is_(None))
-            .filter(OktaGroup.id == self.requested_group.id)
-            .first()
-        )
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(OktaGroup.id == self.requested_group.id)
+        ).first()
 
         # Audit logging
         _ctx = get_request_context()

--- a/api/operations/create_tag.py
+++ b/api/operations/create_tag.py
@@ -5,7 +5,7 @@ from typing import Any, Optional, TypedDict
 import logging
 
 from api.context import get_request_context
-from sqlalchemy import func
+from sqlalchemy import func, select
 
 from api.extensions import db
 from api.models import OktaUser, Tag
@@ -28,22 +28,18 @@ class CreateTag:
             self.tag = tag
 
         self.current_user_id = getattr(
-            db.session.query(OktaUser)
-            .filter(OktaUser.deleted_at.is_(None))
-            .filter(OktaUser.id == current_user_id)
-            .first(),
+            db.session.scalars(
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+            ).first(),
             "id",
             None,
         )
 
     def execute(self) -> Tag:
         # Do not allow non-deleted groups with the same name (case-insensitive)
-        existing_tag = (
-            db.session.query(Tag)
-            .filter(func.lower(Tag.name) == func.lower(self.tag.name))
-            .filter(Tag.deleted_at.is_(None))
-            .first()
-        )
+        existing_tag = db.session.scalars(
+            select(Tag).where(func.lower(Tag.name) == func.lower(self.tag.name)).where(Tag.deleted_at.is_(None))
+        ).first()
         if existing_tag is not None:
             return existing_tag
 

--- a/api/operations/delete_app.py
+++ b/api/operations/delete_app.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import logging
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select, update
 from api.context import get_request_context
 
 from api.extensions import db
@@ -14,15 +14,14 @@ from api.schemas import AuditLogSchema, EventType
 class DeleteApp:
     def __init__(self, *, app: App | str, current_user_id: Optional[str] = None):
         if isinstance(app, str):
-            self.app = db.session.query(App).filter(App.deleted_at.is_(None)).filter(App.id == app).first()
+            self.app = db.session.scalars(select(App).where(App.deleted_at.is_(None)).where(App.id == app)).first()
         else:
             self.app = app
 
         self.current_user_id = getattr(
-            db.session.query(OktaUser)
-            .filter(OktaUser.deleted_at.is_(None))
-            .filter(OktaUser.id == current_user_id)
-            .first(),
+            db.session.scalars(
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+            ).first(),
             "id",
             None,
         )
@@ -56,21 +55,24 @@ class DeleteApp:
         db.session.commit()
 
         # Delete all associated Okta App Groups and end their membership
-        app_groups = (
-            db.session.query(AppGroup).filter(AppGroup.deleted_at.is_(None)).filter(AppGroup.app_id == self.app.id)
-        )
+        app_groups = db.session.scalars(
+            select(AppGroup).where(AppGroup.deleted_at.is_(None)).where(AppGroup.app_id == self.app.id)
+        ).all()
         app_group_ids = [ag.id for ag in app_groups]
         for app_group_id in app_group_ids:
             DeleteGroup(group=app_group_id, current_user_id=self.current_user_id).execute()
 
         # End all tag mappings for this app (OktaGroupTagMaps are ended by the DeleteGroup operation above)
-        db.session.query(AppTagMap).filter(AppTagMap.app_id == self.app.id).filter(
-            or_(
-                AppTagMap.ended_at.is_(None),
-                AppTagMap.ended_at > func.now(),
+        db.session.execute(
+            update(AppTagMap)
+            .where(AppTagMap.app_id == self.app.id)
+            .where(
+                or_(
+                    AppTagMap.ended_at.is_(None),
+                    AppTagMap.ended_at > func.now(),
+                )
             )
-        ).update(
-            {AppTagMap.ended_at: func.now()},
-            synchronize_session="fetch",
+            .values({AppTagMap.ended_at: func.now()})
+            .execution_options(synchronize_session="fetch")
         )
         db.session.commit()

--- a/api/operations/delete_group.py
+++ b/api/operations/delete_group.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import logging
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select, update
 from api.context import get_request_context
 from sqlalchemy.orm import joinedload, selectin_polymorphic
 
@@ -30,20 +30,18 @@ from api.schemas import AuditLogSchema, EventType
 
 class DeleteGroup:
     def __init__(self, *, group: OktaGroup | str, sync_to_okta: bool = True, current_user_id: Optional[str] = None):
-        self.group = (
-            db.session.query(OktaGroup)
+        self.group = db.session.scalars(
+            select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
-            .filter(OktaGroup.id == (group if isinstance(group, str) else group.id))
-            .first()
-        )
+            .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+        ).first()
 
         self.sync_to_okta = sync_to_okta
 
         self.current_user_id = getattr(
-            db.session.query(OktaUser)
-            .filter(OktaUser.deleted_at.is_(None))
-            .filter(OktaUser.id == current_user_id)
-            .first(),
+            db.session.scalars(
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+            ).first(),
             "id",
             None,
         )
@@ -58,7 +56,9 @@ class DeleteGroup:
 
         # Prevent deletion of the Access owner group
         if type(self.group) is AppGroup and self.group.is_owner:
-            app = db.session.query(App).filter(App.id == self.group.app_id).filter(App.deleted_at.is_(None)).first()
+            app = db.session.scalars(
+                select(App).where(App.id == self.group.app_id).where(App.deleted_at.is_(None))
+            ).first()
             if app is not None and app.name == App.ACCESS_APP_RESERVED_NAME:
                 raise ValueError("Access application owner group cannot be deleted")
 
@@ -89,95 +89,113 @@ class DeleteGroup:
 
         # End all group members including group members via a role
         group_memberships_query = (
-            db.session.query(OktaUserGroupMember)
-            .filter(
+            select(OktaUserGroupMember)
+            .where(
                 or_(
                     OktaUserGroupMember.ended_at.is_(None),
                     OktaUserGroupMember.ended_at > func.now(),
                 )
             )
-            .filter(OktaUserGroupMember.group_id == self.group.id)
+            .where(OktaUserGroupMember.group_id == self.group.id)
         )
 
         direct_members_to_remove_ids = [
             m.user_id
-            for m in group_memberships_query.filter(OktaUserGroupMember.is_owner.is_(False))
-            .filter(OktaUserGroupMember.role_group_map_id.is_(None))
-            .all()
+            for m in db.session.scalars(
+                group_memberships_query.where(OktaUserGroupMember.is_owner.is_(False)).where(
+                    OktaUserGroupMember.role_group_map_id.is_(None)
+                )
+            ).all()
         ]
         direct_owners_to_remove_ids = [
             m.user_id
-            for m in group_memberships_query.filter(OktaUserGroupMember.is_owner.is_(True))
-            .filter(OktaUserGroupMember.role_group_map_id.is_(None))
-            .all()
+            for m in db.session.scalars(
+                group_memberships_query.where(OktaUserGroupMember.is_owner.is_(True)).where(
+                    OktaUserGroupMember.role_group_map_id.is_(None)
+                )
+            ).all()
         ]
 
-        group_memberships_query.update({OktaUserGroupMember.ended_at: func.now()}, synchronize_session="fetch")
-
-        # End all roles associations where this group was a member
-        db.session.query(RoleGroupMap).filter(
-            or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now())
-        ).filter(RoleGroupMap.group_id == self.group.id).update(
-            {RoleGroupMap.ended_at: func.now()}, synchronize_session="fetch"
-        )
-
-        if type(self.group) is RoleGroup:
-            # End all group memberships via the role grant
-            db.session.query(OktaUserGroupMember).filter(
+        db.session.execute(
+            update(OktaUserGroupMember)
+            .where(
                 or_(
                     OktaUserGroupMember.ended_at.is_(None),
                     OktaUserGroupMember.ended_at > func.now(),
                 )
-            ).filter(
-                OktaUserGroupMember.role_group_map_id.in_(
-                    db.session.query(RoleGroupMap.id)
-                    .filter(
-                        or_(
-                            RoleGroupMap.ended_at.is_(None),
-                            RoleGroupMap.ended_at > func.now(),
-                        )
+            )
+            .where(OktaUserGroupMember.group_id == self.group.id)
+            .values({OktaUserGroupMember.ended_at: func.now()})
+            .execution_options(synchronize_session="fetch")
+        )
+
+        # End all roles associations where this group was a member
+        db.session.execute(
+            update(RoleGroupMap)
+            .where(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
+            .where(RoleGroupMap.group_id == self.group.id)
+            .values({RoleGroupMap.ended_at: func.now()})
+            .execution_options(synchronize_session="fetch")
+        )
+
+        if type(self.group) is RoleGroup:
+            # End all group memberships via the role grant
+            db.session.execute(
+                update(OktaUserGroupMember)
+                .where(
+                    or_(
+                        OktaUserGroupMember.ended_at.is_(None),
+                        OktaUserGroupMember.ended_at > func.now(),
                     )
-                    .filter(RoleGroupMap.role_group_id == self.group.id)
                 )
-            ).update(
-                {OktaUserGroupMember.ended_at: func.now()},
-                synchronize_session="fetch",
+                .where(
+                    OktaUserGroupMember.role_group_map_id.in_(
+                        select(RoleGroupMap.id)
+                        .where(
+                            or_(
+                                RoleGroupMap.ended_at.is_(None),
+                                RoleGroupMap.ended_at > func.now(),
+                            )
+                        )
+                        .where(RoleGroupMap.role_group_id == self.group.id)
+                    )
+                )
+                .values({OktaUserGroupMember.ended_at: func.now()})
+                .execution_options(synchronize_session="fetch")
             )
 
             # Check if there are other OktaUserGroupMembers for this user/group
             # combination before removing group membership in Okta, there can be multiple role groups
             # which allow group access for this user
             role_associated_groups_mappings_query = (
-                db.session.query(RoleGroupMap)
-                .filter(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
-                .filter(RoleGroupMap.role_group_id == self.group.id)
+                select(RoleGroupMap)
+                .where(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
+                .where(RoleGroupMap.role_group_id == self.group.id)
             )
 
             if self.sync_to_okta:
-                role_associated_groups_mappings = role_associated_groups_mappings_query.all()
+                role_associated_groups_mappings = db.session.scalars(role_associated_groups_mappings_query).all()
 
-                removed_role_group_users_with_other_access = (
-                    db.session.query(OktaUserGroupMember)
-                    .with_entities(
+                removed_role_group_users_with_other_access = db.session.execute(
+                    select(
                         OktaUserGroupMember.user_id,
                         OktaUserGroupMember.group_id,
                         OktaUserGroupMember.is_owner,
                     )
-                    .filter(
+                    .where(
                         or_(
                             OktaUserGroupMember.ended_at.is_(None),
                             OktaUserGroupMember.ended_at > func.now(),
                         )
                     )
-                    .filter(OktaUserGroupMember.user_id.in_(direct_members_to_remove_ids + direct_owners_to_remove_ids))
-                    .filter(OktaUserGroupMember.group_id.in_([r.group_id for r in role_associated_groups_mappings]))
+                    .where(OktaUserGroupMember.user_id.in_(direct_members_to_remove_ids + direct_owners_to_remove_ids))
+                    .where(OktaUserGroupMember.group_id.in_([r.group_id for r in role_associated_groups_mappings]))
                     .group_by(
                         OktaUserGroupMember.user_id,
                         OktaUserGroupMember.group_id,
                         OktaUserGroupMember.is_owner,
                     )
-                    .all()
-                )
+                ).all()
 
                 for role_associated_group_map in role_associated_groups_mappings:
                     if not role_associated_group_map.is_owner:
@@ -214,20 +232,23 @@ class DeleteGroup:
                             )
 
             # End all group attachments to this role
-            role_associated_groups_mappings_query.update(
-                {RoleGroupMap.ended_at: func.now()}, synchronize_session="fetch"
+            db.session.execute(
+                update(RoleGroupMap)
+                .where(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
+                .where(RoleGroupMap.role_group_id == self.group.id)
+                .values({RoleGroupMap.ended_at: func.now()})
+                .execution_options(synchronize_session="fetch")
             )
 
         db.session.commit()
 
         # Reject all pending access requests for this group
-        obsolete_access_requests = (
-            db.session.query(AccessRequest)
-            .filter(AccessRequest.requested_group_id == self.group.id)
-            .filter(AccessRequest.status == AccessRequestStatus.PENDING)
-            .filter(AccessRequest.resolved_at.is_(None))
-            .all()
-        )
+        obsolete_access_requests = db.session.scalars(
+            select(AccessRequest)
+            .where(AccessRequest.requested_group_id == self.group.id)
+            .where(AccessRequest.status == AccessRequestStatus.PENDING)
+            .where(AccessRequest.resolved_at.is_(None))
+        ).all()
         for obsolete_access_request in obsolete_access_requests:
             RejectAccessRequest(
                 access_request=obsolete_access_request,
@@ -237,18 +258,17 @@ class DeleteGroup:
 
         # Reject all pending role requests touching this group, either as the
         # requested target or as the requester role.
-        obsolete_role_requests = (
-            db.session.query(RoleRequest)
-            .filter(
+        obsolete_role_requests = db.session.scalars(
+            select(RoleRequest)
+            .where(
                 or_(
                     RoleRequest.requested_group_id == self.group.id,
                     RoleRequest.requester_role_id == self.group.id,
                 )
             )
-            .filter(RoleRequest.status == AccessRequestStatus.PENDING)
-            .filter(RoleRequest.resolved_at.is_(None))
-            .all()
-        )
+            .where(RoleRequest.status == AccessRequestStatus.PENDING)
+            .where(RoleRequest.resolved_at.is_(None))
+        ).all()
         for obsolete_role_request in obsolete_role_requests:
             RejectRoleRequest(
                 role_request=obsolete_role_request,
@@ -257,16 +277,19 @@ class DeleteGroup:
             ).execute()
 
         # End all tag mappings for this group
-        db.session.query(OktaGroupTagMap).filter(
-            or_(
-                OktaGroupTagMap.ended_at.is_(None),
-                OktaGroupTagMap.ended_at > func.now(),
+        db.session.execute(
+            update(OktaGroupTagMap)
+            .where(
+                or_(
+                    OktaGroupTagMap.ended_at.is_(None),
+                    OktaGroupTagMap.ended_at > func.now(),
+                )
             )
-        ).filter(
-            OktaGroupTagMap.group_id == self.group.id,
-        ).update(
-            {OktaGroupTagMap.ended_at: func.now()},
-            synchronize_session="fetch",
+            .where(
+                OktaGroupTagMap.group_id == self.group.id,
+            )
+            .values({OktaGroupTagMap.ended_at: func.now()})
+            .execution_options(synchronize_session="fetch")
         )
         db.session.commit()
 

--- a/api/operations/delete_tag.py
+++ b/api/operations/delete_tag.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import logging
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select, update
 from api.context import get_request_context
 
 from api.extensions import db
@@ -12,12 +12,11 @@ from api.schemas import AuditLogSchema, EventType
 
 class DeleteTag:
     def __init__(self, *, tag: Tag | str, current_user_id: Optional[str] = None):
-        self.tag = db.session.query(Tag).filter(Tag.id == (tag if isinstance(tag, str) else tag.id)).first()
+        self.tag = db.session.scalars(select(Tag).where(Tag.id == (tag if isinstance(tag, str) else tag.id))).first()
         self.current_user_id = getattr(
-            db.session.query(OktaUser)
-            .filter(OktaUser.deleted_at.is_(None))
-            .filter(OktaUser.id == current_user_id)
-            .first(),
+            db.session.scalars(
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+            ).first(),
             "id",
             None,
         )
@@ -48,21 +47,31 @@ class DeleteTag:
         self.tag.deleted_at = func.now()
 
         # End all active group tag mappings for tag
-        db.session.query(OktaGroupTagMap).filter(
-            or_(
-                OktaGroupTagMap.ended_at.is_(None),
-                OktaGroupTagMap.ended_at > func.now(),
+        db.session.execute(
+            update(OktaGroupTagMap)
+            .where(
+                or_(
+                    OktaGroupTagMap.ended_at.is_(None),
+                    OktaGroupTagMap.ended_at > func.now(),
+                )
             )
-        ).filter(OktaGroupTagMap.tag_id == self.tag.id).update(
-            {OktaGroupTagMap.ended_at: func.now()}, synchronize_session="fetch"
+            .where(OktaGroupTagMap.tag_id == self.tag.id)
+            .values({OktaGroupTagMap.ended_at: func.now()})
+            .execution_options(synchronize_session="fetch")
         )
 
         # End all active app tag mappings for tag
-        db.session.query(AppTagMap).filter(
-            or_(
-                AppTagMap.ended_at.is_(None),
-                AppTagMap.ended_at > func.now(),
+        db.session.execute(
+            update(AppTagMap)
+            .where(
+                or_(
+                    AppTagMap.ended_at.is_(None),
+                    AppTagMap.ended_at > func.now(),
+                )
             )
-        ).filter(AppTagMap.tag_id == self.tag.id).update({AppTagMap.ended_at: func.now()}, synchronize_session="fetch")
+            .where(AppTagMap.tag_id == self.tag.id)
+            .values({AppTagMap.ended_at: func.now()})
+            .execution_options(synchronize_session="fetch")
+        )
 
         db.session.commit()

--- a/api/operations/delete_user.py
+++ b/api/operations/delete_user.py
@@ -120,13 +120,12 @@ class DeleteUser:
         # Reject pending role requests by the deleted user. ApproveRoleRequest
         # doesn't guard on a deleted requester, so a surviving one would still
         # grant the role access to the group after the requester is gone.
-        obsolete_role_requests = (
-            db.session.query(RoleRequest)
-            .filter(RoleRequest.requester_user_id == self.user.id)
-            .filter(RoleRequest.status == AccessRequestStatus.PENDING)
-            .filter(RoleRequest.resolved_at.is_(None))
-            .all()
-        )
+        obsolete_role_requests = db.session.scalars(
+            select(RoleRequest)
+            .where(RoleRequest.requester_user_id == self.user.id)
+            .where(RoleRequest.status == AccessRequestStatus.PENDING)
+            .where(RoleRequest.resolved_at.is_(None))
+        ).all()
         for obsolete_role_request in obsolete_role_requests:
             RejectRoleRequest(
                 role_request=obsolete_role_request,
@@ -135,13 +134,12 @@ class DeleteUser:
             ).execute()
 
         # Reject pending group requests by the deleted user, mirroring above.
-        obsolete_group_requests = (
-            db.session.query(GroupRequest)
-            .filter(GroupRequest.requester_user_id == self.user.id)
-            .filter(GroupRequest.status == AccessRequestStatus.PENDING)
-            .filter(GroupRequest.resolved_at.is_(None))
-            .all()
-        )
+        obsolete_group_requests = db.session.scalars(
+            select(GroupRequest)
+            .where(GroupRequest.requester_user_id == self.user.id)
+            .where(GroupRequest.status == AccessRequestStatus.PENDING)
+            .where(GroupRequest.resolved_at.is_(None))
+        ).all()
         for obsolete_group_request in obsolete_group_requests:
             RejectGroupRequest(
                 group_request=obsolete_group_request,

--- a/api/operations/delete_user.py
+++ b/api/operations/delete_user.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import (
     joinedload,
 )
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select, update
 from api.extensions import db
 from api.models import (
     AccessRequest,
@@ -23,17 +23,16 @@ from api.services import okta
 class DeleteUser:
     def __init__(self, *, user: OktaUser | str, sync_to_okta: bool = True, current_user_id: Optional[str] = None):
         if isinstance(user, str):
-            self.user = db.session.query(OktaUser).filter(OktaUser.id == user).first()
+            self.user = db.session.scalars(select(OktaUser).where(OktaUser.id == user)).first()
         else:
             self.user = user
 
         self.sync_to_okta = sync_to_okta
 
         self.current_user_id = getattr(
-            db.session.query(OktaUser)
-            .filter(OktaUser.deleted_at.is_(None))
-            .filter(OktaUser.id == current_user_id)
-            .first(),
+            db.session.scalars(
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+            ).first(),
             "id",
             None,
         )
@@ -51,14 +50,14 @@ class DeleteUser:
 
         # End all user memberships including group memberships via a role
         group_access_query = (
-            db.session.query(OktaUserGroupMember)
-            .filter(
+            select(OktaUserGroupMember)
+            .where(
                 or_(
                     OktaUserGroupMember.ended_at.is_(None),
                     OktaUserGroupMember.ended_at > func.now(),
                 )
             )
-            .filter(OktaUserGroupMember.user_id == self.user.id)
+            .where(OktaUserGroupMember.user_id == self.user.id)
         )
 
         if self.sync_to_okta:
@@ -66,11 +65,14 @@ class DeleteUser:
             managed_group_access_query = (
                 group_access_query.options(joinedload(OktaUserGroupMember.group))
                 .join(OktaUserGroupMember.group)
-                .filter(OktaGroup.is_managed.is_(True))
+                .where(OktaGroup.is_managed.is_(True))
             )
             # Remove user from group membership in Okta
             group_memberships_to_remove_ids = [
-                m.group_id for m in managed_group_access_query.filter(OktaUserGroupMember.is_owner.is_(False)).all()
+                m.group_id
+                for m in db.session.scalars(
+                    managed_group_access_query.where(OktaUserGroupMember.is_owner.is_(False))
+                ).all()
             ]
 
             for group_id in group_memberships_to_remove_ids:
@@ -78,23 +80,36 @@ class DeleteUser:
 
             # Remove user from group ownerships in Okta
             group_ownerships_to_remove_ids = [
-                m.group_id for m in managed_group_access_query.filter(OktaUserGroupMember.is_owner.is_(True)).all()
+                m.group_id
+                for m in db.session.scalars(
+                    managed_group_access_query.where(OktaUserGroupMember.is_owner.is_(True))
+                ).all()
             ]
 
             for group_id in group_ownerships_to_remove_ids:
                 okta_tasks.append(asyncio.create_task(okta.async_remove_owner_from_group(group_id, self.user.id)))
 
-        group_access_query.update({OktaUserGroupMember.ended_at: func.now()}, synchronize_session="fetch")
+        db.session.execute(
+            update(OktaUserGroupMember)
+            .where(
+                or_(
+                    OktaUserGroupMember.ended_at.is_(None),
+                    OktaUserGroupMember.ended_at > func.now(),
+                )
+            )
+            .where(OktaUserGroupMember.user_id == self.user.id)
+            .values({OktaUserGroupMember.ended_at: func.now()})
+            .execution_options(synchronize_session="fetch")
+        )
 
         db.session.commit()
 
-        obsolete_access_requests = (
-            db.session.query(AccessRequest)
-            .filter(AccessRequest.requester_user_id == self.user.id)
-            .filter(AccessRequest.status == AccessRequestStatus.PENDING)
-            .filter(AccessRequest.resolved_at.is_(None))
-            .all()
-        )
+        obsolete_access_requests = db.session.scalars(
+            select(AccessRequest)
+            .where(AccessRequest.requester_user_id == self.user.id)
+            .where(AccessRequest.status == AccessRequestStatus.PENDING)
+            .where(AccessRequest.resolved_at.is_(None))
+        ).all()
         for obsolete_access_request in obsolete_access_requests:
             RejectAccessRequest(
                 access_request=obsolete_access_request,

--- a/api/operations/modify_app_tags.py
+++ b/api/operations/modify_app_tags.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import logging
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select, update
 from api.context import get_request_context
 
 from api.extensions import db
@@ -20,24 +20,22 @@ class ModifyAppTags:
         tags_to_remove: list[str] = [],
         current_user_id: Optional[str],
     ):
-        self.app = (
-            db.session.query(App)
-            .filter(App.deleted_at.is_(None))
-            .filter(App.id == (app if isinstance(app, str) else app.id))
-            .first()
-        )
+        self.app = db.session.scalars(
+            select(App).where(App.deleted_at.is_(None)).where(App.id == (app if isinstance(app, str) else app.id))
+        ).first()
 
-        self.tags_to_add = db.session.query(Tag).filter(Tag.deleted_at.is_(None)).filter(Tag.id.in_(tags_to_add)).all()
+        self.tags_to_add = db.session.scalars(
+            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(tags_to_add))
+        ).all()
 
-        self.tags_to_remove = (
-            db.session.query(Tag).filter(Tag.deleted_at.is_(None)).filter(Tag.id.in_(tags_to_remove)).all()
-        )
+        self.tags_to_remove = db.session.scalars(
+            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(tags_to_remove))
+        ).all()
 
         self.current_user_id = getattr(
-            db.session.query(OktaUser)
-            .filter(OktaUser.deleted_at.is_(None))
-            .filter(OktaUser.id == current_user_id)
-            .first(),
+            db.session.scalars(
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+            ).first(),
             "id",
             None,
         )
@@ -46,22 +44,21 @@ class ModifyAppTags:
         if len(self.tags_to_add) > 0:
             # Only add tags that are not already associated with this app
             tag_ids_to_add = [t.id for t in self.tags_to_add]
-            existing_tag_maps = (
-                db.session.query(AppTagMap)
-                .filter(
+            existing_tag_maps = db.session.scalars(
+                select(AppTagMap)
+                .where(
                     or_(
                         AppTagMap.ended_at.is_(None),
                         AppTagMap.ended_at > func.now(),
                     )
                 )
-                .filter(
+                .where(
                     AppTagMap.app_id == self.app.id,
                 )
-                .filter(
+                .where(
                     AppTagMap.tag_id.in_(tag_ids_to_add),
                 )
-                .all()
-            )
+            ).all()
 
             new_tag_ids_to_add = set(tag_ids_to_add) - set([m.tag_id for m in existing_tag_maps])
 
@@ -74,25 +71,21 @@ class ModifyAppTags:
                 )
             db.session.commit()
 
-            new_app_tag_maps = (
-                db.session.query(AppTagMap)
-                .filter(AppTagMap.tag_id.in_(new_tag_ids_to_add))
-                .filter(AppTagMap.app_id == self.app.id)
-                .filter(
+            new_app_tag_maps = db.session.scalars(
+                select(AppTagMap)
+                .where(AppTagMap.tag_id.in_(new_tag_ids_to_add))
+                .where(AppTagMap.app_id == self.app.id)
+                .where(
                     or_(
                         AppTagMap.ended_at.is_(None),
                         AppTagMap.ended_at > func.now(),
                     )
                 )
-                .all()
-            )
+            ).all()
 
-            all_app_groups = (
-                db.session.query(AppGroup)
-                .filter(AppGroup.app_id == self.app.id)
-                .filter(AppGroup.deleted_at.is_(None))
-                .all()
-            )
+            all_app_groups = db.session.scalars(
+                select(AppGroup).where(AppGroup.app_id == self.app.id).where(AppGroup.deleted_at.is_(None))
+            ).all()
             for app_tag_map in new_app_tag_maps:
                 for app_group in all_app_groups:
                     db.session.add(
@@ -112,10 +105,10 @@ class ModifyAppTags:
         if len(self.tags_to_remove) > 0:
             tag_ids_to_remove = [t.id for t in self.tags_to_remove]
             existing_tag_maps_query = (
-                db.session.query(AppTagMap)
-                .filter(AppTagMap.tag_id.in_(tag_ids_to_remove))
-                .filter(AppTagMap.app_id == self.app.id)
-                .filter(
+                select(AppTagMap)
+                .where(AppTagMap.tag_id.in_(tag_ids_to_remove))
+                .where(AppTagMap.app_id == self.app.id)
+                .where(
                     or_(
                         AppTagMap.ended_at.is_(None),
                         AppTagMap.ended_at > func.now(),
@@ -123,22 +116,34 @@ class ModifyAppTags:
                 )
             )
 
-            existing_tag_maps = existing_tag_maps_query.all()
-            db.session.query(OktaGroupTagMap).filter(
-                or_(
-                    OktaGroupTagMap.ended_at.is_(None),
-                    OktaGroupTagMap.ended_at > func.now(),
+            existing_tag_maps = db.session.scalars(existing_tag_maps_query).all()
+            db.session.execute(
+                update(OktaGroupTagMap)
+                .where(
+                    or_(
+                        OktaGroupTagMap.ended_at.is_(None),
+                        OktaGroupTagMap.ended_at > func.now(),
+                    )
                 )
-            ).filter(
-                OktaGroupTagMap.app_tag_map_id.in_([m.id for m in existing_tag_maps]),
-            ).update(
-                {OktaGroupTagMap.ended_at: func.now()},
-                synchronize_session="fetch",
+                .where(
+                    OktaGroupTagMap.app_tag_map_id.in_([m.id for m in existing_tag_maps]),
+                )
+                .values({OktaGroupTagMap.ended_at: func.now()})
+                .execution_options(synchronize_session="fetch")
             )
 
-            existing_tag_maps_query.update(
-                {AppTagMap.ended_at: func.now()},
-                synchronize_session="fetch",
+            db.session.execute(
+                update(AppTagMap)
+                .where(AppTagMap.tag_id.in_(tag_ids_to_remove))
+                .where(AppTagMap.app_id == self.app.id)
+                .where(
+                    or_(
+                        AppTagMap.ended_at.is_(None),
+                        AppTagMap.ended_at > func.now(),
+                    )
+                )
+                .values({AppTagMap.ended_at: func.now()})
+                .execution_options(synchronize_session="fetch")
             )
             db.session.commit()
 

--- a/api/operations/modify_group_details.py
+++ b/api/operations/modify_group_details.py
@@ -1,7 +1,7 @@
 import logging
 
 from api.context import get_request_context
-from sqlalchemy import func
+from sqlalchemy import func, select
 from sqlalchemy.orm import with_polymorphic
 
 from api.extensions import db
@@ -39,12 +39,11 @@ class ModifyGroupDetails:
 
         # Do not allow non-deleted groups with the same name (case-insensitive)
         if self.name is not None and old_name.lower() != self.name.lower():
-            existing_group = (
-                db.session.query(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-                .filter(func.lower(OktaGroup.name) == func.lower(self.name))
-                .filter(OktaGroup.deleted_at.is_(None))
-                .first()
-            )
+            existing_group = db.session.scalars(
+                select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+                .where(func.lower(OktaGroup.name) == func.lower(self.name))
+                .where(OktaGroup.deleted_at.is_(None))
+            ).first()
             if existing_group is not None:
                 raise ValueError("Group already exists with the same name")
 

--- a/api/operations/modify_group_details.py
+++ b/api/operations/modify_group_details.py
@@ -56,7 +56,9 @@ class ModifyGroupDetails:
             and self.name != old_name
             and type(self.group) is AppGroup
         ):
-            app = db.session.query(App).filter(App.id == self.group.app_id).filter(App.deleted_at.is_(None)).first()
+            app = db.session.scalars(
+                select(App).where(App.id == self.group.app_id).where(App.deleted_at.is_(None))
+            ).first()
             if app is None:
                 raise ValueError("App for AppGroup does not exist")
             app_group_name_prefix = (

--- a/api/operations/modify_group_tags.py
+++ b/api/operations/modify_group_tags.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import logging
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select, update
 from api.context import get_request_context
 from sqlalchemy.orm import joinedload, selectin_polymorphic
 
@@ -21,25 +21,25 @@ class ModifyGroupTags:
         tags_to_remove: list[str] = [],
         current_user_id: Optional[str],
     ):
-        self.group = (
-            db.session.query(OktaGroup)
+        self.group = db.session.scalars(
+            select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
-            .filter(OktaGroup.deleted_at.is_(None))
-            .filter(OktaGroup.id == (group if isinstance(group, str) else group.id))
-            .first()
-        )
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+        ).first()
 
-        self.tags_to_add = db.session.query(Tag).filter(Tag.deleted_at.is_(None)).filter(Tag.id.in_(tags_to_add)).all()
+        self.tags_to_add = db.session.scalars(
+            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(tags_to_add))
+        ).all()
 
-        self.tags_to_remove = (
-            db.session.query(Tag).filter(Tag.deleted_at.is_(None)).filter(Tag.id.in_(tags_to_remove)).all()
-        )
+        self.tags_to_remove = db.session.scalars(
+            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(tags_to_remove))
+        ).all()
 
         self.current_user_id = getattr(
-            db.session.query(OktaUser)
-            .filter(OktaUser.deleted_at.is_(None))
-            .filter(OktaUser.id == current_user_id)
-            .first(),
+            db.session.scalars(
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+            ).first(),
             "id",
             None,
         )
@@ -48,25 +48,24 @@ class ModifyGroupTags:
         if len(self.tags_to_add) > 0:
             # Only add tags that are not already associated with the group
             tag_ids_to_add = [t.id for t in self.tags_to_add]
-            existing_tag_maps = (
-                db.session.query(OktaGroupTagMap)
-                .filter(
+            existing_tag_maps = db.session.scalars(
+                select(OktaGroupTagMap)
+                .where(
                     or_(
                         OktaGroupTagMap.ended_at.is_(None),
                         OktaGroupTagMap.ended_at > func.now(),
                     )
                 )
-                .filter(
+                .where(
                     OktaGroupTagMap.group_id == self.group.id,
                 )
-                .filter(
+                .where(
                     OktaGroupTagMap.tag_id.in_(tag_ids_to_add),
                 )
-                .filter(
+                .where(
                     OktaGroupTagMap.app_tag_map_id.is_(None),
                 )
-                .all()
-            )
+            ).all()
 
             new_tag_ids_to_add = set(tag_ids_to_add) - set([m.tag_id for m in existing_tag_maps])
 
@@ -85,20 +84,25 @@ class ModifyGroupTags:
             db.session.commit()
 
         if len(self.tags_to_remove) > 0:
-            db.session.query(OktaGroupTagMap).filter(
-                or_(
-                    OktaGroupTagMap.ended_at.is_(None),
-                    OktaGroupTagMap.ended_at > func.now(),
+            db.session.execute(
+                update(OktaGroupTagMap)
+                .where(
+                    or_(
+                        OktaGroupTagMap.ended_at.is_(None),
+                        OktaGroupTagMap.ended_at > func.now(),
+                    )
                 )
-            ).filter(
-                OktaGroupTagMap.group_id == self.group.id,
-            ).filter(
-                OktaGroupTagMap.tag_id.in_([t.id for t in self.tags_to_remove]),
-            ).filter(
-                OktaGroupTagMap.app_tag_map_id.is_(None),
-            ).update(
-                {OktaGroupTagMap.ended_at: func.now()},
-                synchronize_session="fetch",
+                .where(
+                    OktaGroupTagMap.group_id == self.group.id,
+                )
+                .where(
+                    OktaGroupTagMap.tag_id.in_([t.id for t in self.tags_to_remove]),
+                )
+                .where(
+                    OktaGroupTagMap.app_tag_map_id.is_(None),
+                )
+                .values({OktaGroupTagMap.ended_at: func.now()})
+                .execution_options(synchronize_session="fetch")
             )
             db.session.commit()
 
@@ -107,13 +111,12 @@ class ModifyGroupTags:
             email = None
             if self.current_user_id is not None:
                 email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
-                group = (
-                    db.session.query(OktaGroup)
+                group = db.session.scalars(
+                    select(OktaGroup)
                     .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
-                    .filter(OktaGroup.deleted_at.is_(None))
-                    .filter(OktaGroup.id == self.group.id)
-                    .first()
-                )
+                    .where(OktaGroup.deleted_at.is_(None))
+                    .where(OktaGroup.id == self.group.id)
+                ).first()
 
             _ctx = get_request_context()
             logging.getLogger("access.audit").info(

--- a/api/operations/modify_group_type.py
+++ b/api/operations/modify_group_type.py
@@ -3,7 +3,7 @@ from typing import Optional
 import logging
 
 from api.context import get_request_context
-from sqlalchemy import delete, func, insert, or_
+from sqlalchemy import delete, func, insert, or_, select, update
 from sqlalchemy.orm import joinedload, selectin_polymorphic
 
 from api.extensions import db
@@ -26,20 +26,18 @@ from api.schemas import AuditLogSchema, EventType
 
 class ModifyGroupType:
     def __init__(self, *, group: OktaGroup | str, group_changes: OktaGroup, current_user_id: Optional[str]):
-        self.group = (
-            db.session.query(OktaGroup)
+        self.group = db.session.scalars(
+            select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
-            .filter(OktaGroup.deleted_at.is_(None))
-            .filter(OktaGroup.id == (group if isinstance(group, str) else group.id))
-            .first()
-        )
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+        ).first()
 
         self.group_changes = group_changes
         self.current_user_id = getattr(
-            db.session.query(OktaUser)
-            .filter(OktaUser.deleted_at.is_(None))
-            .filter(OktaUser.id == current_user_id)
-            .first(),
+            db.session.scalars(
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+            ).first(),
             "id",
             None,
         )
@@ -62,16 +60,16 @@ class ModifyGroupType:
                     )
 
                 # End all group attachments to this role and all group memberships via the role grant
-                active_role_associated_groups = (
-                    db.session.query(RoleGroupMap)
-                    .filter(
+                active_role_associated_groups = db.session.scalars(
+                    select(RoleGroupMap)
+                    .where(
                         or_(
                             RoleGroupMap.ended_at.is_(None),
                             RoleGroupMap.ended_at > func.now(),
                         )
                     )
-                    .filter(RoleGroupMap.role_group_id == self.group.id)
-                )
+                    .where(RoleGroupMap.role_group_id == self.group.id)
+                ).all()
                 ModifyRoleGroups(
                     role_group=self.group,
                     current_user_id=self.current_user_id,
@@ -112,16 +110,18 @@ class ModifyGroupType:
                         db.session.rollback()
 
                 # Remove app tag map for this group that is no longer attached to an app
-                db.session.query(OktaGroupTagMap).filter(
-                    or_(
-                        OktaGroupTagMap.ended_at.is_(None),
-                        OktaGroupTagMap.ended_at > func.now(),
+                db.session.execute(
+                    update(OktaGroupTagMap)
+                    .where(
+                        or_(
+                            OktaGroupTagMap.ended_at.is_(None),
+                            OktaGroupTagMap.ended_at > func.now(),
+                        )
                     )
-                ).filter(OktaGroupTagMap.group_id == self.group.id).filter(
-                    OktaGroupTagMap.app_tag_map_id.isnot(None)
-                ).update(
-                    {OktaGroupTagMap.app_tag_map_id: None},
-                    synchronize_session="fetch",
+                    .where(OktaGroupTagMap.group_id == self.group.id)
+                    .where(OktaGroupTagMap.app_tag_map_id.isnot(None))
+                    .values({OktaGroupTagMap.app_tag_map_id: None})
+                    .execution_options(synchronize_session="fetch")
                 )
                 db.session.commit()
 
@@ -135,28 +135,24 @@ class ModifyGroupType:
             self.group.type = OktaGroup.__mapper_args__["polymorphic_identity"]
             db.session.commit()
 
-            self.group = (
-                db.session.query(OktaGroup)
-                .filter(OktaGroup.deleted_at.is_(None))
-                .filter(OktaGroup.id == group_id)
-                .first()
-            )
+            self.group = db.session.scalars(
+                select(OktaGroup).where(OktaGroup.deleted_at.is_(None)).where(OktaGroup.id == group_id)
+            ).first()
 
             # Create new child table row
             if type(self.group_changes) is RoleGroup:
                 # Convert any group memberships and ownerships via a role to direct group memberships and ownerships
-                active_group_users_from_role = (
-                    db.session.query(OktaUserGroupMember)
-                    .filter(
+                active_group_users_from_role = db.session.scalars(
+                    select(OktaUserGroupMember)
+                    .where(
                         or_(
                             OktaUserGroupMember.ended_at.is_(None),
                             OktaUserGroupMember.ended_at > func.now(),
                         )
                     )
-                    .filter(OktaUserGroupMember.role_group_map_id.is_not(None))
-                    .filter(OktaUserGroupMember.group_id == group_id)
-                    .all()
-                )
+                    .where(OktaUserGroupMember.role_group_map_id.is_not(None))
+                    .where(OktaUserGroupMember.group_id == group_id)
+                ).all()
                 # Add all group memberships and ownerships via a role grant as direct memberships and ownerships
                 # Do this in a loop so we can preserve the ended_at value
                 for group_user in active_group_users_from_role:
@@ -176,17 +172,16 @@ class ModifyGroupType:
                         ).execute()
 
                 # Remove all group memberships and ownerships via a role grant
-                active_role_associated_groups = (
-                    db.session.query(RoleGroupMap)
-                    .filter(
+                active_role_associated_groups = db.session.scalars(
+                    select(RoleGroupMap)
+                    .where(
                         or_(
                             RoleGroupMap.ended_at.is_(None),
                             RoleGroupMap.ended_at > func.now(),
                         )
                     )
-                    .filter(RoleGroupMap.group_id == group_id)
-                    .all()
-                )
+                    .where(RoleGroupMap.group_id == group_id)
+                ).all()
                 for role_group_map in active_role_associated_groups:
                     if role_group_map.is_owner:
                         ModifyRoleGroups(
@@ -220,20 +215,19 @@ class ModifyGroupType:
 
             # Add all app tags to this new app group, after we've updated the group type
             if type(self.group_changes) is AppGroup:
-                app_tag_maps = (
-                    db.session.query(AppTagMap)
+                app_tag_maps = db.session.scalars(
+                    select(AppTagMap)
                     .options(joinedload(AppTagMap.active_tag))
-                    .filter(
+                    .where(
                         or_(
                             AppTagMap.ended_at.is_(None),
                             AppTagMap.ended_at > func.now(),
                         )
                     )
-                    .filter(
+                    .where(
                         AppTagMap.app_id == self.group_changes.app_id,
                     )
-                    .all()
-                )
+                ).all()
                 for app_tag_map in app_tag_maps:
                     db.session.add(
                         OktaGroupTagMap(
@@ -249,13 +243,12 @@ class ModifyGroupType:
                 ).execute()
 
             # Return a new lookup for the group
-            self.group = (
-                db.session.query(OktaGroup)
+            self.group = db.session.scalars(
+                select(OktaGroup)
                 .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
-                .filter(OktaGroup.deleted_at.is_(None))
-                .filter(OktaGroup.id == group_id)
-                .first()
-            )
+                .where(OktaGroup.deleted_at.is_(None))
+                .where(OktaGroup.id == group_id)
+            ).first()
 
             # Invoke group_created hook after converting to an AppGroup (symmetric
             # with group_deleted which fires when converting away from AppGroup).

--- a/api/operations/modify_group_users.py
+++ b/api/operations/modify_group_users.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional
 
 import logging
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select, update
 from api.context import get_request_context
 from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload
 
@@ -47,17 +47,16 @@ class ModifyGroupUsers:
         created_reason: str = "",
         notify: bool = True,
     ):
-        self.group = (
-            db.session.query(OktaGroup)
+        self.group = db.session.scalars(
+            select(OktaGroup)
             .options(
                 selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
                 joinedload(AppGroup.app),
                 selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
             )
-            .filter(OktaGroup.deleted_at.is_(None))
-            .filter(OktaGroup.id == (group if isinstance(group, str) else group.id))
-            .first()
-        )
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+        ).first()
 
         # Determine the minimum time allowed for group membership and ownership by current group tags
         tags = [tag_map.active_tag for tag_map in self.group.active_group_tags]
@@ -76,67 +75,54 @@ class ModifyGroupUsers:
 
         self.members_to_add = []
         if len(members_to_add) > 0:
-            self.members_to_add = (
-                db.session.query(OktaUser)
-                .filter(OktaUser.id.in_(members_to_add))
-                .filter(OktaUser.deleted_at.is_(None))
-                .all()
-            )
+            self.members_to_add = db.session.scalars(
+                select(OktaUser).where(OktaUser.id.in_(members_to_add)).where(OktaUser.deleted_at.is_(None))
+            ).all()
 
         self.owners_to_add = []
         if len(owners_to_add) > 0:
-            self.owners_to_add = (
-                db.session.query(OktaUser)
-                .filter(OktaUser.id.in_(owners_to_add))
-                .filter(OktaUser.deleted_at.is_(None))
-                .all()
-            )
+            self.owners_to_add = db.session.scalars(
+                select(OktaUser).where(OktaUser.id.in_(owners_to_add)).where(OktaUser.deleted_at.is_(None))
+            ).all()
 
         self.members_should_expire = []
         if len(members_should_expire) > 0:
-            self.members_should_expire = (
-                db.session.query(OktaUserGroupMember)
-                .filter(OktaUserGroupMember.id.in_(members_should_expire))
-                .filter(OktaUserGroupMember.group_id == self.group.id)
-                .filter(OktaUserGroupMember.ended_at > func.now())
-                .filter(OktaUserGroupMember.is_owner.is_(False))
+            self.members_should_expire = db.session.scalars(
+                select(OktaUserGroupMember)
+                .where(OktaUserGroupMember.id.in_(members_should_expire))
+                .where(OktaUserGroupMember.group_id == self.group.id)
+                .where(OktaUserGroupMember.ended_at > func.now())
+                .where(OktaUserGroupMember.is_owner.is_(False))
             ).all()
 
         self.owners_should_expire = []
         if len(owners_should_expire) > 0:
-            self.owners_should_expire = (
-                db.session.query(OktaUserGroupMember)
-                .filter(OktaUserGroupMember.id.in_(owners_should_expire))
-                .filter(OktaUserGroupMember.group_id == self.group.id)
-                .filter(OktaUserGroupMember.ended_at > func.now())
-                .filter(OktaUserGroupMember.is_owner.is_(True))
+            self.owners_should_expire = db.session.scalars(
+                select(OktaUserGroupMember)
+                .where(OktaUserGroupMember.id.in_(owners_should_expire))
+                .where(OktaUserGroupMember.group_id == self.group.id)
+                .where(OktaUserGroupMember.ended_at > func.now())
+                .where(OktaUserGroupMember.is_owner.is_(True))
             ).all()
 
         self.members_to_remove = []
         if len(members_to_remove) > 0:
-            self.members_to_remove = (
-                db.session.query(OktaUser)
-                .filter(OktaUser.id.in_(members_to_remove))
-                .filter(OktaUser.deleted_at.is_(None))
-                .all()
-            )
+            self.members_to_remove = db.session.scalars(
+                select(OktaUser).where(OktaUser.id.in_(members_to_remove)).where(OktaUser.deleted_at.is_(None))
+            ).all()
 
         self.owners_to_remove = []
         if len(owners_to_remove) > 0:
-            self.owners_to_remove = (
-                db.session.query(OktaUser)
-                .filter(OktaUser.id.in_(owners_to_remove))
-                .filter(OktaUser.deleted_at.is_(None))
-                .all()
-            )
+            self.owners_to_remove = db.session.scalars(
+                select(OktaUser).where(OktaUser.id.in_(owners_to_remove)).where(OktaUser.deleted_at.is_(None))
+            ).all()
 
         self.sync_to_okta = sync_to_okta
 
         self.current_user_id = getattr(
-            db.session.query(OktaUser)
-            .filter(OktaUser.deleted_at.is_(None))
-            .filter(OktaUser.id == current_user_id)
-            .first(),
+            db.session.scalars(
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+            ).first(),
             "id",
             None,
         )
@@ -224,65 +210,73 @@ class ModifyGroupUsers:
 
         # End group memberships and ownerships
         if len(remove_changed_members) > 0 or len(remove_changed_owners) > 0:
-            db.session.query(OktaUserGroupMember).filter(
-                or_(
-                    OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > func.now(),
+            db.session.execute(
+                update(OktaUserGroupMember)
+                .where(
+                    or_(
+                        OktaUserGroupMember.ended_at.is_(None),
+                        OktaUserGroupMember.ended_at > func.now(),
+                    )
                 )
-            ).filter(OktaUserGroupMember.group_id == self.group.id).filter(
-                OktaUserGroupMember.is_owner.is_(False)
-            ).filter(OktaUserGroupMember.user_id.in_([m.id for m in remove_changed_members])).filter(
-                OktaUserGroupMember.role_group_map_id.is_(None)
-            ).update(
-                {OktaUserGroupMember.ended_at: func.now(), OktaUserGroupMember.ended_actor_id: self.current_user_id},
-                synchronize_session="fetch",
+                .where(OktaUserGroupMember.group_id == self.group.id)
+                .where(OktaUserGroupMember.is_owner.is_(False))
+                .where(OktaUserGroupMember.user_id.in_([m.id for m in remove_changed_members]))
+                .where(OktaUserGroupMember.role_group_map_id.is_(None))
+                .values(
+                    {OktaUserGroupMember.ended_at: func.now(), OktaUserGroupMember.ended_actor_id: self.current_user_id}
+                )
+                .execution_options(synchronize_session="fetch")
             )
 
-            db.session.query(OktaUserGroupMember).filter(
-                or_(
-                    OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > func.now(),
+            db.session.execute(
+                update(OktaUserGroupMember)
+                .where(
+                    or_(
+                        OktaUserGroupMember.ended_at.is_(None),
+                        OktaUserGroupMember.ended_at > func.now(),
+                    )
                 )
-            ).filter(OktaUserGroupMember.group_id == self.group.id).filter(
-                OktaUserGroupMember.is_owner.is_(True)
-            ).filter(OktaUserGroupMember.user_id.in_([m.id for m in remove_changed_owners])).filter(
-                OktaUserGroupMember.role_group_map_id.is_(None)
-            ).update(
-                {OktaUserGroupMember.ended_at: func.now(), OktaUserGroupMember.ended_actor_id: self.current_user_id},
-                synchronize_session="fetch",
+                .where(OktaUserGroupMember.group_id == self.group.id)
+                .where(OktaUserGroupMember.is_owner.is_(True))
+                .where(OktaUserGroupMember.user_id.in_([m.id for m in remove_changed_owners]))
+                .where(OktaUserGroupMember.role_group_map_id.is_(None))
+                .values(
+                    {OktaUserGroupMember.ended_at: func.now(), OktaUserGroupMember.ended_actor_id: self.current_user_id}
+                )
+                .execution_options(synchronize_session="fetch")
             )
 
             # For role groups, members to be removed should also be removed from all role associated groups
             if type(self.group) is RoleGroup:
-                role_associated_groups_mappings = (
-                    db.session.query(RoleGroupMap)
-                    .filter(
+                role_associated_groups_mappings = db.session.scalars(
+                    select(RoleGroupMap)
+                    .where(
                         or_(
                             RoleGroupMap.ended_at.is_(None),
                             RoleGroupMap.ended_at > func.now(),
                         )
                     )
-                    .filter(RoleGroupMap.role_group_id == self.group.id)
-                    .all()
-                )
+                    .where(RoleGroupMap.role_group_id == self.group.id)
+                ).all()
                 role_associated_group_memberships = (
-                    db.session.query(OktaUserGroupMember)
-                    .filter(
+                    update(OktaUserGroupMember)
+                    .where(
                         or_(
                             OktaUserGroupMember.ended_at.is_(None),
                             OktaUserGroupMember.ended_at > func.now(),
                         )
                     )
-                    .filter(OktaUserGroupMember.user_id.in_([m.id for m in remove_changed_members]))
-                    .filter(OktaUserGroupMember.role_group_map_id.in_([m.id for m in role_associated_groups_mappings]))
+                    .where(OktaUserGroupMember.user_id.in_([m.id for m in remove_changed_members]))
+                    .where(OktaUserGroupMember.role_group_map_id.in_([m.id for m in role_associated_groups_mappings]))
                 )
 
-                role_associated_group_memberships.update(
-                    {
-                        OktaUserGroupMember.ended_at: func.now(),
-                        OktaUserGroupMember.ended_actor_id: self.current_user_id,
-                    },
-                    synchronize_session="fetch",
+                db.session.execute(
+                    role_associated_group_memberships.values(
+                        {
+                            OktaUserGroupMember.ended_at: func.now(),
+                            OktaUserGroupMember.ended_actor_id: self.current_user_id,
+                        }
+                    ).execution_options(synchronize_session="fetch")
                 )
 
         # Remove members and owners from Okta groups
@@ -292,20 +286,18 @@ class ModifyGroupUsers:
             # which allow group access for this user
             members_to_remove_ids = [m.id for m in self.members_to_remove]
             owners_to_remove_ids = [m.id for m in self.owners_to_remove]
-            removed_users_with_other_access = (
-                db.session.query(OktaUserGroupMember)
-                .with_entities(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
-                .filter(
+            removed_users_with_other_access = db.session.execute(
+                select(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
+                .where(
                     or_(
                         OktaUserGroupMember.ended_at.is_(None),
                         OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
-                .filter(OktaUserGroupMember.group_id == self.group.id)
-                .filter(OktaUserGroupMember.user_id.in_(members_to_remove_ids + owners_to_remove_ids))
+                .where(OktaUserGroupMember.group_id == self.group.id)
+                .where(OktaUserGroupMember.user_id.in_(members_to_remove_ids + owners_to_remove_ids))
                 .group_by(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
-                .all()
-            )
+            ).all()
             removed_members_with_other_access_ids = [
                 m.user_id for m in removed_users_with_other_access if not m.is_owner
             ]
@@ -331,45 +323,42 @@ class ModifyGroupUsers:
 
             # For role groups, members to be removed should also be removed from all role associated groups
             if type(self.group) is RoleGroup:
-                role_associated_groups_mappings = (
-                    db.session.query(RoleGroupMap)
+                role_associated_groups_mappings = db.session.scalars(
+                    select(RoleGroupMap)
                     .options(joinedload(RoleGroupMap.active_group))
                     .join(RoleGroupMap.active_group)
-                    .filter(OktaGroup.is_managed.is_(True))
-                    .filter(
+                    .where(OktaGroup.is_managed.is_(True))
+                    .where(
                         or_(
                             RoleGroupMap.ended_at.is_(None),
                             RoleGroupMap.ended_at > func.now(),
                         )
                     )
-                    .filter(RoleGroupMap.role_group_id == self.group.id)
-                    .all()
-                )
+                    .where(RoleGroupMap.role_group_id == self.group.id)
+                ).all()
                 # Check if there are other OktaUserGroupMembers for this user/group
                 # combination before removing group membership, there can be multiple role groups
                 # which allow group access for this user
-                removed_role_group_users_with_other_access = (
-                    db.session.query(OktaUserGroupMember)
-                    .with_entities(
+                removed_role_group_users_with_other_access = db.session.execute(
+                    select(
                         OktaUserGroupMember.user_id,
                         OktaUserGroupMember.group_id,
                         OktaUserGroupMember.is_owner,
                     )
-                    .filter(
+                    .where(
                         or_(
                             OktaUserGroupMember.ended_at.is_(None),
                             OktaUserGroupMember.ended_at > func.now(),
                         )
                     )
-                    .filter(OktaUserGroupMember.user_id.in_(members_to_remove_ids + owners_to_remove_ids))
-                    .filter(OktaUserGroupMember.group_id.in_([r.group_id for r in role_associated_groups_mappings]))
+                    .where(OktaUserGroupMember.user_id.in_(members_to_remove_ids + owners_to_remove_ids))
+                    .where(OktaUserGroupMember.group_id.in_([r.group_id for r in role_associated_groups_mappings]))
                     .group_by(
                         OktaUserGroupMember.user_id,
                         OktaUserGroupMember.group_id,
                         OktaUserGroupMember.is_owner,
                     )
-                    .all()
-                )
+                ).all()
                 for role_associated_group_map in role_associated_groups_mappings:
                     if not role_associated_group_map.is_owner:
                         removed_members_with_other_access_ids = [
@@ -443,19 +432,19 @@ class ModifyGroupUsers:
         # Only relevant for the expiring groups page so not adding checks for this field anywhere else since OK if marked to expire
         # then manually renewed from group page or with an access request
         if len(self.members_should_expire) > 0:
-            db.session.query(OktaUserGroupMember).filter(
-                OktaUserGroupMember.id.in_(m.id for m in self.members_should_expire)
-            ).update(
-                {OktaUserGroupMember.should_expire: True},
-                synchronize_session="fetch",
+            db.session.execute(
+                update(OktaUserGroupMember)
+                .where(OktaUserGroupMember.id.in_(m.id for m in self.members_should_expire))
+                .values({OktaUserGroupMember.should_expire: True})
+                .execution_options(synchronize_session="fetch")
             )
 
         if len(self.owners_should_expire) > 0:
-            db.session.query(OktaUserGroupMember).filter(
-                OktaUserGroupMember.id.in_(m.id for m in self.owners_should_expire)
-            ).update(
-                {OktaUserGroupMember.should_expire: True},
-                synchronize_session="fetch",
+            db.session.execute(
+                update(OktaUserGroupMember)
+                .where(OktaUserGroupMember.id.in_(m.id for m in self.owners_should_expire))
+                .values({OktaUserGroupMember.should_expire: True})
+                .execution_options(synchronize_session="fetch")
             )
 
         # Commit all changes so far
@@ -465,22 +454,20 @@ class ModifyGroupUsers:
         if len(self.members_to_add) > 0 or len(self.owners_to_add) > 0:
             # Check which members being added currently have NO active memberships (to track first-time access)
             members_to_add_ids = [m.id for m in self.members_to_add]
-            existing_members_with_access = (
-                db.session.query(OktaUserGroupMember)
-                .with_entities(OktaUserGroupMember.user_id)
-                .filter(
+            existing_members_with_access = db.session.scalars(
+                select(OktaUserGroupMember.user_id)
+                .where(
                     or_(
                         OktaUserGroupMember.ended_at.is_(None),
                         OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
-                .filter(OktaUserGroupMember.group_id == self.group.id)
-                .filter(OktaUserGroupMember.user_id.in_(members_to_add_ids))
-                .filter(OktaUserGroupMember.is_owner.is_(False))
+                .where(OktaUserGroupMember.group_id == self.group.id)
+                .where(OktaUserGroupMember.user_id.in_(members_to_add_ids))
+                .where(OktaUserGroupMember.is_owner.is_(False))
                 .group_by(OktaUserGroupMember.user_id)
-                .all()
-            )
-            existing_members_with_access_ids = set([m.user_id for m in existing_members_with_access])
+            ).all()
+            existing_members_with_access_ids = set(existing_members_with_access)
             members_gaining_first_access_ids = set(members_to_add_ids) - existing_members_with_access_ids
 
             # Track members who are gaining their first access to this group
@@ -526,20 +513,19 @@ class ModifyGroupUsers:
 
             # For role groups, new members should also be added to all Access-managed role associated groups
             if type(self.group) is RoleGroup:
-                role_associated_groups_mappings = (
-                    db.session.query(RoleGroupMap)
+                role_associated_groups_mappings = db.session.scalars(
+                    select(RoleGroupMap)
                     .options(joinedload(RoleGroupMap.active_group))
                     .join(RoleGroupMap.active_group)
-                    .filter(OktaGroup.is_managed.is_(True))
-                    .filter(
+                    .where(OktaGroup.is_managed.is_(True))
+                    .where(
                         or_(
                             RoleGroupMap.ended_at.is_(None),
                             RoleGroupMap.ended_at > func.now(),
                         )
                     )
-                    .filter(RoleGroupMap.role_group_id == self.group.id)
-                    .all()
-                )
+                    .where(RoleGroupMap.role_group_id == self.group.id)
+                ).all()
 
                 # Check which members being added currently have NO active memberships in role-associated groups
                 role_associated_group_ids = [m.group_id for m in role_associated_groups_mappings]
@@ -549,23 +535,21 @@ class ModifyGroupUsers:
                     for group_id in role_associated_group_ids:
                         existing_access_by_group[group_id] = set()
 
-                    existing_role_members_with_access = (
-                        db.session.query(OktaUserGroupMember)
-                        .with_entities(
+                    existing_role_members_with_access = db.session.execute(
+                        select(
                             OktaUserGroupMember.user_id,
                             OktaUserGroupMember.group_id,
                         )
-                        .filter(
+                        .where(
                             or_(
                                 OktaUserGroupMember.ended_at.is_(None),
                                 OktaUserGroupMember.ended_at > func.now(),
                             )
                         )
-                        .filter(OktaUserGroupMember.user_id.in_(members_to_add_ids))
-                        .filter(OktaUserGroupMember.group_id.in_(role_associated_group_ids))
+                        .where(OktaUserGroupMember.user_id.in_(members_to_add_ids))
+                        .where(OktaUserGroupMember.group_id.in_(role_associated_group_ids))
                         .group_by(OktaUserGroupMember.user_id, OktaUserGroupMember.group_id)
-                        .all()
-                    )
+                    ).all()
                     for row in existing_role_members_with_access:
                         existing_access_by_group[row.group_id].add(row.user_id)
 
@@ -654,20 +638,19 @@ class ModifyGroupUsers:
 
             # Approve any pending access requests for access granted by this operation
             pending_requests_query = (
-                db.session.query(AccessRequest)
+                select(AccessRequest)
                 .options(joinedload(AccessRequest.requested_group))
-                .filter(AccessRequest.status == AccessRequestStatus.PENDING)
-                .filter(AccessRequest.resolved_at.is_(None))
+                .where(AccessRequest.status == AccessRequestStatus.PENDING)
+                .where(AccessRequest.resolved_at.is_(None))
             )
 
             # Find all pending membership access requests to approve for this group
             # and groups associated if this a role group
-            pending_member_requests = (
-                pending_requests_query.filter(AccessRequest.requested_group_id.in_(group_memberships_added.keys()))
-                .filter(AccessRequest.requester_user_id.in_([m.id for m in self.members_to_add]))
-                .filter(AccessRequest.request_ownership.is_(False))
-                .all()
-            )
+            pending_member_requests = db.session.scalars(
+                pending_requests_query.where(AccessRequest.requested_group_id.in_(group_memberships_added.keys()))
+                .where(AccessRequest.requester_user_id.in_([m.id for m in self.members_to_add]))
+                .where(AccessRequest.request_ownership.is_(False))
+            ).all()
             for access_request in pending_member_requests:
                 async_tasks.append(
                     self._approve_access_request(
@@ -677,12 +660,11 @@ class ModifyGroupUsers:
                 )
 
             # Find all pending ownership requests to approve for this group
-            pending_owner_requests = (
-                pending_requests_query.filter(AccessRequest.requested_group_id == self.group.id)
-                .filter(AccessRequest.requester_user_id.in_([m.id for m in self.owners_to_add]))
-                .filter(AccessRequest.request_ownership.is_(True))
-                .all()
-            )
+            pending_owner_requests = db.session.scalars(
+                pending_requests_query.where(AccessRequest.requested_group_id == self.group.id)
+                .where(AccessRequest.requester_user_id.in_([m.id for m in self.owners_to_add]))
+                .where(AccessRequest.request_ownership.is_(True))
+            ).all()
             for access_request in pending_owner_requests:
                 async_tasks.append(
                     self._approve_access_request(
@@ -692,14 +674,13 @@ class ModifyGroupUsers:
                 )
 
             # Find all pending ownership requests to approve for groups associated if this a role group
-            pending_role_associated_owner_requests = (
-                pending_requests_query.filter(
+            pending_role_associated_owner_requests = db.session.scalars(
+                pending_requests_query.where(
                     AccessRequest.requested_group_id.in_(set(group_ownerships_added.keys()) - set([self.group.id]))
                 )
-                .filter(AccessRequest.requester_user_id.in_([m.id for m in self.members_to_add]))
-                .filter(AccessRequest.request_ownership.is_(True))
-                .all()
-            )
+                .where(AccessRequest.requester_user_id.in_([m.id for m in self.members_to_add]))
+                .where(AccessRequest.request_ownership.is_(True))
+            ).all()
             for access_request in pending_role_associated_owner_requests:
                 async_tasks.append(
                     self._approve_access_request(

--- a/api/operations/modify_groups_time_limit.py
+++ b/api/operations/modify_groups_time_limit.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select, update
 from api.extensions import db
 from api.models import OktaGroup, OktaUserGroupMember, RoleGroup, RoleGroupMap, Tag
 from api.models.tag import coalesce_constraints
@@ -9,22 +9,20 @@ from api.models.tag import coalesce_constraints
 class ModifyGroupsTimeLimit:
     def __init__(self, groups: list[str] | set[str], tags: list[str] | set[str]):
         # Only include groups that are managed
-        self.groups = (
-            db.session.query(OktaGroup)
-            .filter(OktaGroup.id.in_(groups))
-            .filter(OktaGroup.deleted_at.is_(None))
-            .filter(OktaGroup.is_managed.is_(True))
-            .all()
-        )
-        self.role_groups = (
-            db.session.query(RoleGroup)
-            .filter(RoleGroup.id.in_(groups))
-            .filter(RoleGroup.deleted_at.is_(None))
-            .filter(RoleGroup.is_managed.is_(True))
-            .all()
-        )
+        self.groups = db.session.scalars(
+            select(OktaGroup)
+            .where(OktaGroup.id.in_(groups))
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(OktaGroup.is_managed.is_(True))
+        ).all()
+        self.role_groups = db.session.scalars(
+            select(RoleGroup)
+            .where(RoleGroup.id.in_(groups))
+            .where(RoleGroup.deleted_at.is_(None))
+            .where(RoleGroup.is_managed.is_(True))
+        ).all()
 
-        self.tags = db.session.query(Tag).filter(Tag.id.in_(tags)).filter(Tag.deleted_at.is_(None)).all()
+        self.tags = db.session.scalars(select(Tag).where(Tag.id.in_(tags)).where(Tag.deleted_at.is_(None))).all()
 
     def execute(self) -> None:
         if len(self.groups) == 0:
@@ -37,104 +35,114 @@ class ModifyGroupsTimeLimit:
         if membership_seconds_limit is not None:
             membership_time_limit_from_now = datetime.now(UTC) + timedelta(seconds=membership_seconds_limit)
             # Reduce all user memberships for the given groups to minimum allowed time limit
-            db.session.query(OktaUserGroupMember).filter(
-                OktaUserGroupMember.group_id.in_([g.id for g in self.groups])
-            ).filter(OktaUserGroupMember.is_owner.is_(False)).filter(
-                or_(
-                    OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > membership_time_limit_from_now,
+            db.session.execute(
+                update(OktaUserGroupMember)
+                .where(OktaUserGroupMember.group_id.in_([g.id for g in self.groups]))
+                .where(OktaUserGroupMember.is_owner.is_(False))
+                .where(
+                    or_(
+                        OktaUserGroupMember.ended_at.is_(None),
+                        OktaUserGroupMember.ended_at > membership_time_limit_from_now,
+                    )
                 )
-            ).update(
-                {OktaUserGroupMember.ended_at: membership_time_limit_from_now},
-                synchronize_session="fetch",
+                .values({OktaUserGroupMember.ended_at: membership_time_limit_from_now})
+                .execution_options(synchronize_session="fetch")
             )
             # Reduce all role memberships for the given groups to the minimum allowed time limit
-            db.session.query(RoleGroupMap).filter(RoleGroupMap.group_id.in_([g.id for g in self.groups])).filter(
-                RoleGroupMap.is_owner.is_(False)
-            ).filter(
-                or_(
-                    RoleGroupMap.ended_at.is_(None),
-                    RoleGroupMap.ended_at > membership_time_limit_from_now,
+            db.session.execute(
+                update(RoleGroupMap)
+                .where(RoleGroupMap.group_id.in_([g.id for g in self.groups]))
+                .where(RoleGroupMap.is_owner.is_(False))
+                .where(
+                    or_(
+                        RoleGroupMap.ended_at.is_(None),
+                        RoleGroupMap.ended_at > membership_time_limit_from_now,
+                    )
                 )
-            ).update(
-                {RoleGroupMap.ended_at: membership_time_limit_from_now},
-                synchronize_session="fetch",
+                .values({RoleGroupMap.ended_at: membership_time_limit_from_now})
+                .execution_options(synchronize_session="fetch")
             )
             # Reduce all user memberships for groups associated with any given role groups
             # to the minimum allowed time limit
-            role_group_map_associations = (
-                db.session.query(RoleGroupMap)
-                .filter(RoleGroupMap.role_group_id.in_([g.id for g in self.role_groups]))
-                .filter(RoleGroupMap.is_owner.is_(False))
-                .filter(
+            role_group_map_associations = db.session.scalars(
+                select(RoleGroupMap)
+                .where(RoleGroupMap.role_group_id.in_([g.id for g in self.role_groups]))
+                .where(RoleGroupMap.is_owner.is_(False))
+                .where(
                     or_(
                         RoleGroupMap.ended_at.is_(None),
                         RoleGroupMap.ended_at > func.now(),
                     )
                 )
-                .all()
-            )
-            db.session.query(OktaUserGroupMember).filter(
-                OktaUserGroupMember.role_group_map_id.in_([m.id for m in role_group_map_associations])
-            ).filter(OktaUserGroupMember.is_owner.is_(False)).filter(
-                or_(
-                    OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > membership_time_limit_from_now,
+            ).all()
+            db.session.execute(
+                update(OktaUserGroupMember)
+                .where(OktaUserGroupMember.role_group_map_id.in_([m.id for m in role_group_map_associations]))
+                .where(OktaUserGroupMember.is_owner.is_(False))
+                .where(
+                    or_(
+                        OktaUserGroupMember.ended_at.is_(None),
+                        OktaUserGroupMember.ended_at > membership_time_limit_from_now,
+                    )
                 )
-            ).update(
-                {OktaUserGroupMember.ended_at: membership_time_limit_from_now},
-                synchronize_session="fetch",
+                .values({OktaUserGroupMember.ended_at: membership_time_limit_from_now})
+                .execution_options(synchronize_session="fetch")
             )
             db.session.commit()
         if ownership_seconds_limit is not None:
             ownership_time_limit_from_now = datetime.now(UTC) + timedelta(seconds=ownership_seconds_limit)
             # Reduce all user ownerships for the given groups to minimum allowed time limit
-            db.session.query(OktaUserGroupMember).filter(
-                OktaUserGroupMember.group_id.in_([g.id for g in self.groups])
-            ).filter(OktaUserGroupMember.is_owner.is_(True)).filter(
-                or_(
-                    OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > ownership_time_limit_from_now,
+            db.session.execute(
+                update(OktaUserGroupMember)
+                .where(OktaUserGroupMember.group_id.in_([g.id for g in self.groups]))
+                .where(OktaUserGroupMember.is_owner.is_(True))
+                .where(
+                    or_(
+                        OktaUserGroupMember.ended_at.is_(None),
+                        OktaUserGroupMember.ended_at > ownership_time_limit_from_now,
+                    )
                 )
-            ).update(
-                {OktaUserGroupMember.ended_at: ownership_time_limit_from_now},
-                synchronize_session="fetch",
+                .values({OktaUserGroupMember.ended_at: ownership_time_limit_from_now})
+                .execution_options(synchronize_session="fetch")
             )
             # Reduce all role ownerships for the given groups to the minimum allowed time limit
-            db.session.query(RoleGroupMap).filter(RoleGroupMap.group_id.in_([g.id for g in self.groups])).filter(
-                RoleGroupMap.is_owner.is_(True)
-            ).filter(
-                or_(
-                    RoleGroupMap.ended_at.is_(None),
-                    RoleGroupMap.ended_at > ownership_time_limit_from_now,
+            db.session.execute(
+                update(RoleGroupMap)
+                .where(RoleGroupMap.group_id.in_([g.id for g in self.groups]))
+                .where(RoleGroupMap.is_owner.is_(True))
+                .where(
+                    or_(
+                        RoleGroupMap.ended_at.is_(None),
+                        RoleGroupMap.ended_at > ownership_time_limit_from_now,
+                    )
                 )
-            ).update(
-                {RoleGroupMap.ended_at: ownership_time_limit_from_now},
-                synchronize_session="fetch",
+                .values({RoleGroupMap.ended_at: ownership_time_limit_from_now})
+                .execution_options(synchronize_session="fetch")
             )
             # Reduce all user ownerships for groups associated with any given role groups
             # to the minimum allowed time limit
-            role_group_map_associations = (
-                db.session.query(RoleGroupMap)
-                .filter(RoleGroupMap.role_group_id.in_([g.id for g in self.role_groups]))
-                .filter(RoleGroupMap.is_owner.is_(True))
-                .filter(
+            role_group_map_associations = db.session.scalars(
+                select(RoleGroupMap)
+                .where(RoleGroupMap.role_group_id.in_([g.id for g in self.role_groups]))
+                .where(RoleGroupMap.is_owner.is_(True))
+                .where(
                     or_(
                         RoleGroupMap.ended_at.is_(None),
                         RoleGroupMap.ended_at > func.now(),
                     )
                 )
-                .all()
-            )
-            db.session.query(OktaUserGroupMember).filter(
-                OktaUserGroupMember.role_group_map_id.in_([m.id for m in role_group_map_associations])
-            ).filter(OktaUserGroupMember.is_owner.is_(True)).filter(
-                or_(
-                    OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > membership_time_limit_from_now,
+            ).all()
+            db.session.execute(
+                update(OktaUserGroupMember)
+                .where(OktaUserGroupMember.role_group_map_id.in_([m.id for m in role_group_map_associations]))
+                .where(OktaUserGroupMember.is_owner.is_(True))
+                .where(
+                    or_(
+                        OktaUserGroupMember.ended_at.is_(None),
+                        OktaUserGroupMember.ended_at > membership_time_limit_from_now,
+                    )
                 )
-            ).update(
-                {OktaUserGroupMember.ended_at: membership_time_limit_from_now},
-                synchronize_session="fetch",
+                .values({OktaUserGroupMember.ended_at: membership_time_limit_from_now})
+                .execution_options(synchronize_session="fetch")
             )
             db.session.commit()

--- a/api/operations/modify_role_groups.py
+++ b/api/operations/modify_role_groups.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional
 
 import logging
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select, update
 from api.context import get_request_context
 from sqlalchemy.orm import selectinload
 
@@ -47,12 +47,9 @@ class ModifyRoleGroups:
         notify: bool = True,
     ):
         if isinstance(role_group, str):
-            self.role = (
-                db.session.query(RoleGroup)
-                .filter(RoleGroup.deleted_at.is_(None))
-                .filter(RoleGroup.id == role_group)
-                .first()
-            )
+            self.role = db.session.scalars(
+                select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == role_group)
+            ).first()
         else:
             self.role = role_group
 
@@ -60,74 +57,65 @@ class ModifyRoleGroups:
 
         self.groups_to_add = []
         if len(groups_to_add) > 0:
-            self.groups_to_add = (
-                db.session.query(OktaGroup)
+            self.groups_to_add = db.session.scalars(
+                select(OktaGroup)
                 .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
-                .filter(OktaGroup.id.in_(groups_to_add))
-                .filter(OktaGroup.is_managed.is_(True))
-                .filter(OktaGroup.deleted_at.is_(None))
+                .where(OktaGroup.id.in_(groups_to_add))
+                .where(OktaGroup.is_managed.is_(True))
+                .where(OktaGroup.deleted_at.is_(None))
                 # Don't allow Roles to be added as Groups to Roles
-                .filter(OktaGroup.type != RoleGroup.__mapper_args__["polymorphic_identity"])
-                .all()
-            )
+                .where(OktaGroup.type != RoleGroup.__mapper_args__["polymorphic_identity"])
+            ).all()
         self.owner_groups_to_add = []
         if len(owner_groups_to_add) > 0:
-            self.owner_groups_to_add = (
-                db.session.query(OktaGroup)
+            self.owner_groups_to_add = db.session.scalars(
+                select(OktaGroup)
                 .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
-                .filter(OktaGroup.id.in_(owner_groups_to_add))
-                .filter(OktaGroup.is_managed.is_(True))
-                .filter(OktaGroup.deleted_at.is_(None))
+                .where(OktaGroup.id.in_(owner_groups_to_add))
+                .where(OktaGroup.is_managed.is_(True))
+                .where(OktaGroup.deleted_at.is_(None))
                 # Don't allow Roles to be added as Groups to Roles
-                .filter(OktaGroup.type != RoleGroup.__mapper_args__["polymorphic_identity"])
-                .all()
-            )
+                .where(OktaGroup.type != RoleGroup.__mapper_args__["polymorphic_identity"])
+            ).all()
 
         self.groups_should_expire = []
         if len(groups_should_expire) > 0:
-            self.groups_should_expire = (
-                db.session.query(RoleGroupMap)
-                .filter(RoleGroupMap.id.in_(groups_should_expire))
-                .filter(RoleGroupMap.role_group_id == self.role.id)
-                .filter(RoleGroupMap.ended_at > func.now())
-                .filter(RoleGroupMap.is_owner.is_(False))
+            self.groups_should_expire = db.session.scalars(
+                select(RoleGroupMap)
+                .where(RoleGroupMap.id.in_(groups_should_expire))
+                .where(RoleGroupMap.role_group_id == self.role.id)
+                .where(RoleGroupMap.ended_at > func.now())
+                .where(RoleGroupMap.is_owner.is_(False))
             ).all()
 
         self.owner_groups_should_expire = []
         if len(owner_groups_should_expire) > 0:
-            self.owner_groups_should_expire = (
-                db.session.query(RoleGroupMap)
-                .filter(RoleGroupMap.id.in_(owner_groups_should_expire))
-                .filter(RoleGroupMap.role_group_id == self.role.id)
-                .filter(RoleGroupMap.ended_at > func.now())
-                .filter(RoleGroupMap.is_owner.is_(True))
+            self.owner_groups_should_expire = db.session.scalars(
+                select(RoleGroupMap)
+                .where(RoleGroupMap.id.in_(owner_groups_should_expire))
+                .where(RoleGroupMap.role_group_id == self.role.id)
+                .where(RoleGroupMap.ended_at > func.now())
+                .where(RoleGroupMap.is_owner.is_(True))
             ).all()
 
         self.groups_to_remove = []
         if len(groups_to_remove) > 0:
-            self.groups_to_remove = (
-                db.session.query(OktaGroup)
-                .filter(OktaGroup.id.in_(groups_to_remove))
-                .filter(OktaGroup.deleted_at.is_(None))
-                .all()
-            )
+            self.groups_to_remove = db.session.scalars(
+                select(OktaGroup).where(OktaGroup.id.in_(groups_to_remove)).where(OktaGroup.deleted_at.is_(None))
+            ).all()
 
         self.owner_groups_to_remove = []
         if len(owner_groups_to_remove) > 0:
-            self.owner_groups_to_remove = (
-                db.session.query(OktaGroup)
-                .filter(OktaGroup.id.in_(owner_groups_to_remove))
-                .filter(OktaGroup.deleted_at.is_(None))
-                .all()
-            )
+            self.owner_groups_to_remove = db.session.scalars(
+                select(OktaGroup).where(OktaGroup.id.in_(owner_groups_to_remove)).where(OktaGroup.deleted_at.is_(None))
+            ).all()
 
         self.sync_to_okta = sync_to_okta
 
         self.current_user_id = getattr(
-            db.session.query(OktaUser)
-            .filter(OktaUser.deleted_at.is_(None))
-            .filter(OktaUser.id == current_user_id)
-            .first(),
+            db.session.scalars(
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+            ).first(),
             "id",
             None,
         )
@@ -220,43 +208,41 @@ class ModifyRoleGroups:
             # combination before removing role, there can be multiple role groups
             # which allow group access for this user
 
-            active_role_members = (
-                db.session.query(OktaUserGroupMember)
-                .filter(
+            active_role_members = db.session.scalars(
+                select(OktaUserGroupMember)
+                .where(
                     or_(
                         OktaUserGroupMember.ended_at.is_(None),
                         OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
-                .filter(OktaUserGroupMember.group_id == self.role.id)
-                .filter(OktaUserGroupMember.is_owner.is_(False))
-            )
+                .where(OktaUserGroupMember.group_id == self.role.id)
+                .where(OktaUserGroupMember.is_owner.is_(False))
+            ).all()
 
             role_members_to_remove_ids = [m.user_id for m in active_role_members]
             groups_to_remove_ids = [m.id for m in self.groups_to_remove]
             owner_groups_to_remove_ids = [m.id for m in self.owner_groups_to_remove]
-            removed_role_group_users_with_other_access = (
-                db.session.query(OktaUserGroupMember)
-                .with_entities(
+            removed_role_group_users_with_other_access = db.session.execute(
+                select(
                     OktaUserGroupMember.user_id,
                     OktaUserGroupMember.group_id,
                     OktaUserGroupMember.is_owner,
                 )
-                .filter(
+                .where(
                     or_(
                         OktaUserGroupMember.ended_at.is_(None),
                         OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
-                .filter(OktaUserGroupMember.user_id.in_(role_members_to_remove_ids))
-                .filter(OktaUserGroupMember.group_id.in_(groups_to_remove_ids + owner_groups_to_remove_ids))
+                .where(OktaUserGroupMember.user_id.in_(role_members_to_remove_ids))
+                .where(OktaUserGroupMember.group_id.in_(groups_to_remove_ids + owner_groups_to_remove_ids))
                 .group_by(
                     OktaUserGroupMember.user_id,
                     OktaUserGroupMember.group_id,
                     OktaUserGroupMember.is_owner,
                 )
-                .all()
-            )
+            ).all()
 
             for group_id in groups_to_remove_ids:
                 removed_members_with_other_access_ids = [
@@ -273,12 +259,11 @@ class ModifyRoleGroups:
                     group = db.session.get(OktaGroup, group_id)
                     plugin_id = get_app_group_lifecycle_plugin_to_invoke(group)
                     if plugin_id is not None:
-                        members_losing_access = (
-                            db.session.query(OktaUser)
-                            .filter(OktaUser.id.in_(okta_members_to_remove_ids))
-                            .filter(OktaUser.deleted_at.is_(None))
-                            .all()
-                        )
+                        members_losing_access = db.session.scalars(
+                            select(OktaUser)
+                            .where(OktaUser.id.in_(okta_members_to_remove_ids))
+                            .where(OktaUser.deleted_at.is_(None))
+                        ).all()
                         try:
                             hook = get_app_group_lifecycle_hook()
                             hook.group_members_removed(
@@ -315,17 +300,19 @@ class ModifyRoleGroups:
         # Only relevant for the expiring roles page so not adding checks for this field anywhere else since OK if marked to expire
         # then manually renewed from group/role page or with an access request
         if len(self.groups_should_expire) > 0:
-            db.session.query(RoleGroupMap).filter(RoleGroupMap.id.in_(m.id for m in self.groups_should_expire)).update(
-                {RoleGroupMap.should_expire: True},
-                synchronize_session="fetch",
+            db.session.execute(
+                update(RoleGroupMap)
+                .where(RoleGroupMap.id.in_(m.id for m in self.groups_should_expire))
+                .values({RoleGroupMap.should_expire: True})
+                .execution_options(synchronize_session="fetch")
             )
 
         if len(self.owner_groups_should_expire) > 0:
-            db.session.query(RoleGroupMap).filter(
-                RoleGroupMap.id.in_(m.id for m in self.owner_groups_should_expire)
-            ).update(
-                {RoleGroupMap.should_expire: True},
-                synchronize_session="fetch",
+            db.session.execute(
+                update(RoleGroupMap)
+                .where(RoleGroupMap.id.in_(m.id for m in self.owner_groups_should_expire))
+                .values({RoleGroupMap.should_expire: True})
+                .execution_options(synchronize_session="fetch")
             )
 
         # Commit all changes so far
@@ -382,35 +369,32 @@ class ModifyRoleGroups:
 
             # Group members of a role should be added as members to all newly added groups
             # and owner groups associated with that role
-            active_role_memberships = (
-                db.session.query(OktaUserGroupMember)
-                .filter(
+            active_role_memberships = db.session.scalars(
+                select(OktaUserGroupMember)
+                .where(
                     or_(
                         OktaUserGroupMember.ended_at.is_(None),
                         OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
-                .filter(OktaUserGroupMember.group_id == self.role.id)
-                .filter(OktaUserGroupMember.is_owner.is_(False))
-                .all()
-            )
+                .where(OktaUserGroupMember.group_id == self.role.id)
+                .where(OktaUserGroupMember.is_owner.is_(False))
+            ).all()
             group_memberships_added: Dict[str, Dict[str, OktaUserGroupMember]] = {}
             for role_associated_group_map in role_memberships_added.values():
                 group_memberships_added[role_associated_group_map.group_id] = role_associated_membership_added = {}
 
                 # Check which members being added currently have NO active memberships (to track first-time access)
                 members_to_add_ids = [m.user_id for m in active_role_memberships]
-                existing_members_with_access = (
-                    db.session.query(OktaUserGroupMember)
-                    .with_entities(OktaUserGroupMember.user_id)
-                    .filter(or_(OktaUserGroupMember.ended_at.is_(None), OktaUserGroupMember.ended_at > func.now()))
-                    .filter(OktaUserGroupMember.group_id == role_associated_group_map.group_id)
-                    .filter(OktaUserGroupMember.user_id.in_(members_to_add_ids))
-                    .filter(OktaUserGroupMember.is_owner.is_(False))
+                existing_members_with_access = db.session.scalars(
+                    select(OktaUserGroupMember.user_id)
+                    .where(or_(OktaUserGroupMember.ended_at.is_(None), OktaUserGroupMember.ended_at > func.now()))
+                    .where(OktaUserGroupMember.group_id == role_associated_group_map.group_id)
+                    .where(OktaUserGroupMember.user_id.in_(members_to_add_ids))
+                    .where(OktaUserGroupMember.is_owner.is_(False))
                     .group_by(OktaUserGroupMember.user_id)
-                    .all()
-                )
-                existing_member_ids = {m.user_id for m in existing_members_with_access}
+                ).all()
+                existing_member_ids = set(existing_members_with_access)
                 members_gaining_access_ids = set(members_to_add_ids) - existing_member_ids
 
                 # Invoke app group lifecycle plugin hooks for added members
@@ -418,12 +402,11 @@ class ModifyRoleGroups:
                     group = role_associated_group_map.active_group
                     plugin_id = get_app_group_lifecycle_plugin_to_invoke(group)
                     if plugin_id is not None:
-                        members_gaining_access = (
-                            db.session.query(OktaUser)
-                            .filter(OktaUser.id.in_(members_gaining_access_ids))
-                            .filter(OktaUser.deleted_at.is_(None))
-                            .all()
-                        )
+                        members_gaining_access = db.session.scalars(
+                            select(OktaUser)
+                            .where(OktaUser.id.in_(members_gaining_access_ids))
+                            .where(OktaUser.deleted_at.is_(None))
+                        ).all()
                         try:
                             hook = get_app_group_lifecycle_hook()
                             hook.group_members_added(
@@ -509,19 +492,18 @@ class ModifyRoleGroups:
 
             # Approve any pending access requests for access granted by this operation
             pending_requests_query = (
-                db.session.query(AccessRequest)
-                .filter(AccessRequest.status == AccessRequestStatus.PENDING)
-                .filter(AccessRequest.resolved_at.is_(None))
+                select(AccessRequest)
+                .where(AccessRequest.status == AccessRequestStatus.PENDING)
+                .where(AccessRequest.resolved_at.is_(None))
             )
             active_role_membership_ids = [m.user_id for m in active_role_memberships]
 
             # Find all pending membership requests to approve for groups added as members via this role
-            pending_member_requests = (
-                pending_requests_query.filter(AccessRequest.requested_group_id.in_(group_memberships_added.keys()))
-                .filter(AccessRequest.requester_user_id.in_(active_role_membership_ids))
-                .filter(AccessRequest.request_ownership.is_(False))
-                .all()
-            )
+            pending_member_requests = db.session.scalars(
+                pending_requests_query.where(AccessRequest.requested_group_id.in_(group_memberships_added.keys()))
+                .where(AccessRequest.requester_user_id.in_(active_role_membership_ids))
+                .where(AccessRequest.request_ownership.is_(False))
+            ).all()
             for access_request in pending_member_requests:
                 async_tasks.append(
                     self._approve_access_request(
@@ -531,12 +513,11 @@ class ModifyRoleGroups:
                 )
 
             # Find all pending ownership requests to approve for groups added as owners via this role
-            pending_role_associated_owner_requests = (
-                pending_requests_query.filter(AccessRequest.requested_group_id.in_(group_ownerships_added.keys()))
-                .filter(AccessRequest.requester_user_id.in_(active_role_membership_ids))
-                .filter(AccessRequest.request_ownership.is_(True))
-                .all()
-            )
+            pending_role_associated_owner_requests = db.session.scalars(
+                pending_requests_query.where(AccessRequest.requested_group_id.in_(group_ownerships_added.keys()))
+                .where(AccessRequest.requester_user_id.in_(active_role_membership_ids))
+                .where(AccessRequest.request_ownership.is_(True))
+            ).all()
             for access_request in pending_role_associated_owner_requests:
                 async_tasks.append(
                     self._approve_access_request(
@@ -547,18 +528,18 @@ class ModifyRoleGroups:
 
             # Approve any pending role requests for memberships granted by this operation
             pending_role_requests_query = (
-                db.session.query(RoleRequest)
-                .filter(RoleRequest.status == AccessRequestStatus.PENDING)
-                .filter(RoleRequest.resolved_at.is_(None))
-                .filter(RoleRequest.requester_role == self.role)
+                select(RoleRequest)
+                .where(RoleRequest.status == AccessRequestStatus.PENDING)
+                .where(RoleRequest.resolved_at.is_(None))
+                .where(RoleRequest.requester_role == self.role)
             )
 
             added_group_ids = [group.id for group in self.groups_to_add]
-            pending_role_memberships = (
-                pending_role_requests_query.filter(RoleRequest.request_ownership.is_(False))
-                .filter(RoleRequest.requested_group_id.in_(added_group_ids))
-                .all()
-            )
+            pending_role_memberships = db.session.scalars(
+                pending_role_requests_query.where(RoleRequest.request_ownership.is_(False)).where(
+                    RoleRequest.requested_group_id.in_(added_group_ids)
+                )
+            ).all()
             for role_request in pending_role_memberships:
                 async_tasks.append(
                     self._approve_role_request(role_request, role_memberships_added[role_request.requested_group_id])
@@ -566,11 +547,11 @@ class ModifyRoleGroups:
 
             # Approve any pending role requests for ownerships granted by this operation
             added_owner_group_ids = [group.id for group in self.owner_groups_to_add]
-            pending_role_ownerships = (
-                pending_role_requests_query.filter(RoleRequest.request_ownership.is_(True))
-                .filter(RoleRequest.requested_group_id.in_(added_owner_group_ids))
-                .all()
-            )
+            pending_role_ownerships = db.session.scalars(
+                pending_role_requests_query.where(RoleRequest.request_ownership.is_(True)).where(
+                    RoleRequest.requested_group_id.in_(added_owner_group_ids)
+                )
+            ).all()
             for role_request in pending_role_ownerships:
                 async_tasks.append(
                     self._approve_role_request(role_request, role_ownerships_added[role_request.requested_group_id])
@@ -591,39 +572,44 @@ class ModifyRoleGroups:
             return
 
         # Role user members should be removed from any groups associated with that role being removed
-        old_role_associated_groups_mappings = (
-            db.session.query(RoleGroupMap)
-            .filter(
+        old_role_associated_groups_mappings = db.session.scalars(
+            select(RoleGroupMap)
+            .where(
                 or_(
                     RoleGroupMap.ended_at.is_(None),
                     RoleGroupMap.ended_at > func.now(),
                 )
             )
-            .filter(RoleGroupMap.role_group_id == self.role.id)
-            .filter(RoleGroupMap.group_id.in_([g.id for g in groups_to_remove]))
-            .filter(RoleGroupMap.is_owner == owner_groups)
-            .all()
-        )
+            .where(RoleGroupMap.role_group_id == self.role.id)
+            .where(RoleGroupMap.group_id.in_([g.id for g in groups_to_remove]))
+            .where(RoleGroupMap.is_owner == owner_groups)
+        ).all()
 
         # End group memberships via role
-        db.session.query(OktaUserGroupMember).filter(
-            or_(
-                OktaUserGroupMember.ended_at.is_(None),
-                OktaUserGroupMember.ended_at > func.now(),
+        db.session.execute(
+            update(OktaUserGroupMember)
+            .where(
+                or_(
+                    OktaUserGroupMember.ended_at.is_(None),
+                    OktaUserGroupMember.ended_at > func.now(),
+                )
             )
-        ).filter(OktaUserGroupMember.role_group_map_id.in_([m.id for m in old_role_associated_groups_mappings])).update(
-            {OktaUserGroupMember.ended_at: func.now(), OktaUserGroupMember.ended_actor_id: self.current_user_id},
-            synchronize_session="fetch",
+            .where(OktaUserGroupMember.role_group_map_id.in_([m.id for m in old_role_associated_groups_mappings]))
+            .values(
+                {OktaUserGroupMember.ended_at: func.now(), OktaUserGroupMember.ended_actor_id: self.current_user_id}
+            )
+            .execution_options(synchronize_session="fetch")
         )
 
         # End mappings of role associated group to role
-        db.session.query(RoleGroupMap).filter(
-            or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now())
-        ).filter(RoleGroupMap.role_group_id == self.role.id).filter(
-            RoleGroupMap.group_id.in_([g.id for g in groups_to_remove])
-        ).filter(RoleGroupMap.is_owner == owner_groups).update(
-            {RoleGroupMap.ended_at: func.now(), RoleGroupMap.ended_actor_id: self.current_user_id},
-            synchronize_session="fetch",
+        db.session.execute(
+            update(RoleGroupMap)
+            .where(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
+            .where(RoleGroupMap.role_group_id == self.role.id)
+            .where(RoleGroupMap.group_id.in_([g.id for g in groups_to_remove]))
+            .where(RoleGroupMap.is_owner == owner_groups)
+            .values({RoleGroupMap.ended_at: func.now(), RoleGroupMap.ended_actor_id: self.current_user_id})
+            .execution_options(synchronize_session="fetch")
         )
 
     def _approve_access_request(

--- a/api/operations/reject_access_request.py
+++ b/api/operations/reject_access_request.py
@@ -3,7 +3,7 @@ from typing import Optional
 import logging
 
 from api.context import get_request_context
-from sqlalchemy import func, nullsfirst
+from sqlalchemy import func, nullsfirst, select
 from sqlalchemy.orm import joinedload, selectin_polymorphic
 
 from api.exceptions import ConflictError
@@ -28,18 +28,17 @@ class RejectAccessRequest:
         # reject; both serialize on this row and the loser hits the resolved
         # guard. No-op on SQLite.
         request_id = access_request if isinstance(access_request, str) else access_request.id
-        self.access_request = (
-            db.session.query(AccessRequest).filter(AccessRequest.id == request_id).with_for_update().first()
-        )
+        self.access_request = db.session.scalars(
+            select(AccessRequest).where(AccessRequest.id == request_id).with_for_update()
+        ).first()
 
         if current_user_id is None:
             self.rejecter_id = None
         elif isinstance(current_user_id, str):
             self.rejecter_id = getattr(
-                db.session.query(OktaUser)
-                .filter(OktaUser.deleted_at.is_(None))
-                .filter(OktaUser.id == current_user_id)
-                .first(),
+                db.session.scalars(
+                    select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                ).first(),
                 "id",
                 None,
             )
@@ -71,13 +70,12 @@ class RejectAccessRequest:
         if self.rejecter_id is not None:
             email = getattr(db.session.get(OktaUser, self.rejecter_id), "email", None)
 
-        group = (
-            db.session.query(OktaGroup)
+        group = db.session.scalars(
+            select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
-            .filter(OktaGroup.id == self.access_request.requested_group_id)
+            .where(OktaGroup.id == self.access_request.requested_group_id)
             .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
-            .first()
-        )
+        ).first()
 
         _ctx = get_request_context()
 

--- a/api/operations/reject_group_request.py
+++ b/api/operations/reject_group_request.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import logging
 
-from sqlalchemy import func
+from sqlalchemy import func, select
 from api.context import get_request_context
 
 from api.exceptions import ConflictError
@@ -28,19 +28,16 @@ class RejectGroupRequest:
         # reject; both serialize on this row and the loser hits the resolved
         # guard. No-op on SQLite.
         request_id = group_request if isinstance(group_request, str) else group_request.id
-        self.group_request = (
-            db.session.query(GroupRequest).filter(GroupRequest.id == request_id).with_for_update().first()
-        )
+        self.group_request = db.session.scalars(
+            select(GroupRequest).where(GroupRequest.id == request_id).with_for_update()
+        ).first()
 
         if current_user_id is None:
             self.rejecter_id = None
         elif isinstance(current_user_id, str):
-            user = (
-                db.session.query(OktaUser)
-                .filter(OktaUser.deleted_at.is_(None))
-                .filter(OktaUser.id == current_user_id)
-                .first()
-            )
+            user = db.session.scalars(
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+            ).first()
             self.rejecter_id = user.id if user else None
         else:
             self.rejecter_id = current_user_id.id
@@ -73,10 +70,10 @@ class RejectGroupRequest:
                 if not is_global_admin:
                     # Check app ownership if this is an app group request
                     if resolved_app_id is not None:
-                        is_app_owner = (
-                            db.session.query(OktaUserGroupMember)
+                        is_app_owner = db.session.scalars(
+                            select(OktaUserGroupMember)
                             .join(AppGroup, OktaUserGroupMember.group_id == AppGroup.id)
-                            .filter(
+                            .where(
                                 AppGroup.app_id == resolved_app_id,
                                 AppGroup.is_owner.is_(True),
                                 AppGroup.deleted_at.is_(None),
@@ -84,8 +81,7 @@ class RejectGroupRequest:
                                 OktaUserGroupMember.is_owner.is_(True),
                                 OktaUserGroupMember.ended_at.is_(None),
                             )
-                            .first()
-                        )
+                        ).first()
 
                         if not is_app_owner:
                             return self.group_request

--- a/api/operations/reject_role_request.py
+++ b/api/operations/reject_role_request.py
@@ -3,7 +3,7 @@ from typing import Optional
 import logging
 
 from api.context import get_request_context
-from sqlalchemy import func, nullsfirst
+from sqlalchemy import func, nullsfirst, select
 from sqlalchemy.orm import joinedload, selectin_polymorphic
 
 from api.exceptions import ConflictError
@@ -28,16 +28,17 @@ class RejectRoleRequest:
         # reject; both serialize on this row and the loser hits the resolved
         # guard. No-op on SQLite.
         request_id = role_request if isinstance(role_request, str) else role_request.id
-        self.role_request = db.session.query(RoleRequest).filter(RoleRequest.id == request_id).with_for_update().first()
+        self.role_request = db.session.scalars(
+            select(RoleRequest).where(RoleRequest.id == request_id).with_for_update()
+        ).first()
 
         if current_user_id is None:
             self.rejecter_id = None
         elif isinstance(current_user_id, str):
             self.rejecter_id = getattr(
-                db.session.query(OktaUser)
-                .filter(OktaUser.deleted_at.is_(None))
-                .filter(OktaUser.id == current_user_id)
-                .first(),
+                db.session.scalars(
+                    select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                ).first(),
                 "id",
                 None,
             )
@@ -69,13 +70,12 @@ class RejectRoleRequest:
         if self.rejecter_id is not None:
             email = getattr(db.session.get(OktaUser, self.rejecter_id), "email", None)
 
-        group = (
-            db.session.query(OktaGroup)
+        group = db.session.scalars(
+            select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup]), joinedload(AppGroup.app))
-            .filter(OktaGroup.id == self.role_request.requested_group_id)
+            .where(OktaGroup.id == self.role_request.requested_group_id)
             .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
-            .first()
-        )
+        ).first()
 
         _ctx = get_request_context()
 

--- a/api/operations/unmanage_group.py
+++ b/api/operations/unmanage_group.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from sqlalchemy.orm import selectin_polymorphic
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select, update
 from api.extensions import db
 from api.models import (
     AccessRequest,
@@ -25,18 +25,16 @@ logger = logging.getLogger(__name__)
 # Run this operation when a group becomes unmanaged by Access
 class UnmanageGroup:
     def __init__(self, *, group: OktaGroup | str, current_user_id: Optional[str] = None):
-        self.group = (
-            db.session.query(OktaGroup)
+        self.group = db.session.scalars(
+            select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-            .filter(OktaGroup.id == (group if isinstance(group, str) else group.id))
-            .first()
-        )
+            .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+        ).first()
 
         self.current_user_id = getattr(
-            db.session.query(OktaUser)
-            .filter(OktaUser.deleted_at.is_(None))
-            .filter(OktaUser.id == current_user_id)
-            .first(),
+            db.session.scalars(
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+            ).first(),
             "id",
             None,
         )
@@ -49,18 +47,18 @@ class UnmanageGroup:
 
         # End all group memberships and ownerships via a role (not direct memberships or ownerships)
         active_access_via_roles_query = (
-            db.session.query(OktaUserGroupMember)
-            .filter(
+            select(OktaUserGroupMember)
+            .where(
                 or_(
                     OktaUserGroupMember.ended_at.is_(None),
                     OktaUserGroupMember.ended_at > func.now(),
                 )
             )
-            .filter(OktaUserGroupMember.group_id == self.group.id)
-            .filter(OktaUserGroupMember.role_group_map_id.isnot(None))
+            .where(OktaUserGroupMember.group_id == self.group.id)
+            .where(OktaUserGroupMember.role_group_map_id.isnot(None))
         )
 
-        for active_access_via_role in active_access_via_roles_query.all():
+        for active_access_via_role in db.session.scalars(active_access_via_roles_query).all():
             logger.info(
                 f"User {active_access_via_role.user_id} has invalid "
                 f"{'ownership' if active_access_via_role.is_owner else 'membership'} "
@@ -68,19 +66,29 @@ class UnmanageGroup:
             )
 
         if not dry_run:
-            active_access_via_roles_query.update(
-                {OktaUserGroupMember.ended_at: func.now()}, synchronize_session="fetch"
+            db.session.execute(
+                update(OktaUserGroupMember)
+                .where(
+                    or_(
+                        OktaUserGroupMember.ended_at.is_(None),
+                        OktaUserGroupMember.ended_at > func.now(),
+                    )
+                )
+                .where(OktaUserGroupMember.group_id == self.group.id)
+                .where(OktaUserGroupMember.role_group_map_id.isnot(None))
+                .values({OktaUserGroupMember.ended_at: func.now()})
+                .execution_options(synchronize_session="fetch")
             )
             db.session.commit()
 
         # End all roles associations where this group was a member
         active_role_assignments_query = (
-            db.session.query(RoleGroupMap)
-            .filter(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
-            .filter(RoleGroupMap.group_id == self.group.id)
+            select(RoleGroupMap)
+            .where(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
+            .where(RoleGroupMap.group_id == self.group.id)
         )
 
-        for active_role_assignment in active_role_assignments_query.all():
+        for active_role_assignment in db.session.scalars(active_role_assignments_query).all():
             logger.info(
                 f"Role {active_role_assignment.role_group_id} has invalid "
                 f"{'ownership' if active_role_assignment.is_owner else 'membership'} "
@@ -88,20 +96,25 @@ class UnmanageGroup:
             )
 
         if not dry_run:
-            active_role_assignments_query.update({RoleGroupMap.ended_at: func.now()}, synchronize_session="fetch")
+            db.session.execute(
+                update(RoleGroupMap)
+                .where(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
+                .where(RoleGroupMap.group_id == self.group.id)
+                .values({RoleGroupMap.ended_at: func.now()})
+                .execution_options(synchronize_session="fetch")
+            )
             db.session.commit()
 
         # If this groups is a RoleGroup, do not remove the groups associated with the role
         # Unmanaged roles can still be associated with groups
 
         # Reject all pending access requests for this group
-        obsolete_access_requests = (
-            db.session.query(AccessRequest)
-            .filter(AccessRequest.requested_group_id == self.group.id)
-            .filter(AccessRequest.status == AccessRequestStatus.PENDING)
-            .filter(AccessRequest.resolved_at.is_(None))
-            .all()
-        )
+        obsolete_access_requests = db.session.scalars(
+            select(AccessRequest)
+            .where(AccessRequest.requested_group_id == self.group.id)
+            .where(AccessRequest.status == AccessRequestStatus.PENDING)
+            .where(AccessRequest.resolved_at.is_(None))
+        ).all()
         for obsolete_access_request in obsolete_access_requests:
             logger.info(
                 f"Rejecting obsolete access request {obsolete_access_request.id} "
@@ -116,18 +129,17 @@ class UnmanageGroup:
 
         # Reject all pending role requests touching this group, either as the
         # requested target or as the requester role.
-        obsolete_role_requests = (
-            db.session.query(RoleRequest)
-            .filter(
+        obsolete_role_requests = db.session.scalars(
+            select(RoleRequest)
+            .where(
                 or_(
                     RoleRequest.requested_group_id == self.group.id,
                     RoleRequest.requester_role_id == self.group.id,
                 )
             )
-            .filter(RoleRequest.status == AccessRequestStatus.PENDING)
-            .filter(RoleRequest.resolved_at.is_(None))
-            .all()
-        )
+            .where(RoleRequest.status == AccessRequestStatus.PENDING)
+            .where(RoleRequest.resolved_at.is_(None))
+        ).all()
         for obsolete_role_request in obsolete_role_requests:
             logger.info(
                 f"Rejecting obsolete role request {obsolete_role_request.id} for unmanaged group {self.group.id}"

--- a/api/routers/access_requests.py
+++ b/api/routers/access_requests.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query
 
-from sqlalchemy import String, cast, or_
+from sqlalchemy import String, cast, or_, select
 from sqlalchemy.orm import aliased, joinedload, selectin_polymorphic, selectinload
 from starlette.requests import Request
 
@@ -83,21 +83,21 @@ def list_access_requests(
     current_user_id: CurrentUserId,
     q_args: Annotated[SearchAccessRequestQuery, Query()],
 ) -> Page[AccessRequestSummary]:
-    query = db.query(AccessRequest).options(*_summary_load_options()).order_by(AccessRequest.created_at.desc())
+    stmt = select(AccessRequest).options(*_summary_load_options()).order_by(AccessRequest.created_at.desc())
 
     # Honored search filters: status, requester_user_id, requested_group_id,
     # assignee_user_id, resolver_user_id. The frontend sends these from the
     # URL bar on the requests list page; without them the client-side
     # filters do nothing.
     if q_args.status:
-        query = query.filter(AccessRequest.status == q_args.status)
+        stmt = stmt.where(AccessRequest.status == q_args.status)
 
     if q_args.requester_user_id:
         if q_args.requester_user_id == "@me":
-            query = query.filter(AccessRequest.requester_user_id == current_user_id)
+            stmt = stmt.where(AccessRequest.requester_user_id == current_user_id)
         else:
             requester_alias = aliased(OktaUser)
-            query = query.join(AccessRequest.requester.of_type(requester_alias)).filter(
+            stmt = stmt.join(AccessRequest.requester.of_type(requester_alias)).where(
                 or_(
                     AccessRequest.requester_user_id == q_args.requester_user_id,
                     requester_alias.email.ilike(q_args.requester_user_id),
@@ -105,7 +105,7 @@ def list_access_requests(
             )
 
     if q_args.requested_group_id:
-        query = query.join(AccessRequest.requested_group).filter(
+        stmt = stmt.join(AccessRequest.requested_group).where(
             or_(
                 AccessRequest.requested_group_id == q_args.requested_group_id,
                 OktaGroup.name.ilike(q_args.requested_group_id),
@@ -114,23 +114,21 @@ def list_access_requests(
 
     if q_args.assignee_user_id:
         assignee_user_id = current_user_id if q_args.assignee_user_id == "@me" else q_args.assignee_user_id
-        assignee_user = (
-            db.query(OktaUser)
-            .filter(or_(OktaUser.id == assignee_user_id, OktaUser.email.ilike(assignee_user_id)))
-            .first()
-        )
+        assignee_user = db.scalars(
+            select(OktaUser).where(or_(OktaUser.id == assignee_user_id, OktaUser.email.ilike(assignee_user_id)))
+        ).first()
         if assignee_user is not None:
             groups_owned_subquery = (
-                db.query(OktaGroup.id)
+                select(OktaGroup.id)
                 .options(selectinload(OktaGroup.active_user_ownerships))
                 .join(OktaGroup.active_user_ownerships)
-                .filter(OktaGroup.deleted_at.is_(None))
-                .filter(OktaUserGroupMember.user_id == assignee_user.id)
+                .where(OktaGroup.deleted_at.is_(None))
+                .where(OktaUserGroupMember.user_id == assignee_user.id)
                 .subquery()
             )
             owner_app_group_alias = aliased(AppGroup)
             app_groups_owned_subquery = (
-                db.query(AppGroup.id)
+                select(AppGroup.id)
                 .options(
                     joinedload(AppGroup.app)
                     .joinedload(App.active_owner_app_groups.of_type(owner_app_group_alias))
@@ -139,25 +137,25 @@ def list_access_requests(
                 .join(AppGroup.app)
                 .join(App.active_owner_app_groups.of_type(owner_app_group_alias))
                 .join(owner_app_group_alias.active_user_ownerships)
-                .filter(AppGroup.deleted_at.is_(None))
-                .filter(OktaUserGroupMember.user_id == assignee_user.id)
+                .where(AppGroup.deleted_at.is_(None))
+                .where(OktaUserGroupMember.user_id == assignee_user.id)
                 .subquery()
             )
-            query = query.join(AccessRequest.requested_group).filter(
+            stmt = stmt.join(AccessRequest.requested_group).where(
                 or_(
                     OktaGroup.id.in_(groups_owned_subquery),
                     OktaGroup.id.in_(app_groups_owned_subquery),
                 )
             )
         else:
-            query = query.filter(False)
+            stmt = stmt.where(False)
 
     if q_args.resolver_user_id:
         if q_args.resolver_user_id == "@me":
-            query = query.filter(AccessRequest.resolver_user_id == current_user_id)
+            stmt = stmt.where(AccessRequest.resolver_user_id == current_user_id)
         else:
             resolver_alias = aliased(OktaUser)
-            query = query.outerjoin(AccessRequest.resolver.of_type(resolver_alias)).filter(
+            stmt = stmt.outerjoin(AccessRequest.resolver.of_type(resolver_alias)).where(
                 or_(
                     AccessRequest.resolver_user_id == q_args.resolver_user_id,
                     resolver_alias.email.ilike(q_args.resolver_user_id),
@@ -170,11 +168,11 @@ def list_access_requests(
         like = f"%{q_args.q}%"
         q_requester_alias = aliased(OktaUser)
         q_resolver_alias = aliased(OktaUser)
-        query = (
-            query.join(AccessRequest.requester.of_type(q_requester_alias))
+        stmt = (
+            stmt.join(AccessRequest.requester.of_type(q_requester_alias))
             .join(AccessRequest.requested_group)
             .outerjoin(AccessRequest.resolver.of_type(q_resolver_alias))
-            .filter(
+            .where(
                 or_(
                     AccessRequest.id.like(f"{q_args.q}%"),
                     cast(AccessRequest.status, String).ilike(like),
@@ -193,12 +191,14 @@ def list_access_requests(
                 )
             )
         )
-    return paginate(db, query, transformer=validated(AccessRequestSummary))
+    return paginate(db, stmt, transformer=validated(AccessRequestSummary))
 
 
 @router.get("/{access_request_id}", name="access_request_by_id")
 def get_access_request(access_request_id: str, db: DbSession, current_user_id: CurrentUserId) -> AccessRequestDetail:
-    ar = db.query(AccessRequest).options(*_detail_load_options()).filter(AccessRequest.id == access_request_id).first()
+    ar = db.scalars(
+        select(AccessRequest).options(*_detail_load_options()).where(AccessRequest.id == access_request_id)
+    ).first()
     if ar is None:
         raise HTTPException(404, "Not Found")
     return AccessRequestDetail.model_validate(ar, from_attributes=True)
@@ -210,10 +210,14 @@ def post_access_request(
     db: DbSession,
     current_user_id: CurrentUserId,
 ) -> AccessRequestSummary:
-    requester = db.query(OktaUser).filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first()
+    requester = db.scalars(
+        select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+    ).first()
     if requester is None:
         raise HTTPException(403, "Current user is not allowed to perform this action")
-    group = db.query(OktaGroup).filter(OktaGroup.id == body.group_id).filter(OktaGroup.deleted_at.is_(None)).first()
+    group = db.scalars(
+        select(OktaGroup).where(OktaGroup.id == body.group_id).where(OktaGroup.deleted_at.is_(None))
+    ).first()
     if group is None:
         raise HTTPException(404, "Group not found")
     if not group.is_managed:
@@ -222,15 +226,14 @@ def post_access_request(
     # Auto-cancel any prior PENDING access request from the same user for the
     # same group + ownership mode. Without this, a user clicking "Request"
     # twice produces multiple PENDING rows that approvers see as duplicates.
-    existing_pending = (
-        db.query(AccessRequest)
-        .filter(AccessRequest.status == AccessRequestStatus.PENDING)
-        .filter(AccessRequest.requester_user_id == requester.id)
-        .filter(AccessRequest.requested_group_id == group.id)
-        .filter(AccessRequest.request_ownership.is_(body.group_owner))
-        .filter(AccessRequest.resolved_at.is_(None))
-        .all()
-    )
+    existing_pending = db.scalars(
+        select(AccessRequest)
+        .where(AccessRequest.status == AccessRequestStatus.PENDING)
+        .where(AccessRequest.requester_user_id == requester.id)
+        .where(AccessRequest.requested_group_id == group.id)
+        .where(AccessRequest.request_ownership.is_(body.group_owner))
+        .where(AccessRequest.resolved_at.is_(None))
+    ).all()
     for prior in existing_pending:
         RejectAccessRequest(
             access_request=prior,
@@ -250,7 +253,9 @@ def post_access_request(
         # Belt and suspenders — `is_managed` is the only path that returns
         # None today, but covering the contract guards against drift.
         raise HTTPException(400, "Access request could not be created")
-    refreshed = db.query(AccessRequest).options(*_summary_load_options()).filter(AccessRequest.id == ar.id).first()
+    refreshed = db.scalars(
+        select(AccessRequest).options(*_summary_load_options()).where(AccessRequest.id == ar.id)
+    ).first()
     return AccessRequestSummary.model_validate(refreshed, from_attributes=True)
 
 
@@ -264,12 +269,11 @@ def put_access_request(
     from api.auth.permissions import can_manage_group
     from api.operations.constraints import CheckForReason
 
-    ar = (
-        db.query(AccessRequest)
+    ar = db.scalars(
+        select(AccessRequest)
         .options(joinedload(AccessRequest.active_requested_group))
-        .filter(AccessRequest.id == access_request_id)
-        .first()
-    )
+        .where(AccessRequest.id == access_request_id)
+    ).first()
     if ar is None:
         raise HTTPException(404, "Not Found")
 
@@ -309,7 +313,7 @@ def put_access_request(
             notify_requester=ar.requester_user_id != current_user_id,
             current_user_id=current_user_id,
         ).execute()
-    refreshed = (
-        db.query(AccessRequest).options(*_summary_load_options()).filter(AccessRequest.id == access_request_id).first()
-    )
+    refreshed = db.scalars(
+        select(AccessRequest).options(*_summary_load_options()).where(AccessRequest.id == access_request_id)
+    ).first()
     return AccessRequestSummary.model_validate(refreshed, from_attributes=True)

--- a/api/routers/apps.py
+++ b/api/routers/apps.py
@@ -6,7 +6,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm import joinedload, selectinload
 from starlette.requests import Request
 
@@ -67,22 +67,21 @@ def list_apps(
     current_user_id: CurrentUserId,
     q_args: Annotated[SearchAppQuery, Query()],
 ) -> Page[AppSummary]:
-    query = db.query(App).filter(App.deleted_at.is_(None)).order_by(func.lower(App.name))
+    stmt = select(App).where(App.deleted_at.is_(None)).order_by(func.lower(App.name))
     if q_args.q:
         like = f"%{q_args.q}%"
-        query = query.filter(or_(App.name.ilike(like), App.description.ilike(like)))
-    return paginate(db, query, transformer=validated(AppSummary))
+        stmt = stmt.where(or_(App.name.ilike(like), App.description.ilike(like)))
+    return paginate(db, stmt, transformer=validated(AppSummary))
 
 
 @router.get("/{app_id}", name="app_by_id")
 def get_app(app_id: str, db: DbSession, current_user_id: CurrentUserId) -> AppDetail:
-    app = (
-        db.query(App)
+    app = db.scalars(
+        select(App)
         .options(*APP_LOAD_OPTIONS)
-        .filter(App.deleted_at.is_(None))
-        .filter(or_(App.id == app_id, App.name == app_id))
-        .first()
-    )
+        .where(App.deleted_at.is_(None))
+        .where(or_(App.id == app_id, App.name == app_id))
+    ).first()
     if app is None:
         raise HTTPException(404, "Not Found")
     return AppDetail.model_validate(app, from_attributes=True)
@@ -100,9 +99,9 @@ def post_app(
     description = body.description if body.description is not None else ""
 
     # Reject duplicates by name.
-    existing = (
-        db.query(App).filter(func.lower(App.name) == func.lower(body.name)).filter(App.deleted_at.is_(None)).first()
-    )
+    existing = db.scalars(
+        select(App).where(func.lower(App.name) == func.lower(body.name)).where(App.deleted_at.is_(None))
+    ).first()
     if existing is not None:
         raise HTTPException(400, "App already exists with the same name")
 
@@ -111,17 +110,16 @@ def post_app(
     if db.get(OktaUser, current_user_id) is not None:
         owner_id = current_user_id
     if body.initial_owner_id is not None:
-        owner = (
-            db.query(OktaUser)
-            .filter(OktaUser.deleted_at.is_(None))
-            .filter(
+        owner = db.scalars(
+            select(OktaUser)
+            .where(OktaUser.deleted_at.is_(None))
+            .where(
                 or_(
                     OktaUser.id == body.initial_owner_id,
                     OktaUser.email.ilike(body.initial_owner_id),
                 )
             )
-            .first()
-        )
+        ).first()
         if owner is None:
             raise HTTPException(400, "Given App initial_owner_id is not a valid user")
         owner_id = owner.id
@@ -131,12 +129,9 @@ def post_app(
 
     owner_role_ids: list[str] = []
     if body.initial_owner_role_ids is not None:
-        roles = (
-            db.query(RoleGroup)
-            .filter(RoleGroup.id.in_(body.initial_owner_role_ids))
-            .filter(RoleGroup.deleted_at.is_(None))
-            .all()
-        )
+        roles = db.scalars(
+            select(RoleGroup).where(RoleGroup.id.in_(body.initial_owner_role_ids)).where(RoleGroup.deleted_at.is_(None))
+        ).all()
         owner_role_ids = [r.id for r in roles]
         if len(owner_role_ids) != len(body.initial_owner_role_ids):
             raise HTTPException(400, "Given App initial_owner_role_ids contains invalid role ids")
@@ -153,13 +148,12 @@ def post_app(
     from sqlalchemy.orm import with_polymorphic
 
     poly_group = with_polymorphic(OktaGroup, [_AppGroup, RoleGroup])
-    existing_owner_group = (
-        db.query(poly_group)
+    existing_owner_group = db.scalars(
+        select(poly_group)
         .options(selectinload(poly_group.active_user_ownerships))
-        .filter(func.lower(OktaGroup.name) == func.lower(owner_group_name))
-        .filter(OktaGroup.deleted_at.is_(None))
-        .first()
-    )
+        .where(func.lower(OktaGroup.name) == func.lower(owner_group_name))
+        .where(OktaGroup.deleted_at.is_(None))
+    ).first()
     if existing_owner_group is not None and len(existing_owner_group.active_user_ownerships) > 0:
         raise HTTPException(
             409,
@@ -181,7 +175,7 @@ def post_app(
         tags=body.tags_to_add or [],
         current_user_id=current_user_id,
     ).execute()
-    refreshed = db.query(App).options(*APP_LOAD_OPTIONS).filter(App.id == created.id).first()
+    refreshed = db.scalars(select(App).options(*APP_LOAD_OPTIONS).where(App.id == created.id)).first()
     return AppDetail.model_validate(refreshed, from_attributes=True)
 
 
@@ -240,9 +234,9 @@ def put_app(
     # Reject duplicate name on rename
     new_name = body.name
     if new_name and new_name.lower() != app_obj.name.lower():
-        existing = (
-            db.query(App).filter(func.lower(App.name) == func.lower(new_name)).filter(App.deleted_at.is_(None)).first()
-        )
+        existing = db.scalars(
+            select(App).where(func.lower(App.name) == func.lower(new_name)).where(App.deleted_at.is_(None))
+        ).first()
         if existing is not None:
             raise HTTPException(400, "App already exists with the same name")
 
@@ -263,7 +257,7 @@ def put_app(
                 tags_to_remove=tags_to_remove,
                 current_user_id=current_user_id,
             ).execute()
-            refreshed = db.query(App).options(*APP_LOAD_OPTIONS).filter(App.id == app_obj.id).first()
+            refreshed = db.scalars(select(App).options(*APP_LOAD_OPTIONS).where(App.id == app_obj.id)).first()
             return AppDetail.model_validate(refreshed, from_attributes=True)
         raise HTTPException(400, "Only tags can be modified for the Access application")
 
@@ -288,7 +282,7 @@ def put_app(
     if app_obj.name != old_app_name:
         old_prefix = f"{_AppGroup.APP_GROUP_NAME_PREFIX}{old_app_name}{_AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}"
         new_prefix = f"{_AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}{_AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}"
-        app_groups = db.query(_AppGroup).filter(_AppGroup.app_id == app_obj.id).all()
+        app_groups = db.scalars(select(_AppGroup).where(_AppGroup.app_id == app_obj.id)).all()
         for ag in app_groups:
             if ag.name.startswith(old_prefix):
                 suffix = ag.name[len(old_prefix) :]
@@ -307,7 +301,7 @@ def put_app(
         current_user_id=current_user_id,
     ).execute()
 
-    refreshed = db.query(App).options(*APP_LOAD_OPTIONS).filter(App.id == app_obj.id).first()
+    refreshed = db.scalars(select(App).options(*APP_LOAD_OPTIONS).where(App.id == app_obj.id)).first()
 
     # Audit logging — both name renames and plugin assignment/configuration
     # changes.

--- a/api/routers/audit.py
+++ b/api/routers/audit.py
@@ -16,7 +16,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, HTTPException, Query
 
-from sqlalchemy import and_, func, not_, nullsfirst, nullslast, or_
+from sqlalchemy import and_, func, not_, nullsfirst, nullslast, or_, select
 from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.orm import aliased, joinedload, selectin_polymorphic, selectinload, with_polymorphic
 
@@ -75,12 +75,11 @@ def _resolve_me(value: str | None, current_user_id: str) -> str | None:
 def _resolve_user(db: DbSession, value: str | None) -> OktaUser | None:
     if value is None:
         return None
-    user = (
-        db.query(OktaUser)
-        .filter(or_(OktaUser.id == value, OktaUser.email.ilike(value)))
+    user = db.scalars(
+        select(OktaUser)
+        .where(or_(OktaUser.id == value, OktaUser.email.ilike(value)))
         .order_by(nullsfirst(OktaUser.deleted_at.desc()))
-        .first()
-    )
+    ).first()
     if user is None:
         raise HTTPException(404, "Not Found")
     return user
@@ -89,12 +88,11 @@ def _resolve_user(db: DbSession, value: str | None) -> OktaUser | None:
 def _resolve_group(db: DbSession, value: str | None) -> OktaGroup | None:
     if value is None:
         return None
-    group = (
-        db.query(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-        .filter(or_(OktaGroup.id == value, OktaGroup.name == value))
+    group = db.scalars(
+        select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+        .where(or_(OktaGroup.id == value, OktaGroup.name == value))
         .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
-        .first()
-    )
+    ).first()
     if group is None:
         raise HTTPException(404, "Not Found")
     return group
@@ -103,12 +101,11 @@ def _resolve_group(db: DbSession, value: str | None) -> OktaGroup | None:
 def _resolve_role(db: DbSession, value: str | None) -> RoleGroup | None:
     if value is None:
         return None
-    role = (
-        db.query(RoleGroup)
-        .filter(or_(RoleGroup.id == value, RoleGroup.name == value))
+    role = db.scalars(
+        select(RoleGroup)
+        .where(or_(RoleGroup.id == value, RoleGroup.name == value))
         .order_by(nullsfirst(RoleGroup.deleted_at.desc()))
-        .first()
-    )
+    ).first()
     if role is None:
         raise HTTPException(404, "Not Found")
     return role
@@ -314,8 +311,8 @@ def users_and_groups(
             ),
         )
 
-    query = (
-        db.query(OktaUserGroupMember)
+    stmt = (
+        select(OktaUserGroupMember)
         .options(
             joinedload(OktaUserGroupMember.user),
             joinedload(OktaUserGroupMember.created_actor),
@@ -329,43 +326,39 @@ def users_and_groups(
     )
 
     if user is not None:
-        query = query.filter(OktaUserGroupMember.user_id == user.id)
+        stmt = stmt.where(OktaUserGroupMember.user_id == user.id)
     if group is not None:
-        query = query.filter(OktaUserGroupMember.group_id == group.id)
+        stmt = stmt.where(OktaUserGroupMember.group_id == group.id)
 
     # Owner filter — only return memberships in groups owned by `owner`,
     # either directly or transitively via the owning app.
     if owner is not None:
-        owner_group_ids = [
-            row.group_id
-            for row in db.query(OktaUserGroupMember.group_id)
-            .filter(OktaUserGroupMember.user_id == owner.id)
-            .filter(OktaUserGroupMember.is_owner.is_(True))
-            .filter(
+        owner_group_ids = db.scalars(
+            select(OktaUserGroupMember.group_id)
+            .where(OktaUserGroupMember.user_id == owner.id)
+            .where(OktaUserGroupMember.is_owner.is_(True))
+            .where(
                 or_(
                     OktaUserGroupMember.ended_at.is_(None),
                     OktaUserGroupMember.ended_at > func.now(),
                 )
             )
-            .all()
-        ]
+        ).all()
         app_owner_group_ids = [
             ag.id
-            for ag in db.query(AppGroup)
-            .filter(AppGroup.id.in_(owner_group_ids))
-            .filter(AppGroup.is_owner.is_(True))
-            .all()
+            for ag in db.scalars(
+                select(AppGroup).where(AppGroup.id.in_(owner_group_ids)).where(AppGroup.is_owner.is_(True))
+            ).all()
         ]
-        app_ids = [ag.app_id for ag in db.query(AppGroup).filter(AppGroup.id.in_(app_owner_group_ids)).all()]
+        app_ids = [ag.app_id for ag in db.scalars(select(AppGroup).where(AppGroup.id.in_(app_owner_group_ids))).all()]
         app_groups_owned_ids = [
             ag.id
-            for ag in db.query(AppGroup)
-            .filter(AppGroup.app_id.in_(app_ids))
-            .filter(AppGroup.deleted_at.is_(None))
-            .all()
+            for ag in db.scalars(
+                select(AppGroup).where(AppGroup.app_id.in_(app_ids)).where(AppGroup.deleted_at.is_(None))
+            ).all()
         ]
         if q_args.app_owner is True:
-            query = query.filter(
+            stmt = stmt.where(
                 or_(
                     OktaUserGroupMember.group_id.in_(owner_group_ids),
                     OktaUserGroupMember.group_id.in_(app_groups_owned_ids),
@@ -373,22 +366,20 @@ def users_and_groups(
             )
         else:
             # Exclude app groups that have at least one direct owner who isn't `owner`.
-            directly_owned_by_others_ids = [
-                m.group_id
-                for m in db.query(OktaUserGroupMember.group_id)
-                .filter(OktaUserGroupMember.group_id.in_(app_groups_owned_ids))
-                .filter(OktaUserGroupMember.user_id != owner.id)
-                .filter(OktaUserGroupMember.is_owner.is_(True))
-                .filter(
+            directly_owned_by_others_ids = db.scalars(
+                select(OktaUserGroupMember.group_id)
+                .where(OktaUserGroupMember.group_id.in_(app_groups_owned_ids))
+                .where(OktaUserGroupMember.user_id != owner.id)
+                .where(OktaUserGroupMember.is_owner.is_(True))
+                .where(
                     or_(
                         OktaUserGroupMember.ended_at.is_(None),
                         OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
-                .all()
-            ]
+            ).all()
             visible_app_groups = set(app_groups_owned_ids) - set(directly_owned_by_others_ids)
-            query = query.filter(
+            stmt = stmt.where(
                 or_(
                     OktaUserGroupMember.group_id.in_(owner_group_ids),
                     OktaUserGroupMember.group_id.in_(visible_app_groups),
@@ -397,20 +388,20 @@ def users_and_groups(
         # When filtering by `owner_id`, exclude the owner's own memberships:
         # the frontend's "expiring access" review page expects to see *other*
         # users whose access the owner needs to renew, not the owner.
-        query = query.filter(OktaUserGroupMember.user_id != owner.id)
+        stmt = stmt.where(OktaUserGroupMember.user_id != owner.id)
 
     if q_args.owner is not None:
-        query = query.filter(OktaUserGroupMember.is_owner == q_args.owner)
+        stmt = stmt.where(OktaUserGroupMember.is_owner == q_args.owner)
 
     if q_args.active is True:
-        query = query.filter(
+        stmt = stmt.where(
             or_(
                 OktaUserGroupMember.ended_at.is_(None),
                 OktaUserGroupMember.ended_at > func.now(),
             )
         )
     elif q_args.active is False:
-        query = query.filter(
+        stmt = stmt.where(
             and_(
                 OktaUserGroupMember.ended_at.is_not(None),
                 OktaUserGroupMember.ended_at < func.now(),
@@ -418,19 +409,19 @@ def users_and_groups(
         )
 
     if q_args.needs_review is True:
-        query = query.filter(OktaUserGroupMember.should_expire.is_(False))
+        stmt = stmt.where(OktaUserGroupMember.should_expire.is_(False))
 
     if q_args.direct is True:
-        query = query.filter(not_(OktaUserGroupMember.active_role_group_mapping.has()))
+        stmt = stmt.where(not_(OktaUserGroupMember.active_role_group_mapping.has()))
 
     if q_args.deleted is False:
-        query = query.filter(OktaUser.deleted_at.is_(None))
+        stmt = stmt.where(OktaUser.deleted_at.is_(None))
 
     if q_args.managed is not None:
-        query = query.filter(group_alias.is_managed == q_args.managed)
+        stmt = stmt.where(group_alias.is_managed == q_args.managed)
 
     if q_args.start_date is not None and q_args.end_date is not None:
-        query = query.filter(
+        stmt = stmt.where(
             and_(
                 OktaUserGroupMember.ended_at.is_not(None),
                 OktaUserGroupMember.ended_at > _unix_to_utc_naive(q_args.start_date),
@@ -458,11 +449,11 @@ def users_and_groups(
             (OktaUser.first_name + " " + OktaUser.last_name).ilike(like),
         )
         if user is not None:
-            query = query.filter(or_(*group_cols))
+            stmt = stmt.where(or_(*group_cols))
         if group is not None:
-            query = query.filter(or_(*user_cols))
+            stmt = stmt.where(or_(*user_cols))
         if owner is not None or (user is None and group is None):
-            query = query.filter(or_(*group_cols, *user_cols))
+            stmt = stmt.where(or_(*group_cols, *user_cols))
 
     # Compound order_by — the tail tie-breaker keeps page boundaries stable
     # when two rows share the primary sort value. Without it, paginated
@@ -479,7 +470,7 @@ def users_and_groups(
         tail = (group_alias.name if user is not None else func.lower(OktaUser.email)).asc()
         return (nulls_order(primary_dir), tail)
 
-    query = query.order_by(*_users_audit_ordering())
+    stmt = stmt.order_by(*_users_audit_ordering())
 
     # When `direct` is present and neither `user_id` nor `owner_id` is set,
     # re-apply the order_by using the email/created_at compound shape so
@@ -489,15 +480,15 @@ def users_and_groups(
         if q_args.order_by == AuditOrderBy.moniker:
             primary = func.lower(OktaUser.email)
             primary_dir = primary.desc() if q_args.order_desc else primary.asc()
-            query = query.order_by(nulls_order(primary_dir), nullslast(OktaUserGroupMember.created_at.asc()))
+            stmt = stmt.order_by(nulls_order(primary_dir), nullslast(OktaUserGroupMember.created_at.asc()))
         else:
             col = getattr(OktaUserGroupMember, q_args.order_by.value)
             primary_dir = col.desc() if q_args.order_desc else col.asc()
-            query = query.order_by(nulls_order(primary_dir), func.lower(OktaUser.email).asc())
+            stmt = stmt.order_by(nulls_order(primary_dir), func.lower(OktaUser.email).asc())
 
     return paginate(
         db,
-        query,
+        stmt,
         transformer=lambda items: [_audit_user_group_row(m, include_role_associations) for m in items],
     )
 
@@ -520,8 +511,8 @@ def groups_and_roles(
 
     group_alias = aliased(OktaGroup)
 
-    query = (
-        db.query(RoleGroupMap)
+    stmt = (
+        select(RoleGroupMap)
         .options(
             joinedload(RoleGroupMap.role_group),
             joinedload(RoleGroupMap.created_actor),
@@ -540,63 +531,57 @@ def groups_and_roles(
     )
 
     if role is not None:
-        query = query.filter(RoleGroupMap.role_group_id == role.id)
+        stmt = stmt.where(RoleGroupMap.role_group_id == role.id)
     if group is not None:
-        query = query.filter(RoleGroupMap.group_id == group.id)
+        stmt = stmt.where(RoleGroupMap.group_id == group.id)
 
     if owner is not None:
-        owner_group_ids = [
-            row.group_id
-            for row in db.query(OktaUserGroupMember.group_id)
-            .filter(OktaUserGroupMember.user_id == owner.id)
-            .filter(OktaUserGroupMember.is_owner.is_(True))
-            .filter(
+        owner_group_ids = db.scalars(
+            select(OktaUserGroupMember.group_id)
+            .where(OktaUserGroupMember.user_id == owner.id)
+            .where(OktaUserGroupMember.is_owner.is_(True))
+            .where(
                 or_(
                     OktaUserGroupMember.ended_at.is_(None),
                     OktaUserGroupMember.ended_at > func.now(),
                 )
             )
-            .all()
-        ]
+        ).all()
         app_owner_group_ids = [
             ag.id
-            for ag in db.query(AppGroup)
-            .filter(AppGroup.id.in_(owner_group_ids))
-            .filter(AppGroup.is_owner.is_(True))
-            .all()
+            for ag in db.scalars(
+                select(AppGroup).where(AppGroup.id.in_(owner_group_ids)).where(AppGroup.is_owner.is_(True))
+            ).all()
         ]
-        app_ids = [ag.app_id for ag in db.query(AppGroup).filter(AppGroup.id.in_(app_owner_group_ids)).all()]
+        app_ids = [ag.app_id for ag in db.scalars(select(AppGroup).where(AppGroup.id.in_(app_owner_group_ids))).all()]
         app_groups_owned_ids = [
             ag.id
-            for ag in db.query(AppGroup)
-            .filter(AppGroup.app_id.in_(app_ids))
-            .filter(AppGroup.deleted_at.is_(None))
-            .all()
+            for ag in db.scalars(
+                select(AppGroup).where(AppGroup.app_id.in_(app_ids)).where(AppGroup.deleted_at.is_(None))
+            ).all()
         ]
         if q_args.app_owner is True:
-            query = query.filter(
+            stmt = stmt.where(
                 or_(
                     RoleGroupMap.group_id.in_(owner_group_ids),
                     RoleGroupMap.group_id.in_(app_groups_owned_ids),
                 )
             )
         else:
-            directly_owned_by_others_ids = [
-                m.group_id
-                for m in db.query(OktaUserGroupMember.group_id)
-                .filter(OktaUserGroupMember.group_id.in_(app_groups_owned_ids))
-                .filter(OktaUserGroupMember.user_id != owner.id)
-                .filter(OktaUserGroupMember.is_owner.is_(True))
-                .filter(
+            directly_owned_by_others_ids = db.scalars(
+                select(OktaUserGroupMember.group_id)
+                .where(OktaUserGroupMember.group_id.in_(app_groups_owned_ids))
+                .where(OktaUserGroupMember.user_id != owner.id)
+                .where(OktaUserGroupMember.is_owner.is_(True))
+                .where(
                     or_(
                         OktaUserGroupMember.ended_at.is_(None),
                         OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
-                .all()
-            ]
+            ).all()
             visible_app_groups = set(app_groups_owned_ids) - set(directly_owned_by_others_ids)
-            query = query.filter(
+            stmt = stmt.where(
                 or_(
                     RoleGroupMap.group_id.in_(owner_group_ids),
                     RoleGroupMap.group_id.in_(visible_app_groups),
@@ -604,26 +589,24 @@ def groups_and_roles(
             )
 
     if role_owner is not None:
-        role_owner_role_ids = [
-            row.group_id
-            for row in db.query(OktaUserGroupMember.group_id)
-            .filter(OktaUserGroupMember.user_id == role_owner.id)
-            .filter(OktaUserGroupMember.is_owner.is_(True))
-            .filter(
+        role_owner_role_ids = db.scalars(
+            select(OktaUserGroupMember.group_id)
+            .where(OktaUserGroupMember.user_id == role_owner.id)
+            .where(OktaUserGroupMember.is_owner.is_(True))
+            .where(
                 or_(
                     OktaUserGroupMember.ended_at.is_(None),
                     OktaUserGroupMember.ended_at > func.now(),
                 )
             )
-            .all()
-        ]
+        ).all()
         # Access admins additionally see roles that have NO active owner —
         # those are the roles only an admin can resolve expiring access for.
         unowned_admin_role_ids: list[str] = []
         if is_access_admin(db, role_owner.id):
             owners_subquery = (
-                db.query(OktaUserGroupMember.group_id)
-                .filter(
+                select(OktaUserGroupMember.group_id)
+                .where(
                     and_(
                         OktaUserGroupMember.is_owner.is_(True),
                         or_(
@@ -636,11 +619,11 @@ def groups_and_roles(
             )
             unowned_admin_role_ids = [
                 rg.id
-                for rg in db.query(RoleGroup)
-                .filter(and_(RoleGroup.deleted_at.is_(None), ~RoleGroup.id.in_(owners_subquery)))
-                .all()
+                for rg in db.scalars(
+                    select(RoleGroup).where(and_(RoleGroup.deleted_at.is_(None), ~RoleGroup.id.in_(owners_subquery)))
+                ).all()
             ]
-        query = query.filter(
+        stmt = stmt.where(
             or_(
                 RoleGroupMap.role_group_id.in_(role_owner_role_ids),
                 RoleGroupMap.role_group_id.in_(unowned_admin_role_ids),
@@ -648,17 +631,17 @@ def groups_and_roles(
         )
 
     if q_args.owner is not None:
-        query = query.filter(RoleGroupMap.is_owner == q_args.owner)
+        stmt = stmt.where(RoleGroupMap.is_owner == q_args.owner)
 
     if q_args.active is True:
-        query = query.filter(
+        stmt = stmt.where(
             or_(
                 RoleGroupMap.ended_at.is_(None),
                 RoleGroupMap.ended_at > func.now(),
             )
         )
     elif q_args.active is False:
-        query = query.filter(
+        stmt = stmt.where(
             and_(
                 RoleGroupMap.ended_at.is_not(None),
                 RoleGroupMap.ended_at < func.now(),
@@ -666,13 +649,13 @@ def groups_and_roles(
         )
 
     if q_args.needs_review is True:
-        query = query.filter(RoleGroupMap.should_expire.is_(False))
+        stmt = stmt.where(RoleGroupMap.should_expire.is_(False))
 
     if q_args.managed is not None:
-        query = query.filter(group_alias.is_managed == q_args.managed)
+        stmt = stmt.where(group_alias.is_managed == q_args.managed)
 
     if q_args.start_date is not None and q_args.end_date is not None:
-        query = query.filter(
+        stmt = stmt.where(
             and_(
                 RoleGroupMap.ended_at.is_not(None),
                 RoleGroupMap.ended_at > _unix_to_utc_naive(q_args.start_date),
@@ -697,11 +680,11 @@ def groups_and_roles(
             group_alias.description.ilike(like),
         )
         if group is not None:
-            query = query.filter(or_(*role_cols))
+            stmt = stmt.where(or_(*role_cols))
         if role is not None:
-            query = query.filter(or_(*group_cols))
+            stmt = stmt.where(or_(*group_cols))
         if owner is not None or (group is None and role is None):
-            query = query.filter(or_(*role_cols, *group_cols))
+            stmt = stmt.where(or_(*role_cols, *group_cols))
 
     # Compound order_by — the tail tie-breaker keeps page boundaries stable.
     # Primary column depends on context: when `group_id` is pinned, the
@@ -719,10 +702,10 @@ def groups_and_roles(
         tail = (RoleGroup.name if role is None and group is not None else group_alias.name).asc()
         return (nulls_order(primary_dir), tail)
 
-    query = query.order_by(*_groups_audit_ordering())
+    stmt = stmt.order_by(*_groups_audit_ordering())
 
     return paginate(
         db,
-        query,
+        stmt,
         transformer=lambda items: [_audit_group_role_row(rgm) for rgm in items],
     )

--- a/api/routers/group_requests.py
+++ b/api/routers/group_requests.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query
 from fastapi_pagination.ext.sqlalchemy import paginate
-from sqlalchemy import String, and_, cast, or_
+from sqlalchemy import String, and_, cast, or_, select
 from sqlalchemy.orm import aliased, joinedload
 from starlette.requests import Request
 
@@ -46,17 +46,17 @@ def list_group_requests(
     from api.auth.permissions import is_access_admin
     from api.models.app_group import get_app_managers
 
-    query = db.query(GroupRequest).options(*_load_options()).order_by(GroupRequest.created_at.desc())
+    stmt = select(GroupRequest).options(*_load_options()).order_by(GroupRequest.created_at.desc())
 
     if q_args.status:
-        query = query.filter(GroupRequest.status == q_args.status)
+        stmt = stmt.where(GroupRequest.status == q_args.status)
 
     if q_args.requester_user_id:
         if q_args.requester_user_id == "@me":
-            query = query.filter(GroupRequest.requester_user_id == current_user_id)
+            stmt = stmt.where(GroupRequest.requester_user_id == current_user_id)
         else:
             requester_alias = aliased(OktaUser)
-            query = query.join(GroupRequest.requester.of_type(requester_alias)).filter(
+            stmt = stmt.join(GroupRequest.requester.of_type(requester_alias)).where(
                 or_(
                     GroupRequest.requester_user_id == q_args.requester_user_id,
                     requester_alias.email.ilike(q_args.requester_user_id),
@@ -64,47 +64,45 @@ def list_group_requests(
             )
 
     if q_args.requested_group_type:
-        query = query.filter(GroupRequest.requested_group_type == q_args.requested_group_type)
+        stmt = stmt.where(GroupRequest.requested_group_type == q_args.requested_group_type)
 
     if q_args.requested_app_id:
-        query = query.filter(GroupRequest.requested_app_id == q_args.requested_app_id)
+        stmt = stmt.where(GroupRequest.requested_app_id == q_args.requested_app_id)
 
     if q_args.assignee_user_id:
         # "Requests I can resolve". Admins see every pending request; app
         # owners see app-group requests for apps they own. In both cases the
         # assignee's own requests are stripped out.
         assignee_user_id = current_user_id if q_args.assignee_user_id == "@me" else q_args.assignee_user_id
-        assignee_user = (
-            db.query(OktaUser)
-            .filter(or_(OktaUser.id == assignee_user_id, OktaUser.email.ilike(assignee_user_id)))
-            .first()
-        )
+        assignee_user = db.scalars(
+            select(OktaUser).where(or_(OktaUser.id == assignee_user_id, OktaUser.email.ilike(assignee_user_id)))
+        ).first()
         if assignee_user is not None:
             if not is_access_admin(db, assignee_user.id):
                 owned_app_ids: list[str] = []
-                for app in db.query(App).filter(App.deleted_at.is_(None)).all():
+                for app in db.scalars(select(App).where(App.deleted_at.is_(None))).all():
                     manager_ids = [m.id for m in get_app_managers(app.id)]
                     if assignee_user.id in manager_ids:
                         owned_app_ids.append(app.id)
                 if owned_app_ids:
-                    query = query.filter(
+                    stmt = stmt.where(
                         and_(
                             GroupRequest.requested_app_id.in_(owned_app_ids),
                             GroupRequest.requested_group_type == "app_group",
                         )
                     )
                 else:
-                    query = query.filter(False)
-            query = query.filter(GroupRequest.requester_user_id != assignee_user.id)
+                    stmt = stmt.where(False)
+            stmt = stmt.where(GroupRequest.requester_user_id != assignee_user.id)
         else:
-            query = query.filter(False)
+            stmt = stmt.where(False)
 
     if q_args.resolver_user_id:
         if q_args.resolver_user_id == "@me":
-            query = query.filter(GroupRequest.resolver_user_id == current_user_id)
+            stmt = stmt.where(GroupRequest.resolver_user_id == current_user_id)
         else:
             resolver_alias = aliased(OktaUser)
-            query = query.outerjoin(GroupRequest.resolver.of_type(resolver_alias)).filter(
+            stmt = stmt.outerjoin(GroupRequest.resolver.of_type(resolver_alias)).where(
                 or_(
                     GroupRequest.resolver_user_id == q_args.resolver_user_id,
                     resolver_alias.email.ilike(q_args.resolver_user_id),
@@ -117,10 +115,10 @@ def list_group_requests(
         like = f"%{q_args.q}%"
         q_requester_alias = aliased(OktaUser)
         q_resolver_alias = aliased(OktaUser)
-        query = (
-            query.join(GroupRequest.requester.of_type(q_requester_alias))
+        stmt = (
+            stmt.join(GroupRequest.requester.of_type(q_requester_alias))
             .outerjoin(GroupRequest.resolver.of_type(q_resolver_alias))
-            .filter(
+            .where(
                 or_(
                     GroupRequest.id.like(f"{q_args.q}%"),
                     cast(GroupRequest.status, String).ilike(like),
@@ -144,12 +142,12 @@ def list_group_requests(
             )
         )
 
-    return paginate(db, query, transformer=validated(GroupRequestDetail))
+    return paginate(db, stmt, transformer=validated(GroupRequestDetail))
 
 
 @router.get("/{group_request_id}", name="group_request_by_id")
 def get_group_request(group_request_id: str, db: DbSession, current_user_id: CurrentUserId) -> GroupRequestDetail:
-    gr = db.query(GroupRequest).options(*_load_options()).filter(GroupRequest.id == group_request_id).first()
+    gr = db.scalars(select(GroupRequest).options(*_load_options()).where(GroupRequest.id == group_request_id)).first()
     if gr is None:
         raise HTTPException(404, "Not Found")
     return GroupRequestDetail.model_validate(gr, from_attributes=True)
@@ -163,7 +161,9 @@ def post_group_request(
 ) -> GroupRequestDetail:
     # Soft-deleted requesters cannot create new requests; Flask returned 403
     # here, not 404.
-    requester = db.query(OktaUser).filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first()
+    requester = db.scalars(
+        select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+    ).first()
     if requester is None:
         raise HTTPException(403, "Current user is not allowed to perform this action")
 
@@ -173,29 +173,31 @@ def post_group_request(
     if body.requested_group_type == "app_group":
         if requested_app_id is None:
             raise HTTPException(400, "app_id is required for app group requests")
-        app = db.query(App).filter(App.deleted_at.is_(None)).filter(App.id == requested_app_id).first()
+        app = db.scalars(select(App).where(App.deleted_at.is_(None)).where(App.id == requested_app_id)).first()
         if app is None:
             raise HTTPException(404, "App not found")
 
     # Every requested tag id must resolve to a non-deleted tag.
     if body.requested_group_tags:
-        tags = db.query(Tag).filter(Tag.deleted_at.is_(None)).filter(Tag.id.in_(body.requested_group_tags)).all()
+        tags = db.scalars(
+            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(body.requested_group_tags))
+        ).all()
         if len(tags) != len(body.requested_group_tags):
             raise HTTPException(400, "One or more tags not found")
 
     # Auto-cancel any prior PENDING request from the same user for the same
     # group name (and same app, for app-group requests). Without this a user
     # clicking "Request" twice produces multiple PENDING rows.
-    existing_query = (
-        db.query(GroupRequest)
-        .filter(GroupRequest.requested_group_name == body.requested_group_name)
-        .filter(GroupRequest.requester_user_id == current_user_id)
-        .filter(GroupRequest.status == AccessRequestStatus.PENDING)
-        .filter(GroupRequest.resolved_at.is_(None))
+    existing_stmt = (
+        select(GroupRequest)
+        .where(GroupRequest.requested_group_name == body.requested_group_name)
+        .where(GroupRequest.requester_user_id == current_user_id)
+        .where(GroupRequest.status == AccessRequestStatus.PENDING)
+        .where(GroupRequest.resolved_at.is_(None))
     )
     if body.requested_group_type == "app_group":
-        existing_query = existing_query.filter(GroupRequest.requested_app_id == requested_app_id)
-    for prior in existing_query.all():
+        existing_stmt = existing_stmt.where(GroupRequest.requested_app_id == requested_app_id)
+    for prior in db.scalars(existing_stmt).all():
         RejectGroupRequest(
             group_request=prior,
             rejection_reason="Closed due to duplicate group request creation",
@@ -215,7 +217,7 @@ def post_group_request(
     ).execute()
     if gr is None:
         raise HTTPException(400, "Failed to create group request")
-    refreshed = db.query(GroupRequest).options(*_load_options()).filter(GroupRequest.id == gr.id).first()
+    refreshed = db.scalars(select(GroupRequest).options(*_load_options()).where(GroupRequest.id == gr.id)).first()
     return GroupRequestDetail.model_validate(refreshed, from_attributes=True)
 
 
@@ -229,7 +231,7 @@ def put_group_request(
     from api.auth.permissions import is_access_admin
     from api.models.app_group import get_app_managers
 
-    gr = db.query(GroupRequest).options(*_load_options()).filter(GroupRequest.id == group_request_id).first()
+    gr = db.scalars(select(GroupRequest).options(*_load_options()).where(GroupRequest.id == group_request_id)).first()
     if gr is None:
         raise HTTPException(404, "Not Found")
 
@@ -291,5 +293,7 @@ def put_group_request(
             rejection_reason=resolution_reason,
             notify_requester=gr.requester_user_id != current_user_id,
         ).execute()
-    refreshed = db.query(GroupRequest).options(*_load_options()).filter(GroupRequest.id == group_request_id).first()
+    refreshed = db.scalars(
+        select(GroupRequest).options(*_load_options()).where(GroupRequest.id == group_request_id)
+    ).first()
     return GroupRequestDetail.model_validate(refreshed, from_attributes=True)

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -320,7 +320,7 @@ def put_group(
             if isinstance(body, _AppGroupUpdateBody) and "app_id" in fields_set
             else getattr(group, "app_id", None)
         )
-        conversion_app = db.query(App).filter(App.id == target_app_id).filter(App.deleted_at.is_(None)).first()
+        conversion_app = db.scalars(select(App).where(App.id == target_app_id).where(App.deleted_at.is_(None))).first()
         if conversion_app is None:
             raise HTTPException(400, "App for AppGroup does not exist")
         app_group_name_prefix = (

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -18,7 +18,7 @@ from fastapi import APIRouter, HTTPException, Query
 
 from fastapi.responses import RedirectResponse
 from pydantic import TypeAdapter
-from sqlalchemy import func, nullsfirst, or_
+from sqlalchemy import func, nullsfirst, or_, select
 from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload, with_polymorphic
 from starlette.requests import Request
 
@@ -90,13 +90,12 @@ _group_adapter: TypeAdapter[Any] = TypeAdapter(GroupDetail)
 
 
 def _load_group_with_options(db: DbSession, group_id: str) -> OktaGroup | None:
-    return (
-        db.query(OktaGroup)
+    return db.scalars(
+        select(OktaGroup)
         .options(*DEFAULT_LOAD_OPTIONS)
-        .filter(or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
+        .where(or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
         .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
-        .first()
-    )
+    ).first()
 
 
 @router.get("", name="groups")
@@ -106,8 +105,8 @@ def list_groups(
     current_user_id: CurrentUserId,
     q_args: Annotated[SearchGroupQuery, Query()],
 ) -> Page[GroupSummary]:
-    query = (
-        db.query(OktaGroup)
+    stmt = (
+        select(OktaGroup)
         .options(
             selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
             selectinload(OktaGroup.active_group_tags).options(*group_tag_map_options()),
@@ -117,16 +116,16 @@ def list_groups(
             selectinload(RoleGroup.active_role_associated_group_owner_mappings).options(*role_group_map_options()),
             joinedload(AppGroup.app),
         )
-        .filter(OktaGroup.deleted_at.is_(None))
+        .where(OktaGroup.deleted_at.is_(None))
         .order_by(func.lower(OktaGroup.name))
     )
     if q_args.q:
         like = f"%{q_args.q}%"
-        query = query.filter(or_(OktaGroup.name.ilike(like), OktaGroup.description.ilike(like)))
+        stmt = stmt.where(or_(OktaGroup.name.ilike(like), OktaGroup.description.ilike(like)))
     if q_args.managed is not None:
-        query = query.filter(OktaGroup.is_managed == q_args.managed)
+        stmt = stmt.where(OktaGroup.is_managed == q_args.managed)
 
-    return paginate(db, query, transformer=validated(GroupSummary))
+    return paginate(db, stmt, transformer=validated(GroupSummary))
 
 
 @router.get("/{group_id}", name="group_by_id")
@@ -166,12 +165,11 @@ def post_group(
     ):
         raise HTTPException(403, "Current user is not allowed to perform this action")
 
-    existing = (
-        db.query(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-        .filter(func.lower(OktaGroup.name) == func.lower(group.name))
-        .filter(OktaGroup.deleted_at.is_(None))
-        .first()
-    )
+    existing = db.scalars(
+        select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+        .where(func.lower(OktaGroup.name) == func.lower(group.name))
+        .where(OktaGroup.deleted_at.is_(None))
+    ).first()
     if existing is not None:
         raise HTTPException(400, "Group already exists with the same name")
 
@@ -264,7 +262,7 @@ def put_group(
         and "app_id" in fields_set
         and body.app_id != group.app_id
     ):
-        target_app = db.query(App).filter(App.id == body.app_id).filter(App.deleted_at.is_(None)).first()
+        target_app = db.scalars(select(App).where(App.id == body.app_id).where(App.deleted_at.is_(None))).first()
         if target_app is None:
             raise HTTPException(404, "Not Found")
         if not (
@@ -437,28 +435,26 @@ def get_group_audit(group_id: str, request: Request, current_user_id: CurrentUse
 
 @router.get("/{group_id}/members", name="group_members_by_id")
 def get_group_members(group_id: str, db: DbSession, current_user_id: CurrentUserId) -> GroupMembersSummary:
-    group = (
-        db.query(OktaGroup)
-        .filter(OktaGroup.deleted_at.is_(None))
-        .filter(or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
-        .first()
-    )
+    group = db.scalars(
+        select(OktaGroup)
+        .where(OktaGroup.deleted_at.is_(None))
+        .where(or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
+    ).first()
     if group is None:
         raise HTTPException(404, "Not Found")
 
-    base_query = (
-        db.query(OktaUserGroupMember)
-        .with_entities(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
-        .filter(
+    base_stmt = (
+        select(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
+        .where(
             or_(
                 OktaUserGroupMember.ended_at.is_(None),
                 OktaUserGroupMember.ended_at > func.now(),
             )
         )
-        .filter(OktaUserGroupMember.group_id == group.id)
+        .where(OktaUserGroupMember.group_id == group.id)
         .group_by(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
     )
-    rows = base_query.all()
+    rows = db.execute(base_stmt).all()
     return GroupMembersSummary(
         members=[r.user_id for r in rows if not r.is_owner],
         owners=[r.user_id for r in rows if r.is_owner],
@@ -472,12 +468,11 @@ def put_group_members(
     current_user_id: CurrentUserId,
     body: GroupMember | None = None,
 ) -> GroupMembersSummary:
-    group = (
-        db.query(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-        .filter(OktaGroup.deleted_at.is_(None))
-        .filter(or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
-        .first()
-    )
+    group = db.scalars(
+        select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+        .where(OktaGroup.deleted_at.is_(None))
+        .where(or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
+    ).first()
     if group is None:
         raise HTTPException(404, "Not Found")
     # Body is `Optional` so the missing-group 404 above fires even when the

--- a/api/routers/role_requests.py
+++ b/api/routers/role_requests.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query
 
-from sqlalchemy import String, and_, cast, not_, or_
+from sqlalchemy import String, and_, cast, not_, or_, select
 from sqlalchemy.orm import aliased, joinedload, selectinload
 from starlette.requests import Request
 
@@ -92,17 +92,17 @@ def list_role_requests(
 ) -> Page[RoleRequestSummary]:
     from api.auth.permissions import is_access_admin
 
-    query = db.query(RoleRequest).options(*_summary_load_options()).order_by(RoleRequest.created_at.desc())
+    stmt = select(RoleRequest).options(*_summary_load_options()).order_by(RoleRequest.created_at.desc())
 
     if q_args.status:
-        query = query.filter(RoleRequest.status == q_args.status)
+        stmt = stmt.where(RoleRequest.status == q_args.status)
 
     if q_args.requester_user_id:
         if q_args.requester_user_id == "@me":
-            query = query.filter(RoleRequest.requester_user_id == current_user_id)
+            stmt = stmt.where(RoleRequest.requester_user_id == current_user_id)
         else:
             requester_alias = aliased(OktaUser)
-            query = query.join(RoleRequest.requester.of_type(requester_alias)).filter(
+            stmt = stmt.join(RoleRequest.requester.of_type(requester_alias)).where(
                 or_(
                     RoleRequest.requester_user_id == q_args.requester_user_id,
                     requester_alias.email.ilike(q_args.requester_user_id),
@@ -110,7 +110,7 @@ def list_role_requests(
             )
 
     if q_args.requester_role_id:
-        query = query.join(RoleRequest.requester_role).filter(
+        stmt = stmt.join(RoleRequest.requester_role).where(
             or_(
                 RoleRequest.requester_role_id == q_args.requester_role_id,
                 RoleGroup.name.ilike(q_args.requester_role_id),
@@ -118,7 +118,7 @@ def list_role_requests(
         )
 
     if q_args.requested_group_id:
-        query = query.join(RoleRequest.requested_group).filter(
+        stmt = stmt.join(RoleRequest.requested_group).where(
             or_(
                 RoleRequest.requested_group_id == q_args.requested_group_id,
                 OktaGroup.name.ilike(q_args.requested_group_id),
@@ -133,23 +133,21 @@ def list_role_requests(
         # Non-admins are restricted to groups they own, and pre-filtered to
         # exclude requests they can't resolve due to those same tags.
         assignee_user_id = current_user_id if q_args.assignee_user_id == "@me" else q_args.assignee_user_id
-        assignee_user = (
-            db.query(OktaUser)
-            .filter(or_(OktaUser.id == assignee_user_id, OktaUser.email.ilike(assignee_user_id)))
-            .first()
-        )
+        assignee_user = db.scalars(
+            select(OktaUser).where(or_(OktaUser.id == assignee_user_id, OktaUser.email.ilike(assignee_user_id)))
+        ).first()
         if assignee_user is not None:
             groups_owned_subquery = (
-                db.query(OktaGroup.id)
+                select(OktaGroup.id)
                 .options(selectinload(OktaGroup.active_user_ownerships))
                 .join(OktaGroup.active_user_ownerships)
-                .filter(OktaGroup.deleted_at.is_(None))
-                .filter(OktaUserGroupMember.user_id == assignee_user.id)
+                .where(OktaGroup.deleted_at.is_(None))
+                .where(OktaUserGroupMember.user_id == assignee_user.id)
                 .subquery()
             )
             owner_app_group_alias = aliased(AppGroup)
             app_groups_owned_subquery = (
-                db.query(AppGroup.id)
+                select(AppGroup.id)
                 .options(
                     joinedload(AppGroup.app)
                     .joinedload(App.active_owner_app_groups.of_type(owner_app_group_alias))
@@ -158,8 +156,8 @@ def list_role_requests(
                 .join(AppGroup.app)
                 .join(App.active_owner_app_groups.of_type(owner_app_group_alias))
                 .join(owner_app_group_alias.active_user_ownerships)
-                .filter(AppGroup.deleted_at.is_(None))
-                .filter(OktaUserGroupMember.user_id == assignee_user.id)
+                .where(AppGroup.deleted_at.is_(None))
+                .where(OktaUserGroupMember.user_id == assignee_user.id)
                 .subquery()
             )
 
@@ -169,8 +167,8 @@ def list_role_requests(
                 # existing owner is in the requester role's membership.
                 tagged_owner_requests = [
                     rr
-                    for rr in (
-                        db.query(RoleRequest)
+                    for rr in db.scalars(
+                        select(RoleRequest)
                         .options(
                             joinedload(RoleRequest.requester_role).options(
                                 selectinload(OktaGroup.active_user_memberships)
@@ -180,10 +178,9 @@ def list_role_requests(
                                 selectinload(OktaGroup.active_user_ownerships),
                             ),
                         )
-                        .filter(RoleRequest.status == AccessRequestStatus.PENDING)
-                        .filter(RoleRequest.request_ownership.is_(True))
-                        .all()
-                    )
+                        .where(RoleRequest.status == AccessRequestStatus.PENDING)
+                        .where(RoleRequest.request_ownership.is_(True))
+                    ).all()
                     if coalesce_constraints(
                         constraint_key=Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY,
                         tags=[tm.active_tag for tm in rr.requested_group.active_group_tags],
@@ -191,8 +188,8 @@ def list_role_requests(
                 ]
                 tagged_member_requests = [
                     rr
-                    for rr in (
-                        db.query(RoleRequest)
+                    for rr in db.scalars(
+                        select(RoleRequest)
                         .options(
                             joinedload(RoleRequest.requester_role).options(
                                 selectinload(OktaGroup.active_user_memberships)
@@ -202,10 +199,9 @@ def list_role_requests(
                                 selectinload(OktaGroup.active_user_ownerships),
                             ),
                         )
-                        .filter(RoleRequest.status == AccessRequestStatus.PENDING)
-                        .filter(RoleRequest.request_ownership.is_(False))
-                        .all()
-                    )
+                        .where(RoleRequest.status == AccessRequestStatus.PENDING)
+                        .where(RoleRequest.request_ownership.is_(False))
+                    ).all()
                     if coalesce_constraints(
                         constraint_key=Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY,
                         tags=[tm.active_tag for tm in rr.requested_group.active_group_tags],
@@ -218,7 +214,7 @@ def list_role_requests(
                     if all(o.user_id in role_member_ids for o in req.requested_group.active_user_ownerships):
                         blocked_request_ids.append(req.id)
 
-                query = query.join(RoleRequest.requested_group).filter(
+                stmt = stmt.join(RoleRequest.requested_group).where(
                     or_(
                         OktaGroup.id.in_(groups_owned_subquery),
                         OktaGroup.id.in_(app_groups_owned_subquery),
@@ -226,7 +222,7 @@ def list_role_requests(
                     )
                 )
             else:
-                query = query.join(RoleRequest.requested_group).filter(
+                stmt = stmt.join(RoleRequest.requested_group).where(
                     or_(
                         OktaGroup.id.in_(groups_owned_subquery),
                         OktaGroup.id.in_(app_groups_owned_subquery),
@@ -234,14 +230,17 @@ def list_role_requests(
                 )
 
                 owned_groups = (
-                    db.query(OktaGroup)
-                    .options(joinedload(OktaGroup.active_group_tags))
-                    .filter(
-                        or_(
-                            OktaGroup.id.in_(groups_owned_subquery),
-                            OktaGroup.id.in_(app_groups_owned_subquery),
+                    db.scalars(
+                        select(OktaGroup)
+                        .options(joinedload(OktaGroup.active_group_tags))
+                        .where(
+                            or_(
+                                OktaGroup.id.in_(groups_owned_subquery),
+                                OktaGroup.id.in_(app_groups_owned_subquery),
+                            )
                         )
                     )
+                    .unique()
                     .all()
                 )
                 owned_groups_no_self_owner = [
@@ -262,10 +261,12 @@ def list_role_requests(
                 ]
                 role_membership_ids = [
                     rg.id
-                    for rg in db.query(RoleGroup).options(joinedload(RoleGroup.active_user_memberships)).all()
+                    for rg in db.scalars(select(RoleGroup).options(joinedload(RoleGroup.active_user_memberships)))
+                    .unique()
+                    .all()
                     if assignee_user.id in [m.user_id for m in rg.active_user_memberships]
                 ]
-                query = query.filter(
+                stmt = stmt.where(
                     not_(
                         or_(
                             and_(
@@ -282,16 +283,16 @@ def list_role_requests(
                     )
                 )
             # Whether admin or not, never include the assignee's own requests.
-            query = query.filter(RoleRequest.requester_user_id != assignee_user.id)
+            stmt = stmt.where(RoleRequest.requester_user_id != assignee_user.id)
         else:
-            query = query.filter(False)
+            stmt = stmt.where(False)
 
     if q_args.resolver_user_id:
         if q_args.resolver_user_id == "@me":
-            query = query.filter(RoleRequest.resolver_user_id == current_user_id)
+            stmt = stmt.where(RoleRequest.resolver_user_id == current_user_id)
         else:
             resolver_alias = aliased(OktaUser)
-            query = query.outerjoin(RoleRequest.resolver.of_type(resolver_alias)).filter(
+            stmt = stmt.outerjoin(RoleRequest.resolver.of_type(resolver_alias)).where(
                 or_(
                     RoleRequest.resolver_user_id == q_args.resolver_user_id,
                     resolver_alias.email.ilike(q_args.resolver_user_id),
@@ -306,12 +307,12 @@ def list_role_requests(
         q_resolver_alias = aliased(OktaUser)
         q_role_alias = aliased(OktaGroup)
         q_group_alias = aliased(OktaGroup)
-        query = (
-            query.join(RoleRequest.requester.of_type(q_requester_alias))
+        stmt = (
+            stmt.join(RoleRequest.requester.of_type(q_requester_alias))
             .join(RoleRequest.requester_role.of_type(q_role_alias))
             .join(RoleRequest.requested_group.of_type(q_group_alias))
             .outerjoin(RoleRequest.resolver.of_type(q_resolver_alias))
-            .filter(
+            .where(
                 or_(
                     RoleRequest.id.like(f"{q_args.q}%"),
                     cast(RoleRequest.status, String).ilike(like),
@@ -333,12 +334,14 @@ def list_role_requests(
             )
         )
 
-    return paginate(db, query, transformer=validated(RoleRequestSummary))
+    return paginate(db, stmt, transformer=validated(RoleRequestSummary))
 
 
 @router.get("/{role_request_id}", name="role_request_by_id")
 def get_role_request(role_request_id: str, db: DbSession, current_user_id: CurrentUserId) -> RoleRequestDetail:
-    rr = db.query(RoleRequest).options(*_detail_load_options()).filter(RoleRequest.id == role_request_id).first()
+    rr = db.scalars(
+        select(RoleRequest).options(*_detail_load_options()).where(RoleRequest.id == role_request_id)
+    ).first()
     if rr is None:
         raise HTTPException(404, "Not Found")
     return RoleRequestDetail.model_validate(rr, from_attributes=True)
@@ -352,13 +355,19 @@ def post_role_request(
 ) -> RoleRequestSummary:
     from api.auth import permissions as _perms
 
-    requester = db.query(OktaUser).filter(OktaUser.deleted_at.is_(None)).filter(OktaUser.id == current_user_id).first()
-    role = db.query(RoleGroup).filter(RoleGroup.deleted_at.is_(None)).filter(RoleGroup.id == body.role_id).first()
+    requester = db.scalars(
+        select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+    ).first()
+    role = db.scalars(
+        select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == body.role_id)
+    ).first()
     if role is None:
         raise HTTPException(404, "Not Found")
     if requester is None or not _perms.can_manage_group(db, current_user_id, role):
         raise HTTPException(403, "Current user is not allowed to perform this action")
-    group = db.query(OktaGroup).filter(OktaGroup.deleted_at.is_(None)).filter(OktaGroup.id == body.group_id).first()
+    group = db.scalars(
+        select(OktaGroup).where(OktaGroup.deleted_at.is_(None)).where(OktaGroup.id == body.group_id)
+    ).first()
     if group is None:
         raise HTTPException(404, "Not Found")
     if not group.is_managed:
@@ -367,16 +376,15 @@ def post_role_request(
         raise HTTPException(400, "Role requests may only be made for groups and app groups (not roles).")
 
     # Close any existing pending duplicate requests
-    existing = (
-        db.query(RoleRequest)
-        .filter(RoleRequest.requester_user_id == current_user_id)
-        .filter(RoleRequest.requester_role_id == body.role_id)
-        .filter(RoleRequest.requested_group_id == body.group_id)
-        .filter(RoleRequest.request_ownership == body.group_owner)
-        .filter(RoleRequest.status == AccessRequestStatus.PENDING)
-        .filter(RoleRequest.resolved_at.is_(None))
-        .all()
-    )
+    existing = db.scalars(
+        select(RoleRequest)
+        .where(RoleRequest.requester_user_id == current_user_id)
+        .where(RoleRequest.requester_role_id == body.role_id)
+        .where(RoleRequest.requested_group_id == body.group_id)
+        .where(RoleRequest.request_ownership == body.group_owner)
+        .where(RoleRequest.status == AccessRequestStatus.PENDING)
+        .where(RoleRequest.resolved_at.is_(None))
+    ).all()
     for old in existing:
         RejectRoleRequest(
             role_request=old,
@@ -392,7 +400,7 @@ def post_role_request(
         request_reason=body.reason or "",
         request_ending_at=body.ending_at,
     ).execute()
-    refreshed = db.query(RoleRequest).options(*_summary_load_options()).filter(RoleRequest.id == rr.id).first()
+    refreshed = db.scalars(select(RoleRequest).options(*_summary_load_options()).where(RoleRequest.id == rr.id)).first()
     return RoleRequestSummary.model_validate(refreshed or rr, from_attributes=True)
 
 
@@ -406,7 +414,9 @@ def put_role_request(
     from api.auth import permissions as _perms
     from api.operations.constraints import CheckForReason
 
-    rr = db.query(RoleRequest).options(*_summary_load_options()).filter(RoleRequest.id == role_request_id).first()
+    rr = db.scalars(
+        select(RoleRequest).options(*_summary_load_options()).where(RoleRequest.id == role_request_id)
+    ).first()
     if rr is None:
         raise HTTPException(404, "Not Found")
 
@@ -449,7 +459,7 @@ def put_role_request(
             rejection_reason=body.reason or "",
             notify_requester=rr.requester_user_id != current_user_id,
         ).execute()
-    refreshed = (
-        db.query(RoleRequest).options(*_summary_load_options()).filter(RoleRequest.id == role_request_id).first()
-    )
+    refreshed = db.scalars(
+        select(RoleRequest).options(*_summary_load_options()).where(RoleRequest.id == role_request_id)
+    ).first()
     return RoleRequestSummary.model_validate(refreshed, from_attributes=True)

--- a/api/routers/roles.py
+++ b/api/routers/roles.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, HTTPException, Query
 
 from fastapi.responses import RedirectResponse
 from pydantic import TypeAdapter
-from sqlalchemy import func, nullsfirst, or_
+from sqlalchemy import func, nullsfirst, or_, select
 from starlette.requests import Request
 
 from api.auth import permissions as _perms
@@ -49,49 +49,45 @@ def list_roles(
     # deliberately don't reuse `_GROUP_LOAD_OPTIONS` here: those eager-loads
     # populate fields the list shape doesn't expose, so each call would
     # issue extra round trips for data that gets discarded.
-    query = db.query(RoleGroup).filter(RoleGroup.deleted_at.is_(None)).order_by(func.lower(RoleGroup.name))
+    stmt = select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).order_by(func.lower(RoleGroup.name))
 
     # Filter to roles owned by `owner_id` (id or email; supports `@me`).
     if q_args.owner_id:
         owner_id = current_user_id if q_args.owner_id == "@me" else q_args.owner_id
-        owner = (
-            db.query(OktaUser)
-            .filter(or_(OktaUser.id == owner_id, OktaUser.email.ilike(owner_id)))
+        owner = db.scalars(
+            select(OktaUser)
+            .where(or_(OktaUser.id == owner_id, OktaUser.email.ilike(owner_id)))
             .order_by(nullsfirst(OktaUser.deleted_at.desc()))
-            .first()
-        )
+        ).first()
         if owner is None:
             raise HTTPException(404, "Not Found")
-        owned_role_ids = [
-            row.group_id
-            for row in db.query(OktaUserGroupMember.group_id)
-            .filter(OktaUserGroupMember.user_id == owner.id)
-            .filter(OktaUserGroupMember.is_owner.is_(True))
-            .filter(
+        owned_role_ids = db.scalars(
+            select(OktaUserGroupMember.group_id)
+            .where(OktaUserGroupMember.user_id == owner.id)
+            .where(OktaUserGroupMember.is_owner.is_(True))
+            .where(
                 or_(
                     OktaUserGroupMember.ended_at.is_(None),
                     OktaUserGroupMember.ended_at > func.now(),
                 )
             )
-            .all()
-        ]
-        query = query.filter(RoleGroup.id.in_(owned_role_ids))
+        ).all()
+        stmt = stmt.where(RoleGroup.id.in_(owned_role_ids))
 
     if q_args.q:
         like = f"%{q_args.q}%"
-        query = query.filter(or_(RoleGroup.name.ilike(like), RoleGroup.description.ilike(like)))
-    return paginate(db, query, transformer=validated(RoleGroupListItem))
+        stmt = stmt.where(or_(RoleGroup.name.ilike(like), RoleGroup.description.ilike(like)))
+    return paginate(db, stmt, transformer=validated(RoleGroupListItem))
 
 
 @router.get("/{role_id}", name="role_by_id")
 def get_role(role_id: str, db: DbSession, current_user_id: CurrentUserId) -> GroupDetail:
-    role = (
-        db.query(RoleGroup)
+    role = db.scalars(
+        select(RoleGroup)
         .options(*_GROUP_LOAD_OPTIONS)
-        .filter(or_(RoleGroup.id == role_id, RoleGroup.name == role_id))
+        .where(or_(RoleGroup.id == role_id, RoleGroup.name == role_id))
         .order_by(nullsfirst(RoleGroup.deleted_at.desc()))
-        .first()
-    )
+    ).first()
     if role is None:
         raise HTTPException(404, "Not Found")
     return _role_adapter.validate_python(role, from_attributes=True)
@@ -108,20 +104,18 @@ def get_role_audit(role_id: str, request: Request, current_user_id: CurrentUserI
 
 @router.get("/{role_id}/members", name="role_members_by_id")
 def get_role_members(role_id: str, db: DbSession, current_user_id: CurrentUserId) -> RoleMembersSummary:
-    role = (
-        db.query(RoleGroup)
-        .filter(RoleGroup.deleted_at.is_(None))
-        .filter(or_(RoleGroup.id == role_id, RoleGroup.name == role_id))
-        .first()
-    )
+    role = db.scalars(
+        select(RoleGroup)
+        .where(RoleGroup.deleted_at.is_(None))
+        .where(or_(RoleGroup.id == role_id, RoleGroup.name == role_id))
+    ).first()
     if role is None:
         raise HTTPException(404, "Not Found")
-    mappings = (
-        db.query(RoleGroupMap)
-        .filter(RoleGroupMap.role_group_id == role.id)
-        .filter(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
-        .all()
-    )
+    mappings = db.scalars(
+        select(RoleGroupMap)
+        .where(RoleGroupMap.role_group_id == role.id)
+        .where(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
+    ).all()
     return RoleMembersSummary(
         groups_in_role=[m.group_id for m in mappings if not m.is_owner],
         groups_owned_by_role=[m.group_id for m in mappings if m.is_owner],
@@ -140,12 +134,11 @@ def put_role_members(
     from api.models import AppGroup, RoleGroupMap
     from api.operations.constraints import CheckForReason, CheckForSelfAdd
 
-    role = (
-        db.query(RoleGroup)
-        .filter(RoleGroup.deleted_at.is_(None))
-        .filter(or_(RoleGroup.id == role_id, RoleGroup.name == role_id))
-        .first()
-    )
+    role = db.scalars(
+        select(RoleGroup)
+        .where(RoleGroup.deleted_at.is_(None))
+        .where(or_(RoleGroup.id == role_id, RoleGroup.name == role_id))
+    ).first()
     if role is None:
         raise HTTPException(404, "Not Found")
     # Body is `Optional` so the missing-role 404 above fires even when the
@@ -157,31 +150,28 @@ def put_role_members(
     # Authorization: should_expire requires can_manage_group on each affected group.
     if body.groups_should_expire or body.owner_groups_should_expire:
         all_should_expire_ids = body.groups_should_expire + body.owner_groups_should_expire
-        maps = (
-            db.query(RoleGroupMap)
-            .filter(RoleGroupMap.id.in_(all_should_expire_ids))
-            .filter(RoleGroupMap.role_group_id == role.id)
-            .all()
-        )
+        maps = db.scalars(
+            select(RoleGroupMap)
+            .where(RoleGroupMap.id.in_(all_should_expire_ids))
+            .where(RoleGroupMap.role_group_id == role.id)
+        ).all()
         affected_group_ids = [m.group_id for m in maps]
-        affected_groups = (
-            db.query(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-            .filter(OktaGroup.deleted_at.is_(None))
-            .filter(OktaGroup.id.in_(affected_group_ids))
-            .all()
-        )
+        affected_groups = db.scalars(
+            select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(OktaGroup.id.in_(affected_group_ids))
+        ).all()
         for g in affected_groups:
             if not _perms.can_manage_group(db, current_user_id, g):
                 raise HTTPException(403, "Current user is not allowed to perform this action")
 
     if not _perms.is_access_admin(db, current_user_id):
         # Each group being added: must be group owner or app owner.
-        added_groups = (
-            db.query(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-            .filter(OktaGroup.deleted_at.is_(None))
-            .filter(OktaGroup.id.in_(body.groups_to_add + body.owner_groups_to_add))
-            .all()
-        )
+        added_groups = db.scalars(
+            select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(OktaGroup.id.in_(body.groups_to_add + body.owner_groups_to_add))
+        ).all()
         for g in added_groups:
             if not _perms.is_group_owner(db, current_user_id, g) and not _perms.is_app_owner_group_owner(
                 db, current_user_id, app_group=g if isinstance(g, AppGroup) else None
@@ -190,12 +180,11 @@ def put_role_members(
 
         # Each group being removed: role owners exempt; otherwise must own the group/app.
         if not _perms.is_group_owner(db, current_user_id, role):
-            removed_groups = (
-                db.query(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-                .filter(OktaGroup.deleted_at.is_(None))
-                .filter(OktaGroup.id.in_(body.groups_to_remove + body.owner_groups_to_remove))
-                .all()
-            )
+            removed_groups = db.scalars(
+                select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+                .where(OktaGroup.deleted_at.is_(None))
+                .where(OktaGroup.id.in_(body.groups_to_remove + body.owner_groups_to_remove))
+            ).all()
             for g in removed_groups:
                 if not _perms.is_group_owner(db, current_user_id, g) and not _perms.is_app_owner_group_owner(
                     db, current_user_id, app_group=g if isinstance(g, AppGroup) else None
@@ -205,12 +194,11 @@ def put_role_members(
     # Reject changes to unmanaged groups.
     affected_ids = body.groups_to_add + body.owner_groups_to_add + body.groups_to_remove + body.owner_groups_to_remove
     if affected_ids:
-        unmanaged_count = (
-            db.query(func.count(OktaGroup.id))
-            .filter(OktaGroup.id.in_(affected_ids))
-            .filter(OktaGroup.deleted_at.is_(None))
-            .filter(OktaGroup.is_managed.is_(False))
-            .scalar()
+        unmanaged_count = db.scalar(
+            select(func.count(OktaGroup.id))
+            .where(OktaGroup.id.in_(affected_ids))
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(OktaGroup.is_managed.is_(False))
         )
         if unmanaged_count and unmanaged_count > 0:
             raise HTTPException(400, "Groups not managed by Access cannot be modified")
@@ -218,12 +206,11 @@ def put_role_members(
     # Reject role-in-role nesting. Roles can only contain non-role groups.
     add_ids = body.groups_to_add + body.owner_groups_to_add
     if add_ids:
-        role_in_add_count = (
-            db.query(func.count(OktaGroup.id))
-            .filter(OktaGroup.id.in_(add_ids))
-            .filter(OktaGroup.deleted_at.is_(None))
-            .filter(OktaGroup.type == RoleGroup.__mapper_args__["polymorphic_identity"])
-            .scalar()
+        role_in_add_count = db.scalar(
+            select(func.count(OktaGroup.id))
+            .where(OktaGroup.id.in_(add_ids))
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(OktaGroup.type == RoleGroup.__mapper_args__["polymorphic_identity"])
         )
         if role_in_add_count and role_in_add_count > 0:
             raise HTTPException(400, "Roles cannot be added to other Roles")

--- a/api/routers/tags.py
+++ b/api/routers/tags.py
@@ -7,7 +7,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from sqlalchemy import func, nullsfirst, or_
+from sqlalchemy import func, nullsfirst, or_, select
 from sqlalchemy.orm import joinedload, selectinload
 from starlette.requests import Request
 
@@ -51,11 +51,11 @@ def list_tags(
     current_user_id: CurrentUserId,
     q_args: Annotated[SearchTagQuery, Query()],
 ) -> Page[TagListItem]:
-    query = db.query(Tag).filter(Tag.deleted_at.is_(None)).order_by(func.lower(Tag.name))
+    stmt = select(Tag).where(Tag.deleted_at.is_(None)).order_by(func.lower(Tag.name))
     if q_args.q:
         like = f"%{q_args.q}%"
-        query = query.filter(or_(Tag.name.ilike(like), Tag.description.ilike(like)))
-    return paginate(db, query, transformer=validated(TagListItem))
+        stmt = stmt.where(or_(Tag.name.ilike(like), Tag.description.ilike(like)))
+    return paginate(db, stmt, transformer=validated(TagListItem))
 
 
 @router.get("/{tag_id}", name="tag_by_id")
@@ -63,13 +63,12 @@ def get_tag(tag_id: str, db: DbSession, current_user_id: CurrentUserId) -> TagDe
     # `nullsfirst(deleted_at.desc())` makes an active row beat a soft-deleted
     # row that shares the same name. Without the order, `.first()` may return
     # an old deleted tag and 404 on a name that still exists.
-    tag = (
-        db.query(Tag)
+    tag = db.scalars(
+        select(Tag)
         .options(*_TAG_LOAD_OPTIONS)
-        .filter(or_(Tag.id == tag_id, Tag.name == tag_id))
+        .where(or_(Tag.id == tag_id, Tag.name == tag_id))
         .order_by(nullsfirst(Tag.deleted_at.desc()))
-        .first()
-    )
+    ).first()
     if tag is None:
         raise HTTPException(404, "Not Found")
     return TagDetail.model_validate(tag, from_attributes=True)
@@ -85,9 +84,9 @@ def post_tag(
     # Reject duplicates by name. Without this, CreateTag.execute() silently
     # returns the existing tag and the endpoint replies 201 with the wrong
     # row, which clients don't expect.
-    existing = (
-        db.query(Tag).filter(func.lower(Tag.name) == func.lower(body.name)).filter(Tag.deleted_at.is_(None)).first()
-    )
+    existing = db.scalars(
+        select(Tag).where(func.lower(Tag.name) == func.lower(body.name)).where(Tag.deleted_at.is_(None))
+    ).first()
     if existing is not None:
         raise HTTPException(400, "Tag already exists with the same name")
 
@@ -98,7 +97,7 @@ def post_tag(
         enabled=body.enabled,
     )
     created = CreateTag(tag=tag, current_user_id=current_user_id).execute()
-    refreshed = db.query(Tag).options(*_TAG_LOAD_OPTIONS).filter(Tag.id == created.id).first()
+    refreshed = db.scalars(select(Tag).options(*_TAG_LOAD_OPTIONS).where(Tag.id == created.id)).first()
     return TagDetail.model_validate(refreshed or created, from_attributes=True)
 
 
@@ -114,7 +113,9 @@ def put_tag(
 
     from api.operations import ModifyGroupsTimeLimit
 
-    tag = db.query(Tag).filter(Tag.deleted_at.is_(None)).filter(or_(Tag.id == tag_id, Tag.name == tag_id)).first()
+    tag = db.scalars(
+        select(Tag).where(Tag.deleted_at.is_(None)).where(or_(Tag.id == tag_id, Tag.name == tag_id))
+    ).first()
     if tag is None:
         raise HTTPException(404, "Not Found")
     payload = body.model_dump(exclude_unset=True)
@@ -132,13 +133,12 @@ def put_tag(
     # Reject renames that collide with another existing tag (case-insensitive).
     new_name = payload.get("name")
     if new_name and new_name.lower() != tag.name.lower():
-        collision = (
-            db.query(Tag)
-            .filter(Tag.id != tag.id)
-            .filter(func.lower(Tag.name) == func.lower(new_name))
-            .filter(Tag.deleted_at.is_(None))
-            .first()
-        )
+        collision = db.scalars(
+            select(Tag)
+            .where(Tag.id != tag.id)
+            .where(func.lower(Tag.name) == func.lower(new_name))
+            .where(Tag.deleted_at.is_(None))
+        ).first()
         if collision is not None:
             raise HTTPException(400, "Tag already exists with the same name")
 
@@ -154,14 +154,14 @@ def put_tag(
     # Re-evaluate time-limit constraints for groups associated with this tag.
     # `ModifyGroupsTimeLimit` commits, expiring objects, so we re-load
     # `refreshed` afterwards before serializing.
-    pre_refresh = db.query(Tag).options(selectinload(Tag.active_group_tags)).filter(Tag.id == tag.id).first()
+    pre_refresh = db.scalars(select(Tag).options(selectinload(Tag.active_group_tags)).where(Tag.id == tag.id)).first()
     if pre_refresh is not None and pre_refresh.active_group_tags:
         ModifyGroupsTimeLimit(
             groups=[tm.group_id for tm in pre_refresh.active_group_tags],
             tags=[pre_refresh.id],
         ).execute()
 
-    refreshed = db.query(Tag).options(*_TAG_LOAD_OPTIONS).filter(Tag.id == tag.id).first()
+    refreshed = db.scalars(select(Tag).options(*_TAG_LOAD_OPTIONS).where(Tag.id == tag.id)).first()
 
     email = getattr(db.get(OktaUser, current_user_id), "email", None) if current_user_id else None
     _ctx = get_request_context()
@@ -189,7 +189,9 @@ def delete_tag(
     _admin: str = Depends(require_access_admin),
     current_user_id: CurrentUserId = None,  # type: ignore[assignment]
 ) -> DeleteMessage:
-    tag = db.query(Tag).filter(Tag.deleted_at.is_(None)).filter(or_(Tag.id == tag_id, Tag.name == tag_id)).first()
+    tag = db.scalars(
+        select(Tag).where(Tag.deleted_at.is_(None)).where(or_(Tag.id == tag_id, Tag.name == tag_id))
+    ).first()
     if tag is None:
         raise HTTPException(404, "Not Found")
     DeleteTag(tag=tag, current_user_id=current_user_id).execute()

--- a/api/routers/users.py
+++ b/api/routers/users.py
@@ -13,7 +13,7 @@ from typing import Annotated
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import RedirectResponse
 from fastapi_pagination.ext.sqlalchemy import paginate
-from sqlalchemy import cast, func, nullsfirst, or_
+from sqlalchemy import cast, func, nullsfirst, or_, select
 from sqlalchemy.orm import joinedload, selectinload, with_polymorphic
 from sqlalchemy.sql import sqltypes
 
@@ -46,7 +46,7 @@ def list_users(
     current_user_id: CurrentUserId,
     q_args: Annotated[SearchUserQuery, Query()],
 ) -> Page[OktaUserSummary]:
-    query = db.query(OktaUser).filter(OktaUser.deleted_at.is_(None)).order_by(func.lower(OktaUser.email))
+    stmt = select(OktaUser).where(OktaUser.deleted_at.is_(None)).order_by(func.lower(OktaUser.email))
 
     if q_args.q:
         like = f"%{q_args.q}%"
@@ -64,7 +64,7 @@ def list_users(
             attr_query = [f'@."{attr}" like_regex "%s" flag "i"' for attr in search_attributes]
             search_jsonpath = f"strict $ ? ({' || '.join(attr_query)})"
             format_params = [query_regex_quote_escaped] * len(search_attributes)
-            query = query.filter(
+            stmt = stmt.where(
                 or_(
                     OktaUser.email.ilike(like),
                     OktaUser.first_name.ilike(like),
@@ -84,7 +84,7 @@ def list_users(
             )
         else:
             # Naive search of JSON field (matches both keys and values).
-            query = query.filter(
+            stmt = stmt.where(
                 or_(
                     OktaUser.email.ilike(like),
                     OktaUser.first_name.ilike(like),
@@ -95,7 +95,7 @@ def list_users(
                 )
             )
 
-    return paginate(db, query, transformer=validated(OktaUserSummary))
+    return paginate(db, stmt, transformer=validated(OktaUserSummary))
 
 
 @router.get("/{user_id}", name="user_by_id")
@@ -103,17 +103,16 @@ def get_user(user_id: str, db: DbSession, current_user_id: CurrentUserId) -> Okt
     if user_id == "@me":
         user_id = current_user_id
 
-    user = (
-        db.query(OktaUser)
+    user = db.scalars(
+        select(OktaUser)
         .options(
             selectinload(OktaUser.active_group_memberships).options(*user_group_member_options()),
             selectinload(OktaUser.active_group_ownerships).options(*user_group_member_options()),
             joinedload(OktaUser.manager),
         )
-        .filter(or_(OktaUser.id == user_id, OktaUser.email.ilike(user_id)))
+        .where(or_(OktaUser.id == user_id, OktaUser.email.ilike(user_id)))
         .order_by(nullsfirst(OktaUser.deleted_at.desc()))
-        .first()
-    )
+    ).first()
     if user is None:
         raise HTTPException(status_code=404, detail="Not Found")
     return OktaUserDetail.model_validate(user, from_attributes=True)

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from datetime import date, datetime, timedelta, timezone
 from typing import List
 
-from sqlalchemy import and_, func, or_
+from sqlalchemy import and_, func, or_, select
 from api.config import settings
 from sqlalchemy.orm import (
     aliased,
@@ -49,7 +49,7 @@ def sync_users() -> None:
 
     # Hydrate all users into sql alchemy context at once
     # to avoid a roundtrip for each user
-    _ = db.session.query(OktaUser).all()
+    _ = db.session.scalars(select(OktaUser)).all()
 
     for user in users:
         logger.info(f"Syncing user {user.id}")
@@ -74,9 +74,9 @@ def sync_users() -> None:
     # Delete users and end all group memberships in the DB for users that are suspended/deactivated in Okta
     deleted_user_ids = [u.id for u in filter(lambda u: u.get_deleted_at() is not None, users)]
 
-    users_to_delete = (
-        db.session.query(OktaUser).filter(OktaUser.id.in_(deleted_user_ids)).filter(OktaUser.deleted_at.is_(None)).all()
-    )
+    users_to_delete = db.session.scalars(
+        select(OktaUser).where(OktaUser.id.in_(deleted_user_ids)).where(OktaUser.deleted_at.is_(None))
+    ).all()
 
     for db_user in users_to_delete:
         logger.info(f"Deleting user in DB {db_user.id} that was suspended/deactivated in Okta")
@@ -85,25 +85,21 @@ def sync_users() -> None:
     # Delete users and end all group memberships in the DB for users that are deleted in Okta
     active_user_ids = [u.id for u in filter(lambda u: u.get_deleted_at() is None, users)]
 
-    more_users_to_delete = (
-        db.session.query(OktaUser)
-        .filter(OktaUser.id.not_in(active_user_ids))
-        .filter(OktaUser.deleted_at.is_(None))
-        .all()
-    )
+    more_users_to_delete = db.session.scalars(
+        select(OktaUser).where(OktaUser.id.not_in(active_user_ids)).where(OktaUser.deleted_at.is_(None))
+    ).all()
 
     for db_user in more_users_to_delete:
         logger.info(f"Deleting user in DB {db_user.id} that was deleted in Okta")
         DeleteUser(user=db_user.id, sync_to_okta=False).execute()
 
     # End all active group memberships in the DB for users that were previously deleted
-    db_deleted_users_with_access = (
-        db.session.query(OktaUserGroupMember)
+    db_deleted_users_with_access = db.session.scalars(
+        select(OktaUserGroupMember)
         .join(OktaUserGroupMember.user)
-        .filter(OktaUser.deleted_at.isnot(None))
-        .filter(or_(OktaUserGroupMember.ended_at.is_(None), OktaUserGroupMember.ended_at > func.now()))
-        .all()
-    )
+        .where(OktaUser.deleted_at.isnot(None))
+        .where(or_(OktaUserGroupMember.ended_at.is_(None), OktaUserGroupMember.ended_at > func.now()))
+    ).all()
     for user_id in set([u.user_id for u in db_deleted_users_with_access]):
         logger.info(f"Ending active group ownerships/memberships for deleted user in DB {user_id}")
         DeleteUser(user=user_id).execute()
@@ -130,7 +126,7 @@ def sync_groups(act_as_authority: bool) -> None:
     logger.info("Group sync starting")
 
     groups_in_okta = okta.list_groups()
-    db_group_ids = {row.id for row in db.session.query(OktaGroup.id).filter(OktaGroup.deleted_at.is_(None)).all()}
+    db_group_ids = set(db.session.scalars(select(OktaGroup.id).where(OktaGroup.deleted_at.is_(None))).all())
 
     group_ids_with_group_rules = okta.list_groups_with_active_rules()
 
@@ -188,7 +184,7 @@ def sync_group_memberships(act_as_authority: bool) -> None:
 
     # Hydrate all groups into sql alchemy context at once
     # to avoid a roundtrip for each group
-    _ = db.session.query(with_polymorphic(OktaGroup, [AppGroup, RoleGroup])).all()
+    _ = db.session.scalars(select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))).all()
 
     group_ids_with_group_rules = okta.list_groups_with_active_rules()
 
@@ -206,16 +202,18 @@ def sync_group_memberships(act_as_authority: bool) -> None:
 
             db_all_group_members = {
                 row.id: row.user_id
-                for row in db.session.query(
-                    OktaUserGroupMember.user_id,
-                    OktaUserGroupMember.id,
-                ).filter(
-                    OktaUserGroupMember.group_id == group.id,
-                    OktaUserGroupMember.is_owner.is_(False),
-                    or_(
-                        OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > func.now(),
-                    ),
+                for row in db.session.execute(
+                    select(
+                        OktaUserGroupMember.user_id,
+                        OktaUserGroupMember.id,
+                    ).where(
+                        OktaUserGroupMember.group_id == group.id,
+                        OktaUserGroupMember.is_owner.is_(False),
+                        or_(
+                            OktaUserGroupMember.ended_at.is_(None),
+                            OktaUserGroupMember.ended_at > func.now(),
+                        ),
+                    )
                 )
             }
 
@@ -294,46 +292,49 @@ def sync_group_ownerships(act_as_authority: bool) -> None:
 
             db_all_group_owners = {
                 row.id: row.user_id
-                for row in db.session.query(
-                    OktaUserGroupMember.user_id,
-                    OktaUserGroupMember.id,
-                ).filter(
-                    OktaUserGroupMember.group_id == group.id,
-                    OktaUserGroupMember.is_owner.is_(True),
-                    or_(
-                        OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > func.now(),
-                    ),
+                for row in db.session.execute(
+                    select(
+                        OktaUserGroupMember.user_id,
+                        OktaUserGroupMember.id,
+                    ).where(
+                        OktaUserGroupMember.group_id == group.id,
+                        OktaUserGroupMember.is_owner.is_(True),
+                        or_(
+                            OktaUserGroupMember.ended_at.is_(None),
+                            OktaUserGroupMember.ended_at > func.now(),
+                        ),
+                    )
                 )
             }
 
             # If the group ownership is managed by Access and there are no owners for it
             # check to see if it's an AppGroup and if so, add the app owners as owners in Okta
             if act_authoritatively and len(db_all_group_owners) == 0:
-                app_group = (
-                    db.session.query(AppGroup)
+                app_group = db.session.scalars(
+                    select(AppGroup)
                     .options(
                         joinedload(AppGroup.app).options(selectinload(App.active_owner_app_groups)),
                     )
-                    .filter(AppGroup.deleted_at.is_(None))
-                    .filter(AppGroup.id == group.id)
-                    .first()
-                )
+                    .where(AppGroup.deleted_at.is_(None))
+                    .where(AppGroup.id == group.id)
+                ).first()
 
                 if app_group is not None and not app_group.is_owner:
                     app_owner_group_ids = [g.id for g in app_group.app.active_owner_app_groups]
                     db_all_group_owners = {
                         row.id: row.user_id
-                        for row in db.session.query(
-                            OktaUserGroupMember.user_id,
-                            OktaUserGroupMember.id,
-                        ).filter(
-                            OktaUserGroupMember.group_id.in_(app_owner_group_ids),
-                            OktaUserGroupMember.is_owner.is_(True),
-                            or_(
-                                OktaUserGroupMember.ended_at.is_(None),
-                                OktaUserGroupMember.ended_at > func.now(),
-                            ),
+                        for row in db.session.execute(
+                            select(
+                                OktaUserGroupMember.user_id,
+                                OktaUserGroupMember.id,
+                            ).where(
+                                OktaUserGroupMember.group_id.in_(app_owner_group_ids),
+                                OktaUserGroupMember.is_owner.is_(True),
+                                or_(
+                                    OktaUserGroupMember.ended_at.is_(None),
+                                    OktaUserGroupMember.ended_at > func.now(),
+                                ),
+                            )
                         )
                     }
 
@@ -394,28 +395,26 @@ def expire_access_requests() -> None:
     logger.info("Access request expiration started.")
     MAX_ACCESS_REQUEST_AGE_SECONDS = settings.MAX_ACCESS_REQUEST_AGE_SECONDS
 
-    older_than_max = (
-        db.session.query(AccessRequest)
-        .filter(AccessRequest.status == AccessRequestStatus.PENDING)
-        .filter(AccessRequest.resolved_at.is_(None))
-        .filter(
+    older_than_max = db.session.scalars(
+        select(AccessRequest)
+        .where(AccessRequest.status == AccessRequestStatus.PENDING)
+        .where(AccessRequest.resolved_at.is_(None))
+        .where(
             AccessRequest.created_at < datetime.now(timezone.utc) - timedelta(seconds=MAX_ACCESS_REQUEST_AGE_SECONDS)
         )
-        .all()
-    )
+    ).all()
     for access_request in older_than_max:
         RejectAccessRequest(
             access_request=access_request,
             rejection_reason="Closed because the request expired",
         ).execute()
 
-    older_than_request = (
-        db.session.query(AccessRequest)
-        .filter(AccessRequest.status == AccessRequestStatus.PENDING)
-        .filter(AccessRequest.resolved_at.is_(None))
-        .filter(AccessRequest.request_ending_at < func.now())
-        .all()
-    )
+    older_than_request = db.session.scalars(
+        select(AccessRequest)
+        .where(AccessRequest.status == AccessRequestStatus.PENDING)
+        .where(AccessRequest.resolved_at.is_(None))
+        .where(AccessRequest.request_ending_at < func.now())
+    ).all()
     for access_request in older_than_request:
         RejectAccessRequest(
             access_request=access_request,
@@ -436,27 +435,25 @@ def expiring_access_notifications_user() -> None:
         next_day = day + timedelta(days=3)
         weekend_notif_tomorrow = True
 
-    db_memberships_expiring_tomorrow = (
-        db.session.query(OktaUserGroupMember)
+    db_memberships_expiring_tomorrow = db.session.scalars(
+        select(OktaUserGroupMember)
         .options(joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group))
         .join(OktaUserGroupMember.active_user)
         .join(OktaUserGroupMember.active_group)
-        .filter(OktaGroup.is_managed.is_(True))
-        .filter(and_(OktaUserGroupMember.ended_at >= day, OktaUserGroupMember.ended_at < next_day))
-        .filter(OktaUserGroupMember.role_group_map_id.is_(None))
-        .filter(OktaUserGroupMember.should_expire.is_(False))
-        .all()
-    )
+        .where(OktaGroup.is_managed.is_(True))
+        .where(and_(OktaUserGroupMember.ended_at >= day, OktaUserGroupMember.ended_at < next_day))
+        .where(OktaUserGroupMember.role_group_map_id.is_(None))
+        .where(OktaUserGroupMember.should_expire.is_(False))
+    ).all()
 
     # remove OktaUserGroupMembers from the list where there's a role that grants the same access
-    db_memberships_roles = (
-        db.session.query(OktaUserGroupMember)
+    db_memberships_roles = db.session.scalars(
+        select(OktaUserGroupMember)
         .options(joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group))
         .join(OktaUserGroupMember.active_user)
         .join(OktaUserGroupMember.active_group)
-        .filter(OktaUserGroupMember.role_group_map_id.is_not(None))
-        .all()
-    )
+        .where(OktaUserGroupMember.role_group_map_id.is_not(None))
+    ).all()
 
     user_id_group_id_roles = set((member.user_id, member.group_id) for member in db_memberships_roles)
 
@@ -482,17 +479,16 @@ def expiring_access_notifications_user() -> None:
         next_day = day + timedelta(days=3)
         weekend_notif_week = True
 
-    db_memberships_expiring_next_week = (
-        db.session.query(OktaUserGroupMember)
+    db_memberships_expiring_next_week = db.session.scalars(
+        select(OktaUserGroupMember)
         .options(joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group))
         .join(OktaUserGroupMember.active_user)
         .join(OktaUserGroupMember.active_group)
-        .filter(OktaGroup.is_managed.is_(True))
-        .filter(and_(OktaUserGroupMember.ended_at >= day, OktaUserGroupMember.ended_at < next_day))
-        .filter(OktaUserGroupMember.role_group_map_id.is_(None))
-        .filter(OktaUserGroupMember.should_expire.is_(False))
-        .all()
-    )
+        .where(OktaGroup.is_managed.is_(True))
+        .where(and_(OktaUserGroupMember.ended_at >= day, OktaUserGroupMember.ended_at < next_day))
+        .where(OktaUserGroupMember.role_group_map_id.is_(None))
+        .where(OktaUserGroupMember.should_expire.is_(False))
+    ).all()
 
     # remove OktaUserGroupMembers from the list where there's a role that grants the same access
     db_memberships_expiring_next_week = [
@@ -558,17 +554,16 @@ def expiring_access_notifications_owner() -> None:
     next_week = day + timedelta(weeks=1)
 
     # Expiring groups
-    db_memberships_expiring_this_week = (
-        db.session.query(OktaUserGroupMember)
+    db_memberships_expiring_this_week = db.session.scalars(
+        select(OktaUserGroupMember)
         .options(joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group))
         .join(OktaUserGroupMember.active_user)
         .join(OktaUserGroupMember.active_group)
-        .filter(OktaGroup.is_managed.is_(True))
-        .filter(and_(OktaUserGroupMember.ended_at >= day, OktaUserGroupMember.ended_at < next_week))
-        .filter(OktaUserGroupMember.role_group_map_id.is_(None))
-        .filter(OktaUserGroupMember.should_expire.is_(False))
-        .all()
-    )
+        .where(OktaGroup.is_managed.is_(True))
+        .where(and_(OktaUserGroupMember.ended_at >= day, OktaUserGroupMember.ended_at < next_week))
+        .where(OktaUserGroupMember.role_group_map_id.is_(None))
+        .where(OktaUserGroupMember.should_expire.is_(False))
+    ).all()
 
     access_owners = get_access_owners()
 
@@ -618,17 +613,16 @@ def expiring_access_notifications_owner() -> None:
     one_week = date.today() + timedelta(weeks=1)
     two_weeks = one_week + timedelta(weeks=1)
 
-    db_memberships_expiring_next_week = (
-        db.session.query(OktaUserGroupMember)
+    db_memberships_expiring_next_week = db.session.scalars(
+        select(OktaUserGroupMember)
         .options(joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group))
         .join(OktaUserGroupMember.active_user)
         .join(OktaUserGroupMember.active_group)
-        .filter(OktaGroup.is_managed.is_(True))
-        .filter(and_(OktaUserGroupMember.ended_at >= one_week, OktaUserGroupMember.ended_at < two_weeks))
-        .filter(OktaUserGroupMember.role_group_map_id.is_(None))
-        .filter(OktaUserGroupMember.should_expire.is_(False))
-        .all()
-    )
+        .where(OktaGroup.is_managed.is_(True))
+        .where(and_(OktaUserGroupMember.ended_at >= one_week, OktaUserGroupMember.ended_at < two_weeks))
+        .where(OktaUserGroupMember.role_group_map_id.is_(None))
+        .where(OktaUserGroupMember.should_expire.is_(False))
+    ).all()
 
     # Map of group owners -> list[OktaUserGroupMember]
     owner_expiring_groups_next: defaultdict[OktaUser, list[OktaUserGroupMember]] = defaultdict(list)
@@ -721,18 +715,17 @@ def expiring_access_notifications_owner() -> None:
     day = date.today()
     next_week = day + timedelta(weeks=1)
 
-    db_roles_expiring_this_week = (
-        db.session.query(RoleGroupMap)
+    db_roles_expiring_this_week = db.session.scalars(
+        select(RoleGroupMap)
         .options(
             joinedload(RoleGroupMap.active_role_group), joinedload(RoleGroupMap.active_group.of_type(all_group_types))
         )
         .join(RoleGroupMap.active_role_group.of_type(role_group_alias))
         .join(RoleGroupMap.active_group)
-        .filter(OktaGroup.is_managed.is_(True))
-        .filter(and_(RoleGroupMap.ended_at >= day, RoleGroupMap.ended_at < next_week))
-        .filter(RoleGroupMap.should_expire.is_(False))
-        .all()
-    )
+        .where(OktaGroup.is_managed.is_(True))
+        .where(and_(RoleGroupMap.ended_at >= day, RoleGroupMap.ended_at < next_week))
+        .where(RoleGroupMap.should_expire.is_(False))
+    ).all()
 
     # Map of group owners -> list[RoleGroupMap]
     owner_expiring_roles_this: defaultdict[OktaUser, list[RoleGroupMap]] = defaultdict(list)
@@ -773,18 +766,17 @@ def expiring_access_notifications_owner() -> None:
     one_week = date.today() + timedelta(weeks=1)
     two_weeks = one_week + timedelta(weeks=1)
 
-    db_roles_expiring_next_week = (
-        db.session.query(RoleGroupMap)
+    db_roles_expiring_next_week = db.session.scalars(
+        select(RoleGroupMap)
         .options(
             joinedload(RoleGroupMap.active_role_group), joinedload(RoleGroupMap.active_group.of_type(all_group_types))
         )
         .join(RoleGroupMap.active_role_group.of_type(role_group_alias))
         .join(RoleGroupMap.active_group)
-        .filter(OktaGroup.is_managed.is_(True))
-        .filter(and_(RoleGroupMap.ended_at >= one_week, RoleGroupMap.ended_at < two_weeks))
-        .filter(RoleGroupMap.should_expire.is_(False))
-        .all()
-    )
+        .where(OktaGroup.is_managed.is_(True))
+        .where(and_(RoleGroupMap.ended_at >= one_week, RoleGroupMap.ended_at < two_weeks))
+        .where(RoleGroupMap.should_expire.is_(False))
+    ).all()
 
     # Map of group owners -> list[RoleGroupMap]
     owner_expiring_roles_next: defaultdict[OktaUser, list[RoleGroupMap]] = defaultdict(list)
@@ -882,18 +874,17 @@ def expiring_access_notifications_role_owner() -> None:
         next_day = day + timedelta(days=3)
         weekend_notif_tomorrow = True
 
-    db_roles_expiring_tomorrow = (
-        db.session.query(RoleGroupMap)
+    db_roles_expiring_tomorrow = db.session.scalars(
+        select(RoleGroupMap)
         .options(
             joinedload(RoleGroupMap.active_role_group), joinedload(RoleGroupMap.active_group.of_type(all_group_types))
         )
         .join(RoleGroupMap.active_role_group.of_type(role_group_alias))
         .join(RoleGroupMap.active_group)
-        .filter(OktaGroup.is_managed.is_(True))
-        .filter(and_(RoleGroupMap.ended_at >= day, RoleGroupMap.ended_at < next_day))
-        .filter(RoleGroupMap.should_expire.is_(False))
-        .all()
-    )
+        .where(OktaGroup.is_managed.is_(True))
+        .where(and_(RoleGroupMap.ended_at >= day, RoleGroupMap.ended_at < next_day))
+        .where(RoleGroupMap.should_expire.is_(False))
+    ).all()
 
     # Map of role owners -> list[RoleGroupMap]
     role_owner_expiring_roles_tomorrow: defaultdict[OktaUser, list[RoleGroupMap]] = defaultdict(list)
@@ -913,18 +904,17 @@ def expiring_access_notifications_role_owner() -> None:
         next_day = day + timedelta(days=3)
         weekend_notif_week = True
 
-    db_roles_expiring_next_week = (
-        db.session.query(RoleGroupMap)
+    db_roles_expiring_next_week = db.session.scalars(
+        select(RoleGroupMap)
         .options(
             joinedload(RoleGroupMap.active_role_group), joinedload(RoleGroupMap.active_group.of_type(all_group_types))
         )
         .join(RoleGroupMap.active_role_group.of_type(role_group_alias))
         .join(RoleGroupMap.active_group)
-        .filter(OktaGroup.is_managed.is_(True))
-        .filter(and_(RoleGroupMap.ended_at >= day, RoleGroupMap.ended_at < next_day))
-        .filter(RoleGroupMap.should_expire.is_(False))
-        .all()
-    )
+        .where(OktaGroup.is_managed.is_(True))
+        .where(and_(RoleGroupMap.ended_at >= day, RoleGroupMap.ended_at < next_day))
+        .where(RoleGroupMap.should_expire.is_(False))
+    ).all()
 
     # Map of role owners -> list[RoleGroupMap]
     role_owner_expiring_roles_next: defaultdict[OktaUser, list[RoleGroupMap]] = defaultdict(list)


### PR DESCRIPTION
Part of the async-SQLAlchemy migration stack (stacked on #475).

Rewrites every legacy `db.session.query(...)` call site (~350 across operations, routers, auth, models, syncer, integrity, manage, and MCP) to 2.0-style `select()`/`update()`/`delete()` statements executed via `session.scalars()/execute()/scalar()`. Still fully synchronous — identical SQL and behavior. The legacy Query API does not exist on `AsyncSession`, so modernizing first keeps the eventual async diff down to `await` insertion.

Notes:
- bulk updates keep `synchronize_session="fetch"` via `execution_options`
- the six `with_for_update` row-lock sites are preserved verbatim
- `.unique()` added at the two collection-joinedload sites the legacy Query deduped implicitly
- `paginate()` now receives `Select` statements (supported by fastapi-pagination 0.15.13 with identical transformer semantics)
- the MCP `_paginate_query` helper takes the session explicitly and mirrors fastapi-pagination's count shape

`db.session.query` no longer appears anywhere in `api/`. Full suite green (515 tests), ruff + mypy clean.

## PR stack

Merge bottom-up; each PR is based on the branch of the one before it (retarget to `main` as predecessors merge).

1. #475 — async dependency prep (SQLAlchemy[asyncio] 2.0.50, asyncpg, aiosqlite)
2. #476 — legacy Query API -> 2.0-style statements (~350 sites) ⬅️ **this PR**
3. #477 — eliminate lazy loading and commit-expiration from the ORM layer
4. #478 — operation DB resolution out of `__init__` into `_resolve()`
5. #479 — keep `db.session` access out of spawned notification tasks
6. #480 — **the async flip** (production + tests + docs)
7. #481 — surface failed Okta/notification fan-out tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)


