### PR TITLE
[async 3/7] refactor: eliminate lazy loading and commit-expiration from the ORM layer

### DIFF
--- a/POST_MIGRATION_TODO.md
+++ b/POST_MIGRATION_TODO.md
@@ -37,18 +37,6 @@ re-used across `apps.py`, `groups.py`, `tags.py`, `users.py`,
 `role_requests.py`, and `audit.py`, so the loader stays in lockstep
 with the schema. 281/281 tests green.
 
-**Lazy-loading audit landed.** The five `lazy="select"` relationships
-(`OktaGroup.active_group_tags`, `RoleGroupMap.active_group`,
-`AppGroup.app`, `OktaGroupTagMap.active_tag`,
-`OktaGroupTagMap.active_app_tag_mapping`) are now `lazy="raise_on_sql"`
-like everything else — the audit-route eager topology covers the nested
-`active_role_associated_group_*_mappings.active_group` paths the old
-Flask-era comment claimed were unsupported. The sessionmaker also runs
-`expire_on_commit=False` now (required for async: expired-attribute
-access on an `AsyncSession` raises `MissingGreenlet`); post-operation
-reload sites in routers call `db.expire_all()` before re-querying so
-responses reflect committed state.
-
 **Still to do under this item:**
 - Per-route `DEFAULT_LOAD_OPTIONS` for redundant joins; some routes
   pre-load more than they emit.

--- a/POST_MIGRATION_TODO.md
+++ b/POST_MIGRATION_TODO.md
@@ -37,9 +37,19 @@ re-used across `apps.py`, `groups.py`, `tags.py`, `users.py`,
 `role_requests.py`, and `audit.py`, so the loader stays in lockstep
 with the schema. 281/281 tests green.
 
+**Lazy-loading audit landed.** The five `lazy="select"` relationships
+(`OktaGroup.active_group_tags`, `RoleGroupMap.active_group`,
+`AppGroup.app`, `OktaGroupTagMap.active_tag`,
+`OktaGroupTagMap.active_app_tag_mapping`) are now `lazy="raise_on_sql"`
+like everything else — the audit-route eager topology covers the nested
+`active_role_associated_group_*_mappings.active_group` paths the old
+Flask-era comment claimed were unsupported. The sessionmaker also runs
+`expire_on_commit=False` now (required for async: expired-attribute
+access on an `AsyncSession` raises `MissingGreenlet`); post-operation
+reload sites in routers call `db.expire_all()` before re-querying so
+responses reflect committed state.
+
 **Still to do under this item:**
-- Audit `lazy="raise_on_sql"` usages on models — confirm each is still
-  load-bearing now that `dump_orm` is the strict default.
 - Per-route `DEFAULT_LOAD_OPTIONS` for redundant joins; some routes
   pre-load more than they emit.
 

--- a/api/extensions.py
+++ b/api/extensions.py
@@ -92,7 +92,12 @@ class _DB:
         self._sessionmaker = sessionmaker(
             bind=engine,
             autoflush=False,
-            expire_on_commit=True,
+            # Loaded state survives commits. Required for the async flip:
+            # expired-attribute access on an AsyncSession raises MissingGreenlet,
+            # and operations/syncer keep using ORM objects across mid-flow
+            # commits. Attributes assigned SQL expressions (e.g. func.now())
+            # still expire at flush and need an explicit refresh before use.
+            expire_on_commit=False,
         )
         self._scoped = scoped_session(self._sessionmaker, scopefunc=lambda: _session_scope.get())
 

--- a/api/mcp/tools.py
+++ b/api/mcp/tools.py
@@ -1196,6 +1196,9 @@ def _register_write_tools(mcp: "FastMCP") -> None:
             if ar is None:
                 return _error("Access request could not be created")
 
+            # Drop cached ORM state so the response reflects what the operation
+            # committed (expire_on_commit=False keeps pre-operation state otherwise).
+            db.expire_all()
             refreshed = db.scalars(
                 select(AccessRequest).options(*_access_request_summary_load_options()).where(AccessRequest.id == ar.id)
             ).first()
@@ -1308,6 +1311,9 @@ def _register_write_tools(mcp: "FastMCP") -> None:
             ).execute()
             if rr is None:
                 return _error("Role request could not be created")
+            # Drop cached ORM state so the response reflects what the operation
+            # committed (expire_on_commit=False keeps pre-operation state otherwise).
+            db.expire_all()
             refreshed = db.scalars(
                 select(RoleRequest).options(*_role_request_summary_load_options()).where(RoleRequest.id == rr.id)
             ).first()
@@ -1428,6 +1434,9 @@ def _register_write_tools(mcp: "FastMCP") -> None:
             ).execute()
             if gr is None:
                 return _error("Group request could not be created")
+            # Drop cached ORM state so the response reflects what the operation
+            # committed (expire_on_commit=False keeps pre-operation state otherwise).
+            db.expire_all()
             refreshed = db.scalars(
                 select(GroupRequest).options(*_group_request_load_options()).where(GroupRequest.id == gr.id)
             ).first()

--- a/api/mcp/tools.py
+++ b/api/mcp/tools.py
@@ -260,19 +260,30 @@ def _access_request_detail_load_options() -> tuple:
         joinedload(AccessRequest.requester),
         joinedload(AccessRequest.active_requester),
         requested_group_load,
-        selectinload(AccessRequest.active_requested_group),
+        # Must carry its own polymorphic + app loaders; see the matching
+        # comment in api/routers/access_requests.py.
+        selectinload(AccessRequest.active_requested_group).options(
+            selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
+            joinedload(AppGroup.app),
+        ),
         joinedload(AccessRequest.resolver),
         joinedload(AccessRequest.active_resolver),
     )
 
 
 def _access_request_summary_load_options() -> tuple:
-    return (
+    # The polymorphic + AppGroup.app loaders must be nested under each group
+    # relationship - applied at the top level of a select(AccessRequest) they
+    # target the wrong entity and never run.
+    group_load_options = (
         selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
+        joinedload(AppGroup.app),
+    )
+    return (
         joinedload(AccessRequest.requester),
         joinedload(AccessRequest.active_requester),
-        selectinload(AccessRequest.requested_group),
-        selectinload(AccessRequest.active_requested_group),
+        selectinload(AccessRequest.requested_group).options(*group_load_options),
+        selectinload(AccessRequest.active_requested_group).options(*group_load_options),
         joinedload(AccessRequest.resolver),
         joinedload(AccessRequest.active_resolver),
     )

--- a/api/models/core_models.py
+++ b/api/models/core_models.py
@@ -441,16 +441,13 @@ class OktaGroup(Base):
         back_populates="group",
         lazy="raise_on_sql",
     )
-    # SQLAlchemy doesn't seem to support loading
-    # group.active_role_associated_group_[member|owner]_mappings.active_group when a group_id or user_id is specified
-    # in GET /api/audit/users so we have to enable "select" lazy loading.
     active_group_tags: Mapped[List["OktaGroupTagMap"]] = relationship(
         "OktaGroupTagMap",
         primaryjoin="and_(OktaGroup.id == OktaGroupTagMap.group_id, "
         "or_(OktaGroupTagMap.ended_at.is_(None), OktaGroupTagMap.ended_at > func.now()))",
         back_populates="active_group",
         viewonly=True,
-        lazy="select",
+        lazy="raise_on_sql",
     )
 
     __mapper_args__ = {
@@ -516,10 +513,7 @@ class RoleGroupMap(Base):
         back_populates="active_role_mappings",
         foreign_keys=[group_id],
         viewonly=True,
-        # SQLAlchemy doesn't seem to support loading
-        # group.active_role_associated_group_[member|owner]_mappings.active_group when a group_id or user_id is specified
-        # in GET /api/audit/users so we have to enable "select" lazy loading.
-        lazy="select",
+        lazy="raise_on_sql",
         innerjoin=True,
     )
 
@@ -620,10 +614,7 @@ class AppGroup(OktaGroup):
     # group to administer and manage membership of the app owner group
     is_owner: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=expression.false(), default=False)
 
-    # SQLAlchemy doesn't seem to support loading
-    # group.active_role_associated_group_[member|owner]_mappings.active_group when a group_id or user_id is specified
-    # in GET /api/audit/users so we have to enable "select" lazy loading.
-    app: Mapped["App"] = relationship("App", back_populates="app_groups", lazy="select")
+    app: Mapped["App"] = relationship("App", back_populates="app_groups", lazy="raise_on_sql")
 
     __mapper_args__ = {
         "polymorphic_identity": "app_group",
@@ -1142,15 +1133,12 @@ class OktaGroupTagMap(Base):
         foreign_keys=[tag_id],
         lazy="raise_on_sql",
     )
-    # SQLAlchemy doesn't seem to support loading
-    # group.active_role_associated_group_[member|owner]_mappings.active_group when a group_id or user_id is specified
-    # in GET /api/audit/users so we have to enable "select" lazy loading.
     active_tag: Mapped[Tag] = relationship(
         "Tag",
         primaryjoin="and_(Tag.id == OktaGroupTagMap.tag_id, " "Tag.deleted_at.is_(None))",
         back_populates="active_group_tags",
         viewonly=True,
-        lazy="select",
+        lazy="raise_on_sql",
         innerjoin=True,
     )
     enabled_active_tag: Mapped[Tag] = relationship(
@@ -1181,9 +1169,6 @@ class OktaGroupTagMap(Base):
         foreign_keys=[app_tag_map_id],
         lazy="raise_on_sql",
     )
-    # SQLAlchemy doesn't seem to support loading
-    # group.active_role_associated_group_[member|owner]_mappings.active_group when a group_id or user_id is specified
-    # in GET /api/audit/users so we have to enable "select" lazy loading.
     active_app_tag_mapping: Mapped["AppTagMap"] = relationship(
         "AppTagMap",
         primaryjoin="and_(AppTagMap.id == OktaGroupTagMap.app_tag_map_id, "
@@ -1191,7 +1176,7 @@ class OktaGroupTagMap(Base):
         back_populates="active_group_tag_mappings",
         foreign_keys=[app_tag_map_id],
         viewonly=True,
-        lazy="select",
+        lazy="raise_on_sql",
     )
 
 

--- a/api/operations/modify_group_users.py
+++ b/api/operations/modify_group_users.py
@@ -325,7 +325,15 @@ class ModifyGroupUsers:
             if type(self.group) is RoleGroup:
                 role_associated_groups_mappings = db.session.scalars(
                     select(RoleGroupMap)
-                    .options(joinedload(RoleGroupMap.active_group))
+                    # Eager-load `active_group` with its polymorphic subtype and
+                    # `AppGroup.app` so the app-group-lifecycle hook path below can
+                    # read `associated_group.app` without tripping raise_on_sql.
+                    .options(
+                        selectinload(RoleGroupMap.active_group).options(
+                            selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
+                            joinedload(AppGroup.app),
+                        )
+                    )
                     .join(RoleGroupMap.active_group)
                     .where(OktaGroup.is_managed.is_(True))
                     .where(
@@ -515,7 +523,15 @@ class ModifyGroupUsers:
             if type(self.group) is RoleGroup:
                 role_associated_groups_mappings = db.session.scalars(
                     select(RoleGroupMap)
-                    .options(joinedload(RoleGroupMap.active_group))
+                    # Eager-load `active_group` with its polymorphic subtype and
+                    # `AppGroup.app` so the app-group-lifecycle hook path below can
+                    # read `associated_group.app` without tripping raise_on_sql.
+                    .options(
+                        selectinload(RoleGroupMap.active_group).options(
+                            selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
+                            joinedload(AppGroup.app),
+                        )
+                    )
                     .join(RoleGroupMap.active_group)
                     .where(OktaGroup.is_managed.is_(True))
                     .where(

--- a/api/operations/modify_role_groups.py
+++ b/api/operations/modify_role_groups.py
@@ -106,7 +106,12 @@ class ModifyRoleGroups:
         self.groups_to_remove = []
         if len(groups_to_remove) > 0:
             self.groups_to_remove = db.session.scalars(
-                select(OktaGroup).where(OktaGroup.id.in_(groups_to_remove)).where(OktaGroup.deleted_at.is_(None))
+                select(OktaGroup)
+                # `app` is eager-loaded so the app-group-lifecycle hook path below
+                # can read `group.app` without tripping `lazy="raise_on_sql"`.
+                .options(selectin_polymorphic(OktaGroup, [AppGroup]), joinedload(AppGroup.app))
+                .where(OktaGroup.id.in_(groups_to_remove))
+                .where(OktaGroup.deleted_at.is_(None))
             ).all()
 
         self.owner_groups_to_remove = []
@@ -249,6 +254,7 @@ class ModifyRoleGroups:
                 )
             ).all()
 
+            groups_to_remove_by_id = {group.id: group for group in self.groups_to_remove}
             for group_id in groups_to_remove_ids:
                 removed_members_with_other_access_ids = [
                     m.user_id
@@ -261,7 +267,9 @@ class ModifyRoleGroups:
 
                 # Invoke app group lifecycle plugin hooks for removed members
                 if len(okta_members_to_remove_ids) > 0:
-                    group = db.session.get(OktaGroup, group_id)
+                    # Use the eager-loaded group (with `app`) rather than a bare
+                    # db.session.get, so the hook path can read `group.app`.
+                    group = groups_to_remove_by_id[group_id]
                     plugin_id = get_app_group_lifecycle_plugin_to_invoke(group)
                     if plugin_id is not None:
                         members_losing_access = db.session.scalars(

--- a/api/operations/modify_role_groups.py
+++ b/api/operations/modify_role_groups.py
@@ -6,12 +6,13 @@ import logging
 
 from sqlalchemy import func, or_, select, update
 from api.context import get_request_context
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload
 
 from api.extensions import db
 from api.models import (
     AccessRequest,
     AccessRequestStatus,
+    AppGroup,
     OktaGroup,
     OktaGroupTagMap,
     OktaUser,
@@ -59,7 +60,11 @@ class ModifyRoleGroups:
         if len(groups_to_add) > 0:
             self.groups_to_add = db.session.scalars(
                 select(OktaGroup)
-                .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
+                .options(
+                    selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
+                    selectin_polymorphic(OktaGroup, [AppGroup]),
+                    joinedload(AppGroup.app),
+                )
                 .where(OktaGroup.id.in_(groups_to_add))
                 .where(OktaGroup.is_managed.is_(True))
                 .where(OktaGroup.deleted_at.is_(None))
@@ -380,6 +385,7 @@ class ModifyRoleGroups:
                 .where(OktaUserGroupMember.group_id == self.role.id)
                 .where(OktaUserGroupMember.is_owner.is_(False))
             ).all()
+            groups_added_by_id = {group.id: group for group in self.groups_to_add}
             group_memberships_added: Dict[str, Dict[str, OktaUserGroupMember]] = {}
             for role_associated_group_map in role_memberships_added.values():
                 group_memberships_added[role_associated_group_map.group_id] = role_associated_membership_added = {}
@@ -399,7 +405,7 @@ class ModifyRoleGroups:
 
                 # Invoke app group lifecycle plugin hooks for added members
                 if len(members_gaining_access_ids) > 0:
-                    group = role_associated_group_map.active_group
+                    group = groups_added_by_id[role_associated_group_map.group_id]
                     plugin_id = get_app_group_lifecycle_plugin_to_invoke(group)
                     if plugin_id is not None:
                         members_gaining_access = db.session.scalars(

--- a/api/routers/access_requests.py
+++ b/api/routers/access_requests.py
@@ -253,6 +253,9 @@ def post_access_request(
         # Belt and suspenders — `is_managed` is the only path that returns
         # None today, but covering the contract guards against drift.
         raise HTTPException(400, "Access request could not be created")
+    # Drop cached ORM state so the response reflects what the operation
+    # committed (expire_on_commit=False keeps pre-operation state otherwise).
+    db.expire_all()
     refreshed = db.scalars(
         select(AccessRequest).options(*_summary_load_options()).where(AccessRequest.id == ar.id)
     ).first()
@@ -313,6 +316,9 @@ def put_access_request(
             notify_requester=ar.requester_user_id != current_user_id,
             current_user_id=current_user_id,
         ).execute()
+    # Drop cached ORM state so the response reflects what the operation
+    # committed (expire_on_commit=False keeps pre-operation state otherwise).
+    db.expire_all()
     refreshed = db.scalars(
         select(AccessRequest).options(*_summary_load_options()).where(AccessRequest.id == access_request_id)
     ).first()

--- a/api/routers/access_requests.py
+++ b/api/routers/access_requests.py
@@ -72,13 +72,20 @@ def _detail_load_options() -> tuple:
 def _summary_load_options() -> tuple:
     """Slim eager-loads for list / POST / PUT (`AccessRequestSummary`).
     Skips the per-type tag and role-association loaders the summary shape
-    doesn't expose."""
-    return (
+    doesn't expose. The polymorphic + `AppGroup.app` loaders must be nested
+    under each group relationship — applied at the top level of a
+    `select(AccessRequest)` they target the wrong entity and never run,
+    leaving `AppGroup.app` unloaded so the `requested_group` app ref raises
+    `lazy="raise_on_sql"` at serialization time."""
+    group_load_options = (
         selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
+        joinedload(AppGroup.app),
+    )
+    return (
         joinedload(AccessRequest.requester),
         joinedload(AccessRequest.active_requester),
-        selectinload(AccessRequest.requested_group),
-        selectinload(AccessRequest.active_requested_group),
+        selectinload(AccessRequest.requested_group).options(*group_load_options),
+        selectinload(AccessRequest.active_requested_group).options(*group_load_options),
         joinedload(AccessRequest.resolver),
         joinedload(AccessRequest.active_resolver),
     )

--- a/api/routers/access_requests.py
+++ b/api/routers/access_requests.py
@@ -55,7 +55,15 @@ def _detail_load_options() -> tuple:
         joinedload(AccessRequest.requester),
         joinedload(AccessRequest.active_requester),
         requested_group_load,
-        selectinload(AccessRequest.active_requested_group),
+        # `active_requested_group` resolves to the same row as
+        # `requested_group`, but it must carry its own polymorphic + app
+        # loaders: relying on the sibling loader to warm the identity map is
+        # ordering-dependent (loader paths are applied in unordered-dict
+        # order) and leaves `AppGroup.app` unloaded when this one runs first.
+        selectinload(AccessRequest.active_requested_group).options(
+            selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
+            joinedload(AppGroup.app),
+        ),
         joinedload(AccessRequest.resolver),
         joinedload(AccessRequest.active_resolver),
     )

--- a/api/routers/apps.py
+++ b/api/routers/apps.py
@@ -175,6 +175,9 @@ def post_app(
         tags=body.tags_to_add or [],
         current_user_id=current_user_id,
     ).execute()
+    # Drop cached ORM state so the response reflects what the operation
+    # committed (expire_on_commit=False keeps pre-operation state otherwise).
+    db.expire_all()
     refreshed = db.scalars(select(App).options(*APP_LOAD_OPTIONS).where(App.id == created.id)).first()
     return AppDetail.model_validate(refreshed, from_attributes=True)
 
@@ -257,6 +260,9 @@ def put_app(
                 tags_to_remove=tags_to_remove,
                 current_user_id=current_user_id,
             ).execute()
+            # Drop cached ORM state so the response reflects what the operation
+            # committed (expire_on_commit=False keeps pre-operation state otherwise).
+            db.expire_all()
             refreshed = db.scalars(select(App).options(*APP_LOAD_OPTIONS).where(App.id == app_obj.id)).first()
             return AppDetail.model_validate(refreshed, from_attributes=True)
         raise HTTPException(400, "Only tags can be modified for the Access application")
@@ -301,6 +307,9 @@ def put_app(
         current_user_id=current_user_id,
     ).execute()
 
+    # Drop cached ORM state so the response reflects what the operation
+    # committed (expire_on_commit=False keeps pre-operation state otherwise).
+    db.expire_all()
     refreshed = db.scalars(select(App).options(*APP_LOAD_OPTIONS).where(App.id == app_obj.id)).first()
 
     # Audit logging — both name renames and plugin assignment/configuration

--- a/api/routers/audit.py
+++ b/api/routers/audit.py
@@ -179,12 +179,12 @@ def _group_ref_for_audit(g: Any, include_role_associations: bool) -> _GroupRefFo
         o_raw = getattr(g, "active_role_associated_group_owner_mappings", None) or []
         member_mappings = [r for r in (_role_associated_mapping_for_audit(rgm) for rgm in m_raw) if r is not None]
         owner_mappings = [r for r in (_role_associated_mapping_for_audit(rgm) for rgm in o_raw) if r is not None]
-    # `active_group_tags` is `lazy="select"`. Reading it on an unwarmed instance
-    # would fire one SELECT per row. Only emit the tag rows when the relationship
-    # has been eager-loaded; otherwise leave the list empty. The OktaGroupTagMap
-    # rows back-reference the parent group (a self-loop) and the AppTagMap rows
-    # carry `lazy="raise_on_sql"` relationships that aren't warmed in this scope,
-    # so build both models by hand and skip the fields that would touch them.
+    # `active_group_tags` is `lazy="raise_on_sql"`. Only emit the tag rows when
+    # the relationship has been eager-loaded; otherwise leave the list empty.
+    # The OktaGroupTagMap rows back-reference the parent group (a self-loop)
+    # and the AppTagMap rows carry `lazy="raise_on_sql"` relationships that
+    # aren't warmed in this scope, so build both models by hand and skip the
+    # fields that would touch them.
     state = sa_inspect(g)
     active_group_tags: list[OktaGroupTagMapDetail] = []
     if state is not None and "active_group_tags" not in state.unloaded:

--- a/api/routers/group_requests.py
+++ b/api/routers/group_requests.py
@@ -217,6 +217,9 @@ def post_group_request(
     ).execute()
     if gr is None:
         raise HTTPException(400, "Failed to create group request")
+    # Drop cached ORM state so the response reflects what the operation
+    # committed (expire_on_commit=False keeps pre-operation state otherwise).
+    db.expire_all()
     refreshed = db.scalars(select(GroupRequest).options(*_load_options()).where(GroupRequest.id == gr.id)).first()
     return GroupRequestDetail.model_validate(refreshed, from_attributes=True)
 
@@ -293,6 +296,9 @@ def put_group_request(
             rejection_reason=resolution_reason,
             notify_requester=gr.requester_user_id != current_user_id,
         ).execute()
+    # Drop cached ORM state so the response reflects what the operation
+    # committed (expire_on_commit=False keeps pre-operation state otherwise).
+    db.expire_all()
     refreshed = db.scalars(
         select(GroupRequest).options(*_load_options()).where(GroupRequest.id == group_request_id)
     ).first()

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -90,6 +90,10 @@ _group_adapter: TypeAdapter[Any] = TypeAdapter(GroupDetail)
 
 
 def _load_group_with_options(db: DbSession, group_id: str) -> OktaGroup | None:
+    # Routes call this after operations mutate the group; with
+    # expire_on_commit=False the identity map would otherwise serve
+    # pre-operation relationship state, so drop cached ORM state first.
+    db.expire_all()
     return db.scalars(
         select(OktaGroup)
         .options(*DEFAULT_LOAD_OPTIONS)

--- a/api/routers/role_requests.py
+++ b/api/routers/role_requests.py
@@ -400,6 +400,9 @@ def post_role_request(
         request_reason=body.reason or "",
         request_ending_at=body.ending_at,
     ).execute()
+    # Drop cached ORM state so the response reflects what the operation
+    # committed (expire_on_commit=False keeps pre-operation state otherwise).
+    db.expire_all()
     refreshed = db.scalars(select(RoleRequest).options(*_summary_load_options()).where(RoleRequest.id == rr.id)).first()
     return RoleRequestSummary.model_validate(refreshed or rr, from_attributes=True)
 
@@ -459,6 +462,9 @@ def put_role_request(
             rejection_reason=body.reason or "",
             notify_requester=rr.requester_user_id != current_user_id,
         ).execute()
+    # Drop cached ORM state so the response reflects what the operation
+    # committed (expire_on_commit=False keeps pre-operation state otherwise).
+    db.expire_all()
     refreshed = db.scalars(
         select(RoleRequest).options(*_summary_load_options()).where(RoleRequest.id == role_request_id)
     ).first()

--- a/api/routers/tags.py
+++ b/api/routers/tags.py
@@ -97,6 +97,9 @@ def post_tag(
         enabled=body.enabled,
     )
     created = CreateTag(tag=tag, current_user_id=current_user_id).execute()
+    # Drop cached ORM state so the response reflects what the operation
+    # committed (expire_on_commit=False keeps pre-operation state otherwise).
+    db.expire_all()
     refreshed = db.scalars(select(Tag).options(*_TAG_LOAD_OPTIONS).where(Tag.id == created.id)).first()
     return TagDetail.model_validate(refreshed or created, from_attributes=True)
 
@@ -161,6 +164,9 @@ def put_tag(
             tags=[pre_refresh.id],
         ).execute()
 
+    # Drop cached ORM state so the response reflects what the operation
+    # committed (expire_on_commit=False keeps pre-operation state otherwise).
+    db.expire_all()
     refreshed = db.scalars(select(Tag).options(*_TAG_LOAD_OPTIONS).where(Tag.id == tag.id)).first()
 
     email = getattr(db.get(OktaUser, current_user_id), "email", None) if current_user_id else None

--- a/tests/test_access_request.py
+++ b/tests/test_access_request.py
@@ -1027,6 +1027,9 @@ def test_get_access_request_detail_requested_group_for_role_group(
     ).execute()
     assert ar is not None
 
+    # drop identity-map state staled by the ops above (expire_on_commit=False)
+    db.session.expire_all()
+
     rep = client.get(url_for("api-access-requests.access_request_by_id", access_request_id=ar.id))
     assert rep.status_code == 200, rep.text
     data = rep.json()

--- a/tests/test_app_group_lifecycle_plugin.py
+++ b/tests/test_app_group_lifecycle_plugin.py
@@ -1486,6 +1486,62 @@ class TestPluginMembershipHooks:
         assert len(test_plugin.members_removed_calls) == 1
         assert test_plugin.members_removed_calls[0] == (test_group.id, [user.id])
 
+    def test_role_associated_lifecycle_hooks_survive_cold_session(
+        self, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture
+    ) -> None:
+        """Regression for the AppGroup.app raise_on_sql flip: the role-associated
+        lifecycle paths read `group.app` via get_app_group_lifecycle_plugin_to_invoke,
+        so the operation's own query must eager-load `active_group` + `AppGroup.app`.
+        Warm-session tests miss a missing eager-load because `app` is many-to-one
+        and resolves from the identity map without SQL; each membership change here
+        runs after `expunge_all()` to force the cold load a production request sees.
+        Covers modify_group_users add/remove cascades and the modify_role_groups
+        group-removal cascade.
+        """
+        from api.operations import ModifyGroupUsers, ModifyRoleGroups
+
+        test_app = AppFactory.build(
+            name="TestApp_ColdSession",
+            app_group_lifecycle_plugin=DummyPlugin.ID,
+            plugin_data={DummyPlugin.ID: {"configuration": {"enabled": True}}},
+        )
+        test_group = AppGroupFactory.build(
+            app_id=test_app.id,
+            is_managed=True,
+            name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{test_app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}ColdGroup",
+            plugin_data={DummyPlugin.ID: {"configuration": {"group_id": "external_cold"}}},
+        )
+        role_group = RoleGroupFactory.build(name="TestRoleCold", is_managed=True)
+        user = OktaUserFactory.build()
+        db.session.add_all([test_app, test_group, role_group, user])
+        db.session.commit()
+
+        mocker.patch.object(okta, "async_add_user_to_group", return_value=None)
+        mocker.patch.object(okta, "async_remove_user_from_group", return_value=None)
+
+        ModifyRoleGroups(role_group=role_group, groups_to_add=[test_group.id], sync_to_okta=False).execute()
+
+        # Add a member to the role on a cold session -> modify_group_users add
+        # cascade reads associated_group.app.
+        db.session.expunge_all()
+        test_plugin.members_added_calls.clear()
+        ModifyGroupUsers(group=role_group.id, members_to_add=[user.id], sync_to_okta=False).execute()
+        assert test_plugin.members_added_calls == [(test_group.id, [user.id])]
+
+        # Remove the member on a cold session -> modify_group_users remove cascade.
+        db.session.expunge_all()
+        test_plugin.members_removed_calls.clear()
+        ModifyGroupUsers(group=role_group.id, members_to_remove=[user.id], sync_to_okta=False).execute()
+        assert test_plugin.members_removed_calls == [(test_group.id, [user.id])]
+
+        # Re-add the member, then remove the *group* from the role on a cold
+        # session -> modify_role_groups groups_to_remove cascade reads group.app.
+        ModifyGroupUsers(group=role_group.id, members_to_add=[user.id], sync_to_okta=False).execute()
+        db.session.expunge_all()
+        test_plugin.members_removed_calls.clear()
+        ModifyRoleGroups(role_group=role_group.id, groups_to_remove=[test_group.id], sync_to_okta=False).execute()
+        assert test_plugin.members_removed_calls == [(test_group.id, [user.id])]
+
     def test_role_member_removed_but_has_redundant_access_via_another_role(
         self, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture
     ) -> None:

--- a/tests/test_approve_reject_stale_state.py
+++ b/tests/test_approve_reject_stale_state.py
@@ -224,6 +224,9 @@ def test_stale_resolution_then_approve_conflicts_without_granting(
     )
     db.session.commit()
 
+    # drop identity-map state staled by the ops above (expire_on_commit=False)
+    db.session.expire_all()
+
     with pytest.raises(AccessException) as exc:
         op.execute()
     assert exc.value.status_code == 409

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -587,6 +587,9 @@ def test_users_audit_includes_role_associated_group_mappings_when_unfiltered(
     ModifyRoleGroups(role_group=role, groups_to_add=[associated.id], sync_to_okta=False).execute()
     ModifyGroupUsers(group=role, members_to_add=[user.id], sync_to_okta=False).execute()
 
+    # drop identity-map state staled by the ops above (expire_on_commit=False)
+    db.session.expire_all()
+
     rep = client.get(url_for("api-audit.users_and_groups"))
     assert rep.status_code == 200, rep.text
     rows = rep.json()["items"]

--- a/tests/test_disallow_self_add_constraint.py
+++ b/tests/test_disallow_self_add_constraint.py
@@ -96,6 +96,9 @@ def test_disallow_self_add_modify_group_users(
     add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
     remove_owner_from_group_spy = mocker.patch.object(okta, "async_remove_owner_from_group")
 
+    # drop identity-map state staled by the ops above (expire_on_commit=False)
+    db.session.expire_all()
+
     # Add non-admin current_user as the owner of okta_group
     ModifyGroupUsers(group=okta_group, owners_to_add=[current_user.id], sync_to_okta=False).execute()
 

--- a/tests/test_polymorphic_loader_coverage.py
+++ b/tests/test_polymorphic_loader_coverage.py
@@ -1,0 +1,276 @@
+"""Regression battery for the production lazy-load errors that motivated
+demoting five relationships to ``lazy="select"``.
+
+Under the original ``raise_on_sql`` regime, production raised
+``InvalidRequestError: ... is not available due to lazy='raise_on_sql'`` for
+``RoleGroup.active_role_associated_group_member_mappings``,
+``RoleGroupMap.active_group``, ``AppGroup.app``, and
+``OktaGroup.active_group_tags`` — yet the errors never reproduced in tests.
+The reason: ``raise_on_sql`` raises identically under test, so the only
+production-only ingredient was DATA SHAPE. The failing serializations needed
+polymorphic subtypes in nested positions (a role group whose associated groups
+are app groups, tagged groups inside request refs, app groups inside
+membership rows) that the suite never built. Now that the five relationships
+are back on ``raise_on_sql``, this battery builds the production shape once
+and walks every read surface: any eager-load gap fails deterministically here
+instead of as a paged 500.
+
+The error chain maps onto the schema nesting: a role group in a rich position
+serializes its associated-group mappings, each mapping serializes its
+``active_group``, an app-group ``active_group`` serializes its ``app``, and
+every rich group ref serializes ``active_group_tags``.
+"""
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.extensions import Db
+from api.models import OktaGroupTagMap
+from api.operations import (
+    CreateAccessRequest,
+    CreateRoleRequest,
+    ModifyGroupUsers,
+    ModifyRoleGroups,
+)
+from tests.factories import (
+    AppFactory,
+    AppGroupFactory,
+    OktaGroupFactory,
+    OktaUserFactory,
+    RoleGroupFactory,
+    TagFactory,
+)
+
+
+@pytest.fixture
+def production_shape(db: Db) -> dict[str, Any]:
+    """Build the data shape from the production error reports.
+
+    A tagged role group with member+owner associations to a tagged app group
+    and a tagged plain group; a user holding direct and via-role access; a
+    pending access request targeting the ROLE group (the rich detail ref that
+    serializes the role's associated-group mappings); another targeting the
+    app group; and a role request from the role to the app group.
+    """
+    user = OktaUserFactory.build()
+    requester = OktaUserFactory.build()
+    app = AppFactory.build()
+    app_group = AppGroupFactory.build(app_id=app.id, name=f"App-{app.name}-Eng")
+    okta_group = OktaGroupFactory.build()
+    role_group = RoleGroupFactory.build()
+    tags = [TagFactory.build(constraints={}) for _ in range(3)]
+
+    db.session.add_all([user, requester, app, app_group, okta_group, role_group, *tags])
+    db.session.commit()
+    db.session.add_all(
+        [
+            OktaGroupTagMap(tag_id=tags[0].id, group_id=app_group.id),
+            OktaGroupTagMap(tag_id=tags[1].id, group_id=okta_group.id),
+            OktaGroupTagMap(tag_id=tags[2].id, group_id=role_group.id),
+        ]
+    )
+    db.session.commit()
+
+    # Role memberships first, then associate the role to both groups as
+    # member AND owner so `active_role_associated_group_*_mappings` rows
+    # exist with polymorphic `active_group` targets (AppGroup + OktaGroup).
+    ModifyGroupUsers(
+        group=role_group.id, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    ModifyGroupUsers(
+        group=okta_group.id, members_to_add=[requester.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    ModifyRoleGroups(
+        role_group=role_group.id,
+        groups_to_add=[app_group.id, okta_group.id],
+        owner_groups_to_add=[app_group.id],
+        sync_to_okta=False,
+    ).execute()
+
+    # Pending access request targeting the ROLE group: the detail ref
+    # serializes the role's associated-group mappings, and through them each
+    # mapping's active_group and its app.
+    request_role_target = CreateAccessRequest(
+        requester_user=requester, requested_group=role_group, request_reason="role target"
+    ).execute()
+    request_app_target = CreateAccessRequest(
+        requester_user=requester, requested_group=app_group, request_reason="app target"
+    ).execute()
+    role_request = CreateRoleRequest(
+        requester_user=user,
+        requester_role=role_group,
+        requested_group=app_group,
+        request_ownership=False,
+        request_reason="role to app",
+    ).execute()
+
+    shape = {
+        "user": user.id,
+        "requester": requester.id,
+        "app": app.id,
+        "app_group": app_group.id,
+        "okta_group": okta_group.id,
+        "role_group": role_group.id,
+        "tag": tags[0].id,
+        "access_request_role_target": request_role_target.id,
+        "access_request_app_target": request_app_target.id,
+        "role_request": role_request.id,
+    }
+    # Drop identity-map state staled by the ops above (expire_on_commit=False)
+    # so the routes under test load everything through their own loaders.
+    db.session.expire_all()
+    return shape
+
+
+def _get_ok(client: TestClient, url: str) -> Any:
+    rep = client.get(url)
+    assert rep.status_code == 200, f"{url} -> {rep.status_code}: {rep.text[:500]}"
+    return rep.json()
+
+
+def test_group_list_serializes_role_associations_and_apps(
+    app: FastAPI, client: TestClient, db: Db, production_shape: dict[str, Any], url_for: Any
+) -> None:
+    data = _get_ok(client, url_for("api-groups.groups"))
+    by_id = {g["id"]: g for g in data["items"]}
+    role = by_id[production_shape["role_group"]]
+    # the role row exposes its associated-group mappings…
+    assert role["active_role_associated_group_member_mappings"]
+    # …each mapping exposes its active_group…
+    actives = [m["active_group"] for m in role["active_role_associated_group_member_mappings"]]
+    assert all(a is not None for a in actives)
+    # …and the app-group one exposes its app.
+    app_refs = [a for a in actives if a["type"] == "app_group"]
+    assert app_refs and all(a["app"] is not None for a in app_refs)
+    # tags serialize on every row type.
+    assert by_id[production_shape["okta_group"]]["active_group_tags"]
+    assert by_id[production_shape["app_group"]]["active_group_tags"]
+    assert role["active_group_tags"]
+
+
+@pytest.mark.parametrize("key", ["role_group", "app_group", "okta_group"])
+def test_group_detail_for_each_type(
+    app: FastAPI, client: TestClient, db: Db, production_shape: dict[str, Any], url_for: Any, key: str
+) -> None:
+    data = _get_ok(client, url_for("api-groups.group_by_id", group_id=production_shape[key]))
+    assert data["active_group_tags"]
+    if key == "role_group":
+        mappings = data["active_role_associated_group_member_mappings"]
+        assert mappings
+        app_actives = [m["active_group"] for m in mappings if m["active_group"]["type"] == "app_group"]
+        assert app_actives and all(a["app"] is not None for a in app_actives)
+    if key == "app_group":
+        assert data["app"] is not None
+
+
+def test_role_routes(app: FastAPI, client: TestClient, db: Db, production_shape: dict[str, Any], url_for: Any) -> None:
+    _get_ok(client, url_for("api-roles.roles"))
+    detail = _get_ok(client, url_for("api-roles.role_by_id", role_id=production_shape["role_group"]))
+    mappings = detail["active_role_associated_group_member_mappings"]
+    assert mappings
+    assert any(m["active_group"]["type"] == "app_group" and m["active_group"]["app"] for m in mappings)
+    _get_ok(client, url_for("api-roles.role_members_by_id", role_id=production_shape["role_group"]))
+
+
+def test_user_routes_with_via_role_app_group_memberships(
+    app: FastAPI, client: TestClient, db: Db, production_shape: dict[str, Any], url_for: Any
+) -> None:
+    _get_ok(client, url_for("api-users.users"))
+    data = _get_ok(client, url_for("api-users.user_by_id", user_id=production_shape["user"]))
+    groups = [m["active_group"] for m in data["active_group_memberships"] if m.get("active_group")]
+    app_groups = [g for g in groups if g["type"] == "app_group"]
+    # via-role membership rows reach app groups; their `app` ref must be loaded
+    assert app_groups and all(g["app"] is not None for g in app_groups)
+
+
+def test_access_request_detail_role_group_target(
+    app: FastAPI, client: TestClient, db: Db, production_shape: dict[str, Any], url_for: Any
+) -> None:
+    data = _get_ok(
+        client,
+        url_for(
+            "api-access-requests.access_request_by_id",
+            access_request_id=production_shape["access_request_role_target"],
+        ),
+    )
+    rg = data["requested_group"]
+    assert rg["type"] == "role_group"
+    assert rg["active_group_tags"]
+    mappings = rg["active_role_associated_group_member_mappings"]
+    assert mappings
+    app_actives = [
+        m["active_group"] for m in mappings if m["active_group"] and m["active_group"]["type"] == "app_group"
+    ]
+    assert app_actives and all(a["app"] is not None for a in app_actives)
+
+
+def test_access_request_detail_app_group_target_and_lists(
+    app: FastAPI, client: TestClient, db: Db, production_shape: dict[str, Any], url_for: Any
+) -> None:
+    data = _get_ok(
+        client,
+        url_for(
+            "api-access-requests.access_request_by_id",
+            access_request_id=production_shape["access_request_app_target"],
+        ),
+    )
+    assert data["requested_group"]["type"] == "app_group"
+    assert data["requested_group"]["app"] is not None
+    assert data["requested_group"]["active_group_tags"]
+    _get_ok(client, url_for("api-access-requests.access_requests"))
+
+
+def test_role_request_routes(
+    app: FastAPI, client: TestClient, db: Db, production_shape: dict[str, Any], url_for: Any
+) -> None:
+    _get_ok(client, url_for("api-role-requests.role_requests"))
+    data = _get_ok(
+        client, url_for("api-role-requests.role_request_by_id", role_request_id=production_shape["role_request"])
+    )
+    assert data["requested_group"]["type"] == "app_group"
+    assert data["requested_group"]["app"] is not None
+
+
+def test_tag_and_app_routes(
+    app: FastAPI, client: TestClient, db: Db, production_shape: dict[str, Any], url_for: Any
+) -> None:
+    _get_ok(client, url_for("api-tags.tags"))
+    tag_detail = _get_ok(client, url_for("api-tags.tag_by_id", tag_id=production_shape["tag"]))
+    # the tag is attached to the APP group: the nested active_group must carry its app
+    actives = [t["active_group"] for t in tag_detail["active_group_tags"] if t.get("active_group")]
+    assert any(g["type"] == "app_group" and g.get("app") for g in actives)
+    _get_ok(client, url_for("api-apps.apps"))
+    _get_ok(client, url_for("api-apps.app_by_id", app_id=production_shape["app"]))
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        "",  # unfiltered: emits role-associated mappings (the include_role_associations branch)
+        "user_id={user}",
+        "group_id={role_group}",
+        "group_id={app_group}",
+    ],
+)
+def test_audit_users_with_polymorphic_rows(
+    app: FastAPI, client: TestClient, db: Db, production_shape: dict[str, Any], url_for: Any, params: str
+) -> None:
+    # The user_id / group_id filters are the historical unloadable case that
+    # forced lazy="select" on these relationships.
+    url = url_for("api-audit.users_and_groups")
+    qs = params.format(**production_shape)
+    data = _get_ok(client, f"{url}?{qs}" if qs else url)
+    assert data["items"]
+
+
+@pytest.mark.parametrize("params", ["", "role_id={role_group}", "group_id={app_group}"])
+def test_audit_groups_with_polymorphic_rows(
+    app: FastAPI, client: TestClient, db: Db, production_shape: dict[str, Any], url_for: Any, params: str
+) -> None:
+    url = url_for("api-audit.groups_and_roles")
+    qs = params.format(**production_shape)
+    data = _get_ok(client, f"{url}?{qs}" if qs else url)
+    assert data["items"]

--- a/tests/test_polymorphic_loader_coverage.py
+++ b/tests/test_polymorphic_loader_coverage.py
@@ -28,7 +28,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from api.extensions import Db, db as _db
-from api.models import OktaGroupTagMap
+from api.models import AppTagMap, OktaGroupTagMap
 from api.operations import (
     CreateAccessRequest,
     CreateRoleRequest,
@@ -61,15 +61,24 @@ def production_shape(db: Db) -> dict[str, Any]:
     app_group = AppGroupFactory.build(app_id=app.id, name=f"App-{app.name}-Eng")
     okta_group = OktaGroupFactory.build()
     role_group = RoleGroupFactory.build()
-    tags = [TagFactory.build(constraints={}) for _ in range(3)]
+    tags = [TagFactory.build(constraints={}) for _ in range(4)]
 
     db.session.add_all([user, requester, app, app_group, okta_group, role_group, *tags])
+    db.session.commit()
+    # tags[3] is an app-level tag (AppTagMap) that propagates to the app group,
+    # so the app group's OktaGroupTagMap carries a non-None
+    # `active_app_tag_mapping` — the only way that relationship's non-None
+    # serialization path (-> AppTagMapDetail) gets exercised. tags[0..2] are
+    # direct group tags (active_app_tag_mapping is None).
+    app_tag_map = AppTagMap(tag_id=tags[3].id, app_id=app.id)
+    db.session.add(app_tag_map)
     db.session.commit()
     db.session.add_all(
         [
             OktaGroupTagMap(tag_id=tags[0].id, group_id=app_group.id),
             OktaGroupTagMap(tag_id=tags[1].id, group_id=okta_group.id),
             OktaGroupTagMap(tag_id=tags[2].id, group_id=role_group.id),
+            OktaGroupTagMap(tag_id=tags[3].id, group_id=app_group.id, app_tag_map_id=app_tag_map.id),
         ]
     )
     db.session.commit()
@@ -115,6 +124,7 @@ def production_shape(db: Db) -> dict[str, Any]:
         "okta_group": okta_group.id,
         "role_group": role_group.id,
         "tag": tags[0].id,
+        "app_propagated_tag": tags[3].id,
         "access_request_role_target": request_role_target.id,
         "access_request_app_target": request_app_target.id,
         "role_request": role_request.id,
@@ -175,6 +185,16 @@ def test_group_detail_for_each_type(
         assert app_actives and all(a["app"] is not None for a in app_actives)
     if key == "app_group":
         assert data["app"] is not None
+        # Reverse role-association: a role is associated to this app group, so its
+        # mappings serialize RoleGroupMap.active_group from the group side.
+        assert data["active_role_member_mappings"]
+        assert all(m["active_group"] is not None for m in data["active_role_member_mappings"])
+        # The app-propagated tag carries a non-None OktaGroupTagMap.active_app_tag_mapping
+        # (-> AppTagMapDetail); direct tags leave it None, so this is the only place
+        # that relationship's non-None serialization is exercised.
+        propagated = [t for t in data["active_group_tags"] if t.get("active_app_tag_mapping")]
+        assert propagated, "expected the app-propagated tag to serialize active_app_tag_mapping"
+        assert propagated[0]["active_app_tag_mapping"]["active_tag"] is not None
 
 
 def test_role_routes(app: FastAPI, client: TestClient, db: Db, production_shape: dict[str, Any], url_for: Any) -> None:
@@ -243,6 +263,8 @@ def test_role_request_routes(
     )
     assert data["requested_group"]["type"] == "app_group"
     assert data["requested_group"]["app"] is not None
+    # The role-request detail ref serializes OktaGroup.active_group_tags too.
+    assert data["requested_group"]["active_group_tags"]
 
 
 def test_tag_and_app_routes(

--- a/tests/test_polymorphic_loader_coverage.py
+++ b/tests/test_polymorphic_loader_coverage.py
@@ -27,7 +27,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from api.extensions import Db
+from api.extensions import Db, db as _db
 from api.models import OktaGroupTagMap
 from api.operations import (
     CreateAccessRequest,
@@ -119,13 +119,24 @@ def production_shape(db: Db) -> dict[str, Any]:
         "access_request_app_target": request_app_target.id,
         "role_request": role_request.id,
     }
-    # Drop identity-map state staled by the ops above (expire_on_commit=False)
-    # so the routes under test load everything through their own loaders.
-    db.session.expire_all()
+    # Evict every object the setup ops loaded. In tests the HTTP request reuses
+    # this same session, so a warm identity map can serve relationships the
+    # route's own loaders never eager-loaded — masking gaps that fail in
+    # production, where each request gets a cold session. `expunge_all` (not
+    # `expire_all`, which keeps objects in the map) forces the routes to load
+    # everything through their declared options, so a missing eager-load raises
+    # `lazy="raise_on_sql"` deterministically here instead of flaking in CI.
+    db.session.expunge_all()
     return shape
 
 
 def _get_ok(client: TestClient, url: str) -> Any:
+    # The TestClient shares this session, so a prior request (or fixture setup)
+    # can leave relationships warm in the identity map and mask a route whose
+    # own loaders never eager-loaded them. Production gives each request a cold
+    # session, so evict before every call: a missing eager-load then raises
+    # `lazy="raise_on_sql"` deterministically instead of flaking by test order.
+    _db.session.expunge_all()
     rep = client.get(url)
     assert rep.status_code == 200, f"{url} -> {rep.status_code}: {rep.text[:500]}"
     return rep.json()

--- a/tests/test_require_reason_constraint.py
+++ b/tests/test_require_reason_constraint.py
@@ -102,6 +102,9 @@ def test_require_reason_modify_group_users(
         == 1
     )
 
+    # drop identity-map state staled by the ops above (expire_on_commit=False)
+    db.session.expire_all()
+
     # Add the user to the okta group as member without a reason
     data: dict[str, Any] = {
         "members_to_add": [user.id],
@@ -1134,6 +1137,8 @@ def test_require_reason_approve_access_request(
         request_ownership=False,
         request_reason="test reason",
     ).execute()
+
+    db.session.expire_all()
 
     data = {"approved": True, "reason": ""}
 

--- a/tests/test_role_memberships_fix.py
+++ b/tests/test_role_memberships_fix.py
@@ -129,6 +129,9 @@ def test_missing_user_from_group_membership_with_expiring_role_assignment(
     db.session.add(owner_role_group_map)
     db.session.commit()
 
+    # drop identity-map state staled by the ops above (expire_on_commit=False)
+    db.session.expire_all()
+
     add_membership_spy = mocker.patch.object(okta, "add_user_to_group")
     add_ownership_spy = mocker.patch.object(okta, "add_owner_to_group")
 

--- a/tests/test_role_request.py
+++ b/tests/test_role_request.py
@@ -740,6 +740,9 @@ def test_role_request_approvers_tagged(
     db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
     db.session.commit()
 
+    # drop identity-map state staled by the ops above (expire_on_commit=False)
+    db.session.expire_all()
+
     hook = get_notification_hook()
     request_created_notification_spy = mocker.patch.object(hook, "access_role_request_created")
 
@@ -1197,6 +1200,8 @@ def test_owner_cant_add_self_constraint_tag(
 
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag.id))
     db.session.commit()
+
+    db.session.expire_all()
 
     hook = get_notification_hook()
     request_created_notification_spy = mocker.patch.object(hook, "access_role_request_created")


### PR DESCRIPTION
Part of the async-SQLAlchemy migration stack; now rebased directly on `main` (#475, #476 merged).

An `AsyncSession` raises `MissingGreenlet` on any implicit IO from attribute access, so both remaining sources of implicit IO go away before the flip:

1. **`expire_on_commit=False`** on the sessionmaker. Operations and the syncer keep using ORM objects across mid-flow commits; expired-attribute reloads would be implicit IO under async. Post-operation reload sites in routers/MCP now call `db.expire_all()` before re-querying so responses still reflect exactly what the operation committed (the identity map would otherwise serve pre-operation state).
2. **The five remaining `lazy="select"` relationships flip to `raise_on_sql`** (`OktaGroup.active_group_tags`, `RoleGroupMap.active_group`, `AppGroup.app`, `OktaGroupTagMap.active_tag`/`active_app_tag_mapping`). The audit-route eager topology already covers the nested role-associated-mapping paths the old "can't load this" comment claimed were unsupported; the one operation relying on lazy loading (the `group_members_added` hook path in `ModifyRoleGroups`) now uses its already-eager-loaded groups.

Tests gain explicit `db.session.expire_all()` at staleness points: tests share one session with the app under test (production requests each get a fresh scoped session), so the identity map keeps pre-operation state that `expire_on_commit=True` used to discard implicitly.

Full suite green (540 tests), ruff + mypy clean.

### Polymorphic loader regression battery

Also adds `tests/test_polymorphic_loader_coverage.py`: a regression battery for the production `InvalidRequestError ... lazy='raise_on_sql'` errors that originally motivated demoting these five relationships. Those errors never reproduced in tests because `raise_on_sql` raises identically under test — the missing ingredient was data shape (polymorphic subtypes in nested positions: role groups associated to app groups, tagged groups inside request refs). The battery builds that shape and walks every read surface, asserting the nested payloads are populated; all 17 scenarios pass. The suite-conversion commit in #480 carries its async form.

The battery caught a real loader gap that flaked in CI: the access-request **summary** loader (`_summary_load_options`, the `GET /api/requests` list shape) placed `selectin_polymorphic` at the top level of `select(AccessRequest)` — where it targets the wrong entity and never runs — and left `requested_group`/`active_requested_group` as bare `selectinload`s, so `AppGroup.app` was never eager-loaded and serializing an app-group requested_group raised. It's now nested under each group relationship, matching `_detail_load_options` and the MCP loaders. The battery had masked it because the TestClient shares the test session (a prior request warmed `AppGroup.app` in the identity map); `_get_ok` now `expunge_all()`s before every request so any missing eager-load fails deterministically here instead of flaking by hash-seed/GC order in CI.

## PR stack

Merge bottom-up; each PR is based on the branch of the one before it (retarget to `main` as predecessors merge).

1. ~~#475 — async dependency prep (SQLAlchemy[asyncio] 2.0.50, asyncpg, aiosqlite)~~ ✅ merged
2. ~~#476 — legacy Query API -> 2.0-style statements (~350 sites)~~ ✅ merged
3. #477 — eliminate lazy loading and commit-expiration from the ORM layer ⬅️ **this PR** (now on `main`)
4. #478 — operation DB resolution out of `__init__` into `_resolve()`
5. #479 — keep `db.session` access out of spawned notification tasks
6. #480 — **the async flip** (production + tests + docs)
7. #481 — surface failed Okta/notification fan-out tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
