### PR TITLE
[async 4/7] refactor: resolve operation DB lookups as locals in execute()

### DIFF
--- a/api/operations/approve_access_request.py
+++ b/api/operations/approve_access_request.py
@@ -27,6 +27,21 @@ class ApproveAccessRequest:
         ending_at: Optional[datetime] = None,
         notify: bool = True,
     ):
+        self._access_request_arg = access_request
+        self._approver_user_arg = approver_user
+
+        self.approval_reason = approval_reason
+
+        self.ending_at = ending_at
+
+        self.notify = notify
+
+        self.notification_hook = get_notification_hook()
+
+    def _resolve(self) -> None:
+        access_request = self._access_request_arg
+        approver_user = self._approver_user_arg
+
         # Lock the request row for the duration of the transaction so two
         # concurrent approvers can't both pass the pending-state guard below
         # and double-grant. `of=AccessRequest` keeps FOR UPDATE off the
@@ -50,15 +65,8 @@ class ApproveAccessRequest:
             self.approver_id = approver_user.id
             self.approver_email = approver_user.email
 
-        self.approval_reason = approval_reason
-
-        self.ending_at = ending_at
-
-        self.notify = notify
-
-        self.notification_hook = get_notification_hook()
-
     def execute(self) -> AccessRequest:
+        self._resolve()
         # Don't allow approving a request that is already resolved. Raise
         # rather than silently no-op so a stale/concurrent approval surfaces
         # as a conflict instead of looking like a success.

--- a/api/operations/approve_access_request.py
+++ b/api/operations/approve_access_request.py
@@ -38,8 +38,8 @@ class ApproveAccessRequest:
 
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
-        access_request = self._access_request_arg
+    def execute(self) -> AccessRequest:
+        access_request_arg = self._access_request_arg
         approver_user = self._approver_user_arg
 
         # Lock the request row for the duration of the transaction so two
@@ -47,55 +47,56 @@ class ApproveAccessRequest:
         # and double-grant. `of=AccessRequest` keeps FOR UPDATE off the
         # joinedload's nullable outer-join side (Postgres rejects that); it's
         # a no-op on SQLite.
-        self.access_request = db.session.scalars(
+        access_request = db.session.scalars(
             select(AccessRequest)
             .options(joinedload(AccessRequest.active_requested_group))
-            .where(AccessRequest.id == (access_request if isinstance(access_request, str) else access_request.id))
+            .where(
+                AccessRequest.id
+                == (access_request_arg if isinstance(access_request_arg, str) else access_request_arg.id)
+            )
             .with_for_update(of=AccessRequest)
         ).first()
 
         if approver_user is None:
-            self.approver_id = None
-            self.approver_email = None
+            approver_id = None
+            approver_email = None
         elif isinstance(approver_user, str):
             approver = db.session.get(OktaUser, approver_user)
-            self.approver_id = approver.id
-            self.approver_email = approver.email
+            approver_id = approver.id
+            approver_email = approver.email
         else:
-            self.approver_id = approver_user.id
-            self.approver_email = approver_user.email
+            approver_id = approver_user.id
+            approver_email = approver_user.email
 
-    def execute(self) -> AccessRequest:
-        self._resolve()
         # Don't allow approving a request that is already resolved. Raise
         # rather than silently no-op so a stale/concurrent approval surfaces
         # as a conflict instead of looking like a success.
-        if self.access_request.status != AccessRequestStatus.PENDING or self.access_request.resolved_at is not None:
+        if access_request.status != AccessRequestStatus.PENDING or access_request.resolved_at is not None:
             raise ConflictError("Access request is no longer pending")
 
         # Don't allow requester to approve their own request
-        if self.access_request.requester_user_id == self.approver_id:
-            return self.access_request
+        if access_request.requester_user_id == approver_id:
+            return access_request
 
         # Don't allow approving a request if the reason is invalid and required
         valid, _ = CheckForReason(
-            group=self.access_request.requested_group,
+            group=access_request.requested_group,
             reason=self.approval_reason,
-            members_to_add=[self.access_request.requester_user_id] if not self.access_request.request_ownership else [],
-            owners_to_add=[self.access_request.requester_user_id] if self.access_request.request_ownership else [],
+            members_to_add=[access_request.requester_user_id] if not access_request.request_ownership else [],
+            owners_to_add=[access_request.requester_user_id] if access_request.request_ownership else [],
         ).execute_for_group()
         if not valid:
-            return self.access_request
+            return access_request
 
         # Don't allow approving a request if the requester is deleted
-        requester = db.session.get(OktaUser, self.access_request.requester_user_id)
+        requester = db.session.get(OktaUser, access_request.requester_user_id)
         if requester is None or requester.deleted_at is not None:
             raise ResourceGoneError("The requester no longer exists")
 
         # Don't allow approving a request for a deleted or unmanaged group
-        if self.access_request.active_requested_group is None:
+        if access_request.active_requested_group is None:
             raise ResourceGoneError("The requested group no longer exists")
-        if not self.access_request.active_requested_group.is_managed:
+        if not access_request.active_requested_group.is_managed:
             raise InvalidRequestError("Groups not managed by Access cannot be modified")
 
         # Now handled inside ModifyGroupUsers
@@ -110,7 +111,7 @@ class ApproveAccessRequest:
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
             .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == self.access_request.requested_group_id)
+            .where(OktaGroup.id == access_request.requested_group_id)
         ).first()
 
         _ctx = get_request_context()
@@ -121,31 +122,31 @@ class ApproveAccessRequest:
                     "event_type": EventType.access_approve,
                     "user_agent": _ctx.user_agent if _ctx else None,
                     "ip": _ctx.ip if _ctx else None,
-                    "current_user_id": self.approver_id,
-                    "current_user_email": self.approver_email,
+                    "current_user_id": approver_id,
+                    "current_user_email": approver_email,
                     "group": group,
-                    "request": self.access_request,
-                    "requester": db.session.get(OktaUser, self.access_request.requester_user_id),
+                    "request": access_request,
+                    "requester": db.session.get(OktaUser, access_request.requester_user_id),
                 }
             )
         )
 
-        if self.access_request.request_ownership:
+        if access_request.request_ownership:
             ModifyGroupUsers(
-                group=self.access_request.requested_group_id,
-                current_user_id=self.approver_id,
+                group=access_request.requested_group_id,
+                current_user_id=approver_id,
                 users_added_ended_at=self.ending_at,
                 created_reason=self.approval_reason,
-                owners_to_add=[self.access_request.requester_user_id],
+                owners_to_add=[access_request.requester_user_id],
                 notify=self.notify,
             ).execute()
         else:
             ModifyGroupUsers(
-                group=self.access_request.requested_group_id,
-                current_user_id=self.approver_id,
+                group=access_request.requested_group_id,
+                current_user_id=approver_id,
                 users_added_ended_at=self.ending_at,
                 created_reason=self.approval_reason,
-                members_to_add=[self.access_request.requester_user_id],
+                members_to_add=[access_request.requester_user_id],
                 notify=self.notify,
             ).execute()
 
@@ -179,4 +180,4 @@ class ApproveAccessRequest:
         #     notify_requester=True,
         # )
 
-        return self.access_request
+        return access_request

--- a/api/operations/approve_access_request.py
+++ b/api/operations/approve_access_request.py
@@ -27,8 +27,10 @@ class ApproveAccessRequest:
         ending_at: Optional[datetime] = None,
         notify: bool = True,
     ):
-        self._access_request_arg = access_request
-        self._approver_user_arg = approver_user
+        self.access_request_id = access_request if isinstance(access_request, str) else access_request.id
+        self.approver_user_id = (
+            approver_user.id if approver_user is not None and not isinstance(approver_user, str) else approver_user
+        )
 
         self.approval_reason = approval_reason
 
@@ -39,9 +41,6 @@ class ApproveAccessRequest:
         self.notification_hook = get_notification_hook()
 
     def execute(self) -> AccessRequest:
-        access_request_arg = self._access_request_arg
-        approver_user = self._approver_user_arg
-
         # Lock the request row for the duration of the transaction so two
         # concurrent approvers can't both pass the pending-state guard below
         # and double-grant. `of=AccessRequest` keeps FOR UPDATE off the
@@ -50,23 +49,17 @@ class ApproveAccessRequest:
         access_request = db.session.scalars(
             select(AccessRequest)
             .options(joinedload(AccessRequest.active_requested_group))
-            .where(
-                AccessRequest.id
-                == (access_request_arg if isinstance(access_request_arg, str) else access_request_arg.id)
-            )
+            .where(AccessRequest.id == self.access_request_id)
             .with_for_update(of=AccessRequest)
         ).first()
 
-        if approver_user is None:
+        if self.approver_user_id is None:
             approver_id = None
             approver_email = None
-        elif isinstance(approver_user, str):
-            approver = db.session.get(OktaUser, approver_user)
+        else:
+            approver = db.session.get(OktaUser, self.approver_user_id)
             approver_id = approver.id
             approver_email = approver.email
-        else:
-            approver_id = approver_user.id
-            approver_email = approver_user.email
 
         # Don't allow approving a request that is already resolved. Raise
         # rather than silently no-op so a stale/concurrent approval surfaces

--- a/api/operations/approve_group_request.py
+++ b/api/operations/approve_group_request.py
@@ -47,92 +47,90 @@ class ApproveGroupRequest:
         self.bypass_self_approval = bypass_self_approval
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
-        group_request = self._group_request_arg
+    def execute(self) -> Optional[GroupRequest]:
+        group_request_arg = self._group_request_arg
         approver_user = self._approver_user_arg
 
         # Lock the request row for the transaction so concurrent approvers
         # can't both pass the pending-state guard and double-create the group.
         # `of=` keeps FOR UPDATE off the joinedload's nullable outer-join side
         # (Postgres rejects that); no-op on SQLite.
-        self.group_request = db.session.scalars(
+        group_request = db.session.scalars(
             select(GroupRequest)
             .options(joinedload(GroupRequest.active_requester))
-            .where(GroupRequest.id == (group_request if isinstance(group_request, str) else group_request.id))
+            .where(
+                GroupRequest.id == (group_request_arg if isinstance(group_request_arg, str) else group_request_arg.id)
+            )
             .with_for_update(of=GroupRequest)
         ).first()
 
-        self.approver_id: str | None = None
+        approver_id: str | None = None
         if approver_user is None:
-            self.approver_email = None
+            approver_email = None
         elif isinstance(approver_user, str):
             approver = db.session.get(OktaUser, approver_user)
-            self.approver_id = approver.id
-            self.approver_email = approver.email
+            approver_id = approver.id
+            approver_email = approver.email
         else:
-            self.approver_id = approver_user.id
-            self.approver_email = approver_user.email
+            approver_id = approver_user.id
+            approver_email = approver_user.email
 
-    def execute(self) -> Optional[GroupRequest]:
-        self._resolve()
         # Guard against missing group_request
-        if self.group_request is None:
+        if group_request is None:
             return None
 
         # Don't allow approving a request that is already resolved. Raise
         # rather than silently no-op so a stale/concurrent approval surfaces
         # as a conflict instead of looking like a success.
-        if self.group_request.status != AccessRequestStatus.PENDING or self.group_request.resolved_at is not None:
+        if group_request.status != AccessRequestStatus.PENDING or group_request.resolved_at is not None:
             raise ConflictError("Group request is no longer pending")
 
         # Don't allow requester to approve their own request
-        if self.group_request.requester_user_id == self.approver_id and not self.bypass_self_approval:
-            return self.group_request
+        if group_request.requester_user_id == approver_id and not self.bypass_self_approval:
+            return group_request
 
         # Don't allow approving a request if the requester is deleted. (Note:
         # a deleted requester usually can't even load above — active_requester
         # is an inner join filtering deleted_at — so this is a belt-and-braces
         # check that mirrors the historical no-op rather than a 4xx path.)
-        requester = db.session.get(OktaUser, self.group_request.requester_user_id)
+        requester = db.session.get(OktaUser, group_request.requester_user_id)
         if requester is None or requester.deleted_at is not None:
-            return self.group_request
+            return group_request
 
         # Resolve group fields: use resolved_* if set, otherwise fall back to requested_*
         resolved_name = (
-            self.group_request.resolved_group_name
-            if self.group_request.resolved_group_name
-            else self.group_request.requested_group_name
+            group_request.resolved_group_name
+            if group_request.resolved_group_name
+            else group_request.requested_group_name
         )
         resolved_description = (
-            self.group_request.resolved_group_description
-            if self.group_request.resolved_group_description
-            else self.group_request.requested_group_description
+            group_request.resolved_group_description
+            if group_request.resolved_group_description
+            else group_request.requested_group_description
         )
         resolved_type = (
-            self.group_request.resolved_group_type
-            if self.group_request.resolved_group_type
-            else self.group_request.requested_group_type
+            group_request.resolved_group_type
+            if group_request.resolved_group_type
+            else group_request.requested_group_type
         )
         resolved_app_id = (
-            self.group_request.resolved_app_id
-            if self.group_request.resolved_app_id
-            else self.group_request.requested_app_id
+            group_request.resolved_app_id if group_request.resolved_app_id else group_request.requested_app_id
         )
         resolved_tags = (
-            self.group_request.resolved_group_tags
-            if self.group_request.resolved_group_tags
-            else self.group_request.requested_group_tags
+            group_request.resolved_group_tags
+            if group_request.resolved_group_tags
+            else group_request.requested_group_tags
         )
 
         # authorization
         access_owner_ids = {u.id for u in get_access_owners()}
-        is_admin = self.approver_id in access_owner_ids
+        is_admin = approver_id in access_owner_ids
 
         if not is_admin:
-            type_changed = resolved_type != self.group_request.requested_group_type
-            app_changed = resolved_app_id != self.group_request.requested_app_id
+            type_changed = resolved_type != group_request.requested_group_type
+            app_changed = resolved_app_id != group_request.requested_app_id
             if type_changed or app_changed:
-                return self.group_request
+                return group_request
 
         if resolved_app_id is not None:
             # App group request: admins OR owners of that specific app can approve
@@ -144,29 +142,29 @@ class ApproveGroupRequest:
                         AppGroup.app_id == resolved_app_id,
                         AppGroup.is_owner.is_(True),
                         AppGroup.deleted_at.is_(None),
-                        OktaUserGroupMember.user_id == self.approver_id,
+                        OktaUserGroupMember.user_id == approver_id,
                         OktaUserGroupMember.is_owner.is_(True),
                         OktaUserGroupMember.ended_at.is_(None),
                     )
                 ).first()
 
                 if not is_app_owner:
-                    return self.group_request
+                    return group_request
         else:
             # okta_group / role_group request: only admins can approve
             if not is_admin:
-                return self.group_request
+                return group_request
 
         if resolved_type != "app_group" and resolved_name.startswith(AppGroup.APP_GROUP_NAME_PREFIX):
-            return self.group_request
+            return group_request
 
         if resolved_type != "role_group" and resolved_name.startswith(RoleGroup.ROLE_GROUP_NAME_PREFIX):
-            return self.group_request
+            return group_request
 
         if resolved_type == "app_group" and resolved_name.endswith(
             f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
         ):
-            return self.group_request
+            return group_request
 
         existing_group = db.session.scalars(
             select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
@@ -174,7 +172,7 @@ class ApproveGroupRequest:
             .where(OktaGroup.deleted_at.is_(None))
         ).first()
         if existing_group is not None:
-            return self.group_request
+            return group_request
 
         db.session.commit()
 
@@ -187,10 +185,10 @@ class ApproveGroupRequest:
                     "event_type": EventType.group_request_approve,
                     "user_agent": _ctx.user_agent if _ctx else None,
                     "ip": _ctx.ip if _ctx else None,
-                    "current_user_id": self.approver_id,
-                    "current_user_email": self.approver_email,
-                    "group_request": self.group_request,
-                    "requester": db.session.get(OktaUser, self.group_request.requester_user_id),
+                    "current_user_id": approver_id,
+                    "current_user_email": approver_email,
+                    "group_request": group_request,
+                    "requester": db.session.get(OktaUser, group_request.requester_user_id),
                 }
             )
         )
@@ -216,7 +214,7 @@ class ApproveGroupRequest:
         created_group: AppGroup | OktaGroup | RoleGroup = CreateGroup(
             group=new_group,
             tags=resolved_tags,
-            current_user_id=self.approver_id,
+            current_user_id=approver_id,
         ).execute()
 
         # Check tags on created group for ownership length constraints including propagated app tags
@@ -234,9 +232,9 @@ class ApproveGroupRequest:
 
         # Determine the initial ending time: prefer resolved, fall back to requested
         initial_ending_at = (
-            self.group_request.resolved_ownership_ending_at
-            if self.group_request.resolved_ownership_ending_at
-            else self.group_request.requested_ownership_ending_at
+            group_request.resolved_ownership_ending_at
+            if group_request.resolved_ownership_ending_at
+            else group_request.requested_ownership_ending_at
         )
 
         coalesced_ownership_ending_at = coalesce_ended_at(
@@ -247,43 +245,43 @@ class ApproveGroupRequest:
         )
 
         # Update the group request with the coalesced value to ensure consistency
-        self.group_request.resolved_ownership_ending_at = coalesced_ownership_ending_at
+        group_request.resolved_ownership_ending_at = coalesced_ownership_ending_at
 
         # Add the requester as an owner of the newly created group
         # If app owner auto approval, skip if group has owner add constraint (will inherit ownership via app)
         can_add_owner = True
-        if self.bypass_self_approval and self.approver_id is not None:
+        if self.bypass_self_approval and approver_id is not None:
             can_add_owner, _ = CheckForSelfAdd(
-                group=created_group_with_tags, current_user=self.approver_id, owners_to_add=[self.approver_id]
+                group=created_group_with_tags, current_user=approver_id, owners_to_add=[approver_id]
             ).execute_for_group()
 
         if can_add_owner:
             ModifyGroupUsers(
                 group=created_group_with_tags,
-                owners_to_add=[self.group_request.requester_user_id],
+                owners_to_add=[group_request.requester_user_id],
                 users_added_ended_at=coalesced_ownership_ending_at,
-                current_user_id=self.approver_id,
-                created_reason=f"Group request approved: {self.group_request.request_reason}",
+                current_user_id=approver_id,
+                created_reason=f"Group request approved: {group_request.request_reason}",
                 notify=self.notify,
             ).execute()
 
-        self.group_request.status = AccessRequestStatus.APPROVED
-        self.group_request.resolved_at = func.now()
-        self.group_request.resolver_user_id = self.approver_id
-        self.group_request.resolution_reason = self.approval_reason
-        self.group_request.approved_group_id = created_group.id
+        group_request.status = AccessRequestStatus.APPROVED
+        group_request.resolved_at = func.now()
+        group_request.resolver_user_id = approver_id
+        group_request.resolution_reason = self.approval_reason
+        group_request.approved_group_id = created_group.id
 
         db.session.commit()
 
         if self.notify:
-            requester = db.session.get(OktaUser, self.group_request.requester_user_id)
-            approvers = get_all_possible_request_approvers(self.group_request)
+            requester = db.session.get(OktaUser, group_request.requester_user_id)
+            approvers = get_all_possible_request_approvers(group_request)
             self.notification_hook.access_group_request_completed(
-                group_request=self.group_request,
+                group_request=group_request,
                 group=created_group,
                 requester=requester,
                 approvers=approvers,
                 notify_requester=True,
             )
 
-        return self.group_request
+        return group_request

--- a/api/operations/approve_group_request.py
+++ b/api/operations/approve_group_request.py
@@ -39,8 +39,10 @@ class ApproveGroupRequest:
         notify: bool = True,
         bypass_self_approval: bool = False,
     ):
-        self._group_request_arg = group_request
-        self._approver_user_arg = approver_user
+        self.group_request_id = group_request if isinstance(group_request, str) else group_request.id
+        self.approver_user_id = (
+            approver_user.id if approver_user is not None and not isinstance(approver_user, str) else approver_user
+        )
 
         self.approval_reason = approval_reason
         self.notify = notify
@@ -48,9 +50,6 @@ class ApproveGroupRequest:
         self.notification_hook = get_notification_hook()
 
     def execute(self) -> Optional[GroupRequest]:
-        group_request_arg = self._group_request_arg
-        approver_user = self._approver_user_arg
-
         # Lock the request row for the transaction so concurrent approvers
         # can't both pass the pending-state guard and double-create the group.
         # `of=` keeps FOR UPDATE off the joinedload's nullable outer-join side
@@ -58,22 +57,17 @@ class ApproveGroupRequest:
         group_request = db.session.scalars(
             select(GroupRequest)
             .options(joinedload(GroupRequest.active_requester))
-            .where(
-                GroupRequest.id == (group_request_arg if isinstance(group_request_arg, str) else group_request_arg.id)
-            )
+            .where(GroupRequest.id == self.group_request_id)
             .with_for_update(of=GroupRequest)
         ).first()
 
         approver_id: str | None = None
-        if approver_user is None:
+        if self.approver_user_id is None:
             approver_email = None
-        elif isinstance(approver_user, str):
-            approver = db.session.get(OktaUser, approver_user)
+        else:
+            approver = db.session.get(OktaUser, self.approver_user_id)
             approver_id = approver.id
             approver_email = approver.email
-        else:
-            approver_id = approver_user.id
-            approver_email = approver_user.email
 
         # Guard against missing group_request
         if group_request is None:

--- a/api/operations/approve_group_request.py
+++ b/api/operations/approve_group_request.py
@@ -39,6 +39,18 @@ class ApproveGroupRequest:
         notify: bool = True,
         bypass_self_approval: bool = False,
     ):
+        self._group_request_arg = group_request
+        self._approver_user_arg = approver_user
+
+        self.approval_reason = approval_reason
+        self.notify = notify
+        self.bypass_self_approval = bypass_self_approval
+        self.notification_hook = get_notification_hook()
+
+    def _resolve(self) -> None:
+        group_request = self._group_request_arg
+        approver_user = self._approver_user_arg
+
         # Lock the request row for the transaction so concurrent approvers
         # can't both pass the pending-state guard and double-create the group.
         # `of=` keeps FOR UPDATE off the joinedload's nullable outer-join side
@@ -61,12 +73,8 @@ class ApproveGroupRequest:
             self.approver_id = approver_user.id
             self.approver_email = approver_user.email
 
-        self.approval_reason = approval_reason
-        self.notify = notify
-        self.bypass_self_approval = bypass_self_approval
-        self.notification_hook = get_notification_hook()
-
     def execute(self) -> Optional[GroupRequest]:
+        self._resolve()
         # Guard against missing group_request
         if self.group_request is None:
             return None

--- a/api/operations/approve_role_request.py
+++ b/api/operations/approve_role_request.py
@@ -38,63 +38,61 @@ class ApproveRoleRequest:
 
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
-        role_request = self._role_request_arg
+    def execute(self) -> RoleRequest:
+        role_request_arg = self._role_request_arg
         approver_user = self._approver_user_arg
 
         # Lock the request row for the transaction so concurrent approvers
         # can't both pass the pending-state guard and double-grant. `of=` keeps
         # FOR UPDATE off the joinedloads' nullable outer-join sides (Postgres
         # rejects that); no-op on SQLite.
-        self.role_request = db.session.scalars(
+        role_request = db.session.scalars(
             select(RoleRequest)
             .options(joinedload(RoleRequest.active_requested_group), joinedload(RoleRequest.active_requester_role))
-            .where(RoleRequest.id == (role_request if isinstance(role_request, str) else role_request.id))
+            .where(RoleRequest.id == (role_request_arg if isinstance(role_request_arg, str) else role_request_arg.id))
             .with_for_update(of=RoleRequest)
         ).first()
 
         if approver_user is None:
-            self.approver_id = None
-            self.approver_email = None
+            approver_id = None
+            approver_email = None
         elif isinstance(approver_user, str):
             approver = db.session.get(OktaUser, approver_user)
-            self.approver_id = approver.id
-            self.approver_email = approver.email
+            approver_id = approver.id
+            approver_email = approver.email
         else:
-            self.approver_id = approver_user.id
-            self.approver_email = approver_user.email
+            approver_id = approver_user.id
+            approver_email = approver_user.email
 
-    def execute(self) -> RoleRequest:
-        self._resolve()
         # Don't allow approving a request that is already resolved. Raise
         # rather than silently no-op so a stale/concurrent approval surfaces
         # as a conflict instead of looking like a success.
-        if self.role_request.status != AccessRequestStatus.PENDING or self.role_request.resolved_at is not None:
+        if role_request.status != AccessRequestStatus.PENDING or role_request.resolved_at is not None:
             raise ConflictError("Role request is no longer pending")
 
         # Don't allow requester to approve their own request
-        if self.role_request.requester_user_id == self.approver_id:
-            return self.role_request
+        if role_request.requester_user_id == approver_id:
+            return role_request
 
         # Don't allow approving a request if the reason is invalid and required
         valid, _ = CheckForReason(
-            group=self.role_request.requester_role_id,
+            group=role_request.requester_role_id,
             reason=self.approval_reason,
-            members_to_add=[self.role_request.requested_group_id] if not self.role_request.request_ownership else [],
-            owners_to_add=[self.role_request.requested_group_id] if self.role_request.request_ownership else [],
+            members_to_add=[role_request.requested_group_id] if not role_request.request_ownership else [],
+            owners_to_add=[role_request.requested_group_id] if role_request.request_ownership else [],
         ).execute_for_role()
         if not valid:
-            return self.role_request
+            return role_request
 
         # Don't allow approving a request if the requester role is deleted
-        requester = db.session.get(RoleGroup, self.role_request.requester_role_id)
+        requester = db.session.get(RoleGroup, role_request.requester_role_id)
         if requester is None or requester.deleted_at is not None:
             raise ResourceGoneError("The requester role no longer exists")
 
         # Don't allow approving a request for a deleted or unmanaged group
-        if self.role_request.active_requested_group is None:
+        if role_request.active_requested_group is None:
             raise ResourceGoneError("The requested group no longer exists")
-        if not self.role_request.active_requested_group.is_managed:
+        if not role_request.active_requested_group.is_managed:
             raise InvalidRequestError("Groups not managed by Access cannot be modified")
 
         db.session.commit()
@@ -104,7 +102,7 @@ class ApproveRoleRequest:
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup]), joinedload(AppGroup.app))
             .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == self.role_request.requested_group_id)
+            .where(OktaGroup.id == role_request.requested_group_id)
         ).first()
 
         _ctx = get_request_context()
@@ -115,32 +113,32 @@ class ApproveRoleRequest:
                     "event_type": EventType.role_request_approve,
                     "user_agent": _ctx.user_agent if _ctx else None,
                     "ip": _ctx.ip if _ctx else None,
-                    "current_user_id": self.approver_id,
-                    "current_user_email": self.approver_email,
+                    "current_user_id": approver_id,
+                    "current_user_email": approver_email,
                     "group": group,
-                    "role_request": self.role_request,
-                    "requester": db.session.get(OktaUser, self.role_request.requester_user_id),
+                    "role_request": role_request,
+                    "requester": db.session.get(OktaUser, role_request.requester_user_id),
                 }
             )
         )
 
-        if self.role_request.request_ownership:
+        if role_request.request_ownership:
             ModifyRoleGroups(
-                role_group=self.role_request.requester_role,
+                role_group=role_request.requester_role,
                 groups_added_ended_at=self.ending_at,
-                owner_groups_to_add=[self.role_request.requested_group_id],
-                current_user_id=self.approver_id,
+                owner_groups_to_add=[role_request.requested_group_id],
+                current_user_id=approver_id,
                 created_reason=self.approval_reason,
                 notify=self.notify,
             ).execute()
         else:
             ModifyRoleGroups(
-                role_group=self.role_request.requester_role,
+                role_group=role_request.requester_role,
                 groups_added_ended_at=self.ending_at,
-                groups_to_add=[self.role_request.requested_group_id],
-                current_user_id=self.approver_id,
+                groups_to_add=[role_request.requested_group_id],
+                current_user_id=approver_id,
                 created_reason=self.approval_reason,
                 notify=self.notify,
             ).execute()
 
-        return self.role_request
+        return role_request

--- a/api/operations/approve_role_request.py
+++ b/api/operations/approve_role_request.py
@@ -27,6 +27,21 @@ class ApproveRoleRequest:
         ending_at: Optional[datetime] = None,
         notify: bool = True,
     ):
+        self._role_request_arg = role_request
+        self._approver_user_arg = approver_user
+
+        self.approval_reason = approval_reason
+
+        self.ending_at = ending_at
+
+        self.notify = notify
+
+        self.notification_hook = get_notification_hook()
+
+    def _resolve(self) -> None:
+        role_request = self._role_request_arg
+        approver_user = self._approver_user_arg
+
         # Lock the request row for the transaction so concurrent approvers
         # can't both pass the pending-state guard and double-grant. `of=` keeps
         # FOR UPDATE off the joinedloads' nullable outer-join sides (Postgres
@@ -49,15 +64,8 @@ class ApproveRoleRequest:
             self.approver_id = approver_user.id
             self.approver_email = approver_user.email
 
-        self.approval_reason = approval_reason
-
-        self.ending_at = ending_at
-
-        self.notify = notify
-
-        self.notification_hook = get_notification_hook()
-
     def execute(self) -> RoleRequest:
+        self._resolve()
         # Don't allow approving a request that is already resolved. Raise
         # rather than silently no-op so a stale/concurrent approval surfaces
         # as a conflict instead of looking like a success.

--- a/api/operations/approve_role_request.py
+++ b/api/operations/approve_role_request.py
@@ -27,8 +27,10 @@ class ApproveRoleRequest:
         ending_at: Optional[datetime] = None,
         notify: bool = True,
     ):
-        self._role_request_arg = role_request
-        self._approver_user_arg = approver_user
+        self.role_request_id = role_request if isinstance(role_request, str) else role_request.id
+        self.approver_user_id = (
+            approver_user.id if approver_user is not None and not isinstance(approver_user, str) else approver_user
+        )
 
         self.approval_reason = approval_reason
 
@@ -39,9 +41,6 @@ class ApproveRoleRequest:
         self.notification_hook = get_notification_hook()
 
     def execute(self) -> RoleRequest:
-        role_request_arg = self._role_request_arg
-        approver_user = self._approver_user_arg
-
         # Lock the request row for the transaction so concurrent approvers
         # can't both pass the pending-state guard and double-grant. `of=` keeps
         # FOR UPDATE off the joinedloads' nullable outer-join sides (Postgres
@@ -49,20 +48,17 @@ class ApproveRoleRequest:
         role_request = db.session.scalars(
             select(RoleRequest)
             .options(joinedload(RoleRequest.active_requested_group), joinedload(RoleRequest.active_requester_role))
-            .where(RoleRequest.id == (role_request_arg if isinstance(role_request_arg, str) else role_request_arg.id))
+            .where(RoleRequest.id == self.role_request_id)
             .with_for_update(of=RoleRequest)
         ).first()
 
-        if approver_user is None:
+        if self.approver_user_id is None:
             approver_id = None
             approver_email = None
-        elif isinstance(approver_user, str):
-            approver = db.session.get(OktaUser, approver_user)
+        else:
+            approver = db.session.get(OktaUser, self.approver_user_id)
             approver_id = approver.id
             approver_email = approver.email
-        else:
-            approver_id = approver_user.id
-            approver_email = approver_user.email
 
         # Don't allow approving a request that is already resolved. Raise
         # rather than silently no-op so a stale/concurrent approval surfaces

--- a/api/operations/constraints/check_for_reason.py
+++ b/api/operations/constraints/check_for_reason.py
@@ -19,6 +19,15 @@ class CheckForReason:
         members_to_add: list[str] = [],
         owners_to_add: list[str] = [],
     ):
+        self._group_arg = group
+
+        self.reason = reason
+
+        self.members_to_add = members_to_add
+        self.owners_to_add = owners_to_add
+
+    def _resolve(self) -> None:
+        group = self._group_arg
         self.group = db.session.scalars(
             select(OktaGroup)
             .options(
@@ -37,16 +46,12 @@ class CheckForReason:
             .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
         ).first()
 
-        self.reason = reason
-
-        self.members_to_add = members_to_add
-        self.owners_to_add = owners_to_add
-
     @staticmethod
     def invalid_reason(reason: Optional[str]) -> bool:
         return reason is None or reason.strip() == ""
 
     def execute_for_group(self) -> Tuple[bool, str]:
+        self._resolve()
         if self.invalid_reason(self.reason):
             tags = [tag_map.active_tag for tag_map in self.group.active_group_tags]
             if len(self.owners_to_add) > 0:
@@ -92,6 +97,7 @@ class CheckForReason:
         return True, ""
 
     def execute_for_role(self) -> Tuple[bool, str]:
+        self._resolve()
         if type(self.group) is not RoleGroup:
             return True, ""
 

--- a/api/operations/constraints/check_for_reason.py
+++ b/api/operations/constraints/check_for_reason.py
@@ -26,9 +26,13 @@ class CheckForReason:
         self.members_to_add = members_to_add
         self.owners_to_add = owners_to_add
 
-    def _resolve(self) -> None:
-        group = self._group_arg
-        self.group = db.session.scalars(
+    @staticmethod
+    def invalid_reason(reason: Optional[str]) -> bool:
+        return reason is None or reason.strip() == ""
+
+    def execute_for_group(self) -> Tuple[bool, str]:
+        group_arg = self._group_arg
+        group = db.session.scalars(
             select(OktaGroup)
             .options(
                 selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
@@ -43,34 +47,28 @@ class CheckForReason:
                 .joinedload(OktaGroupTagMap.active_tag),
             )
             .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+            .where(OktaGroup.id == (group_arg if isinstance(group_arg, str) else group_arg.id))
         ).first()
 
-    @staticmethod
-    def invalid_reason(reason: Optional[str]) -> bool:
-        return reason is None or reason.strip() == ""
-
-    def execute_for_group(self) -> Tuple[bool, str]:
-        self._resolve()
         if self.invalid_reason(self.reason):
-            tags = [tag_map.active_tag for tag_map in self.group.active_group_tags]
+            tags = [tag_map.active_tag for tag_map in group.active_group_tags]
             if len(self.owners_to_add) > 0:
                 require_owner_reason = coalesce_constraints(
                     constraint_key=Tag.REQUIRE_OWNER_REASON_CONSTRAINT_KEY, tags=tags
                 )
-                if self.group.is_managed and require_owner_reason is True:
-                    return False, f"Reason for adding owners to {self.group.name} group is required due to group tags"
+                if group.is_managed and require_owner_reason is True:
+                    return False, f"Reason for adding owners to {group.name} group is required due to group tags"
             if len(self.members_to_add) > 0:
                 require_member_reason = coalesce_constraints(
                     constraint_key=Tag.REQUIRE_MEMBER_REASON_CONSTRAINT_KEY, tags=tags
                 )
-                if self.group.is_managed and require_member_reason is True:
-                    return False, f"Reason for adding members to {self.group.name} group is required due to group tags"
+                if group.is_managed and require_member_reason is True:
+                    return False, f"Reason for adding members to {group.name} group is required due to group tags"
 
                 # If the group is a role group check to see if a reason is required for adding members or owners
                 # to the associated groups
-                if type(self.group) is RoleGroup and self.group.is_managed:
-                    member_groups = [rm.active_group for rm in self.group.active_role_associated_group_member_mappings]
+                if type(group) is RoleGroup and group.is_managed:
+                    member_groups = [rm.active_group for rm in group.active_role_associated_group_member_mappings]
                     for member_group in member_groups:
                         require_member_reason = coalesce_constraints(
                             constraint_key=Tag.REQUIRE_MEMBER_REASON_CONSTRAINT_KEY,
@@ -80,9 +78,9 @@ class CheckForReason:
                             return (
                                 False,
                                 f"Reason for adding members to {member_group.name} group associated "
-                                + f"with role {self.group.name} is required due to group tags",
+                                + f"with role {group.name} is required due to group tags",
                             )
-                    owner_groups = [rm.active_group for rm in self.group.active_role_associated_group_owner_mappings]
+                    owner_groups = [rm.active_group for rm in group.active_role_associated_group_owner_mappings]
                     for owner_group in owner_groups:
                         require_owner_reason = coalesce_constraints(
                             constraint_key=Tag.REQUIRE_OWNER_REASON_CONSTRAINT_KEY,
@@ -92,13 +90,31 @@ class CheckForReason:
                             return (
                                 False,
                                 f"Reason for adding owners to {owner_group.name} group associated "
-                                + f"with role {self.group.name} is required due to group tags",
+                                + f"with role {group.name} is required due to group tags",
                             )
         return True, ""
 
     def execute_for_role(self) -> Tuple[bool, str]:
-        self._resolve()
-        if type(self.group) is not RoleGroup:
+        group_arg = self._group_arg
+        group = db.session.scalars(
+            select(OktaGroup)
+            .options(
+                selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
+                selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
+                selectinload(RoleGroup.active_role_associated_group_member_mappings)
+                .joinedload(RoleGroupMap.active_group)
+                .selectinload(OktaGroup.active_group_tags)
+                .joinedload(OktaGroupTagMap.active_tag),
+                selectinload(RoleGroup.active_role_associated_group_owner_mappings)
+                .joinedload(RoleGroupMap.active_group)
+                .selectinload(OktaGroup.active_group_tags)
+                .joinedload(OktaGroupTagMap.active_tag),
+            )
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(OktaGroup.id == (group_arg if isinstance(group_arg, str) else group_arg.id))
+        ).first()
+
+        if type(group) is not RoleGroup:
             return True, ""
 
         if self.invalid_reason(self.reason):
@@ -118,7 +134,7 @@ class CheckForReason:
                     if require_member_reason is True:
                         return (
                             False,
-                            f"Reason for adding role {self.group.name} as members "
+                            f"Reason for adding role {group.name} as members "
                             + f"to {member_group.name} group is required due to group tags",
                         )
 
@@ -138,7 +154,7 @@ class CheckForReason:
                     if require_owner_reason is True:
                         return (
                             False,
-                            f"Reason for adding role {self.group.name} as owners "
+                            f"Reason for adding role {group.name} as owners "
                             + f"to {owner_group.name} group is required due to group tags",
                         )
         return True, ""

--- a/api/operations/constraints/check_for_reason.py
+++ b/api/operations/constraints/check_for_reason.py
@@ -19,7 +19,7 @@ class CheckForReason:
         members_to_add: list[str] = [],
         owners_to_add: list[str] = [],
     ):
-        self._group_arg = group
+        self.group_id = group if isinstance(group, str) else group.id
 
         self.reason = reason
 
@@ -31,7 +31,6 @@ class CheckForReason:
         return reason is None or reason.strip() == ""
 
     def execute_for_group(self) -> Tuple[bool, str]:
-        group_arg = self._group_arg
         group = db.session.scalars(
             select(OktaGroup)
             .options(
@@ -47,7 +46,7 @@ class CheckForReason:
                 .joinedload(OktaGroupTagMap.active_tag),
             )
             .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == (group_arg if isinstance(group_arg, str) else group_arg.id))
+            .where(OktaGroup.id == self.group_id)
         ).first()
 
         if self.invalid_reason(self.reason):
@@ -95,7 +94,6 @@ class CheckForReason:
         return True, ""
 
     def execute_for_role(self) -> Tuple[bool, str]:
-        group_arg = self._group_arg
         group = db.session.scalars(
             select(OktaGroup)
             .options(
@@ -111,7 +109,7 @@ class CheckForReason:
                 .joinedload(OktaGroupTagMap.active_tag),
             )
             .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == (group_arg if isinstance(group_arg, str) else group_arg.id))
+            .where(OktaGroup.id == self.group_id)
         ).first()
 
         if type(group) is not RoleGroup:

--- a/api/operations/constraints/check_for_self_add.py
+++ b/api/operations/constraints/check_for_self_add.py
@@ -20,6 +20,16 @@ class CheckForSelfAdd:
         members_to_add: list[str] = [],
         owners_to_add: list[str] = [],
     ):
+        self._group_arg = group
+        self._current_user_arg = current_user
+
+        self.members_to_add = members_to_add
+        self.owners_to_add = owners_to_add
+
+    def _resolve(self) -> None:
+        group = self._group_arg
+        current_user = self._current_user_arg
+
         self.group = db.session.scalars(
             select(OktaGroup)
             .options(
@@ -47,10 +57,8 @@ class CheckForSelfAdd:
                 .where(OktaUser.id == (current_user if isinstance(current_user, str) else current_user.id))
             ).first()
 
-        self.members_to_add = members_to_add
-        self.owners_to_add = owners_to_add
-
     def execute_for_group(self) -> Tuple[bool, str]:
+        self._resolve()
         if self.current_user is None or _is_access_admin(db.session, self.current_user.id):
             return True, ""
 
@@ -109,6 +117,7 @@ class CheckForSelfAdd:
         return True, ""
 
     def execute_for_role(self) -> Tuple[bool, str]:
+        self._resolve()
         if self.current_user is None or _is_access_admin(db.session, self.current_user.id):
             return True, ""
 

--- a/api/operations/constraints/check_for_self_add.py
+++ b/api/operations/constraints/check_for_self_add.py
@@ -26,11 +26,11 @@ class CheckForSelfAdd:
         self.members_to_add = members_to_add
         self.owners_to_add = owners_to_add
 
-    def _resolve(self) -> None:
-        group = self._group_arg
-        current_user = self._current_user_arg
+    def execute_for_group(self) -> Tuple[bool, str]:
+        group_arg = self._group_arg
+        current_user_arg = self._current_user_arg
 
-        self.group = db.session.scalars(
+        group = db.session.scalars(
             select(OktaGroup)
             .options(
                 selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
@@ -45,50 +45,48 @@ class CheckForSelfAdd:
                 .joinedload(OktaGroupTagMap.active_tag),
             )
             .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+            .where(OktaGroup.id == (group_arg if isinstance(group_arg, str) else group_arg.id))
         ).first()
 
-        if current_user is None:
-            self.current_user = None
+        if current_user_arg is None:
+            current_user = None
         else:
-            self.current_user = db.session.scalars(
+            current_user = db.session.scalars(
                 select(OktaUser)
                 .where(OktaUser.deleted_at.is_(None))
-                .where(OktaUser.id == (current_user if isinstance(current_user, str) else current_user.id))
+                .where(OktaUser.id == (current_user_arg if isinstance(current_user_arg, str) else current_user_arg.id))
             ).first()
 
-    def execute_for_group(self) -> Tuple[bool, str]:
-        self._resolve()
-        if self.current_user is None or _is_access_admin(db.session, self.current_user.id):
+        if current_user is None or _is_access_admin(db.session, current_user.id):
             return True, ""
 
-        if len(self.owners_to_add) > 0 and self.current_user.id in self.owners_to_add:
+        if len(self.owners_to_add) > 0 and current_user.id in self.owners_to_add:
             disallow_self_add_ownership = coalesce_constraints(
                 constraint_key=Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY,
-                tags=[tag_map.active_tag for tag_map in self.group.active_group_tags],
+                tags=[tag_map.active_tag for tag_map in group.active_group_tags],
             )
-            if self.group.is_managed and disallow_self_add_ownership is True:
+            if group.is_managed and disallow_self_add_ownership is True:
                 return (
                     False,
                     "Current user is an group owner who is restricted "
-                    + f"from readding themself as owner to {self.group.name} due to group tags",
+                    + f"from readding themself as owner to {group.name} due to group tags",
                 )
-        if len(self.members_to_add) > 0 and self.current_user.id in self.members_to_add:
+        if len(self.members_to_add) > 0 and current_user.id in self.members_to_add:
             disallow_self_add_membership = coalesce_constraints(
                 constraint_key=Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY,
-                tags=[tag_map.active_tag for tag_map in self.group.active_group_tags],
+                tags=[tag_map.active_tag for tag_map in group.active_group_tags],
             )
-            if self.group.is_managed and disallow_self_add_membership is True:
+            if group.is_managed and disallow_self_add_membership is True:
                 return (
                     False,
                     "Current user is a group owner who is restricted "
-                    + f"from adding themself as member to {self.group.name} due to group tags",
+                    + f"from adding themself as member to {group.name} due to group tags",
                 )
 
             # If the group is a role group check to see if a reason is required for adding members or owners
             # to the associated groups
-            if type(self.group) is RoleGroup and self.group.is_managed:
-                member_groups = [rm.active_group for rm in self.group.active_role_associated_group_member_mappings]
+            if type(group) is RoleGroup and group.is_managed:
+                member_groups = [rm.active_group for rm in group.active_role_associated_group_member_mappings]
                 for member_group in member_groups:
                     disallow_self_add_membership = coalesce_constraints(
                         constraint_key=Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY,
@@ -98,10 +96,10 @@ class CheckForSelfAdd:
                         return (
                             False,
                             "Current user is a role owner who is restricted from adding themself as "
-                            + f"member to {self.group.name} because the associated group {member_group.name} "
+                            + f"member to {group.name} because the associated group {member_group.name} "
                             + "has group tags which restricts self-adding membership",
                         )
-                owner_groups = [rm.active_group for rm in self.group.active_role_associated_group_owner_mappings]
+                owner_groups = [rm.active_group for rm in group.active_role_associated_group_owner_mappings]
                 for owner_group in owner_groups:
                     disallow_self_add_ownership = coalesce_constraints(
                         constraint_key=Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY,
@@ -111,17 +109,46 @@ class CheckForSelfAdd:
                         return (
                             False,
                             "Current user is a role owner who is restricted from adding themself as "
-                            + f"member to {self.group.name} because the associated group {member_group.name} "
+                            + f"member to {group.name} because the associated group {member_group.name} "
                             + "has group tags which restricts self-adding ownership",
                         )
         return True, ""
 
     def execute_for_role(self) -> Tuple[bool, str]:
-        self._resolve()
-        if self.current_user is None or _is_access_admin(db.session, self.current_user.id):
+        group_arg = self._group_arg
+        current_user_arg = self._current_user_arg
+
+        group = db.session.scalars(
+            select(OktaGroup)
+            .options(
+                selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
+                selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
+                selectinload(RoleGroup.active_role_associated_group_member_mappings)
+                .joinedload(RoleGroupMap.active_group)
+                .selectinload(OktaGroup.active_group_tags)
+                .joinedload(OktaGroupTagMap.active_tag),
+                selectinload(RoleGroup.active_role_associated_group_owner_mappings)
+                .joinedload(RoleGroupMap.active_group)
+                .selectinload(OktaGroup.active_group_tags)
+                .joinedload(OktaGroupTagMap.active_tag),
+            )
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(OktaGroup.id == (group_arg if isinstance(group_arg, str) else group_arg.id))
+        ).first()
+
+        if current_user_arg is None:
+            current_user = None
+        else:
+            current_user = db.session.scalars(
+                select(OktaUser)
+                .where(OktaUser.deleted_at.is_(None))
+                .where(OktaUser.id == (current_user_arg if isinstance(current_user_arg, str) else current_user_arg.id))
+            ).first()
+
+        if current_user is None or _is_access_admin(db.session, current_user.id):
             return True, ""
 
-        if type(self.group) is not RoleGroup:
+        if type(group) is not RoleGroup:
             return True, ""
 
         # Check to see if the current user is a member of the role,
@@ -130,8 +157,8 @@ class CheckForSelfAdd:
             db.session.scalar(
                 select(func.count()).select_from(
                     select(OktaUserGroupMember)
-                    .where(OktaUserGroupMember.group_id == self.group.id)
-                    .where(OktaUserGroupMember.user_id == self.current_user.id)
+                    .where(OktaUserGroupMember.group_id == group.id)
+                    .where(OktaUserGroupMember.user_id == current_user.id)
                     .where(OktaUserGroupMember.is_owner.is_(False))
                     .where(
                         or_(
@@ -161,7 +188,7 @@ class CheckForSelfAdd:
                         return (
                             False,
                             "Current user is a role member who is restricted from adding "
-                            + f"{self.group.name} as a member to {member_group.name} because that group  "
+                            + f"{group.name} as a member to {member_group.name} because that group  "
                             + "has tags which restricts self-adding membership",
                         )
 
@@ -182,7 +209,7 @@ class CheckForSelfAdd:
                         return (
                             False,
                             "Current user is a role member who is restricted from adding "
-                            + f"{self.group.name} as an owner to {owner_group.name} because that group  "
+                            + f"{group.name} as an owner to {owner_group.name} because that group  "
                             + "has tags which restricts self-adding ownership",
                         )
         return True, ""

--- a/api/operations/constraints/check_for_self_add.py
+++ b/api/operations/constraints/check_for_self_add.py
@@ -20,16 +20,15 @@ class CheckForSelfAdd:
         members_to_add: list[str] = [],
         owners_to_add: list[str] = [],
     ):
-        self._group_arg = group
-        self._current_user_arg = current_user
+        self.group_id = group if isinstance(group, str) else group.id
+        self.current_user_id = (
+            current_user.id if current_user is not None and not isinstance(current_user, str) else current_user
+        )
 
         self.members_to_add = members_to_add
         self.owners_to_add = owners_to_add
 
     def execute_for_group(self) -> Tuple[bool, str]:
-        group_arg = self._group_arg
-        current_user_arg = self._current_user_arg
-
         group = db.session.scalars(
             select(OktaGroup)
             .options(
@@ -45,16 +44,14 @@ class CheckForSelfAdd:
                 .joinedload(OktaGroupTagMap.active_tag),
             )
             .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == (group_arg if isinstance(group_arg, str) else group_arg.id))
+            .where(OktaGroup.id == self.group_id)
         ).first()
 
-        if current_user_arg is None:
+        if self.current_user_id is None:
             current_user = None
         else:
             current_user = db.session.scalars(
-                select(OktaUser)
-                .where(OktaUser.deleted_at.is_(None))
-                .where(OktaUser.id == (current_user_arg if isinstance(current_user_arg, str) else current_user_arg.id))
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self.current_user_id)
             ).first()
 
         if current_user is None or _is_access_admin(db.session, current_user.id):
@@ -115,9 +112,6 @@ class CheckForSelfAdd:
         return True, ""
 
     def execute_for_role(self) -> Tuple[bool, str]:
-        group_arg = self._group_arg
-        current_user_arg = self._current_user_arg
-
         group = db.session.scalars(
             select(OktaGroup)
             .options(
@@ -133,16 +127,14 @@ class CheckForSelfAdd:
                 .joinedload(OktaGroupTagMap.active_tag),
             )
             .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == (group_arg if isinstance(group_arg, str) else group_arg.id))
+            .where(OktaGroup.id == self.group_id)
         ).first()
 
-        if current_user_arg is None:
+        if self.current_user_id is None:
             current_user = None
         else:
             current_user = db.session.scalars(
-                select(OktaUser)
-                .where(OktaUser.deleted_at.is_(None))
-                .where(OktaUser.id == (current_user_arg if isinstance(current_user_arg, str) else current_user_arg.id))
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self.current_user_id)
             ).first()
 
         if current_user is None or _is_access_admin(db.session, current_user.id):

--- a/api/operations/create_access_request.py
+++ b/api/operations/create_access_request.py
@@ -39,8 +39,8 @@ class CreateAccessRequest:
     ):
         self.id = self.__generate_id()
 
-        self._requester_user_arg = requester_user
-        self._requested_group_arg = requested_group
+        self.requester_user_id = requester_user if isinstance(requester_user, str) else requester_user.id
+        self.requested_group_id = requested_group if isinstance(requested_group, str) else requested_group.id
 
         self.request_ownership = request_ownership
         self.request_reason = request_reason
@@ -52,22 +52,13 @@ class CreateAccessRequest:
         self.notification_hook = get_notification_hook()
 
     def execute(self) -> Optional[AccessRequest]:
-        requester_user = self._requester_user_arg
-        requested_group_arg = self._requested_group_arg
-
-        if isinstance(requester_user, str):
-            requester = db.session.get(OktaUser, requester_user)
-        else:
-            requester = requester_user
+        requester = db.session.get(OktaUser, self.requester_user_id)
 
         requested_group = db.session.scalars(
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
             .where(OktaGroup.deleted_at.is_(None))
-            .where(
-                OktaGroup.id
-                == (requested_group_arg if isinstance(requested_group_arg, str) else requested_group_arg.id)
-            )
+            .where(OktaGroup.id == self.requested_group_id)
         ).first()
 
         # Don't allow creating a request for an unmanaged group

--- a/api/operations/create_access_request.py
+++ b/api/operations/create_access_request.py
@@ -51,33 +51,34 @@ class CreateAccessRequest:
         self.conditional_access_hook = get_conditional_access_hook()
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
+    def execute(self) -> Optional[AccessRequest]:
         requester_user = self._requester_user_arg
-        requested_group = self._requested_group_arg
+        requested_group_arg = self._requested_group_arg
 
         if isinstance(requester_user, str):
-            self.requester = db.session.get(OktaUser, requester_user)
+            requester = db.session.get(OktaUser, requester_user)
         else:
-            self.requester = requester_user
+            requester = requester_user
 
-        self.requested_group = db.session.scalars(
+        requested_group = db.session.scalars(
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
             .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == (requested_group if isinstance(requested_group, str) else requested_group.id))
+            .where(
+                OktaGroup.id
+                == (requested_group_arg if isinstance(requested_group_arg, str) else requested_group_arg.id)
+            )
         ).first()
 
-    def execute(self) -> Optional[AccessRequest]:
-        self._resolve()
         # Don't allow creating a request for an unmanaged group
-        if not self.requested_group.is_managed:
+        if not requested_group.is_managed:
             return None
 
         access_request = AccessRequest(
             id=self.id,
             status=AccessRequestStatus.PENDING,
-            requester_user_id=self.requester.id,
-            requested_group_id=self.requested_group.id,
+            requester_user_id=requester.id,
+            requested_group_id=requested_group.id,
             request_ownership=self.request_ownership,
             request_reason=self.request_reason,
             request_ending_at=self.request_ending_at,
@@ -87,19 +88,19 @@ class CreateAccessRequest:
         db.session.commit()
 
         # Fetch the users to notify
-        approvers = get_group_managers(self.requested_group.id)
+        approvers = get_group_managers(requested_group.id)
 
         # If there are no approvers, try to get the app managers
         # or if the only approver is the requester, try to get the app managers
         if (
-            (len(approvers) == 0 and type(self.requested_group) is AppGroup)
-            or (len(approvers) == 1 and approvers[0].id == self.requester.id)
-            and type(self.requested_group) is AppGroup
+            (len(approvers) == 0 and type(requested_group) is AppGroup)
+            or (len(approvers) == 1 and approvers[0].id == requester.id)
+            and type(requested_group) is AppGroup
         ):
-            approvers = get_app_managers(self.requested_group.app_id)
+            approvers = get_app_managers(requested_group.app_id)
 
         # If there are still no approvers, try to get the access owners
-        if len(approvers) == 0 or (len(approvers) == 1 and approvers[0].id == self.requester.id):
+        if len(approvers) == 0 or (len(approvers) == 1 and approvers[0].id == requester.id):
             approvers = get_access_owners()
 
         group = db.session.scalars(
@@ -112,7 +113,7 @@ class CreateAccessRequest:
                 ),
             )
             .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == self.requested_group.id)
+            .where(OktaGroup.id == requested_group.id)
         ).first()
 
         # Audit logging
@@ -124,11 +125,11 @@ class CreateAccessRequest:
                     "event_type": EventType.access_create,
                     "user_agent": _ctx.user_agent if _ctx else None,
                     "ip": _ctx.ip if _ctx else None,
-                    "current_user_id": self.requester.id,
-                    "current_user_email": self.requester.email,
+                    "current_user_id": requester.id,
+                    "current_user_email": requester.email,
                     "group": group,
                     "request": access_request,
-                    "requester": self.requester,
+                    "requester": requester,
                     "group_owners": approvers,
                 }
             )
@@ -138,7 +139,7 @@ class CreateAccessRequest:
             access_request=access_request,
             group=group,
             group_tags=[active_tag_map.enabled_active_tag for active_tag_map in group.active_group_tags],
-            requester=self.requester,
+            requester=requester,
         )
 
         for response in conditional_access_responses:
@@ -162,7 +163,7 @@ class CreateAccessRequest:
         self.notification_hook.access_request_created(
             access_request=access_request,
             group=group,
-            requester=self.requester,
+            requester=requester,
             approvers=approvers,
         )
 

--- a/api/operations/create_access_request.py
+++ b/api/operations/create_access_request.py
@@ -39,6 +39,22 @@ class CreateAccessRequest:
     ):
         self.id = self.__generate_id()
 
+        self._requester_user_arg = requester_user
+        self._requested_group_arg = requested_group
+
+        self.request_ownership = request_ownership
+        self.request_reason = request_reason
+        self.request_ending_at = request_ending_at
+
+        self.request_approvers = select()
+
+        self.conditional_access_hook = get_conditional_access_hook()
+        self.notification_hook = get_notification_hook()
+
+    def _resolve(self) -> None:
+        requester_user = self._requester_user_arg
+        requested_group = self._requested_group_arg
+
         if isinstance(requester_user, str):
             self.requester = db.session.get(OktaUser, requester_user)
         else:
@@ -51,16 +67,8 @@ class CreateAccessRequest:
             .where(OktaGroup.id == (requested_group if isinstance(requested_group, str) else requested_group.id))
         ).first()
 
-        self.request_ownership = request_ownership
-        self.request_reason = request_reason
-        self.request_ending_at = request_ending_at
-
-        self.request_approvers = select()
-
-        self.conditional_access_hook = get_conditional_access_hook()
-        self.notification_hook = get_notification_hook()
-
     def execute(self) -> Optional[AccessRequest]:
+        self._resolve()
         # Don't allow creating a request for an unmanaged group
         if not self.requested_group.is_managed:
             return None

--- a/api/operations/create_app.py
+++ b/api/operations/create_app.py
@@ -41,9 +41,9 @@ class CreateApp:
             app.id = id
             self.app = app
 
-        self._tags_arg = tags
-        self._owner_id_arg = owner_id
-        self._owner_role_ids_arg = owner_role_ids
+        self.tag_ids = tags
+        self.owner_id = owner_id
+        self.owner_role_ids = owner_role_ids
 
         self.app_group_prefix = (
             f"{AppGroup.APP_GROUP_NAME_PREFIX}{self.app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}"
@@ -65,34 +65,33 @@ class CreateApp:
                 if name == self.owner_group_name:
                     continue
                 self.additional_app_groups.append(AppGroup(is_owner=False, name=name, description=description))
-        self._current_user_id_arg = current_user_id
+        self.current_user_id = current_user_id
 
     def execute(self) -> App:
         tag_ids = [
             tag.id
             for tag in db.session.scalars(
-                select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_arg))
+                select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self.tag_ids))
             ).all()
         ]
 
         owner_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._owner_id_arg)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self.owner_id)
             ).first(),
             "id",
             None,
         )
-        owner_role_ids_arg = self._owner_role_ids_arg
         owner_role_ids: Optional[list[str]] = None
-        if owner_role_ids_arg is not None:
+        if self.owner_role_ids is not None:
             owner_roles = db.session.scalars(
-                select(RoleGroup).where(RoleGroup.id.in_(owner_role_ids_arg)).where(RoleGroup.deleted_at.is_(None))
+                select(RoleGroup).where(RoleGroup.id.in_(self.owner_role_ids)).where(RoleGroup.deleted_at.is_(None))
             ).all()
             owner_role_ids = [role.id for role in owner_roles]
 
         current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self.current_user_id)
             ).first(),
             "id",
             None,

--- a/api/operations/create_app.py
+++ b/api/operations/create_app.py
@@ -41,24 +41,9 @@ class CreateApp:
             app.id = id
             self.app = app
 
-        self.tag_ids = [
-            tag.id
-            for tag in db.session.scalars(select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(tags))).all()
-        ]
-
-        self.owner_id = getattr(
-            db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == owner_id)
-            ).first(),
-            "id",
-            None,
-        )
-        self.owner_role_ids = None
-        if owner_role_ids is not None:
-            self.owner_roles = db.session.scalars(
-                select(RoleGroup).where(RoleGroup.id.in_(owner_role_ids)).where(RoleGroup.deleted_at.is_(None))
-            ).all()
-            self.owner_role_ids = [role.id for role in self.owner_roles]
+        self._tags_arg = tags
+        self._owner_id_arg = owner_id
+        self._owner_role_ids_arg = owner_role_ids
 
         self.app_group_prefix = (
             f"{AppGroup.APP_GROUP_NAME_PREFIX}{self.app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}"
@@ -80,15 +65,41 @@ class CreateApp:
                 if name == self.owner_group_name:
                     continue
                 self.additional_app_groups.append(AppGroup(is_owner=False, name=name, description=description))
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
+        self.tag_ids = [
+            tag.id
+            for tag in db.session.scalars(
+                select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_arg))
+            ).all()
+        ]
+
+        self.owner_id = getattr(
+            db.session.scalars(
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._owner_id_arg)
+            ).first(),
+            "id",
+            None,
+        )
+        owner_role_ids = self._owner_role_ids_arg
+        self.owner_role_ids = None
+        if owner_role_ids is not None:
+            self.owner_roles = db.session.scalars(
+                select(RoleGroup).where(RoleGroup.id.in_(owner_role_ids)).where(RoleGroup.deleted_at.is_(None))
+            ).all()
+            self.owner_role_ids = [role.id for role in self.owner_roles]
+
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self) -> App:
+        self._resolve()
         # Do not allow non-deleted apps with the same name
         existing_app = db.session.scalars(
             select(App).where(func.lower(App.name) == func.lower(self.app.name)).where(App.deleted_at.is_(None))

--- a/api/operations/create_app.py
+++ b/api/operations/create_app.py
@@ -67,30 +67,30 @@ class CreateApp:
                 self.additional_app_groups.append(AppGroup(is_owner=False, name=name, description=description))
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
-        self.tag_ids = [
+    def execute(self) -> App:
+        tag_ids = [
             tag.id
             for tag in db.session.scalars(
                 select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_arg))
             ).all()
         ]
 
-        self.owner_id = getattr(
+        owner_id = getattr(
             db.session.scalars(
                 select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._owner_id_arg)
             ).first(),
             "id",
             None,
         )
-        owner_role_ids = self._owner_role_ids_arg
-        self.owner_role_ids = None
-        if owner_role_ids is not None:
-            self.owner_roles = db.session.scalars(
-                select(RoleGroup).where(RoleGroup.id.in_(owner_role_ids)).where(RoleGroup.deleted_at.is_(None))
+        owner_role_ids_arg = self._owner_role_ids_arg
+        owner_role_ids: Optional[list[str]] = None
+        if owner_role_ids_arg is not None:
+            owner_roles = db.session.scalars(
+                select(RoleGroup).where(RoleGroup.id.in_(owner_role_ids_arg)).where(RoleGroup.deleted_at.is_(None))
             ).all()
-            self.owner_role_ids = [role.id for role in self.owner_roles]
+            owner_role_ids = [role.id for role in owner_roles]
 
-        self.current_user_id = getattr(
+        current_user_id = getattr(
             db.session.scalars(
                 select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
@@ -98,8 +98,6 @@ class CreateApp:
             None,
         )
 
-    def execute(self) -> App:
-        self._resolve()
         # Do not allow non-deleted apps with the same name
         existing_app = db.session.scalars(
             select(App).where(func.lower(App.name) == func.lower(self.app.name)).where(App.deleted_at.is_(None))
@@ -109,8 +107,8 @@ class CreateApp:
 
         # Audit logging
         email = None
-        if self.current_user_id is not None:
-            email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
+        if current_user_id is not None:
+            email = getattr(db.session.get(OktaUser, current_user_id), "email", None)
 
         _ctx = get_request_context()
 
@@ -120,10 +118,10 @@ class CreateApp:
                     "event_type": EventType.app_create,
                     "user_agent": _ctx.user_agent if _ctx else None,
                     "ip": _ctx.ip if _ctx else None,
-                    "current_user_id": self.current_user_id,
+                    "current_user_id": current_user_id,
                     "current_user_email": email,
                     "app": self.app,
-                    "owner_id": self.owner_id,
+                    "owner_id": owner_id,
                 }
             )
         )
@@ -146,34 +144,34 @@ class CreateApp:
                 name=self.owner_group_name,
                 description=app_owners_group_description(self.app.name),
             )
-            owner_app_group = CreateGroup(group=owner_app_group, current_user_id=self.current_user_id).execute()
+            owner_app_group = CreateGroup(group=owner_app_group, current_user_id=current_user_id).execute()
         else:
             group_id = existing_owner_group.id
             if type(existing_owner_group) is not AppGroup:
                 ModifyGroupType(
                     group=existing_owner_group,
                     group_changes=AppGroup(app_id=app_id, is_owner=True),
-                    current_user_id=self.current_user_id,
+                    current_user_id=current_user_id,
                 ).execute()
             owner_app_group = db.session.scalars(select(AppGroup).where(AppGroup.id == group_id)).first()
             owner_app_group.app_id = app_id
             owner_app_group.is_owner = True
             db.session.commit()
 
-        if self.owner_id is not None:
+        if owner_id is not None:
             # Add the app owner to the app owner group as members and owners
             ModifyGroupUsers(
                 group=owner_app_group,
-                current_user_id=self.current_user_id,
-                members_to_add=[self.owner_id],
-                owners_to_add=[self.owner_id],
+                current_user_id=current_user_id,
+                members_to_add=[owner_id],
+                owners_to_add=[owner_id],
             ).execute()
 
-        if self.owner_role_ids is not None:
-            for role_id in self.owner_role_ids:
+        if owner_role_ids is not None:
+            for role_id in owner_role_ids:
                 ModifyRoleGroups(
                     role_group=role_id,
-                    current_user_id=self.current_user_id,
+                    current_user_id=current_user_id,
                     groups_to_add=[owner_app_group.id],
                     owner_groups_to_add=[owner_app_group.id],
                 ).execute()
@@ -194,7 +192,7 @@ class CreateApp:
             ModifyGroupType(
                 group=existing_app_group_id,
                 group_changes=AppGroup(app_id=app_id, is_owner=False),
-                current_user_id=self.current_user_id,
+                current_user_id=current_user_id,
             ).execute()
 
         # Create any additional app groups for the app
@@ -209,26 +207,26 @@ class CreateApp:
                 ).first()
 
                 if existing_group is None:
-                    CreateGroup(group=app_group, current_user_id=self.current_user_id).execute()
+                    CreateGroup(group=app_group, current_user_id=current_user_id).execute()
                 else:
                     group_id = existing_group.id
                     if type(existing_owner_group) is not AppGroup:
                         ModifyGroupType(
                             group=existing_owner_group,
                             group_changes=AppGroup(app_id=app_id, is_owner=False),
-                            current_user_id=self.current_user_id,
+                            current_user_id=current_user_id,
                         ).execute()
                     app_group = db.session.scalars(select(AppGroup).where(AppGroup.id == group_id)).first()
                     app_group.app_id = app_id
                     app_group.is_owner = False
                     db.session.commit()
 
-        if len(self.tag_ids) > 0:
+        if len(tag_ids) > 0:
             all_app_groups = db.session.scalars(
                 select(AppGroup).where(AppGroup.app_id == app_id).where(AppGroup.deleted_at.is_(None))
             ).all()
 
-            for tag_id in self.tag_ids:
+            for tag_id in tag_ids:
                 db.session.add(
                     AppTagMap(
                         tag_id=tag_id,

--- a/api/operations/create_group.py
+++ b/api/operations/create_group.py
@@ -30,12 +30,10 @@ class CreateGroup:
         self._tags_arg = tags
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
-        self.tags = db.session.scalars(
-            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_arg))
-        ).all()
+    def execute(self, *, _group: Optional[T] = None) -> T:
+        tags = db.session.scalars(select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_arg))).all()
 
-        self.current_user_id = getattr(
+        current_user_id = getattr(
             db.session.scalars(
                 select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
@@ -43,8 +41,6 @@ class CreateGroup:
             None,
         )
 
-    def execute(self, *, _group: Optional[T] = None) -> T:
-        self._resolve()
         # Do not allow non-deleted groups with the same name (case-insensitive)
         existing_group = db.session.scalars(
             select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
@@ -105,8 +101,8 @@ class CreateGroup:
             db.session.commit()
 
         # Add direct tags
-        if len(self.tags) > 0:
-            for tag in self.tags:
+        if len(tags) > 0:
+            for tag in tags:
                 db.session.add(
                     OktaGroupTagMap(
                         tag_id=tag.id,
@@ -130,8 +126,8 @@ class CreateGroup:
 
         # Audit logging
         email = None
-        if self.current_user_id is not None:
-            email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
+        if current_user_id is not None:
+            email = getattr(db.session.get(OktaUser, current_user_id), "email", None)
 
         group = db.session.scalars(
             select(OktaGroup)
@@ -148,7 +144,7 @@ class CreateGroup:
                     "event_type": EventType.group_create,
                     "user_agent": _ctx.user_agent if _ctx else None,
                     "ip": _ctx.ip if _ctx else None,
-                    "current_user_id": self.current_user_id,
+                    "current_user_id": current_user_id,
                     "current_user_email": email,
                     "group": group,
                 }

--- a/api/operations/create_group.py
+++ b/api/operations/create_group.py
@@ -27,15 +27,15 @@ class CreateGroup:
         else:
             self.group = group
 
-        self._tags_arg = tags
-        self._current_user_id_arg = current_user_id
+        self.tag_ids = tags
+        self.current_user_id = current_user_id
 
     def execute(self, *, _group: Optional[T] = None) -> T:
-        tags = db.session.scalars(select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_arg))).all()
+        tags = db.session.scalars(select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self.tag_ids))).all()
 
         current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self.current_user_id)
             ).first(),
             "id",
             None,

--- a/api/operations/create_group.py
+++ b/api/operations/create_group.py
@@ -27,17 +27,24 @@ class CreateGroup:
         else:
             self.group = group
 
-        self.tags = db.session.scalars(select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(tags))).all()
+        self._tags_arg = tags
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
+        self.tags = db.session.scalars(
+            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_arg))
+        ).all()
 
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self, *, _group: Optional[T] = None) -> T:
+        self._resolve()
         # Do not allow non-deleted groups with the same name (case-insensitive)
         existing_group = db.session.scalars(
             select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))

--- a/api/operations/create_group_request.py
+++ b/api/operations/create_group_request.py
@@ -54,15 +54,13 @@ class CreateGroupRequest:
         self.conditional_access_hook = get_conditional_access_hook()
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
+    def execute(self) -> Optional[GroupRequest]:
         requester_user = self._requester_user_arg
         if isinstance(requester_user, str):
-            self.requester = db.session.get(OktaUser, requester_user)
+            requester = db.session.get(OktaUser, requester_user)
         else:
-            self.requester = requester_user
+            requester = requester_user
 
-    def execute(self) -> Optional[GroupRequest]:
-        self._resolve()
         # Don't allow creating groups with -Owners suffix (reserved for app owner groups)
         if self.requested_group_name.endswith(f"-{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"):
             return None
@@ -122,7 +120,7 @@ class CreateGroupRequest:
         group_request = GroupRequest(
             id=self.id,
             status=AccessRequestStatus.PENDING,
-            requester_user_id=self.requester.id,
+            requester_user_id=requester.id,
             requested_group_name=self.requested_group_name,
             requested_group_description=self.requested_group_description,
             requested_group_type=self.requested_group_type,
@@ -140,10 +138,10 @@ class CreateGroupRequest:
             # Get app owners by checking active owner app groups
             app_owner_user_ids = {u.id for u in get_app_managers(app.id)}
 
-            if self.requester.id in app_owner_user_ids:
+            if requester.id in app_owner_user_ids:
                 ApproveGroupRequest(
                     group_request=group_request,
-                    approver_user=self.requester,
+                    approver_user=requester,
                     approval_reason="Requester owns parent app and can create app groups",
                     notify=False,
                     bypass_self_approval=True,
@@ -176,10 +174,10 @@ class CreateGroupRequest:
                     "event_type": EventType.group_request_create,
                     "user_agent": _ctx.user_agent if _ctx else None,
                     "ip": _ctx.ip if _ctx else None,
-                    "current_user_id": self.requester.id,
-                    "current_user_email": self.requester.email,
+                    "current_user_id": requester.id,
+                    "current_user_email": requester.email,
                     "group_request": group_request,
-                    "requester": self.requester,
+                    "requester": requester,
                 }
             )
         )
@@ -187,7 +185,7 @@ class CreateGroupRequest:
         # Check conditional access hook
         conditional_access_responses = self.conditional_access_hook.group_request_created(
             group_request=group_request,
-            requester=self.requester,
+            requester=requester,
         )
 
         for response in conditional_access_responses:
@@ -210,7 +208,7 @@ class CreateGroupRequest:
         # Send notification to approvers
         self.notification_hook.access_group_request_created(
             group_request=group_request,
-            requester=self.requester,
+            requester=requester,
             approvers=approvers,
         )
 

--- a/api/operations/create_group_request.py
+++ b/api/operations/create_group_request.py
@@ -41,7 +41,7 @@ class CreateGroupRequest:
     ):
         self.id = self.__generate_id()
 
-        self._requester_user_arg = requester_user
+        self.requester_user_id = requester_user if isinstance(requester_user, str) else requester_user.id
 
         self.requested_group_name = requested_group_name
         self.requested_group_description = requested_group_description
@@ -55,11 +55,7 @@ class CreateGroupRequest:
         self.notification_hook = get_notification_hook()
 
     def execute(self) -> Optional[GroupRequest]:
-        requester_user = self._requester_user_arg
-        if isinstance(requester_user, str):
-            requester = db.session.get(OktaUser, requester_user)
-        else:
-            requester = requester_user
+        requester = db.session.get(OktaUser, self.requester_user_id)
 
         # Don't allow creating groups with -Owners suffix (reserved for app owner groups)
         if self.requested_group_name.endswith(f"-{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"):

--- a/api/operations/create_group_request.py
+++ b/api/operations/create_group_request.py
@@ -41,10 +41,7 @@ class CreateGroupRequest:
     ):
         self.id = self.__generate_id()
 
-        if isinstance(requester_user, str):
-            self.requester = db.session.get(OktaUser, requester_user)
-        else:
-            self.requester = requester_user
+        self._requester_user_arg = requester_user
 
         self.requested_group_name = requested_group_name
         self.requested_group_description = requested_group_description
@@ -57,7 +54,15 @@ class CreateGroupRequest:
         self.conditional_access_hook = get_conditional_access_hook()
         self.notification_hook = get_notification_hook()
 
+    def _resolve(self) -> None:
+        requester_user = self._requester_user_arg
+        if isinstance(requester_user, str):
+            self.requester = db.session.get(OktaUser, requester_user)
+        else:
+            self.requester = requester_user
+
     def execute(self) -> Optional[GroupRequest]:
+        self._resolve()
         # Don't allow creating groups with -Owners suffix (reserved for app owner groups)
         if self.requested_group_name.endswith(f"-{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"):
             return None

--- a/api/operations/create_role_request.py
+++ b/api/operations/create_role_request.py
@@ -43,6 +43,22 @@ class CreateRoleRequest:
     ):
         self.id = self.__generate_id()
 
+        self._requester_user_arg = requester_user
+        self._requester_role_arg = requester_role
+        self._requested_group_arg = requested_group
+
+        self.request_ownership = request_ownership
+        self.request_reason = request_reason
+        self.request_ending_at = request_ending_at
+
+        self.conditional_access_hook = get_conditional_access_hook()
+        self.notification_hook = get_notification_hook()
+
+    def _resolve(self) -> None:
+        requester_user = self._requester_user_arg
+        requester_role = self._requester_role_arg
+        requested_group = self._requested_group_arg
+
         if isinstance(requester_user, str):
             self.requester = db.session.get(OktaUser, requester_user)
         else:
@@ -73,14 +89,8 @@ class CreateRoleRequest:
             .where(OktaGroup.id == (requested_group if isinstance(requested_group, str) else requested_group.id))
         ).first()
 
-        self.request_ownership = request_ownership
-        self.request_reason = request_reason
-        self.request_ending_at = request_ending_at
-
-        self.conditional_access_hook = get_conditional_access_hook()
-        self.notification_hook = get_notification_hook()
-
     def execute(self) -> Optional[RoleRequest]:
+        self._resolve()
         # Don't allow creating a request for an unmanaged group
         if not self.requested_group.is_managed:
             return None

--- a/api/operations/create_role_request.py
+++ b/api/operations/create_role_request.py
@@ -43,9 +43,9 @@ class CreateRoleRequest:
     ):
         self.id = self.__generate_id()
 
-        self._requester_user_arg = requester_user
-        self._requester_role_arg = requester_role
-        self._requested_group_arg = requested_group
+        self.requester_user_id = requester_user if isinstance(requester_user, str) else requester_user.id
+        self.requester_role_id = requester_role if isinstance(requester_role, str) else requester_role.id
+        self.requested_group_id = requested_group if isinstance(requested_group, str) else requested_group.id
 
         self.request_ownership = request_ownership
         self.request_reason = request_reason
@@ -55,28 +55,11 @@ class CreateRoleRequest:
         self.notification_hook = get_notification_hook()
 
     def execute(self) -> Optional[RoleRequest]:
-        requester_user = self._requester_user_arg
-        requester_role_arg = self._requester_role_arg
-        requested_group_arg = self._requested_group_arg
+        requester = db.session.get(OktaUser, self.requester_user_id)
 
-        if isinstance(requester_user, str):
-            requester = db.session.get(OktaUser, requester_user)
-        else:
-            requester = requester_user
-
-        if isinstance(requester_role_arg, str):
-            requester_role = db.session.scalars(
-                select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == requester_role_arg)
-            ).first()
-            # self.requester_role = (
-            #     db.session.query(RoleGroup)
-            #     .options(joinedload(OktaUserGroupMember.user))
-            #     .filter(RoleGroup.deleted_at.is_(None))
-            #     .filter(RoleGroup.id == requester_role)
-            #     .first()
-            # )
-        else:
-            requester_role = requester_role_arg
+        requester_role = db.session.scalars(
+            select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == self.requester_role_id)
+        ).first()
 
         requested_group = db.session.scalars(
             select(OktaGroup)
@@ -86,10 +69,7 @@ class CreateRoleRequest:
                 selectinload(OktaGroup.active_group_tags).options(joinedload(OktaGroupTagMap.active_tag)),
             )
             .where(OktaGroup.deleted_at.is_(None))
-            .where(
-                OktaGroup.id
-                == (requested_group_arg if isinstance(requested_group_arg, str) else requested_group_arg.id)
-            )
+            .where(OktaGroup.id == self.requested_group_id)
         ).first()
 
         # Don't allow creating a request for an unmanaged group

--- a/api/operations/create_role_request.py
+++ b/api/operations/create_role_request.py
@@ -54,19 +54,19 @@ class CreateRoleRequest:
         self.conditional_access_hook = get_conditional_access_hook()
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
+    def execute(self) -> Optional[RoleRequest]:
         requester_user = self._requester_user_arg
-        requester_role = self._requester_role_arg
-        requested_group = self._requested_group_arg
+        requester_role_arg = self._requester_role_arg
+        requested_group_arg = self._requested_group_arg
 
         if isinstance(requester_user, str):
-            self.requester = db.session.get(OktaUser, requester_user)
+            requester = db.session.get(OktaUser, requester_user)
         else:
-            self.requester = requester_user
+            requester = requester_user
 
-        if isinstance(requester_role, str):
-            self.requester_role = db.session.scalars(
-                select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == requester_role)
+        if isinstance(requester_role_arg, str):
+            requester_role = db.session.scalars(
+                select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == requester_role_arg)
             ).first()
             # self.requester_role = (
             #     db.session.query(RoleGroup)
@@ -76,9 +76,9 @@ class CreateRoleRequest:
             #     .first()
             # )
         else:
-            self.requester_role = requester_role
+            requester_role = requester_role_arg
 
-        self.requested_group = db.session.scalars(
+        requested_group = db.session.scalars(
             select(OktaGroup)
             .options(
                 selectin_polymorphic(OktaGroup, [AppGroup]),
@@ -86,25 +86,26 @@ class CreateRoleRequest:
                 selectinload(OktaGroup.active_group_tags).options(joinedload(OktaGroupTagMap.active_tag)),
             )
             .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == (requested_group if isinstance(requested_group, str) else requested_group.id))
+            .where(
+                OktaGroup.id
+                == (requested_group_arg if isinstance(requested_group_arg, str) else requested_group_arg.id)
+            )
         ).first()
 
-    def execute(self) -> Optional[RoleRequest]:
-        self._resolve()
         # Don't allow creating a request for an unmanaged group
-        if not self.requested_group.is_managed:
+        if not requested_group.is_managed:
             return None
 
         # Don't allow creating a request for a role group
-        if type(self.requested_group) is RoleGroup:
+        if type(requested_group) is RoleGroup:
             return None
 
         role_request = RoleRequest(
             id=self.id,
             status=AccessRequestStatus.PENDING,
-            requester_user_id=self.requester.id,
-            requester_role_id=self.requester_role.id,
-            requested_group_id=self.requested_group.id,
+            requester_user_id=requester.id,
+            requester_role_id=requester_role.id,
+            requested_group_id=requested_group.id,
             request_ownership=self.request_ownership,
             request_reason=self.request_reason,
             request_ending_at=self.request_ending_at,
@@ -114,15 +115,15 @@ class CreateRoleRequest:
         db.session.commit()
 
         # Fetch the users to notify
-        approvers = get_group_managers(self.requested_group.id)
+        approvers = get_group_managers(requested_group.id)
 
-        requested_group_tags = [tm.active_tag for tm in self.requested_group.active_group_tags]
+        requested_group_tags = [tm.active_tag for tm in requested_group.active_group_tags]
 
         role_memberships = [
             u.user_id
             for u in db.session.scalars(
                 select(OktaUserGroupMember)
-                .where(OktaUserGroupMember.group_id == self.requester_role.id)
+                .where(OktaUserGroupMember.group_id == requester_role.id)
                 .where(OktaUserGroupMember.is_owner.is_(False))
                 .where(
                     or_(
@@ -152,14 +153,14 @@ class CreateRoleRequest:
         # If there are no approvers, try to get the app managers
         # or if the only approver is the requester, try to get the app managers
         if (
-            (len(approvers) == 0 and type(self.requested_group) is AppGroup)
-            or (len(approvers) == 1 and approvers[0].id == self.requester.id)
-            and type(self.requested_group) is AppGroup
+            (len(approvers) == 0 and type(requested_group) is AppGroup)
+            or (len(approvers) == 1 and approvers[0].id == requester.id)
+            and type(requested_group) is AppGroup
         ):
-            approvers = get_app_managers(self.requested_group.app_id)
+            approvers = get_app_managers(requested_group.app_id)
 
         # If there are still no approvers, try to get the access owners
-        if len(approvers) == 0 or (len(approvers) == 1 and approvers[0].id == self.requester.id):
+        if len(approvers) == 0 or (len(approvers) == 1 and approvers[0].id == requester.id):
             approvers = get_access_owners()
 
         group = db.session.scalars(
@@ -172,7 +173,7 @@ class CreateRoleRequest:
                 ),
             )
             .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == self.requested_group.id)
+            .where(OktaGroup.id == requested_group.id)
         ).first()
 
         # Audit logging
@@ -184,11 +185,11 @@ class CreateRoleRequest:
                     "event_type": EventType.role_request_create,
                     "user_agent": _ctx.user_agent if _ctx else None,
                     "ip": _ctx.ip if _ctx else None,
-                    "current_user_id": self.requester.id,
-                    "current_user_email": self.requester.email,
+                    "current_user_id": requester.id,
+                    "current_user_email": requester.email,
                     "group": group,
                     "role_request": role_request,
-                    "requester": self.requester,
+                    "requester": requester,
                     "group_owners": approvers,
                 }
             )
@@ -196,11 +197,11 @@ class CreateRoleRequest:
 
         conditional_access_responses = self.conditional_access_hook.role_request_created(
             role_request=role_request,
-            role=self.requester_role,
-            group=self.requested_group,
+            role=requester_role,
+            group=requested_group,
             group_tags=[active_tag_map.enabled_active_tag for active_tag_map in group.active_group_tags],
-            requester=self.requester,
-            requester_role=self.requester_role,
+            requester=requester,
+            requester_role=requester_role,
         )
 
         for response in conditional_access_responses:
@@ -223,9 +224,9 @@ class CreateRoleRequest:
 
         self.notification_hook.access_role_request_created(
             role_request=role_request,
-            role=self.requester_role,
-            group=self.requested_group,
-            requester=self.requester,
+            role=requester_role,
+            group=requested_group,
+            requester=requester,
             approvers=approvers,
         )
 

--- a/api/operations/create_tag.py
+++ b/api/operations/create_tag.py
@@ -27,15 +27,19 @@ class CreateTag:
             tag.id = id
             self.tag = tag
 
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self) -> Tag:
+        self._resolve()
         # Do not allow non-deleted groups with the same name (case-insensitive)
         existing_tag = db.session.scalars(
             select(Tag).where(func.lower(Tag.name) == func.lower(self.tag.name)).where(Tag.deleted_at.is_(None))

--- a/api/operations/create_tag.py
+++ b/api/operations/create_tag.py
@@ -27,12 +27,12 @@ class CreateTag:
             tag.id = id
             self.tag = tag
 
-        self._current_user_id_arg = current_user_id
+        self.current_user_id = current_user_id
 
     def execute(self) -> Tag:
         current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self.current_user_id)
             ).first(),
             "id",
             None,

--- a/api/operations/create_tag.py
+++ b/api/operations/create_tag.py
@@ -29,8 +29,8 @@ class CreateTag:
 
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
-        self.current_user_id = getattr(
+    def execute(self) -> Tag:
+        current_user_id = getattr(
             db.session.scalars(
                 select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
@@ -38,8 +38,6 @@ class CreateTag:
             None,
         )
 
-    def execute(self) -> Tag:
-        self._resolve()
         # Do not allow non-deleted groups with the same name (case-insensitive)
         existing_tag = db.session.scalars(
             select(Tag).where(func.lower(Tag.name) == func.lower(self.tag.name)).where(Tag.deleted_at.is_(None))
@@ -52,8 +50,8 @@ class CreateTag:
 
         # Audit logging
         email = None
-        if self.current_user_id is not None:
-            email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
+        if current_user_id is not None:
+            email = getattr(db.session.get(OktaUser, current_user_id), "email", None)
 
         _ctx = get_request_context()
 
@@ -63,7 +61,7 @@ class CreateTag:
                     "event_type": EventType.tag_create,
                     "user_agent": _ctx.user_agent if _ctx else None,
                     "ip": _ctx.ip if _ctx else None,
-                    "current_user_id": self.current_user_id,
+                    "current_user_id": current_user_id,
                     "current_user_email": email,
                     "tag": self.tag,
                 }

--- a/api/operations/delete_app.py
+++ b/api/operations/delete_app.py
@@ -13,15 +13,11 @@ from api.schemas import AuditLogSchema, EventType
 
 class DeleteApp:
     def __init__(self, *, app: App | str, current_user_id: Optional[str] = None):
-        self._app_arg = app
+        self.app_id = app if isinstance(app, str) else app.id
         self._current_user_id_arg = current_user_id
 
     def execute(self) -> None:
-        app_arg = self._app_arg
-        if isinstance(app_arg, str):
-            app = db.session.scalars(select(App).where(App.deleted_at.is_(None)).where(App.id == app_arg)).first()
-        else:
-            app = app_arg
+        app = db.session.scalars(select(App).where(App.deleted_at.is_(None)).where(App.id == self.app_id)).first()
 
         current_user_id = getattr(
             db.session.scalars(

--- a/api/operations/delete_app.py
+++ b/api/operations/delete_app.py
@@ -14,14 +14,14 @@ from api.schemas import AuditLogSchema, EventType
 class DeleteApp:
     def __init__(self, *, app: App | str, current_user_id: Optional[str] = None):
         self.app_id = app if isinstance(app, str) else app.id
-        self._current_user_id_arg = current_user_id
+        self.current_user_id = current_user_id
 
     def execute(self) -> None:
         app = db.session.scalars(select(App).where(App.deleted_at.is_(None)).where(App.id == self.app_id)).first()
 
         current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self.current_user_id)
             ).first(),
             "id",
             None,

--- a/api/operations/delete_app.py
+++ b/api/operations/delete_app.py
@@ -13,6 +13,11 @@ from api.schemas import AuditLogSchema, EventType
 
 class DeleteApp:
     def __init__(self, *, app: App | str, current_user_id: Optional[str] = None):
+        self._app_arg = app
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
+        app = self._app_arg
         if isinstance(app, str):
             self.app = db.session.scalars(select(App).where(App.deleted_at.is_(None)).where(App.id == app)).first()
         else:
@@ -20,13 +25,14 @@ class DeleteApp:
 
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self) -> None:
+        self._resolve()
         # Prevent access app deletion
         if self.app.name == App.ACCESS_APP_RESERVED_NAME:
             raise ValueError("The Access Application cannot be deleted")

--- a/api/operations/delete_app.py
+++ b/api/operations/delete_app.py
@@ -16,14 +16,14 @@ class DeleteApp:
         self._app_arg = app
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
-        app = self._app_arg
-        if isinstance(app, str):
-            self.app = db.session.scalars(select(App).where(App.deleted_at.is_(None)).where(App.id == app)).first()
+    def execute(self) -> None:
+        app_arg = self._app_arg
+        if isinstance(app_arg, str):
+            app = db.session.scalars(select(App).where(App.deleted_at.is_(None)).where(App.id == app_arg)).first()
         else:
-            self.app = app
+            app = app_arg
 
-        self.current_user_id = getattr(
+        current_user_id = getattr(
             db.session.scalars(
                 select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
@@ -31,16 +31,14 @@ class DeleteApp:
             None,
         )
 
-    def execute(self) -> None:
-        self._resolve()
         # Prevent access app deletion
-        if self.app.name == App.ACCESS_APP_RESERVED_NAME:
+        if app.name == App.ACCESS_APP_RESERVED_NAME:
             raise ValueError("The Access Application cannot be deleted")
 
         # Audit logging
         email = None
-        if self.current_user_id is not None:
-            email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
+        if current_user_id is not None:
+            email = getattr(db.session.get(OktaUser, current_user_id), "email", None)
 
         _ctx = get_request_context()
 
@@ -50,28 +48,28 @@ class DeleteApp:
                     "event_type": EventType.app_delete,
                     "user_agent": _ctx.user_agent if _ctx else None,
                     "ip": _ctx.ip if _ctx else None,
-                    "current_user_id": self.current_user_id,
+                    "current_user_id": current_user_id,
                     "current_user_email": email,
-                    "app": self.app,
+                    "app": app,
                 }
             )
         )
 
-        self.app.deleted_at = func.now()
+        app.deleted_at = func.now()
         db.session.commit()
 
         # Delete all associated Okta App Groups and end their membership
         app_groups = db.session.scalars(
-            select(AppGroup).where(AppGroup.deleted_at.is_(None)).where(AppGroup.app_id == self.app.id)
+            select(AppGroup).where(AppGroup.deleted_at.is_(None)).where(AppGroup.app_id == app.id)
         ).all()
         app_group_ids = [ag.id for ag in app_groups]
         for app_group_id in app_group_ids:
-            DeleteGroup(group=app_group_id, current_user_id=self.current_user_id).execute()
+            DeleteGroup(group=app_group_id, current_user_id=current_user_id).execute()
 
         # End all tag mappings for this app (OktaGroupTagMaps are ended by the DeleteGroup operation above)
         db.session.execute(
             update(AppTagMap)
-            .where(AppTagMap.app_id == self.app.id)
+            .where(AppTagMap.app_id == app.id)
             .where(
                 or_(
                     AppTagMap.ended_at.is_(None),

--- a/api/operations/delete_group.py
+++ b/api/operations/delete_group.py
@@ -34,7 +34,7 @@ class DeleteGroup:
 
         self.sync_to_okta = sync_to_okta
 
-        self._current_user_id_arg = current_user_id
+        self.current_user_id = current_user_id
 
     def execute(self) -> None:
         # Run asychronously to parallelize Okta API requests
@@ -49,7 +49,7 @@ class DeleteGroup:
 
         current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self.current_user_id)
             ).first(),
             "id",
             None,

--- a/api/operations/delete_group.py
+++ b/api/operations/delete_group.py
@@ -30,7 +30,7 @@ from api.schemas import AuditLogSchema, EventType
 
 class DeleteGroup:
     def __init__(self, *, group: OktaGroup | str, sync_to_okta: bool = True, current_user_id: Optional[str] = None):
-        self._group_arg = group
+        self.group_id = group if isinstance(group, str) else group.id
 
         self.sync_to_okta = sync_to_okta
 
@@ -41,11 +41,10 @@ class DeleteGroup:
         asyncio.run(self._execute())
 
     async def _execute(self) -> None:
-        group_arg = self._group_arg
         group = db.session.scalars(
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
-            .where(OktaGroup.id == (group_arg if isinstance(group_arg, str) else group_arg.id))
+            .where(OktaGroup.id == self.group_id)
         ).first()
 
         current_user_id = getattr(

--- a/api/operations/delete_group.py
+++ b/api/operations/delete_group.py
@@ -30,23 +30,30 @@ from api.schemas import AuditLogSchema, EventType
 
 class DeleteGroup:
     def __init__(self, *, group: OktaGroup | str, sync_to_okta: bool = True, current_user_id: Optional[str] = None):
+        self._group_arg = group
+
+        self.sync_to_okta = sync_to_okta
+
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
+        group = self._group_arg
         self.group = db.session.scalars(
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
             .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
         ).first()
 
-        self.sync_to_okta = sync_to_okta
-
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self) -> None:
+        self._resolve()
         # Run asychronously to parallelize Okta API requests
         asyncio.run(self._execute())
 

--- a/api/operations/delete_group.py
+++ b/api/operations/delete_group.py
@@ -36,15 +36,19 @@ class DeleteGroup:
 
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
-        group = self._group_arg
-        self.group = db.session.scalars(
+    def execute(self) -> None:
+        # Run asychronously to parallelize Okta API requests
+        asyncio.run(self._execute())
+
+    async def _execute(self) -> None:
+        group_arg = self._group_arg
+        group = db.session.scalars(
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
-            .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+            .where(OktaGroup.id == (group_arg if isinstance(group_arg, str) else group_arg.id))
         ).first()
 
-        self.current_user_id = getattr(
+        current_user_id = getattr(
             db.session.scalars(
                 select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
@@ -52,27 +56,19 @@ class DeleteGroup:
             None,
         )
 
-    def execute(self) -> None:
-        self._resolve()
-        # Run asychronously to parallelize Okta API requests
-        asyncio.run(self._execute())
-
-    async def _execute(self) -> None:
         # Create a list of okta asyncio tasks to wait to completion on at the end of this function
         okta_tasks = []
 
         # Prevent deletion of the Access owner group
-        if type(self.group) is AppGroup and self.group.is_owner:
-            app = db.session.scalars(
-                select(App).where(App.id == self.group.app_id).where(App.deleted_at.is_(None))
-            ).first()
+        if type(group) is AppGroup and group.is_owner:
+            app = db.session.scalars(select(App).where(App.id == group.app_id).where(App.deleted_at.is_(None))).first()
             if app is not None and app.name == App.ACCESS_APP_RESERVED_NAME:
                 raise ValueError("Access application owner group cannot be deleted")
 
         # Audit logging
         email = None
-        if self.current_user_id is not None:
-            email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
+        if current_user_id is not None:
+            email = getattr(db.session.get(OktaUser, current_user_id), "email", None)
 
         _ctx = get_request_context()
 
@@ -82,17 +78,17 @@ class DeleteGroup:
                     "event_type": EventType.group_delete,
                     "user_agent": _ctx.user_agent if _ctx else None,
                     "ip": _ctx.ip if _ctx else None,
-                    "current_user_id": self.current_user_id,
+                    "current_user_id": current_user_id,
                     "current_user_email": email,
-                    "group": self.group,
+                    "group": group,
                 }
             )
         )
 
         if self.sync_to_okta:
-            okta_tasks.append(asyncio.create_task(okta.async_delete_group(self.group.id)))
+            okta_tasks.append(asyncio.create_task(okta.async_delete_group(group.id)))
 
-        self.group.deleted_at = func.now()
+        group.deleted_at = func.now()
 
         # End all group members including group members via a role
         group_memberships_query = (
@@ -103,7 +99,7 @@ class DeleteGroup:
                     OktaUserGroupMember.ended_at > func.now(),
                 )
             )
-            .where(OktaUserGroupMember.group_id == self.group.id)
+            .where(OktaUserGroupMember.group_id == group.id)
         )
 
         direct_members_to_remove_ids = [
@@ -131,7 +127,7 @@ class DeleteGroup:
                     OktaUserGroupMember.ended_at > func.now(),
                 )
             )
-            .where(OktaUserGroupMember.group_id == self.group.id)
+            .where(OktaUserGroupMember.group_id == group.id)
             .values({OktaUserGroupMember.ended_at: func.now()})
             .execution_options(synchronize_session="fetch")
         )
@@ -140,12 +136,12 @@ class DeleteGroup:
         db.session.execute(
             update(RoleGroupMap)
             .where(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
-            .where(RoleGroupMap.group_id == self.group.id)
+            .where(RoleGroupMap.group_id == group.id)
             .values({RoleGroupMap.ended_at: func.now()})
             .execution_options(synchronize_session="fetch")
         )
 
-        if type(self.group) is RoleGroup:
+        if type(group) is RoleGroup:
             # End all group memberships via the role grant
             db.session.execute(
                 update(OktaUserGroupMember)
@@ -164,7 +160,7 @@ class DeleteGroup:
                                 RoleGroupMap.ended_at > func.now(),
                             )
                         )
-                        .where(RoleGroupMap.role_group_id == self.group.id)
+                        .where(RoleGroupMap.role_group_id == group.id)
                     )
                 )
                 .values({OktaUserGroupMember.ended_at: func.now()})
@@ -177,7 +173,7 @@ class DeleteGroup:
             role_associated_groups_mappings_query = (
                 select(RoleGroupMap)
                 .where(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
-                .where(RoleGroupMap.role_group_id == self.group.id)
+                .where(RoleGroupMap.role_group_id == group.id)
             )
 
             if self.sync_to_okta:
@@ -242,7 +238,7 @@ class DeleteGroup:
             db.session.execute(
                 update(RoleGroupMap)
                 .where(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
-                .where(RoleGroupMap.role_group_id == self.group.id)
+                .where(RoleGroupMap.role_group_id == group.id)
                 .values({RoleGroupMap.ended_at: func.now()})
                 .execution_options(synchronize_session="fetch")
             )
@@ -252,7 +248,7 @@ class DeleteGroup:
         # Reject all pending access requests for this group
         obsolete_access_requests = db.session.scalars(
             select(AccessRequest)
-            .where(AccessRequest.requested_group_id == self.group.id)
+            .where(AccessRequest.requested_group_id == group.id)
             .where(AccessRequest.status == AccessRequestStatus.PENDING)
             .where(AccessRequest.resolved_at.is_(None))
         ).all()
@@ -260,7 +256,7 @@ class DeleteGroup:
             RejectAccessRequest(
                 access_request=obsolete_access_request,
                 rejection_reason="Closed because the requested group was deleted",
-                current_user_id=self.current_user_id,
+                current_user_id=current_user_id,
             ).execute()
 
         # Reject all pending role requests touching this group, either as the
@@ -269,8 +265,8 @@ class DeleteGroup:
             select(RoleRequest)
             .where(
                 or_(
-                    RoleRequest.requested_group_id == self.group.id,
-                    RoleRequest.requester_role_id == self.group.id,
+                    RoleRequest.requested_group_id == group.id,
+                    RoleRequest.requester_role_id == group.id,
                 )
             )
             .where(RoleRequest.status == AccessRequestStatus.PENDING)
@@ -280,7 +276,7 @@ class DeleteGroup:
             RejectRoleRequest(
                 role_request=obsolete_role_request,
                 rejection_reason="Closed because a group in this role request was deleted",
-                current_user_id=self.current_user_id,
+                current_user_id=current_user_id,
             ).execute()
 
         # End all tag mappings for this group
@@ -293,7 +289,7 @@ class DeleteGroup:
                 )
             )
             .where(
-                OktaGroupTagMap.group_id == self.group.id,
+                OktaGroupTagMap.group_id == group.id,
             )
             .values({OktaGroupTagMap.ended_at: func.now()})
             .execution_options(synchronize_session="fetch")
@@ -301,15 +297,15 @@ class DeleteGroup:
         db.session.commit()
 
         # Invoke app group lifecycle plugin hook, if configured
-        plugin_id = get_app_group_lifecycle_plugin_to_invoke(self.group)
+        plugin_id = get_app_group_lifecycle_plugin_to_invoke(group)
         if plugin_id is not None:
             try:
                 hook = get_app_group_lifecycle_hook()
-                hook.group_deleted(session=db.session, group=self.group, plugin_id=plugin_id)
+                hook.group_deleted(session=db.session, group=group, plugin_id=plugin_id)
                 db.session.commit()
             except Exception:
                 logging.getLogger("api").exception(
-                    f"Failed to invoke group_deleted hook for group {self.group.id} with plugin '{plugin_id}'"
+                    f"Failed to invoke group_deleted hook for group {group.id} with plugin '{plugin_id}'"
                 )
                 db.session.rollback()
 

--- a/api/operations/delete_tag.py
+++ b/api/operations/delete_tag.py
@@ -15,10 +15,12 @@ class DeleteTag:
         self._tag_arg = tag
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
-        tag = self._tag_arg
-        self.tag = db.session.scalars(select(Tag).where(Tag.id == (tag if isinstance(tag, str) else tag.id))).first()
-        self.current_user_id = getattr(
+    def execute(self) -> None:
+        tag_arg = self._tag_arg
+        tag = db.session.scalars(
+            select(Tag).where(Tag.id == (tag_arg if isinstance(tag_arg, str) else tag_arg.id))
+        ).first()
+        current_user_id = getattr(
             db.session.scalars(
                 select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
@@ -26,12 +28,10 @@ class DeleteTag:
             None,
         )
 
-    def execute(self) -> None:
-        self._resolve()
         # Audit logging
         email = None
-        if self.current_user_id is not None:
-            email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
+        if current_user_id is not None:
+            email = getattr(db.session.get(OktaUser, current_user_id), "email", None)
 
         _ctx = get_request_context()
 
@@ -41,16 +41,16 @@ class DeleteTag:
                     "event_type": EventType.tag_delete,
                     "user_agent": _ctx.user_agent if _ctx else None,
                     "ip": _ctx.ip if _ctx else None,
-                    "current_user_id": self.current_user_id,
+                    "current_user_id": current_user_id,
                     "current_user_email": email,
-                    "tag": self.tag,
+                    "tag": tag,
                 }
             )
         )
 
         # Disable and delete tag
-        self.tag.enabled = False
-        self.tag.deleted_at = func.now()
+        tag.enabled = False
+        tag.deleted_at = func.now()
 
         # End all active group tag mappings for tag
         db.session.execute(
@@ -61,7 +61,7 @@ class DeleteTag:
                     OktaGroupTagMap.ended_at > func.now(),
                 )
             )
-            .where(OktaGroupTagMap.tag_id == self.tag.id)
+            .where(OktaGroupTagMap.tag_id == tag.id)
             .values({OktaGroupTagMap.ended_at: func.now()})
             .execution_options(synchronize_session="fetch")
         )
@@ -75,7 +75,7 @@ class DeleteTag:
                     AppTagMap.ended_at > func.now(),
                 )
             )
-            .where(AppTagMap.tag_id == self.tag.id)
+            .where(AppTagMap.tag_id == tag.id)
             .values({AppTagMap.ended_at: func.now()})
             .execution_options(synchronize_session="fetch")
         )

--- a/api/operations/delete_tag.py
+++ b/api/operations/delete_tag.py
@@ -12,16 +12,22 @@ from api.schemas import AuditLogSchema, EventType
 
 class DeleteTag:
     def __init__(self, *, tag: Tag | str, current_user_id: Optional[str] = None):
+        self._tag_arg = tag
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
+        tag = self._tag_arg
         self.tag = db.session.scalars(select(Tag).where(Tag.id == (tag if isinstance(tag, str) else tag.id))).first()
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self) -> None:
+        self._resolve()
         # Audit logging
         email = None
         if self.current_user_id is not None:

--- a/api/operations/delete_tag.py
+++ b/api/operations/delete_tag.py
@@ -13,13 +13,13 @@ from api.schemas import AuditLogSchema, EventType
 class DeleteTag:
     def __init__(self, *, tag: Tag | str, current_user_id: Optional[str] = None):
         self.tag_id = tag if isinstance(tag, str) else tag.id
-        self._current_user_id_arg = current_user_id
+        self.current_user_id = current_user_id
 
     def execute(self) -> None:
         tag = db.session.scalars(select(Tag).where(Tag.id == self.tag_id)).first()
         current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self.current_user_id)
             ).first(),
             "id",
             None,

--- a/api/operations/delete_tag.py
+++ b/api/operations/delete_tag.py
@@ -12,14 +12,11 @@ from api.schemas import AuditLogSchema, EventType
 
 class DeleteTag:
     def __init__(self, *, tag: Tag | str, current_user_id: Optional[str] = None):
-        self._tag_arg = tag
+        self.tag_id = tag if isinstance(tag, str) else tag.id
         self._current_user_id_arg = current_user_id
 
     def execute(self) -> None:
-        tag_arg = self._tag_arg
-        tag = db.session.scalars(
-            select(Tag).where(Tag.id == (tag_arg if isinstance(tag_arg, str) else tag_arg.id))
-        ).first()
+        tag = db.session.scalars(select(Tag).where(Tag.id == self.tag_id)).first()
         current_user_id = getattr(
             db.session.scalars(
                 select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)

--- a/api/operations/delete_user.py
+++ b/api/operations/delete_user.py
@@ -28,14 +28,18 @@ class DeleteUser:
 
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
-        user = self._user_arg
-        if isinstance(user, str):
-            self.user = db.session.scalars(select(OktaUser).where(OktaUser.id == user)).first()
-        else:
-            self.user = user
+    def execute(self) -> None:
+        # Run asychronously to parallelize Okta API requests
+        return asyncio.run(self._execute())
 
-        self.current_user_id = getattr(
+    async def _execute(self) -> None:
+        user_arg = self._user_arg
+        if isinstance(user_arg, str):
+            user = db.session.scalars(select(OktaUser).where(OktaUser.id == user_arg)).first()
+        else:
+            user = user_arg
+
+        current_user_id = getattr(
             db.session.scalars(
                 select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
@@ -43,17 +47,11 @@ class DeleteUser:
             None,
         )
 
-    def execute(self) -> None:
-        self._resolve()
-        # Run asychronously to parallelize Okta API requests
-        return asyncio.run(self._execute())
-
-    async def _execute(self) -> None:
         # Create a list of okta asyncio tasks to wait to completion on at the end of this function
         okta_tasks = []
 
-        if self.user.deleted_at is None:
-            self.user.deleted_at = func.now()
+        if user.deleted_at is None:
+            user.deleted_at = func.now()
 
         # End all user memberships including group memberships via a role
         group_access_query = (
@@ -64,7 +62,7 @@ class DeleteUser:
                     OktaUserGroupMember.ended_at > func.now(),
                 )
             )
-            .where(OktaUserGroupMember.user_id == self.user.id)
+            .where(OktaUserGroupMember.user_id == user.id)
         )
 
         if self.sync_to_okta:
@@ -83,7 +81,7 @@ class DeleteUser:
             ]
 
             for group_id in group_memberships_to_remove_ids:
-                okta_tasks.append(asyncio.create_task(okta.async_remove_user_from_group(group_id, self.user.id)))
+                okta_tasks.append(asyncio.create_task(okta.async_remove_user_from_group(group_id, user.id)))
 
             # Remove user from group ownerships in Okta
             group_ownerships_to_remove_ids = [
@@ -94,7 +92,7 @@ class DeleteUser:
             ]
 
             for group_id in group_ownerships_to_remove_ids:
-                okta_tasks.append(asyncio.create_task(okta.async_remove_owner_from_group(group_id, self.user.id)))
+                okta_tasks.append(asyncio.create_task(okta.async_remove_owner_from_group(group_id, user.id)))
 
         db.session.execute(
             update(OktaUserGroupMember)
@@ -104,7 +102,7 @@ class DeleteUser:
                     OktaUserGroupMember.ended_at > func.now(),
                 )
             )
-            .where(OktaUserGroupMember.user_id == self.user.id)
+            .where(OktaUserGroupMember.user_id == user.id)
             .values({OktaUserGroupMember.ended_at: func.now()})
             .execution_options(synchronize_session="fetch")
         )
@@ -113,7 +111,7 @@ class DeleteUser:
 
         obsolete_access_requests = db.session.scalars(
             select(AccessRequest)
-            .where(AccessRequest.requester_user_id == self.user.id)
+            .where(AccessRequest.requester_user_id == user.id)
             .where(AccessRequest.status == AccessRequestStatus.PENDING)
             .where(AccessRequest.resolved_at.is_(None))
         ).all()
@@ -121,7 +119,7 @@ class DeleteUser:
             RejectAccessRequest(
                 access_request=obsolete_access_request,
                 rejection_reason="Closed because the requestor was deleted",
-                current_user_id=self.current_user_id,
+                current_user_id=current_user_id,
             ).execute()
 
         # Reject pending role requests by the deleted user. ApproveRoleRequest
@@ -129,7 +127,7 @@ class DeleteUser:
         # grant the role access to the group after the requester is gone.
         obsolete_role_requests = db.session.scalars(
             select(RoleRequest)
-            .where(RoleRequest.requester_user_id == self.user.id)
+            .where(RoleRequest.requester_user_id == user.id)
             .where(RoleRequest.status == AccessRequestStatus.PENDING)
             .where(RoleRequest.resolved_at.is_(None))
         ).all()
@@ -137,13 +135,13 @@ class DeleteUser:
             RejectRoleRequest(
                 role_request=obsolete_role_request,
                 rejection_reason="Closed because the requestor was deleted",
-                current_user_id=self.current_user_id,
+                current_user_id=current_user_id,
             ).execute()
 
         # Reject pending group requests by the deleted user, mirroring above.
         obsolete_group_requests = db.session.scalars(
             select(GroupRequest)
-            .where(GroupRequest.requester_user_id == self.user.id)
+            .where(GroupRequest.requester_user_id == user.id)
             .where(GroupRequest.status == AccessRequestStatus.PENDING)
             .where(GroupRequest.resolved_at.is_(None))
         ).all()
@@ -151,7 +149,7 @@ class DeleteUser:
             RejectGroupRequest(
                 group_request=obsolete_group_request,
                 rejection_reason="Closed because the requestor was deleted",
-                current_user_id=self.current_user_id,
+                current_user_id=current_user_id,
             ).execute()
 
         if len(okta_tasks) > 0:

--- a/api/operations/delete_user.py
+++ b/api/operations/delete_user.py
@@ -26,7 +26,7 @@ class DeleteUser:
 
         self.sync_to_okta = sync_to_okta
 
-        self._current_user_id_arg = current_user_id
+        self.current_user_id = current_user_id
 
     def execute(self) -> None:
         # Run asychronously to parallelize Okta API requests
@@ -37,7 +37,7 @@ class DeleteUser:
 
         current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self.current_user_id)
             ).first(),
             "id",
             None,

--- a/api/operations/delete_user.py
+++ b/api/operations/delete_user.py
@@ -22,22 +22,29 @@ from api.services import okta
 
 class DeleteUser:
     def __init__(self, *, user: OktaUser | str, sync_to_okta: bool = True, current_user_id: Optional[str] = None):
+        self._user_arg = user
+
+        self.sync_to_okta = sync_to_okta
+
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
+        user = self._user_arg
         if isinstance(user, str):
             self.user = db.session.scalars(select(OktaUser).where(OktaUser.id == user)).first()
         else:
             self.user = user
 
-        self.sync_to_okta = sync_to_okta
-
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self) -> None:
+        self._resolve()
         # Run asychronously to parallelize Okta API requests
         return asyncio.run(self._execute())
 

--- a/api/operations/delete_user.py
+++ b/api/operations/delete_user.py
@@ -22,7 +22,7 @@ from api.services import okta
 
 class DeleteUser:
     def __init__(self, *, user: OktaUser | str, sync_to_okta: bool = True, current_user_id: Optional[str] = None):
-        self._user_arg = user
+        self.user_id = user if isinstance(user, str) else user.id
 
         self.sync_to_okta = sync_to_okta
 
@@ -33,11 +33,7 @@ class DeleteUser:
         return asyncio.run(self._execute())
 
     async def _execute(self) -> None:
-        user_arg = self._user_arg
-        if isinstance(user_arg, str):
-            user = db.session.scalars(select(OktaUser).where(OktaUser.id == user_arg)).first()
-        else:
-            user = user_arg
+        user = db.session.scalars(select(OktaUser).where(OktaUser.id == self.user_id)).first()
 
         current_user_id = getattr(
             db.session.scalars(

--- a/api/operations/modify_app_tags.py
+++ b/api/operations/modify_app_tags.py
@@ -25,21 +25,23 @@ class ModifyAppTags:
         self._tags_to_remove_arg = tags_to_remove
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
-        app = self._app_arg
-        self.app = db.session.scalars(
-            select(App).where(App.deleted_at.is_(None)).where(App.id == (app if isinstance(app, str) else app.id))
+    def execute(self) -> App:
+        app_arg = self._app_arg
+        app = db.session.scalars(
+            select(App)
+            .where(App.deleted_at.is_(None))
+            .where(App.id == (app_arg if isinstance(app_arg, str) else app_arg.id))
         ).first()
 
-        self.tags_to_add = db.session.scalars(
+        tags_to_add = db.session.scalars(
             select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_add_arg))
         ).all()
 
-        self.tags_to_remove = db.session.scalars(
+        tags_to_remove = db.session.scalars(
             select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_remove_arg))
         ).all()
 
-        self.current_user_id = getattr(
+        current_user_id = getattr(
             db.session.scalars(
                 select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
@@ -47,11 +49,9 @@ class ModifyAppTags:
             None,
         )
 
-    def execute(self) -> App:
-        self._resolve()
-        if len(self.tags_to_add) > 0:
+        if len(tags_to_add) > 0:
             # Only add tags that are not already associated with this app
-            tag_ids_to_add = [t.id for t in self.tags_to_add]
+            tag_ids_to_add = [t.id for t in tags_to_add]
             existing_tag_maps = db.session.scalars(
                 select(AppTagMap)
                 .where(
@@ -61,7 +61,7 @@ class ModifyAppTags:
                     )
                 )
                 .where(
-                    AppTagMap.app_id == self.app.id,
+                    AppTagMap.app_id == app.id,
                 )
                 .where(
                     AppTagMap.tag_id.in_(tag_ids_to_add),
@@ -74,7 +74,7 @@ class ModifyAppTags:
                 db.session.add(
                     AppTagMap(
                         tag_id=tag_id,
-                        app_id=self.app.id,
+                        app_id=app.id,
                     )
                 )
             db.session.commit()
@@ -82,7 +82,7 @@ class ModifyAppTags:
             new_app_tag_maps = db.session.scalars(
                 select(AppTagMap)
                 .where(AppTagMap.tag_id.in_(new_tag_ids_to_add))
-                .where(AppTagMap.app_id == self.app.id)
+                .where(AppTagMap.app_id == app.id)
                 .where(
                     or_(
                         AppTagMap.ended_at.is_(None),
@@ -92,7 +92,7 @@ class ModifyAppTags:
             ).all()
 
             all_app_groups = db.session.scalars(
-                select(AppGroup).where(AppGroup.app_id == self.app.id).where(AppGroup.deleted_at.is_(None))
+                select(AppGroup).where(AppGroup.app_id == app.id).where(AppGroup.deleted_at.is_(None))
             ).all()
             for app_tag_map in new_app_tag_maps:
                 for app_group in all_app_groups:
@@ -110,12 +110,12 @@ class ModifyAppTags:
 
             db.session.commit()
 
-        if len(self.tags_to_remove) > 0:
-            tag_ids_to_remove = [t.id for t in self.tags_to_remove]
+        if len(tags_to_remove) > 0:
+            tag_ids_to_remove = [t.id for t in tags_to_remove]
             existing_tag_maps_query = (
                 select(AppTagMap)
                 .where(AppTagMap.tag_id.in_(tag_ids_to_remove))
-                .where(AppTagMap.app_id == self.app.id)
+                .where(AppTagMap.app_id == app.id)
                 .where(
                     or_(
                         AppTagMap.ended_at.is_(None),
@@ -143,7 +143,7 @@ class ModifyAppTags:
             db.session.execute(
                 update(AppTagMap)
                 .where(AppTagMap.tag_id.in_(tag_ids_to_remove))
-                .where(AppTagMap.app_id == self.app.id)
+                .where(AppTagMap.app_id == app.id)
                 .where(
                     or_(
                         AppTagMap.ended_at.is_(None),
@@ -156,10 +156,10 @@ class ModifyAppTags:
             db.session.commit()
 
         # Audit log if tags changed
-        if len(self.tags_to_add) > 0 or len(self.tags_to_remove) > 0:
+        if len(tags_to_add) > 0 or len(tags_to_remove) > 0:
             email = None
-            if self.current_user_id is not None:
-                email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
+            if current_user_id is not None:
+                email = getattr(db.session.get(OktaUser, current_user_id), "email", None)
 
             _ctx = get_request_context()
             logging.getLogger("access.audit").info(
@@ -168,13 +168,13 @@ class ModifyAppTags:
                         "event_type": EventType.app_modify_tags,
                         "user_agent": _ctx.user_agent if _ctx else None,
                         "ip": _ctx.ip if _ctx else None,
-                        "current_user_id": self.current_user_id,
+                        "current_user_id": current_user_id,
                         "current_user_email": email,
-                        "app": self.app,
-                        "tags_added": self.tags_to_add,
-                        "tags_removed": self.tags_to_remove,
+                        "app": app,
+                        "tags_added": tags_to_add,
+                        "tags_removed": tags_to_remove,
                     }
                 )
             )
 
-        return self.app
+        return app

--- a/api/operations/modify_app_tags.py
+++ b/api/operations/modify_app_tags.py
@@ -21,24 +21,24 @@ class ModifyAppTags:
         current_user_id: Optional[str],
     ):
         self.app_id = app if isinstance(app, str) else app.id
-        self._tags_to_add_arg = tags_to_add
-        self._tags_to_remove_arg = tags_to_remove
-        self._current_user_id_arg = current_user_id
+        self.tag_ids_to_add = tags_to_add
+        self.tag_ids_to_remove = tags_to_remove
+        self.current_user_id = current_user_id
 
     def execute(self) -> App:
         app = db.session.scalars(select(App).where(App.deleted_at.is_(None)).where(App.id == self.app_id)).first()
 
         tags_to_add = db.session.scalars(
-            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_add_arg))
+            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self.tag_ids_to_add))
         ).all()
 
         tags_to_remove = db.session.scalars(
-            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_remove_arg))
+            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self.tag_ids_to_remove))
         ).all()
 
         current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self.current_user_id)
             ).first(),
             "id",
             None,

--- a/api/operations/modify_app_tags.py
+++ b/api/operations/modify_app_tags.py
@@ -20,18 +20,13 @@ class ModifyAppTags:
         tags_to_remove: list[str] = [],
         current_user_id: Optional[str],
     ):
-        self._app_arg = app
+        self.app_id = app if isinstance(app, str) else app.id
         self._tags_to_add_arg = tags_to_add
         self._tags_to_remove_arg = tags_to_remove
         self._current_user_id_arg = current_user_id
 
     def execute(self) -> App:
-        app_arg = self._app_arg
-        app = db.session.scalars(
-            select(App)
-            .where(App.deleted_at.is_(None))
-            .where(App.id == (app_arg if isinstance(app_arg, str) else app_arg.id))
-        ).first()
+        app = db.session.scalars(select(App).where(App.deleted_at.is_(None)).where(App.id == self.app_id)).first()
 
         tags_to_add = db.session.scalars(
             select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_add_arg))

--- a/api/operations/modify_app_tags.py
+++ b/api/operations/modify_app_tags.py
@@ -20,27 +20,35 @@ class ModifyAppTags:
         tags_to_remove: list[str] = [],
         current_user_id: Optional[str],
     ):
+        self._app_arg = app
+        self._tags_to_add_arg = tags_to_add
+        self._tags_to_remove_arg = tags_to_remove
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
+        app = self._app_arg
         self.app = db.session.scalars(
             select(App).where(App.deleted_at.is_(None)).where(App.id == (app if isinstance(app, str) else app.id))
         ).first()
 
         self.tags_to_add = db.session.scalars(
-            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(tags_to_add))
+            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_add_arg))
         ).all()
 
         self.tags_to_remove = db.session.scalars(
-            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(tags_to_remove))
+            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_remove_arg))
         ).all()
 
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self) -> App:
+        self._resolve()
         if len(self.tags_to_add) > 0:
             # Only add tags that are not already associated with this app
             tag_ids_to_add = [t.id for t in self.tags_to_add]

--- a/api/operations/modify_group_tags.py
+++ b/api/operations/modify_group_tags.py
@@ -26,24 +26,24 @@ class ModifyGroupTags:
         self._tags_to_remove_arg = tags_to_remove
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
-        group = self._group_arg
-        self.group = db.session.scalars(
+    def execute(self) -> OktaGroup:
+        group_arg = self._group_arg
+        group = db.session.scalars(
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
             .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+            .where(OktaGroup.id == (group_arg if isinstance(group_arg, str) else group_arg.id))
         ).first()
 
-        self.tags_to_add = db.session.scalars(
+        tags_to_add = db.session.scalars(
             select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_add_arg))
         ).all()
 
-        self.tags_to_remove = db.session.scalars(
+        tags_to_remove = db.session.scalars(
             select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_remove_arg))
         ).all()
 
-        self.current_user_id = getattr(
+        current_user_id = getattr(
             db.session.scalars(
                 select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
@@ -51,11 +51,9 @@ class ModifyGroupTags:
             None,
         )
 
-    def execute(self) -> OktaGroup:
-        self._resolve()
-        if len(self.tags_to_add) > 0:
+        if len(tags_to_add) > 0:
             # Only add tags that are not already associated with the group
-            tag_ids_to_add = [t.id for t in self.tags_to_add]
+            tag_ids_to_add = [t.id for t in tags_to_add]
             existing_tag_maps = db.session.scalars(
                 select(OktaGroupTagMap)
                 .where(
@@ -65,7 +63,7 @@ class ModifyGroupTags:
                     )
                 )
                 .where(
-                    OktaGroupTagMap.group_id == self.group.id,
+                    OktaGroupTagMap.group_id == group.id,
                 )
                 .where(
                     OktaGroupTagMap.tag_id.in_(tag_ids_to_add),
@@ -81,17 +79,17 @@ class ModifyGroupTags:
                 db.session.add(
                     OktaGroupTagMap(
                         tag_id=tag_id,
-                        group_id=self.group.id,
+                        group_id=group.id,
                     )
                 )
 
             # Handle group time limit constraints when adding tags
             # with time limit contraints to a group
-            ModifyGroupsTimeLimit(groups=[self.group.id], tags=new_tag_ids_to_add).execute()
+            ModifyGroupsTimeLimit(groups=[group.id], tags=new_tag_ids_to_add).execute()
 
             db.session.commit()
 
-        if len(self.tags_to_remove) > 0:
+        if len(tags_to_remove) > 0:
             db.session.execute(
                 update(OktaGroupTagMap)
                 .where(
@@ -101,10 +99,10 @@ class ModifyGroupTags:
                     )
                 )
                 .where(
-                    OktaGroupTagMap.group_id == self.group.id,
+                    OktaGroupTagMap.group_id == group.id,
                 )
                 .where(
-                    OktaGroupTagMap.tag_id.in_([t.id for t in self.tags_to_remove]),
+                    OktaGroupTagMap.tag_id.in_([t.id for t in tags_to_remove]),
                 )
                 .where(
                     OktaGroupTagMap.app_tag_map_id.is_(None),
@@ -115,15 +113,15 @@ class ModifyGroupTags:
             db.session.commit()
 
         # Audit log if tags changed
-        if len(self.tags_to_add) > 0 or len(self.tags_to_remove) > 0:
+        if len(tags_to_add) > 0 or len(tags_to_remove) > 0:
             email = None
-            if self.current_user_id is not None:
-                email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
-                group = db.session.scalars(
+            if current_user_id is not None:
+                email = getattr(db.session.get(OktaUser, current_user_id), "email", None)
+                audit_group = db.session.scalars(
                     select(OktaGroup)
                     .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
                     .where(OktaGroup.deleted_at.is_(None))
-                    .where(OktaGroup.id == self.group.id)
+                    .where(OktaGroup.id == group.id)
                 ).first()
 
             _ctx = get_request_context()
@@ -133,13 +131,13 @@ class ModifyGroupTags:
                         "event_type": EventType.group_modify_tags,
                         "user_agent": _ctx.user_agent if _ctx else None,
                         "ip": _ctx.ip if _ctx else None,
-                        "current_user_id": self.current_user_id,
+                        "current_user_id": current_user_id,
                         "current_user_email": email,
-                        "group": group,
-                        "tags_added": self.tags_to_add,
-                        "tags_removed": self.tags_to_remove,
+                        "group": audit_group,
+                        "tags_added": tags_to_add,
+                        "tags_removed": tags_to_remove,
                     }
                 )
             )
 
-        return self.group
+        return group

--- a/api/operations/modify_group_tags.py
+++ b/api/operations/modify_group_tags.py
@@ -21,6 +21,13 @@ class ModifyGroupTags:
         tags_to_remove: list[str] = [],
         current_user_id: Optional[str],
     ):
+        self._group_arg = group
+        self._tags_to_add_arg = tags_to_add
+        self._tags_to_remove_arg = tags_to_remove
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
+        group = self._group_arg
         self.group = db.session.scalars(
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
@@ -29,22 +36,23 @@ class ModifyGroupTags:
         ).first()
 
         self.tags_to_add = db.session.scalars(
-            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(tags_to_add))
+            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_add_arg))
         ).all()
 
         self.tags_to_remove = db.session.scalars(
-            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(tags_to_remove))
+            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_remove_arg))
         ).all()
 
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self) -> OktaGroup:
+        self._resolve()
         if len(self.tags_to_add) > 0:
             # Only add tags that are not already associated with the group
             tag_ids_to_add = [t.id for t in self.tags_to_add]

--- a/api/operations/modify_group_tags.py
+++ b/api/operations/modify_group_tags.py
@@ -21,18 +21,17 @@ class ModifyGroupTags:
         tags_to_remove: list[str] = [],
         current_user_id: Optional[str],
     ):
-        self._group_arg = group
+        self.group_id = group if isinstance(group, str) else group.id
         self._tags_to_add_arg = tags_to_add
         self._tags_to_remove_arg = tags_to_remove
         self._current_user_id_arg = current_user_id
 
     def execute(self) -> OktaGroup:
-        group_arg = self._group_arg
         group = db.session.scalars(
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
             .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == (group_arg if isinstance(group_arg, str) else group_arg.id))
+            .where(OktaGroup.id == self.group_id)
         ).first()
 
         tags_to_add = db.session.scalars(

--- a/api/operations/modify_group_tags.py
+++ b/api/operations/modify_group_tags.py
@@ -22,9 +22,9 @@ class ModifyGroupTags:
         current_user_id: Optional[str],
     ):
         self.group_id = group if isinstance(group, str) else group.id
-        self._tags_to_add_arg = tags_to_add
-        self._tags_to_remove_arg = tags_to_remove
-        self._current_user_id_arg = current_user_id
+        self.tag_ids_to_add = tags_to_add
+        self.tag_ids_to_remove = tags_to_remove
+        self.current_user_id = current_user_id
 
     def execute(self) -> OktaGroup:
         group = db.session.scalars(
@@ -35,16 +35,16 @@ class ModifyGroupTags:
         ).first()
 
         tags_to_add = db.session.scalars(
-            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_add_arg))
+            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self.tag_ids_to_add))
         ).all()
 
         tags_to_remove = db.session.scalars(
-            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_remove_arg))
+            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self.tag_ids_to_remove))
         ).all()
 
         current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self.current_user_id)
             ).first(),
             "id",
             None,

--- a/api/operations/modify_group_type.py
+++ b/api/operations/modify_group_type.py
@@ -26,6 +26,13 @@ from api.schemas import AuditLogSchema, EventType
 
 class ModifyGroupType:
     def __init__(self, *, group: OktaGroup | str, group_changes: OktaGroup, current_user_id: Optional[str]):
+        self._group_arg = group
+
+        self.group_changes = group_changes
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
+        group = self._group_arg
         self.group = db.session.scalars(
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
@@ -33,16 +40,16 @@ class ModifyGroupType:
             .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
         ).first()
 
-        self.group_changes = group_changes
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self) -> OktaGroup:
+        self._resolve()
         # Update group type if it's being modified
         if type(self.group) is not type(self.group_changes):
             group_id = self.group.id

--- a/api/operations/modify_group_type.py
+++ b/api/operations/modify_group_type.py
@@ -26,18 +26,17 @@ from api.schemas import AuditLogSchema, EventType
 
 class ModifyGroupType:
     def __init__(self, *, group: OktaGroup | str, group_changes: OktaGroup, current_user_id: Optional[str]):
-        self._group_arg = group
+        self.group_id = group if isinstance(group, str) else group.id
 
         self.group_changes = group_changes
         self._current_user_id_arg = current_user_id
 
     def execute(self) -> OktaGroup:
-        group_arg = self._group_arg
         group = db.session.scalars(
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
             .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == (group_arg if isinstance(group_arg, str) else group_arg.id))
+            .where(OktaGroup.id == self.group_id)
         ).first()
 
         current_user_id = getattr(

--- a/api/operations/modify_group_type.py
+++ b/api/operations/modify_group_type.py
@@ -29,7 +29,7 @@ class ModifyGroupType:
         self.group_id = group if isinstance(group, str) else group.id
 
         self.group_changes = group_changes
-        self._current_user_id_arg = current_user_id
+        self.current_user_id = current_user_id
 
     def execute(self) -> OktaGroup:
         group = db.session.scalars(
@@ -41,7 +41,7 @@ class ModifyGroupType:
 
         current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self.current_user_id)
             ).first(),
             "id",
             None,

--- a/api/operations/modify_group_type.py
+++ b/api/operations/modify_group_type.py
@@ -31,16 +31,16 @@ class ModifyGroupType:
         self.group_changes = group_changes
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
-        group = self._group_arg
-        self.group = db.session.scalars(
+    def execute(self) -> OktaGroup:
+        group_arg = self._group_arg
+        group = db.session.scalars(
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
             .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+            .where(OktaGroup.id == (group_arg if isinstance(group_arg, str) else group_arg.id))
         ).first()
 
-        self.current_user_id = getattr(
+        current_user_id = getattr(
             db.session.scalars(
                 select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
@@ -48,18 +48,16 @@ class ModifyGroupType:
             None,
         )
 
-    def execute(self) -> OktaGroup:
-        self._resolve()
         # Update group type if it's being modified
-        if type(self.group) is not type(self.group_changes):
-            group_id = self.group.id
-            old_group_type = self.group.type
+        if type(group) is not type(self.group_changes):
+            group_id = group.id
+            old_group_type = group.type
 
             # Clean-up the old child table row
-            if type(self.group) is RoleGroup:
+            if type(group) is RoleGroup:
                 # Bail if changing away from RoleGroup for a group whose name uses the
                 # reserved Role- prefix; non-RoleGroup groups must not carry that prefix
-                if type(self.group_changes) is not RoleGroup and self.group.name.startswith(
+                if type(self.group_changes) is not RoleGroup and group.name.startswith(
                     RoleGroup.ROLE_GROUP_NAME_PREFIX
                 ):
                     raise ValueError(
@@ -75,28 +73,26 @@ class ModifyGroupType:
                             RoleGroupMap.ended_at > func.now(),
                         )
                     )
-                    .where(RoleGroupMap.role_group_id == self.group.id)
+                    .where(RoleGroupMap.role_group_id == group.id)
                 ).all()
                 ModifyRoleGroups(
-                    role_group=self.group,
-                    current_user_id=self.current_user_id,
+                    role_group=group,
+                    current_user_id=current_user_id,
                     groups_to_remove=[g.group_id for g in active_role_associated_groups if not g.is_owner],
                     owner_groups_to_remove=[g.group_id for g in active_role_associated_groups if g.is_owner],
                 ).execute()
                 db.session.commit()
 
                 db.session.execute(delete(RoleGroup.__table__).where(RoleGroup.__table__.c.id == group_id))
-            elif type(self.group) is AppGroup:
+            elif type(group) is AppGroup:
                 # Bail if this is the owner group for the app
                 # which cannot have its type changed
-                if self.group.is_owner:
+                if group.is_owner:
                     raise ValueError("Owner app groups cannot have their type modified")
 
                 # Bail if changing away from AppGroup for a group whose name uses the
                 # reserved App- prefix; non-AppGroup groups must not carry that prefix
-                if type(self.group_changes) is not AppGroup and self.group.name.startswith(
-                    AppGroup.APP_GROUP_NAME_PREFIX
-                ):
+                if type(self.group_changes) is not AppGroup and group.name.startswith(AppGroup.APP_GROUP_NAME_PREFIX):
                     raise ValueError(
                         "The App- prefix cannot be used for non-app groups. Please choose a different group name."
                     )
@@ -104,15 +100,15 @@ class ModifyGroupType:
                 # Invoke group_deleted hook before the AppGroup row is removed so the
                 # plugin can still access group.app and status values (e.g. to delete
                 # the linked GitHub team).
-                plugin_id = get_app_group_lifecycle_plugin_to_invoke(self.group)
+                plugin_id = get_app_group_lifecycle_plugin_to_invoke(group)
                 if plugin_id is not None:
                     try:
                         hook = get_app_group_lifecycle_hook()
-                        hook.group_deleted(session=db.session, group=self.group, plugin_id=plugin_id)
+                        hook.group_deleted(session=db.session, group=group, plugin_id=plugin_id)
                         db.session.commit()
                     except Exception:
                         logging.getLogger("api").exception(
-                            f"Failed to invoke group_deleted hook for group {self.group.id} with plugin '{plugin_id}'"
+                            f"Failed to invoke group_deleted hook for group {group.id} with plugin '{plugin_id}'"
                         )
                         db.session.rollback()
 
@@ -125,7 +121,7 @@ class ModifyGroupType:
                             OktaGroupTagMap.ended_at > func.now(),
                         )
                     )
-                    .where(OktaGroupTagMap.group_id == self.group.id)
+                    .where(OktaGroupTagMap.group_id == group.id)
                     .where(OktaGroupTagMap.app_tag_map_id.isnot(None))
                     .values({OktaGroupTagMap.app_tag_map_id: None})
                     .execution_options(synchronize_session="fetch")
@@ -139,10 +135,10 @@ class ModifyGroupType:
 
             # We've deleted the group child class row group,
             # update the type to the base class type "okta_group"
-            self.group.type = OktaGroup.__mapper_args__["polymorphic_identity"]
+            group.type = OktaGroup.__mapper_args__["polymorphic_identity"]
             db.session.commit()
 
-            self.group = db.session.scalars(
+            group = db.session.scalars(
                 select(OktaGroup).where(OktaGroup.deleted_at.is_(None)).where(OktaGroup.id == group_id)
             ).first()
 
@@ -166,14 +162,14 @@ class ModifyGroupType:
                     if group_user.is_owner:
                         ModifyGroupUsers(
                             group=group_id,
-                            current_user_id=self.current_user_id,
+                            current_user_id=current_user_id,
                             owners_to_add=[group_user.user_id],
                             users_added_ended_at=group_user.ended_at,
                         ).execute()
                     else:
                         ModifyGroupUsers(
                             group=group_id,
-                            current_user_id=self.current_user_id,
+                            current_user_id=current_user_id,
                             members_to_add=[group_user.user_id],
                             users_added_ended_at=group_user.ended_at,
                         ).execute()
@@ -193,13 +189,13 @@ class ModifyGroupType:
                     if role_group_map.is_owner:
                         ModifyRoleGroups(
                             role_group=role_group_map.role_group_id,
-                            current_user_id=self.current_user_id,
+                            current_user_id=current_user_id,
                             owner_groups_to_remove=[role_group_map.group_id],
                         ).execute()
                     else:
                         ModifyRoleGroups(
                             role_group=role_group_map.role_group_id,
-                            current_user_id=self.current_user_id,
+                            current_user_id=current_user_id,
                             groups_to_remove=[role_group_map.group_id],
                         ).execute()
 
@@ -213,7 +209,7 @@ class ModifyGroupType:
                 )
 
             # Update the group type
-            self.group.type = self.group_changes.type
+            group.type = self.group_changes.type
             db.session.commit()
 
             # Expunge the session so the changed object is flushed from the ORM
@@ -250,7 +246,7 @@ class ModifyGroupType:
                 ).execute()
 
             # Return a new lookup for the group
-            self.group = db.session.scalars(
+            group = db.session.scalars(
                 select(OktaGroup)
                 .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
                 .where(OktaGroup.deleted_at.is_(None))
@@ -260,24 +256,23 @@ class ModifyGroupType:
             # Invoke group_created hook after converting to an AppGroup (symmetric
             # with group_deleted which fires when converting away from AppGroup).
             if type(self.group_changes) is AppGroup:
-                plugin_id = get_app_group_lifecycle_plugin_to_invoke(self.group)
+                plugin_id = get_app_group_lifecycle_plugin_to_invoke(group)
                 if plugin_id is not None:
                     try:
                         hook = get_app_group_lifecycle_hook()
-                        hook.group_created(session=db.session, group=self.group, plugin_id=plugin_id)
+                        hook.group_created(session=db.session, group=group, plugin_id=plugin_id)
                         db.session.commit()
                     except Exception:
                         logging.getLogger("api").exception(
-                            f"Failed to invoke group_created hook for group {self.group.id}"
-                            f" with plugin '{plugin_id}'"
+                            f"Failed to invoke group_created hook for group {group.id}" f" with plugin '{plugin_id}'"
                         )
                         db.session.rollback()
 
         # Audit logging if type changed
-        if self.group.type != old_group_type:
+        if group.type != old_group_type:
             email = None
-            if self.current_user_id is not None:
-                email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
+            if current_user_id is not None:
+                email = getattr(db.session.get(OktaUser, current_user_id), "email", None)
 
             _ctx = get_request_context()
             logging.getLogger("access.audit").info(
@@ -286,12 +281,12 @@ class ModifyGroupType:
                         "event_type": EventType.group_modify_type,
                         "user_agent": _ctx.user_agent if _ctx else None,
                         "ip": _ctx.ip if _ctx else None,
-                        "current_user_id": self.current_user_id,
+                        "current_user_id": current_user_id,
                         "current_user_email": email,
-                        "group": self.group,
+                        "group": group,
                         "old_group_type": old_group_type,
                     }
                 )
             )
 
-        return self.group
+        return group

--- a/api/operations/modify_group_users.py
+++ b/api/operations/modify_group_users.py
@@ -47,7 +47,7 @@ class ModifyGroupUsers:
         created_reason: str = "",
         notify: bool = True,
     ):
-        self._group_arg = group
+        self.group_id = group if isinstance(group, str) else group.id
         self._users_added_ended_at_arg = users_added_ended_at
         self._members_to_add_arg = members_to_add
         self._owners_to_add_arg = owners_to_add
@@ -70,7 +70,6 @@ class ModifyGroupUsers:
         return asyncio.run(self._execute())
 
     async def _execute(self) -> OktaGroup:
-        group_arg = self._group_arg
         users_added_ended_at = self._users_added_ended_at_arg
         members_to_add_arg = self._members_to_add_arg
         owners_to_add_arg = self._owners_to_add_arg
@@ -87,7 +86,7 @@ class ModifyGroupUsers:
                 selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
             )
             .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == (group_arg if isinstance(group_arg, str) else group_arg.id))
+            .where(OktaGroup.id == self.group_id)
         ).first()
 
         # Determine the minimum time allowed for group membership and ownership by current group tags

--- a/api/operations/modify_group_users.py
+++ b/api/operations/modify_group_users.py
@@ -47,6 +47,34 @@ class ModifyGroupUsers:
         created_reason: str = "",
         notify: bool = True,
     ):
+        self._group_arg = group
+        self._users_added_ended_at_arg = users_added_ended_at
+        self._members_to_add_arg = members_to_add
+        self._owners_to_add_arg = owners_to_add
+        self._members_should_expire_arg = members_should_expire
+        self._owners_should_expire_arg = owners_should_expire
+        self._members_to_remove_arg = members_to_remove
+        self._owners_to_remove_arg = owners_to_remove
+
+        self.sync_to_okta = sync_to_okta
+
+        self._current_user_id_arg = current_user_id
+
+        self.created_reason = created_reason
+        self.notify = notify
+
+        self.notification_hook = get_notification_hook()
+
+    def _resolve(self) -> None:
+        group = self._group_arg
+        users_added_ended_at = self._users_added_ended_at_arg
+        members_to_add = self._members_to_add_arg
+        owners_to_add = self._owners_to_add_arg
+        members_should_expire = self._members_should_expire_arg
+        owners_should_expire = self._owners_should_expire_arg
+        members_to_remove = self._members_to_remove_arg
+        owners_to_remove = self._owners_to_remove_arg
+
         self.group = db.session.scalars(
             select(OktaGroup)
             .options(
@@ -117,22 +145,16 @@ class ModifyGroupUsers:
                 select(OktaUser).where(OktaUser.id.in_(owners_to_remove)).where(OktaUser.deleted_at.is_(None))
             ).all()
 
-        self.sync_to_okta = sync_to_okta
-
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
-        self.created_reason = created_reason
-        self.notify = notify
-
-        self.notification_hook = get_notification_hook()
-
     def execute(self) -> OktaGroup:
+        self._resolve()
         # Run asychronously to parallelize Okta API requests
         return asyncio.run(self._execute())
 

--- a/api/operations/modify_group_users.py
+++ b/api/operations/modify_group_users.py
@@ -65,17 +65,21 @@ class ModifyGroupUsers:
 
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
-        group = self._group_arg
-        users_added_ended_at = self._users_added_ended_at_arg
-        members_to_add = self._members_to_add_arg
-        owners_to_add = self._owners_to_add_arg
-        members_should_expire = self._members_should_expire_arg
-        owners_should_expire = self._owners_should_expire_arg
-        members_to_remove = self._members_to_remove_arg
-        owners_to_remove = self._owners_to_remove_arg
+    def execute(self) -> OktaGroup:
+        # Run asychronously to parallelize Okta API requests
+        return asyncio.run(self._execute())
 
-        self.group = db.session.scalars(
+    async def _execute(self) -> OktaGroup:
+        group_arg = self._group_arg
+        users_added_ended_at = self._users_added_ended_at_arg
+        members_to_add_arg = self._members_to_add_arg
+        owners_to_add_arg = self._owners_to_add_arg
+        members_should_expire_arg = self._members_should_expire_arg
+        owners_should_expire_arg = self._owners_should_expire_arg
+        members_to_remove_arg = self._members_to_remove_arg
+        owners_to_remove_arg = self._owners_to_remove_arg
+
+        group = db.session.scalars(
             select(OktaGroup)
             .options(
                 selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
@@ -83,66 +87,66 @@ class ModifyGroupUsers:
                 selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
             )
             .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+            .where(OktaGroup.id == (group_arg if isinstance(group_arg, str) else group_arg.id))
         ).first()
 
         # Determine the minimum time allowed for group membership and ownership by current group tags
-        tags = [tag_map.active_tag for tag_map in self.group.active_group_tags]
-        self.members_added_ended_at = coalesce_ended_at(
+        tags = [tag_map.active_tag for tag_map in group.active_group_tags]
+        members_added_ended_at = coalesce_ended_at(
             constraint_key=Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY,
             tags=tags,
             initial_ended_at=users_added_ended_at,
-            group_is_managed=self.group.is_managed,
+            group_is_managed=group.is_managed,
         )
-        self.owners_added_ended_at = coalesce_ended_at(
+        owners_added_ended_at = coalesce_ended_at(
             constraint_key=Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY,
             tags=tags,
             initial_ended_at=users_added_ended_at,
-            group_is_managed=self.group.is_managed,
+            group_is_managed=group.is_managed,
         )
 
-        self.members_to_add = []
-        if len(members_to_add) > 0:
-            self.members_to_add = db.session.scalars(
-                select(OktaUser).where(OktaUser.id.in_(members_to_add)).where(OktaUser.deleted_at.is_(None))
+        members_to_add: list[OktaUser] = []
+        if len(members_to_add_arg) > 0:
+            members_to_add = db.session.scalars(
+                select(OktaUser).where(OktaUser.id.in_(members_to_add_arg)).where(OktaUser.deleted_at.is_(None))
             ).all()
 
-        self.owners_to_add = []
-        if len(owners_to_add) > 0:
-            self.owners_to_add = db.session.scalars(
-                select(OktaUser).where(OktaUser.id.in_(owners_to_add)).where(OktaUser.deleted_at.is_(None))
+        owners_to_add: list[OktaUser] = []
+        if len(owners_to_add_arg) > 0:
+            owners_to_add = db.session.scalars(
+                select(OktaUser).where(OktaUser.id.in_(owners_to_add_arg)).where(OktaUser.deleted_at.is_(None))
             ).all()
 
-        self.members_should_expire = []
-        if len(members_should_expire) > 0:
-            self.members_should_expire = db.session.scalars(
+        members_should_expire: list[OktaUserGroupMember] = []
+        if len(members_should_expire_arg) > 0:
+            members_should_expire = db.session.scalars(
                 select(OktaUserGroupMember)
-                .where(OktaUserGroupMember.id.in_(members_should_expire))
-                .where(OktaUserGroupMember.group_id == self.group.id)
+                .where(OktaUserGroupMember.id.in_(members_should_expire_arg))
+                .where(OktaUserGroupMember.group_id == group.id)
                 .where(OktaUserGroupMember.ended_at > func.now())
                 .where(OktaUserGroupMember.is_owner.is_(False))
             ).all()
 
-        self.owners_should_expire = []
-        if len(owners_should_expire) > 0:
-            self.owners_should_expire = db.session.scalars(
+        owners_should_expire: list[OktaUserGroupMember] = []
+        if len(owners_should_expire_arg) > 0:
+            owners_should_expire = db.session.scalars(
                 select(OktaUserGroupMember)
-                .where(OktaUserGroupMember.id.in_(owners_should_expire))
-                .where(OktaUserGroupMember.group_id == self.group.id)
+                .where(OktaUserGroupMember.id.in_(owners_should_expire_arg))
+                .where(OktaUserGroupMember.group_id == group.id)
                 .where(OktaUserGroupMember.ended_at > func.now())
                 .where(OktaUserGroupMember.is_owner.is_(True))
             ).all()
 
-        self.members_to_remove = []
-        if len(members_to_remove) > 0:
-            self.members_to_remove = db.session.scalars(
-                select(OktaUser).where(OktaUser.id.in_(members_to_remove)).where(OktaUser.deleted_at.is_(None))
+        members_to_remove: list[OktaUser] = []
+        if len(members_to_remove_arg) > 0:
+            members_to_remove = db.session.scalars(
+                select(OktaUser).where(OktaUser.id.in_(members_to_remove_arg)).where(OktaUser.deleted_at.is_(None))
             ).all()
 
-        self.owners_to_remove = []
-        if len(owners_to_remove) > 0:
-            self.owners_to_remove = db.session.scalars(
-                select(OktaUser).where(OktaUser.id.in_(owners_to_remove)).where(OktaUser.deleted_at.is_(None))
+        owners_to_remove: list[OktaUser] = []
+        if len(owners_to_remove_arg) > 0:
+            owners_to_remove = db.session.scalars(
+                select(OktaUser).where(OktaUser.id.in_(owners_to_remove_arg)).where(OktaUser.deleted_at.is_(None))
             ).all()
 
         self.current_user_id = getattr(
@@ -153,43 +157,37 @@ class ModifyGroupUsers:
             None,
         )
 
-    def execute(self) -> OktaGroup:
-        self._resolve()
-        # Run asychronously to parallelize Okta API requests
-        return asyncio.run(self._execute())
-
-    async def _execute(self) -> OktaGroup:
         # Fast return if no changes are being made
         if (
-            len(self.members_to_add)
-            + len(self.members_to_remove)
-            + len(self.members_should_expire)
-            + len(self.owners_to_add)
-            + len(self.owners_to_remove)
-            + len(self.owners_should_expire)
+            len(members_to_add)
+            + len(members_to_remove)
+            + len(members_should_expire)
+            + len(owners_to_add)
+            + len(owners_to_remove)
+            + len(owners_should_expire)
             == 0
         ):
-            return self.group
+            return group
 
         # Check groups tags to see if self-add is allowed
         valid, _ = CheckForSelfAdd(
-            group=self.group,
+            group=group,
             current_user=self.current_user_id,
-            members_to_add=self.members_to_add,
-            owners_to_add=self.owners_to_add,
+            members_to_add=members_to_add,
+            owners_to_add=owners_to_add,
         ).execute_for_group()
         if not valid:
-            return self.group
+            return group
 
         # Check group tags to see if a reason is required for adding members or owners
         valid, _ = CheckForReason(
-            group=self.group,
+            group=group,
             reason=self.created_reason,
-            members_to_add=self.members_to_add,
-            owners_to_add=self.owners_to_add,
+            members_to_add=members_to_add,
+            owners_to_add=owners_to_add,
         ).execute_for_group()
         if not valid:
-            return self.group
+            return group
 
         # Audit logging
         email = None
@@ -206,13 +204,13 @@ class ModifyGroupUsers:
                     "ip": _ctx.ip if _ctx else None,
                     "current_user_id": self.current_user_id,
                     "current_user_email": email,
-                    "group": self.group,
-                    "owners_removed_ids_emails": self.owners_to_remove,
-                    "owners_added_ids_emails": self.owners_to_add,
-                    "owners_should_expire_user_id_group_id": self.owners_should_expire,
-                    "members_removed_ids_emails": self.members_to_remove,
-                    "members_added_ids_emails": self.members_to_add,
-                    "members_should_expire_user_id_group_id": self.members_should_expire,
+                    "group": group,
+                    "owners_removed_ids_emails": owners_to_remove,
+                    "owners_added_ids_emails": owners_to_add,
+                    "owners_should_expire_user_id_group_id": owners_should_expire,
+                    "members_removed_ids_emails": members_to_remove,
+                    "members_added_ids_emails": members_to_add,
+                    "members_should_expire_user_id_group_id": members_should_expire,
                 }
             )
         )
@@ -223,8 +221,8 @@ class ModifyGroupUsers:
         # First remove all users from the group including those that we wish to add.
         # That way we can easily extend time-bounded group memberships and audit when
         # those extensions occured
-        remove_changed_members = self.members_to_remove + self.members_to_add
-        remove_changed_owners = self.owners_to_add + self.owners_to_remove
+        remove_changed_members = members_to_remove + members_to_add
+        remove_changed_owners = owners_to_add + owners_to_remove
 
         # Track access overall lost and gained to pass along to app group lifecycle plugin hooks
         members_lost_by_group: dict[OktaGroup | RoleGroup | None, list[OktaUser]] = {}
@@ -240,7 +238,7 @@ class ModifyGroupUsers:
                         OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
-                .where(OktaUserGroupMember.group_id == self.group.id)
+                .where(OktaUserGroupMember.group_id == group.id)
                 .where(OktaUserGroupMember.is_owner.is_(False))
                 .where(OktaUserGroupMember.user_id.in_([m.id for m in remove_changed_members]))
                 .where(OktaUserGroupMember.role_group_map_id.is_(None))
@@ -258,7 +256,7 @@ class ModifyGroupUsers:
                         OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
-                .where(OktaUserGroupMember.group_id == self.group.id)
+                .where(OktaUserGroupMember.group_id == group.id)
                 .where(OktaUserGroupMember.is_owner.is_(True))
                 .where(OktaUserGroupMember.user_id.in_([m.id for m in remove_changed_owners]))
                 .where(OktaUserGroupMember.role_group_map_id.is_(None))
@@ -269,7 +267,7 @@ class ModifyGroupUsers:
             )
 
             # For role groups, members to be removed should also be removed from all role associated groups
-            if type(self.group) is RoleGroup:
+            if type(group) is RoleGroup:
                 role_associated_groups_mappings = db.session.scalars(
                     select(RoleGroupMap)
                     .where(
@@ -278,7 +276,7 @@ class ModifyGroupUsers:
                             RoleGroupMap.ended_at > func.now(),
                         )
                     )
-                    .where(RoleGroupMap.role_group_id == self.group.id)
+                    .where(RoleGroupMap.role_group_id == group.id)
                 ).all()
                 role_associated_group_memberships = (
                     update(OktaUserGroupMember)
@@ -302,12 +300,12 @@ class ModifyGroupUsers:
                 )
 
         # Remove members and owners from Okta groups
-        if len(self.members_to_remove) > 0 or len(self.owners_to_remove) > 0:
+        if len(members_to_remove) > 0 or len(owners_to_remove) > 0:
             # Check if there are other OktaUserGroupMembers for this user/group
             # combination before removing membership, there can be multiple role groups
             # which allow group access for this user
-            members_to_remove_ids = [m.id for m in self.members_to_remove]
-            owners_to_remove_ids = [m.id for m in self.owners_to_remove]
+            members_to_remove_ids = [m.id for m in members_to_remove]
+            owners_to_remove_ids = [m.id for m in owners_to_remove]
             removed_users_with_other_access = db.session.execute(
                 select(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
                 .where(
@@ -316,7 +314,7 @@ class ModifyGroupUsers:
                         OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
-                .where(OktaUserGroupMember.group_id == self.group.id)
+                .where(OktaUserGroupMember.group_id == group.id)
                 .where(OktaUserGroupMember.user_id.in_(members_to_remove_ids + owners_to_remove_ids))
                 .group_by(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
             ).all()
@@ -326,25 +324,25 @@ class ModifyGroupUsers:
             okta_members_to_remove_ids = set(members_to_remove_ids) - set(removed_members_with_other_access_ids)
 
             # Track members who lost all access to this group
-            members_who_lost_access = [m for m in self.members_to_remove if m.id in okta_members_to_remove_ids]
+            members_who_lost_access = [m for m in members_to_remove if m.id in okta_members_to_remove_ids]
             if len(members_who_lost_access) > 0:
-                members_lost_by_group[self.group] = members_who_lost_access
+                members_lost_by_group[group] = members_who_lost_access
 
-            if self.sync_to_okta and self.group.is_managed:
+            if self.sync_to_okta and group.is_managed:
                 for member_id in okta_members_to_remove_ids:
                     # Remove user from okta group membership if the group is managed by Access
-                    async_tasks.append(asyncio.create_task(okta.async_remove_user_from_group(self.group.id, member_id)))
+                    async_tasks.append(asyncio.create_task(okta.async_remove_user_from_group(group.id, member_id)))
 
             removed_owners_with_other_access_ids = [m.user_id for m in removed_users_with_other_access if m.is_owner]
             okta_owners_to_remove_ids = set(owners_to_remove_ids) - set(removed_owners_with_other_access_ids)
-            if self.sync_to_okta and self.group.is_managed:
+            if self.sync_to_okta and group.is_managed:
                 for owner_id in okta_owners_to_remove_ids:
                     # Remove user from okta group owners if the group is managed by Access
                     # https://help.okta.com/en-us/Content/Topics/identity-governance/group-owner.htm
-                    async_tasks.append(asyncio.create_task(okta.async_remove_owner_from_group(self.group.id, owner_id)))
+                    async_tasks.append(asyncio.create_task(okta.async_remove_owner_from_group(group.id, owner_id)))
 
             # For role groups, members to be removed should also be removed from all role associated groups
-            if type(self.group) is RoleGroup:
+            if type(group) is RoleGroup:
                 role_associated_groups_mappings = db.session.scalars(
                     select(RoleGroupMap)
                     # Eager-load `active_group` with its polymorphic subtype and
@@ -364,7 +362,7 @@ class ModifyGroupUsers:
                             RoleGroupMap.ended_at > func.now(),
                         )
                     )
-                    .where(RoleGroupMap.role_group_id == self.group.id)
+                    .where(RoleGroupMap.role_group_id == group.id)
                 ).all()
                 # Check if there are other OktaUserGroupMembers for this user/group
                 # combination before removing group membership, there can be multiple role groups
@@ -402,7 +400,7 @@ class ModifyGroupUsers:
 
                         # Track members who lost all access to this role-associated group
                         members_who_lost_access_to_role_group = [
-                            m for m in self.members_to_remove if m.id in okta_members_to_remove_ids
+                            m for m in members_to_remove if m.id in okta_members_to_remove_ids
                         ]
                         if len(members_who_lost_access_to_role_group) > 0:
                             associated_group = role_associated_group_map.active_group
@@ -440,18 +438,18 @@ class ModifyGroupUsers:
             db.session.commit()
 
             # Invoke app group lifecycle plugin hooks for removed members
-            for group, members in members_lost_by_group.items():
-                plugin_id = get_app_group_lifecycle_plugin_to_invoke(group)
+            for affected_group, members in members_lost_by_group.items():
+                plugin_id = get_app_group_lifecycle_plugin_to_invoke(affected_group)
                 if plugin_id is not None:
                     try:
                         hook = get_app_group_lifecycle_hook()
                         hook.group_members_removed(
-                            session=db.session, group=group, members=members, plugin_id=plugin_id
+                            session=db.session, group=affected_group, members=members, plugin_id=plugin_id
                         )
                         db.session.commit()
                     except Exception:
                         logging.getLogger("api").exception(
-                            f"Failed to invoke group_members_removed hook for group {group.id if group else None} with plugin '{plugin_id}'"
+                            f"Failed to invoke group_members_removed hook for group {affected_group.id if affected_group else None} with plugin '{plugin_id}'"
                         )
                         db.session.rollback()
 
@@ -461,18 +459,18 @@ class ModifyGroupUsers:
         # Mark relevant OktaUserGroupMembers as 'Should expire'
         # Only relevant for the expiring groups page so not adding checks for this field anywhere else since OK if marked to expire
         # then manually renewed from group page or with an access request
-        if len(self.members_should_expire) > 0:
+        if len(members_should_expire) > 0:
             db.session.execute(
                 update(OktaUserGroupMember)
-                .where(OktaUserGroupMember.id.in_(m.id for m in self.members_should_expire))
+                .where(OktaUserGroupMember.id.in_(m.id for m in members_should_expire))
                 .values({OktaUserGroupMember.should_expire: True})
                 .execution_options(synchronize_session="fetch")
             )
 
-        if len(self.owners_should_expire) > 0:
+        if len(owners_should_expire) > 0:
             db.session.execute(
                 update(OktaUserGroupMember)
-                .where(OktaUserGroupMember.id.in_(m.id for m in self.owners_should_expire))
+                .where(OktaUserGroupMember.id.in_(m.id for m in owners_should_expire))
                 .values({OktaUserGroupMember.should_expire: True})
                 .execution_options(synchronize_session="fetch")
             )
@@ -481,9 +479,9 @@ class ModifyGroupUsers:
         db.session.commit()
 
         # Add new group members and group owners and add them to Okta
-        if len(self.members_to_add) > 0 or len(self.owners_to_add) > 0:
+        if len(members_to_add) > 0 or len(owners_to_add) > 0:
             # Check which members being added currently have NO active memberships (to track first-time access)
-            members_to_add_ids = [m.id for m in self.members_to_add]
+            members_to_add_ids = [m.id for m in members_to_add]
             existing_members_with_access = db.session.scalars(
                 select(OktaUserGroupMember.user_id)
                 .where(
@@ -492,7 +490,7 @@ class ModifyGroupUsers:
                         OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
-                .where(OktaUserGroupMember.group_id == self.group.id)
+                .where(OktaUserGroupMember.group_id == group.id)
                 .where(OktaUserGroupMember.user_id.in_(members_to_add_ids))
                 .where(OktaUserGroupMember.is_owner.is_(False))
                 .group_by(OktaUserGroupMember.user_id)
@@ -502,47 +500,45 @@ class ModifyGroupUsers:
 
             # Track members who are gaining their first access to this group
             if len(members_gaining_first_access_ids) > 0:
-                members_gained_by_group[self.group] = [
-                    m for m in self.members_to_add if m.id in members_gaining_first_access_ids
-                ]
+                members_gained_by_group[group] = [m for m in members_to_add if m.id in members_gaining_first_access_ids]
 
-            group_memberships_added: Dict[str, Dict[str, OktaUserGroupMember]] = {self.group.id: {}}
-            for member in self.members_to_add:
-                if self.sync_to_okta and self.group.is_managed:
+            group_memberships_added: Dict[str, Dict[str, OktaUserGroupMember]] = {group.id: {}}
+            for member in members_to_add:
+                if self.sync_to_okta and group.is_managed:
                     # Add user to Access-managed okta group members
-                    async_tasks.append(asyncio.create_task(okta.async_add_user_to_group(self.group.id, member.id)))
+                    async_tasks.append(asyncio.create_task(okta.async_add_user_to_group(group.id, member.id)))
                 membership_to_add = OktaUserGroupMember(
                     user_id=member.id,
-                    group_id=self.group.id,
+                    group_id=group.id,
                     is_owner=False,
-                    ended_at=self.members_added_ended_at,
+                    ended_at=members_added_ended_at,
                     created_reason=self.created_reason,
                     created_actor_id=self.current_user_id,
-                    ended_actor_id=self.current_user_id if self.members_added_ended_at is not None else None,
+                    ended_actor_id=self.current_user_id if members_added_ended_at is not None else None,
                 )
-                group_memberships_added[self.group.id][member.id] = membership_to_add
+                group_memberships_added[group.id][member.id] = membership_to_add
                 db.session.add(membership_to_add)
 
-            group_ownerships_added: Dict[str, Dict[str, OktaUserGroupMember]] = {self.group.id: {}}
-            for owner in self.owners_to_add:
-                if self.sync_to_okta and self.group.is_managed:
+            group_ownerships_added: Dict[str, Dict[str, OktaUserGroupMember]] = {group.id: {}}
+            for owner in owners_to_add:
+                if self.sync_to_okta and group.is_managed:
                     # Add user to Access-managed okta group owners
                     # https://help.okta.com/en-us/Content/Topics/identity-governance/group-owner.htm
-                    async_tasks.append(asyncio.create_task(okta.async_add_owner_to_group(self.group.id, owner.id)))
+                    async_tasks.append(asyncio.create_task(okta.async_add_owner_to_group(group.id, owner.id)))
                 ownership_to_add = OktaUserGroupMember(
                     user_id=owner.id,
-                    group_id=self.group.id,
+                    group_id=group.id,
                     is_owner=True,
-                    ended_at=self.owners_added_ended_at,
+                    ended_at=owners_added_ended_at,
                     created_reason=self.created_reason,
                     created_actor_id=self.current_user_id,
-                    ended_actor_id=self.current_user_id if self.owners_added_ended_at is not None else None,
+                    ended_actor_id=self.current_user_id if owners_added_ended_at is not None else None,
                 )
-                group_ownerships_added[self.group.id][owner.id] = ownership_to_add
+                group_ownerships_added[group.id][owner.id] = ownership_to_add
                 db.session.add(ownership_to_add)
 
             # For role groups, new members should also be added to all Access-managed role associated groups
-            if type(self.group) is RoleGroup:
+            if type(group) is RoleGroup:
                 role_associated_groups_mappings = db.session.scalars(
                     select(RoleGroupMap)
                     # Eager-load `active_group` with its polymorphic subtype and
@@ -562,7 +558,7 @@ class ModifyGroupUsers:
                             RoleGroupMap.ended_at > func.now(),
                         )
                     )
-                    .where(RoleGroupMap.role_group_id == self.group.id)
+                    .where(RoleGroupMap.role_group_id == group.id)
                 ).all()
 
                 # Check which members being added currently have NO active memberships in role-associated groups
@@ -598,7 +594,7 @@ class ModifyGroupUsers:
                     else:
                         group_memberships_added[role_associated_group_map.group_id] = role_associated_access_added
 
-                    for member in self.members_to_add:
+                    for member in members_to_add:
                         if self.sync_to_okta:
                             if not role_associated_group_map.is_owner:
                                 # Add user to okta group members
@@ -624,12 +620,12 @@ class ModifyGroupUsers:
                         # If the both the role associated group and operation input has an end date,
                         # use the earliest of the two for setting the end date for associated group members and owners
                         if role_associated_group_map.ended_at is None:
-                            associated_users_ended_at = self.members_added_ended_at
-                        elif self.members_added_ended_at is None:
+                            associated_users_ended_at = members_added_ended_at
+                        elif members_added_ended_at is None:
                             associated_users_ended_at = role_associated_group_map.ended_at
                         else:
                             associated_users_ended_at = min(
-                                self.members_added_ended_at.replace(tzinfo=UTC),
+                                members_added_ended_at.replace(tzinfo=UTC),
                                 role_associated_group_map.ended_at.replace(tzinfo=UTC),
                             )
 
@@ -654,23 +650,25 @@ class ModifyGroupUsers:
                         if len(members_gaining_first_access_to_role_group_ids) > 0:
                             associated_group = role_associated_group_map.active_group
                             members_gained_by_group[associated_group] = [
-                                m for m in self.members_to_add if m.id in members_gaining_first_access_to_role_group_ids
+                                m for m in members_to_add if m.id in members_gaining_first_access_to_role_group_ids
                             ]
 
             # Commit changes so far, so we can reference OktaUserGroupMember in approved AccessRequests
             db.session.commit()
 
             # Invoke app group lifecycle plugin hooks for added members
-            for group, members in members_gained_by_group.items():
-                plugin_id = get_app_group_lifecycle_plugin_to_invoke(group)
+            for affected_group, members in members_gained_by_group.items():
+                plugin_id = get_app_group_lifecycle_plugin_to_invoke(affected_group)
                 if plugin_id is not None:
                     try:
                         hook = get_app_group_lifecycle_hook()
-                        hook.group_members_added(session=db.session, group=group, members=members, plugin_id=plugin_id)
+                        hook.group_members_added(
+                            session=db.session, group=affected_group, members=members, plugin_id=plugin_id
+                        )
                         db.session.commit()
                     except Exception:
                         logging.getLogger("api").exception(
-                            f"Failed to invoke group_members_added hook for group {group.id if group else None} with plugin '{plugin_id}'"
+                            f"Failed to invoke group_members_added hook for group {affected_group.id if affected_group else None} with plugin '{plugin_id}'"
                         )
                         db.session.rollback()
 
@@ -686,7 +684,7 @@ class ModifyGroupUsers:
             # and groups associated if this a role group
             pending_member_requests = db.session.scalars(
                 pending_requests_query.where(AccessRequest.requested_group_id.in_(group_memberships_added.keys()))
-                .where(AccessRequest.requester_user_id.in_([m.id for m in self.members_to_add]))
+                .where(AccessRequest.requester_user_id.in_([m.id for m in members_to_add]))
                 .where(AccessRequest.request_ownership.is_(False))
             ).all()
             for access_request in pending_member_requests:
@@ -699,8 +697,8 @@ class ModifyGroupUsers:
 
             # Find all pending ownership requests to approve for this group
             pending_owner_requests = db.session.scalars(
-                pending_requests_query.where(AccessRequest.requested_group_id == self.group.id)
-                .where(AccessRequest.requester_user_id.in_([m.id for m in self.owners_to_add]))
+                pending_requests_query.where(AccessRequest.requested_group_id == group.id)
+                .where(AccessRequest.requester_user_id.in_([m.id for m in owners_to_add]))
                 .where(AccessRequest.request_ownership.is_(True))
             ).all()
             for access_request in pending_owner_requests:
@@ -714,9 +712,9 @@ class ModifyGroupUsers:
             # Find all pending ownership requests to approve for groups associated if this a role group
             pending_role_associated_owner_requests = db.session.scalars(
                 pending_requests_query.where(
-                    AccessRequest.requested_group_id.in_(set(group_ownerships_added.keys()) - set([self.group.id]))
+                    AccessRequest.requested_group_id.in_(set(group_ownerships_added.keys()) - set([group.id]))
                 )
-                .where(AccessRequest.requester_user_id.in_([m.id for m in self.members_to_add]))
+                .where(AccessRequest.requester_user_id.in_([m.id for m in members_to_add]))
                 .where(AccessRequest.request_ownership.is_(True))
             ).all()
             for access_request in pending_role_associated_owner_requests:
@@ -732,7 +730,7 @@ class ModifyGroupUsers:
         if len(async_tasks) > 0:
             await asyncio.wait(async_tasks)
 
-        return self.group
+        return group
 
     def _approve_access_request(
         self, access_request: AccessRequest, added_okta_user_group_member: OktaUserGroupMember

--- a/api/operations/modify_group_users.py
+++ b/api/operations/modify_group_users.py
@@ -48,17 +48,17 @@ class ModifyGroupUsers:
         notify: bool = True,
     ):
         self.group_id = group if isinstance(group, str) else group.id
-        self._users_added_ended_at_arg = users_added_ended_at
-        self._members_to_add_arg = members_to_add
-        self._owners_to_add_arg = owners_to_add
-        self._members_should_expire_arg = members_should_expire
-        self._owners_should_expire_arg = owners_should_expire
-        self._members_to_remove_arg = members_to_remove
-        self._owners_to_remove_arg = owners_to_remove
+        self.users_added_ended_at = users_added_ended_at
+        self.member_ids_to_add = members_to_add
+        self.owner_ids_to_add = owners_to_add
+        self.member_should_expire_ids = members_should_expire
+        self.owner_should_expire_ids = owners_should_expire
+        self.member_ids_to_remove = members_to_remove
+        self.owner_ids_to_remove = owners_to_remove
 
         self.sync_to_okta = sync_to_okta
 
-        self._current_user_id_arg = current_user_id
+        self.current_user_id = current_user_id
 
         self.created_reason = created_reason
         self.notify = notify
@@ -70,14 +70,6 @@ class ModifyGroupUsers:
         return asyncio.run(self._execute())
 
     async def _execute(self) -> OktaGroup:
-        users_added_ended_at = self._users_added_ended_at_arg
-        members_to_add_arg = self._members_to_add_arg
-        owners_to_add_arg = self._owners_to_add_arg
-        members_should_expire_arg = self._members_should_expire_arg
-        owners_should_expire_arg = self._owners_should_expire_arg
-        members_to_remove_arg = self._members_to_remove_arg
-        owners_to_remove_arg = self._owners_to_remove_arg
-
         group = db.session.scalars(
             select(OktaGroup)
             .options(
@@ -94,63 +86,63 @@ class ModifyGroupUsers:
         members_added_ended_at = coalesce_ended_at(
             constraint_key=Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY,
             tags=tags,
-            initial_ended_at=users_added_ended_at,
+            initial_ended_at=self.users_added_ended_at,
             group_is_managed=group.is_managed,
         )
         owners_added_ended_at = coalesce_ended_at(
             constraint_key=Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY,
             tags=tags,
-            initial_ended_at=users_added_ended_at,
+            initial_ended_at=self.users_added_ended_at,
             group_is_managed=group.is_managed,
         )
 
         members_to_add: list[OktaUser] = []
-        if len(members_to_add_arg) > 0:
+        if len(self.member_ids_to_add) > 0:
             members_to_add = db.session.scalars(
-                select(OktaUser).where(OktaUser.id.in_(members_to_add_arg)).where(OktaUser.deleted_at.is_(None))
+                select(OktaUser).where(OktaUser.id.in_(self.member_ids_to_add)).where(OktaUser.deleted_at.is_(None))
             ).all()
 
         owners_to_add: list[OktaUser] = []
-        if len(owners_to_add_arg) > 0:
+        if len(self.owner_ids_to_add) > 0:
             owners_to_add = db.session.scalars(
-                select(OktaUser).where(OktaUser.id.in_(owners_to_add_arg)).where(OktaUser.deleted_at.is_(None))
+                select(OktaUser).where(OktaUser.id.in_(self.owner_ids_to_add)).where(OktaUser.deleted_at.is_(None))
             ).all()
 
         members_should_expire: list[OktaUserGroupMember] = []
-        if len(members_should_expire_arg) > 0:
+        if len(self.member_should_expire_ids) > 0:
             members_should_expire = db.session.scalars(
                 select(OktaUserGroupMember)
-                .where(OktaUserGroupMember.id.in_(members_should_expire_arg))
+                .where(OktaUserGroupMember.id.in_(self.member_should_expire_ids))
                 .where(OktaUserGroupMember.group_id == group.id)
                 .where(OktaUserGroupMember.ended_at > func.now())
                 .where(OktaUserGroupMember.is_owner.is_(False))
             ).all()
 
         owners_should_expire: list[OktaUserGroupMember] = []
-        if len(owners_should_expire_arg) > 0:
+        if len(self.owner_should_expire_ids) > 0:
             owners_should_expire = db.session.scalars(
                 select(OktaUserGroupMember)
-                .where(OktaUserGroupMember.id.in_(owners_should_expire_arg))
+                .where(OktaUserGroupMember.id.in_(self.owner_should_expire_ids))
                 .where(OktaUserGroupMember.group_id == group.id)
                 .where(OktaUserGroupMember.ended_at > func.now())
                 .where(OktaUserGroupMember.is_owner.is_(True))
             ).all()
 
         members_to_remove: list[OktaUser] = []
-        if len(members_to_remove_arg) > 0:
+        if len(self.member_ids_to_remove) > 0:
             members_to_remove = db.session.scalars(
-                select(OktaUser).where(OktaUser.id.in_(members_to_remove_arg)).where(OktaUser.deleted_at.is_(None))
+                select(OktaUser).where(OktaUser.id.in_(self.member_ids_to_remove)).where(OktaUser.deleted_at.is_(None))
             ).all()
 
         owners_to_remove: list[OktaUser] = []
-        if len(owners_to_remove_arg) > 0:
+        if len(self.owner_ids_to_remove) > 0:
             owners_to_remove = db.session.scalars(
-                select(OktaUser).where(OktaUser.id.in_(owners_to_remove_arg)).where(OktaUser.deleted_at.is_(None))
+                select(OktaUser).where(OktaUser.id.in_(self.owner_ids_to_remove)).where(OktaUser.deleted_at.is_(None))
             ).all()
 
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self.current_user_id)
             ).first(),
             "id",
             None,

--- a/api/operations/modify_groups_time_limit.py
+++ b/api/operations/modify_groups_time_limit.py
@@ -11,41 +11,37 @@ class ModifyGroupsTimeLimit:
         self._groups_arg = groups
         self._tags_arg = tags
 
-    def _resolve(self) -> None:
-        groups = self._groups_arg
+    def execute(self) -> None:
+        groups_arg = self._groups_arg
         # Only include groups that are managed
-        self.groups = db.session.scalars(
+        groups = db.session.scalars(
             select(OktaGroup)
-            .where(OktaGroup.id.in_(groups))
+            .where(OktaGroup.id.in_(groups_arg))
             .where(OktaGroup.deleted_at.is_(None))
             .where(OktaGroup.is_managed.is_(True))
         ).all()
-        self.role_groups = db.session.scalars(
+        role_groups = db.session.scalars(
             select(RoleGroup)
-            .where(RoleGroup.id.in_(groups))
+            .where(RoleGroup.id.in_(groups_arg))
             .where(RoleGroup.deleted_at.is_(None))
             .where(RoleGroup.is_managed.is_(True))
         ).all()
 
-        self.tags = db.session.scalars(
-            select(Tag).where(Tag.id.in_(self._tags_arg)).where(Tag.deleted_at.is_(None))
-        ).all()
+        tags = db.session.scalars(select(Tag).where(Tag.id.in_(self._tags_arg)).where(Tag.deleted_at.is_(None))).all()
 
-    def execute(self) -> None:
-        self._resolve()
-        if len(self.groups) == 0:
+        if len(groups) == 0:
             return
 
         # Determine the minimum time allowed for group membership and ownership by current group tags
-        membership_seconds_limit = coalesce_constraints(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, self.tags)
-        ownership_seconds_limit = coalesce_constraints(Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY, self.tags)
+        membership_seconds_limit = coalesce_constraints(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, tags)
+        ownership_seconds_limit = coalesce_constraints(Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY, tags)
         # Handle group time limit constraints when adding tags with time limit contraints to a group
         if membership_seconds_limit is not None:
             membership_time_limit_from_now = datetime.now(UTC) + timedelta(seconds=membership_seconds_limit)
             # Reduce all user memberships for the given groups to minimum allowed time limit
             db.session.execute(
                 update(OktaUserGroupMember)
-                .where(OktaUserGroupMember.group_id.in_([g.id for g in self.groups]))
+                .where(OktaUserGroupMember.group_id.in_([g.id for g in groups]))
                 .where(OktaUserGroupMember.is_owner.is_(False))
                 .where(
                     or_(
@@ -59,7 +55,7 @@ class ModifyGroupsTimeLimit:
             # Reduce all role memberships for the given groups to the minimum allowed time limit
             db.session.execute(
                 update(RoleGroupMap)
-                .where(RoleGroupMap.group_id.in_([g.id for g in self.groups]))
+                .where(RoleGroupMap.group_id.in_([g.id for g in groups]))
                 .where(RoleGroupMap.is_owner.is_(False))
                 .where(
                     or_(
@@ -74,7 +70,7 @@ class ModifyGroupsTimeLimit:
             # to the minimum allowed time limit
             role_group_map_associations = db.session.scalars(
                 select(RoleGroupMap)
-                .where(RoleGroupMap.role_group_id.in_([g.id for g in self.role_groups]))
+                .where(RoleGroupMap.role_group_id.in_([g.id for g in role_groups]))
                 .where(RoleGroupMap.is_owner.is_(False))
                 .where(
                     or_(
@@ -102,7 +98,7 @@ class ModifyGroupsTimeLimit:
             # Reduce all user ownerships for the given groups to minimum allowed time limit
             db.session.execute(
                 update(OktaUserGroupMember)
-                .where(OktaUserGroupMember.group_id.in_([g.id for g in self.groups]))
+                .where(OktaUserGroupMember.group_id.in_([g.id for g in groups]))
                 .where(OktaUserGroupMember.is_owner.is_(True))
                 .where(
                     or_(
@@ -116,7 +112,7 @@ class ModifyGroupsTimeLimit:
             # Reduce all role ownerships for the given groups to the minimum allowed time limit
             db.session.execute(
                 update(RoleGroupMap)
-                .where(RoleGroupMap.group_id.in_([g.id for g in self.groups]))
+                .where(RoleGroupMap.group_id.in_([g.id for g in groups]))
                 .where(RoleGroupMap.is_owner.is_(True))
                 .where(
                     or_(
@@ -131,7 +127,7 @@ class ModifyGroupsTimeLimit:
             # to the minimum allowed time limit
             role_group_map_associations = db.session.scalars(
                 select(RoleGroupMap)
-                .where(RoleGroupMap.role_group_id.in_([g.id for g in self.role_groups]))
+                .where(RoleGroupMap.role_group_id.in_([g.id for g in role_groups]))
                 .where(RoleGroupMap.is_owner.is_(True))
                 .where(
                     or_(

--- a/api/operations/modify_groups_time_limit.py
+++ b/api/operations/modify_groups_time_limit.py
@@ -8,26 +8,25 @@ from api.models.tag import coalesce_constraints
 
 class ModifyGroupsTimeLimit:
     def __init__(self, groups: list[str] | set[str], tags: list[str] | set[str]):
-        self._groups_arg = groups
-        self._tags_arg = tags
+        self.group_ids = groups
+        self.tag_ids = tags
 
     def execute(self) -> None:
-        groups_arg = self._groups_arg
         # Only include groups that are managed
         groups = db.session.scalars(
             select(OktaGroup)
-            .where(OktaGroup.id.in_(groups_arg))
+            .where(OktaGroup.id.in_(self.group_ids))
             .where(OktaGroup.deleted_at.is_(None))
             .where(OktaGroup.is_managed.is_(True))
         ).all()
         role_groups = db.session.scalars(
             select(RoleGroup)
-            .where(RoleGroup.id.in_(groups_arg))
+            .where(RoleGroup.id.in_(self.group_ids))
             .where(RoleGroup.deleted_at.is_(None))
             .where(RoleGroup.is_managed.is_(True))
         ).all()
 
-        tags = db.session.scalars(select(Tag).where(Tag.id.in_(self._tags_arg)).where(Tag.deleted_at.is_(None))).all()
+        tags = db.session.scalars(select(Tag).where(Tag.id.in_(self.tag_ids)).where(Tag.deleted_at.is_(None))).all()
 
         if len(groups) == 0:
             return

--- a/api/operations/modify_groups_time_limit.py
+++ b/api/operations/modify_groups_time_limit.py
@@ -8,6 +8,11 @@ from api.models.tag import coalesce_constraints
 
 class ModifyGroupsTimeLimit:
     def __init__(self, groups: list[str] | set[str], tags: list[str] | set[str]):
+        self._groups_arg = groups
+        self._tags_arg = tags
+
+    def _resolve(self) -> None:
+        groups = self._groups_arg
         # Only include groups that are managed
         self.groups = db.session.scalars(
             select(OktaGroup)
@@ -22,9 +27,12 @@ class ModifyGroupsTimeLimit:
             .where(RoleGroup.is_managed.is_(True))
         ).all()
 
-        self.tags = db.session.scalars(select(Tag).where(Tag.id.in_(tags)).where(Tag.deleted_at.is_(None))).all()
+        self.tags = db.session.scalars(
+            select(Tag).where(Tag.id.in_(self._tags_arg)).where(Tag.deleted_at.is_(None))
+        ).all()
 
     def execute(self) -> None:
+        self._resolve()
         if len(self.groups) == 0:
             return
 

--- a/api/operations/modify_role_groups.py
+++ b/api/operations/modify_role_groups.py
@@ -51,16 +51,16 @@ class ModifyRoleGroups:
 
         self.groups_added_ended_at = groups_added_ended_at
 
-        self._groups_to_add_arg = groups_to_add
-        self._owner_groups_to_add_arg = owner_groups_to_add
-        self._groups_should_expire_arg = groups_should_expire
-        self._owner_groups_should_expire_arg = owner_groups_should_expire
-        self._groups_to_remove_arg = groups_to_remove
-        self._owner_groups_to_remove_arg = owner_groups_to_remove
+        self.group_ids_to_add = groups_to_add
+        self.owner_group_ids_to_add = owner_groups_to_add
+        self.group_should_expire_ids = groups_should_expire
+        self.owner_group_should_expire_ids = owner_groups_should_expire
+        self.group_ids_to_remove = groups_to_remove
+        self.owner_group_ids_to_remove = owner_groups_to_remove
 
         self.sync_to_okta = sync_to_okta
 
-        self._current_user_id_arg = current_user_id
+        self.current_user_id = current_user_id
 
         self.created_reason = created_reason
 
@@ -73,19 +73,12 @@ class ModifyRoleGroups:
         return asyncio.run(self._execute())
 
     async def _execute(self) -> RoleGroup:
-        groups_to_add_arg = self._groups_to_add_arg
-        owner_groups_to_add_arg = self._owner_groups_to_add_arg
-        groups_should_expire_arg = self._groups_should_expire_arg
-        owner_groups_should_expire_arg = self._owner_groups_should_expire_arg
-        groups_to_remove_arg = self._groups_to_remove_arg
-        owner_groups_to_remove_arg = self._owner_groups_to_remove_arg
-
         self.role = db.session.scalars(
             select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == self.role_group_id)
         ).first()
 
         groups_to_add: list[OktaGroup] = []
-        if len(groups_to_add_arg) > 0:
+        if len(self.group_ids_to_add) > 0:
             groups_to_add = db.session.scalars(
                 select(OktaGroup)
                 .options(
@@ -93,18 +86,18 @@ class ModifyRoleGroups:
                     selectin_polymorphic(OktaGroup, [AppGroup]),
                     joinedload(AppGroup.app),
                 )
-                .where(OktaGroup.id.in_(groups_to_add_arg))
+                .where(OktaGroup.id.in_(self.group_ids_to_add))
                 .where(OktaGroup.is_managed.is_(True))
                 .where(OktaGroup.deleted_at.is_(None))
                 # Don't allow Roles to be added as Groups to Roles
                 .where(OktaGroup.type != RoleGroup.__mapper_args__["polymorphic_identity"])
             ).all()
         owner_groups_to_add: list[OktaGroup] = []
-        if len(owner_groups_to_add_arg) > 0:
+        if len(self.owner_group_ids_to_add) > 0:
             owner_groups_to_add = db.session.scalars(
                 select(OktaGroup)
                 .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
-                .where(OktaGroup.id.in_(owner_groups_to_add_arg))
+                .where(OktaGroup.id.in_(self.owner_group_ids_to_add))
                 .where(OktaGroup.is_managed.is_(True))
                 .where(OktaGroup.deleted_at.is_(None))
                 # Don't allow Roles to be added as Groups to Roles
@@ -112,47 +105,47 @@ class ModifyRoleGroups:
             ).all()
 
         groups_should_expire: list[RoleGroupMap] = []
-        if len(groups_should_expire_arg) > 0:
+        if len(self.group_should_expire_ids) > 0:
             groups_should_expire = db.session.scalars(
                 select(RoleGroupMap)
-                .where(RoleGroupMap.id.in_(groups_should_expire_arg))
+                .where(RoleGroupMap.id.in_(self.group_should_expire_ids))
                 .where(RoleGroupMap.role_group_id == self.role.id)
                 .where(RoleGroupMap.ended_at > func.now())
                 .where(RoleGroupMap.is_owner.is_(False))
             ).all()
 
         owner_groups_should_expire: list[RoleGroupMap] = []
-        if len(owner_groups_should_expire_arg) > 0:
+        if len(self.owner_group_should_expire_ids) > 0:
             owner_groups_should_expire = db.session.scalars(
                 select(RoleGroupMap)
-                .where(RoleGroupMap.id.in_(owner_groups_should_expire_arg))
+                .where(RoleGroupMap.id.in_(self.owner_group_should_expire_ids))
                 .where(RoleGroupMap.role_group_id == self.role.id)
                 .where(RoleGroupMap.ended_at > func.now())
                 .where(RoleGroupMap.is_owner.is_(True))
             ).all()
 
         groups_to_remove: list[OktaGroup] = []
-        if len(groups_to_remove_arg) > 0:
+        if len(self.group_ids_to_remove) > 0:
             groups_to_remove = db.session.scalars(
                 select(OktaGroup)
                 # `app` is eager-loaded so the app-group-lifecycle hook path below
                 # can read `group.app` without tripping `lazy="raise_on_sql"`.
                 .options(selectin_polymorphic(OktaGroup, [AppGroup]), joinedload(AppGroup.app))
-                .where(OktaGroup.id.in_(groups_to_remove_arg))
+                .where(OktaGroup.id.in_(self.group_ids_to_remove))
                 .where(OktaGroup.deleted_at.is_(None))
             ).all()
 
         owner_groups_to_remove: list[OktaGroup] = []
-        if len(owner_groups_to_remove_arg) > 0:
+        if len(self.owner_group_ids_to_remove) > 0:
             owner_groups_to_remove = db.session.scalars(
                 select(OktaGroup)
-                .where(OktaGroup.id.in_(owner_groups_to_remove_arg))
+                .where(OktaGroup.id.in_(self.owner_group_ids_to_remove))
                 .where(OktaGroup.deleted_at.is_(None))
             ).all()
 
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self.current_user_id)
             ).first(),
             "id",
             None,

--- a/api/operations/modify_role_groups.py
+++ b/api/operations/modify_role_groups.py
@@ -47,7 +47,7 @@ class ModifyRoleGroups:
         created_reason: str = "",
         notify: bool = True,
     ):
-        self._role_group_arg = role_group
+        self.role_group_id = role_group if isinstance(role_group, str) else role_group.id
 
         self.groups_added_ended_at = groups_added_ended_at
 
@@ -73,7 +73,6 @@ class ModifyRoleGroups:
         return asyncio.run(self._execute())
 
     async def _execute(self) -> RoleGroup:
-        role_group_arg = self._role_group_arg
         groups_to_add_arg = self._groups_to_add_arg
         owner_groups_to_add_arg = self._owner_groups_to_add_arg
         groups_should_expire_arg = self._groups_should_expire_arg
@@ -81,12 +80,9 @@ class ModifyRoleGroups:
         groups_to_remove_arg = self._groups_to_remove_arg
         owner_groups_to_remove_arg = self._owner_groups_to_remove_arg
 
-        if isinstance(role_group_arg, str):
-            self.role = db.session.scalars(
-                select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == role_group_arg)
-            ).first()
-        else:
-            self.role = role_group_arg
+        self.role = db.session.scalars(
+            select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == self.role_group_id)
+        ).first()
 
         groups_to_add: list[OktaGroup] = []
         if len(groups_to_add_arg) > 0:

--- a/api/operations/modify_role_groups.py
+++ b/api/operations/modify_role_groups.py
@@ -47,14 +47,42 @@ class ModifyRoleGroups:
         created_reason: str = "",
         notify: bool = True,
     ):
+        self._role_group_arg = role_group
+
+        self.groups_added_ended_at = groups_added_ended_at
+
+        self._groups_to_add_arg = groups_to_add
+        self._owner_groups_to_add_arg = owner_groups_to_add
+        self._groups_should_expire_arg = groups_should_expire
+        self._owner_groups_should_expire_arg = owner_groups_should_expire
+        self._groups_to_remove_arg = groups_to_remove
+        self._owner_groups_to_remove_arg = owner_groups_to_remove
+
+        self.sync_to_okta = sync_to_okta
+
+        self._current_user_id_arg = current_user_id
+
+        self.created_reason = created_reason
+
+        self.notify = notify
+
+        self.notification_hook = get_notification_hook()
+
+    def _resolve(self) -> None:
+        role_group = self._role_group_arg
+        groups_to_add = self._groups_to_add_arg
+        owner_groups_to_add = self._owner_groups_to_add_arg
+        groups_should_expire = self._groups_should_expire_arg
+        owner_groups_should_expire = self._owner_groups_should_expire_arg
+        groups_to_remove = self._groups_to_remove_arg
+        owner_groups_to_remove = self._owner_groups_to_remove_arg
+
         if isinstance(role_group, str):
             self.role = db.session.scalars(
                 select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == role_group)
             ).first()
         else:
             self.role = role_group
-
-        self.groups_added_ended_at = groups_added_ended_at
 
         self.groups_to_add = []
         if len(groups_to_add) > 0:
@@ -120,23 +148,16 @@ class ModifyRoleGroups:
                 select(OktaGroup).where(OktaGroup.id.in_(owner_groups_to_remove)).where(OktaGroup.deleted_at.is_(None))
             ).all()
 
-        self.sync_to_okta = sync_to_okta
-
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
-        self.created_reason = created_reason
-
-        self.notify = notify
-
-        self.notification_hook = get_notification_hook()
-
     def execute(self) -> RoleGroup:
+        self._resolve()
         # Run asychronously to parallelize Okta API requests
         return asyncio.run(self._execute())
 

--- a/api/operations/modify_role_groups.py
+++ b/api/operations/modify_role_groups.py
@@ -68,84 +68,90 @@ class ModifyRoleGroups:
 
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
-        role_group = self._role_group_arg
-        groups_to_add = self._groups_to_add_arg
-        owner_groups_to_add = self._owner_groups_to_add_arg
-        groups_should_expire = self._groups_should_expire_arg
-        owner_groups_should_expire = self._owner_groups_should_expire_arg
-        groups_to_remove = self._groups_to_remove_arg
-        owner_groups_to_remove = self._owner_groups_to_remove_arg
+    def execute(self) -> RoleGroup:
+        # Run asychronously to parallelize Okta API requests
+        return asyncio.run(self._execute())
 
-        if isinstance(role_group, str):
+    async def _execute(self) -> RoleGroup:
+        role_group_arg = self._role_group_arg
+        groups_to_add_arg = self._groups_to_add_arg
+        owner_groups_to_add_arg = self._owner_groups_to_add_arg
+        groups_should_expire_arg = self._groups_should_expire_arg
+        owner_groups_should_expire_arg = self._owner_groups_should_expire_arg
+        groups_to_remove_arg = self._groups_to_remove_arg
+        owner_groups_to_remove_arg = self._owner_groups_to_remove_arg
+
+        if isinstance(role_group_arg, str):
             self.role = db.session.scalars(
-                select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == role_group)
+                select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == role_group_arg)
             ).first()
         else:
-            self.role = role_group
+            self.role = role_group_arg
 
-        self.groups_to_add = []
-        if len(groups_to_add) > 0:
-            self.groups_to_add = db.session.scalars(
+        groups_to_add: list[OktaGroup] = []
+        if len(groups_to_add_arg) > 0:
+            groups_to_add = db.session.scalars(
                 select(OktaGroup)
                 .options(
                     selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
                     selectin_polymorphic(OktaGroup, [AppGroup]),
                     joinedload(AppGroup.app),
                 )
-                .where(OktaGroup.id.in_(groups_to_add))
+                .where(OktaGroup.id.in_(groups_to_add_arg))
                 .where(OktaGroup.is_managed.is_(True))
                 .where(OktaGroup.deleted_at.is_(None))
                 # Don't allow Roles to be added as Groups to Roles
                 .where(OktaGroup.type != RoleGroup.__mapper_args__["polymorphic_identity"])
             ).all()
-        self.owner_groups_to_add = []
-        if len(owner_groups_to_add) > 0:
-            self.owner_groups_to_add = db.session.scalars(
+        owner_groups_to_add: list[OktaGroup] = []
+        if len(owner_groups_to_add_arg) > 0:
+            owner_groups_to_add = db.session.scalars(
                 select(OktaGroup)
                 .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
-                .where(OktaGroup.id.in_(owner_groups_to_add))
+                .where(OktaGroup.id.in_(owner_groups_to_add_arg))
                 .where(OktaGroup.is_managed.is_(True))
                 .where(OktaGroup.deleted_at.is_(None))
                 # Don't allow Roles to be added as Groups to Roles
                 .where(OktaGroup.type != RoleGroup.__mapper_args__["polymorphic_identity"])
             ).all()
 
-        self.groups_should_expire = []
-        if len(groups_should_expire) > 0:
-            self.groups_should_expire = db.session.scalars(
+        groups_should_expire: list[RoleGroupMap] = []
+        if len(groups_should_expire_arg) > 0:
+            groups_should_expire = db.session.scalars(
                 select(RoleGroupMap)
-                .where(RoleGroupMap.id.in_(groups_should_expire))
+                .where(RoleGroupMap.id.in_(groups_should_expire_arg))
                 .where(RoleGroupMap.role_group_id == self.role.id)
                 .where(RoleGroupMap.ended_at > func.now())
                 .where(RoleGroupMap.is_owner.is_(False))
             ).all()
 
-        self.owner_groups_should_expire = []
-        if len(owner_groups_should_expire) > 0:
-            self.owner_groups_should_expire = db.session.scalars(
+        owner_groups_should_expire: list[RoleGroupMap] = []
+        if len(owner_groups_should_expire_arg) > 0:
+            owner_groups_should_expire = db.session.scalars(
                 select(RoleGroupMap)
-                .where(RoleGroupMap.id.in_(owner_groups_should_expire))
+                .where(RoleGroupMap.id.in_(owner_groups_should_expire_arg))
                 .where(RoleGroupMap.role_group_id == self.role.id)
                 .where(RoleGroupMap.ended_at > func.now())
                 .where(RoleGroupMap.is_owner.is_(True))
             ).all()
 
-        self.groups_to_remove = []
-        if len(groups_to_remove) > 0:
-            self.groups_to_remove = db.session.scalars(
+        groups_to_remove: list[OktaGroup] = []
+        if len(groups_to_remove_arg) > 0:
+            groups_to_remove = db.session.scalars(
                 select(OktaGroup)
                 # `app` is eager-loaded so the app-group-lifecycle hook path below
                 # can read `group.app` without tripping `lazy="raise_on_sql"`.
                 .options(selectin_polymorphic(OktaGroup, [AppGroup]), joinedload(AppGroup.app))
-                .where(OktaGroup.id.in_(groups_to_remove))
+                .where(OktaGroup.id.in_(groups_to_remove_arg))
                 .where(OktaGroup.deleted_at.is_(None))
             ).all()
 
-        self.owner_groups_to_remove = []
-        if len(owner_groups_to_remove) > 0:
-            self.owner_groups_to_remove = db.session.scalars(
-                select(OktaGroup).where(OktaGroup.id.in_(owner_groups_to_remove)).where(OktaGroup.deleted_at.is_(None))
+        owner_groups_to_remove: list[OktaGroup] = []
+        if len(owner_groups_to_remove_arg) > 0:
+            owner_groups_to_remove = db.session.scalars(
+                select(OktaGroup)
+                .where(OktaGroup.id.in_(owner_groups_to_remove_arg))
+                .where(OktaGroup.deleted_at.is_(None))
             ).all()
 
         self.current_user_id = getattr(
@@ -156,20 +162,14 @@ class ModifyRoleGroups:
             None,
         )
 
-    def execute(self) -> RoleGroup:
-        self._resolve()
-        # Run asychronously to parallelize Okta API requests
-        return asyncio.run(self._execute())
-
-    async def _execute(self) -> RoleGroup:
         # Fast return if no changes are being made
         if (
-            len(self.groups_to_add)
-            + len(self.groups_to_remove)
-            + len(self.groups_should_expire)
-            + len(self.owner_groups_to_add)
-            + len(self.owner_groups_to_remove)
-            + len(self.owner_groups_should_expire)
+            len(groups_to_add)
+            + len(groups_to_remove)
+            + len(groups_should_expire)
+            + len(owner_groups_to_add)
+            + len(owner_groups_to_remove)
+            + len(owner_groups_should_expire)
             == 0
         ):
             return self.role
@@ -178,8 +178,8 @@ class ModifyRoleGroups:
         valid, _ = CheckForSelfAdd(
             group=self.role,
             current_user=self.current_user_id,
-            members_to_add=[g.id for g in self.groups_to_add],
-            owners_to_add=[g.id for g in self.owner_groups_to_add],
+            members_to_add=[g.id for g in groups_to_add],
+            owners_to_add=[g.id for g in owner_groups_to_add],
         ).execute_for_role()
         if not valid:
             return self.role
@@ -188,8 +188,8 @@ class ModifyRoleGroups:
         valid, _ = CheckForReason(
             group=self.role,
             reason=self.created_reason,
-            members_to_add=[g.id for g in self.groups_to_add],
-            owners_to_add=[g.id for g in self.owner_groups_to_add],
+            members_to_add=[g.id for g in groups_to_add],
+            owners_to_add=[g.id for g in owner_groups_to_add],
         ).execute_for_role()
         if not valid:
             return self.role
@@ -211,12 +211,12 @@ class ModifyRoleGroups:
                     "current_user_email": email,
                     "role": self.role,
                     "groups_added_ending_at": self.groups_added_ended_at,
-                    "owner_groups_removed_ids_names": self.owner_groups_to_remove,
-                    "owner_groups_added_ids_names": self.owner_groups_to_add,
-                    "owner_groups_should_expire_role_id_group_id": self.owner_groups_should_expire,
-                    "groups_removed_ids_names": self.groups_to_remove,
-                    "groups_added_ids_names": self.groups_to_add,
-                    "groups_should_expire_role_id_group_id": self.groups_should_expire,
+                    "owner_groups_removed_ids_names": owner_groups_to_remove,
+                    "owner_groups_added_ids_names": owner_groups_to_add,
+                    "owner_groups_should_expire_role_id_group_id": owner_groups_should_expire,
+                    "groups_removed_ids_names": groups_to_remove,
+                    "groups_added_ids_names": groups_to_add,
+                    "groups_should_expire_role_id_group_id": groups_should_expire,
                 }
             )
         )
@@ -229,12 +229,12 @@ class ModifyRoleGroups:
         # those extensions occured
 
         # Remove groups from role
-        self.__remove_groups_from_role(self.groups_to_remove + self.groups_to_add, False)
+        self.__remove_groups_from_role(groups_to_remove + groups_to_add, False)
         # Remove owner groups from role
-        self.__remove_groups_from_role(self.owner_groups_to_remove + self.owner_groups_to_add, True)
+        self.__remove_groups_from_role(owner_groups_to_remove + owner_groups_to_add, True)
 
         # Remove role members and owners from Okta groups associated with the role
-        if len(self.groups_to_remove) > 0 or len(self.owner_groups_to_remove) > 0:
+        if len(groups_to_remove) > 0 or len(owner_groups_to_remove) > 0:
             # Check if there are other OktaUserGroupMembers for this user/group
             # combination before removing role, there can be multiple role groups
             # which allow group access for this user
@@ -252,8 +252,8 @@ class ModifyRoleGroups:
             ).all()
 
             role_members_to_remove_ids = [m.user_id for m in active_role_members]
-            groups_to_remove_ids = [m.id for m in self.groups_to_remove]
-            owner_groups_to_remove_ids = [m.id for m in self.owner_groups_to_remove]
+            groups_to_remove_ids = [m.id for m in groups_to_remove]
+            owner_groups_to_remove_ids = [m.id for m in owner_groups_to_remove]
             removed_role_group_users_with_other_access = db.session.execute(
                 select(
                     OktaUserGroupMember.user_id,
@@ -275,7 +275,7 @@ class ModifyRoleGroups:
                 )
             ).all()
 
-            groups_to_remove_by_id = {group.id: group for group in self.groups_to_remove}
+            groups_to_remove_by_id = {group.id: group for group in groups_to_remove}
             for group_id in groups_to_remove_ids:
                 removed_members_with_other_access_ids = [
                     m.user_id
@@ -333,18 +333,18 @@ class ModifyRoleGroups:
         # Mark relevant role memberships and ownerships as 'Should expire'
         # Only relevant for the expiring roles page so not adding checks for this field anywhere else since OK if marked to expire
         # then manually renewed from group/role page or with an access request
-        if len(self.groups_should_expire) > 0:
+        if len(groups_should_expire) > 0:
             db.session.execute(
                 update(RoleGroupMap)
-                .where(RoleGroupMap.id.in_(m.id for m in self.groups_should_expire))
+                .where(RoleGroupMap.id.in_(m.id for m in groups_should_expire))
                 .values({RoleGroupMap.should_expire: True})
                 .execution_options(synchronize_session="fetch")
             )
 
-        if len(self.owner_groups_should_expire) > 0:
+        if len(owner_groups_should_expire) > 0:
             db.session.execute(
                 update(RoleGroupMap)
-                .where(RoleGroupMap.id.in_(m.id for m in self.owner_groups_should_expire))
+                .where(RoleGroupMap.id.in_(m.id for m in owner_groups_should_expire))
                 .values({RoleGroupMap.should_expire: True})
                 .execution_options(synchronize_session="fetch")
             )
@@ -353,9 +353,9 @@ class ModifyRoleGroups:
         db.session.commit()
 
         # Add new groups to role and owner groups to role
-        if len(self.groups_to_add) > 0 or len(self.owner_groups_to_add) > 0:
+        if len(groups_to_add) > 0 or len(owner_groups_to_add) > 0:
             role_memberships_added: Dict[str, RoleGroupMap] = {}
-            for group in self.groups_to_add:
+            for group in groups_to_add:
                 # Handle group time limit constraints when roles are added to groups
                 # with tagged time limits as members
                 membership_ended_at = coalesce_ended_at(
@@ -377,7 +377,7 @@ class ModifyRoleGroups:
                 db.session.add(membership_to_add)
 
             role_ownerships_added: Dict[str, RoleGroupMap] = {}
-            for owner_group in self.owner_groups_to_add:
+            for owner_group in owner_groups_to_add:
                 # Handle group time limit constraints when roles are added to groups
                 # with tagged time limits as owners
                 ownership_ended_at = coalesce_ended_at(
@@ -414,7 +414,7 @@ class ModifyRoleGroups:
                 .where(OktaUserGroupMember.group_id == self.role.id)
                 .where(OktaUserGroupMember.is_owner.is_(False))
             ).all()
-            groups_added_by_id = {group.id: group for group in self.groups_to_add}
+            groups_added_by_id = {group.id: group for group in groups_to_add}
             group_memberships_added: Dict[str, Dict[str, OktaUserGroupMember]] = {}
             for role_associated_group_map in role_memberships_added.values():
                 group_memberships_added[role_associated_group_map.group_id] = role_associated_membership_added = {}
@@ -569,7 +569,7 @@ class ModifyRoleGroups:
                 .where(RoleRequest.requester_role == self.role)
             )
 
-            added_group_ids = [group.id for group in self.groups_to_add]
+            added_group_ids = [group.id for group in groups_to_add]
             pending_role_memberships = db.session.scalars(
                 pending_role_requests_query.where(RoleRequest.request_ownership.is_(False)).where(
                     RoleRequest.requested_group_id.in_(added_group_ids)
@@ -581,7 +581,7 @@ class ModifyRoleGroups:
                 )
 
             # Approve any pending role requests for ownerships granted by this operation
-            added_owner_group_ids = [group.id for group in self.owner_groups_to_add]
+            added_owner_group_ids = [group.id for group in owner_groups_to_add]
             pending_role_ownerships = db.session.scalars(
                 pending_role_requests_query.where(RoleRequest.request_ownership.is_(True)).where(
                     RoleRequest.requested_group_id.in_(added_owner_group_ids)

--- a/api/operations/reject_access_request.py
+++ b/api/operations/reject_access_request.py
@@ -33,22 +33,22 @@ class RejectAccessRequest:
 
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
-        access_request = self._access_request_arg
+    def execute(self) -> AccessRequest:
+        access_request_arg = self._access_request_arg
         current_user_id = self._current_user_id_arg
 
         # Lock the request row so a reject can't race a concurrent approve/
         # reject; both serialize on this row and the loser hits the resolved
         # guard. No-op on SQLite.
-        request_id = access_request if isinstance(access_request, str) else access_request.id
-        self.access_request = db.session.scalars(
+        request_id = access_request_arg if isinstance(access_request_arg, str) else access_request_arg.id
+        access_request = db.session.scalars(
             select(AccessRequest).where(AccessRequest.id == request_id).with_for_update()
         ).first()
 
         if current_user_id is None:
-            self.rejecter_id = None
+            rejecter_id = None
         elif isinstance(current_user_id, str):
-            self.rejecter_id = getattr(
+            rejecter_id = getattr(
                 db.session.scalars(
                     select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
                 ).first(),
@@ -56,32 +56,30 @@ class RejectAccessRequest:
                 None,
             )
         else:
-            self.rejecter_id = current_user_id.id
+            rejecter_id = current_user_id.id
 
-    def execute(self) -> AccessRequest:
-        self._resolve()
         # Don't allow rejecting a request that is already resolved. Raise
         # rather than silently no-op so a stale/concurrent rejection surfaces
         # as a conflict instead of looking like a success.
-        if self.access_request.status != AccessRequestStatus.PENDING or self.access_request.resolved_at is not None:
+        if access_request.status != AccessRequestStatus.PENDING or access_request.resolved_at is not None:
             raise ConflictError("Access request is no longer pending")
 
-        self.access_request.status = AccessRequestStatus.REJECTED
-        self.access_request.resolved_at = func.now()
-        self.access_request.resolver_user_id = self.rejecter_id
-        self.access_request.resolution_reason = self.rejection_reason
+        access_request.status = AccessRequestStatus.REJECTED
+        access_request.resolved_at = func.now()
+        access_request.resolver_user_id = rejecter_id
+        access_request.resolution_reason = self.rejection_reason
 
         db.session.commit()
 
         # Audit logging
         email = None
-        if self.rejecter_id is not None:
-            email = getattr(db.session.get(OktaUser, self.rejecter_id), "email", None)
+        if rejecter_id is not None:
+            email = getattr(db.session.get(OktaUser, rejecter_id), "email", None)
 
         group = db.session.scalars(
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
-            .where(OktaGroup.id == self.access_request.requested_group_id)
+            .where(OktaGroup.id == access_request.requested_group_id)
             .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
         ).first()
 
@@ -93,26 +91,26 @@ class RejectAccessRequest:
                     "event_type": EventType.access_reject,
                     "user_agent": _ctx.user_agent if _ctx else None,
                     "ip": _ctx.ip if _ctx else None,
-                    "current_user_id": self.rejecter_id,
+                    "current_user_id": rejecter_id,
                     "current_user_email": email,
                     "group": group,
-                    "request": self.access_request,
-                    "requester": db.session.get(OktaUser, self.access_request.requester_user_id),
+                    "request": access_request,
+                    "requester": db.session.get(OktaUser, access_request.requester_user_id),
                 }
             )
         )
 
         if self.notify:
-            requester = db.session.get(OktaUser, self.access_request.requester_user_id)
+            requester = db.session.get(OktaUser, access_request.requester_user_id)
 
-            approvers = get_all_possible_request_approvers(self.access_request)
+            approvers = get_all_possible_request_approvers(access_request)
 
             self.notification_hook.access_request_completed(
-                access_request=self.access_request,
+                access_request=access_request,
                 group=group,
                 requester=requester,
                 approvers=approvers,
                 notify_requester=self.notify_requester,
             )
 
-        return self.access_request
+        return access_request

--- a/api/operations/reject_access_request.py
+++ b/api/operations/reject_access_request.py
@@ -24,8 +24,12 @@ class RejectAccessRequest:
         notify_requester: bool = True,
         current_user_id: Optional[str | OktaUser] = None,
     ):
-        self._access_request_arg = access_request
-        self._current_user_id_arg = current_user_id
+        self.access_request_id = access_request if isinstance(access_request, str) else access_request.id
+        self.current_user_id = (
+            current_user_id.id
+            if current_user_id is not None and not isinstance(current_user_id, str)
+            else current_user_id
+        )
 
         self.rejection_reason = rejection_reason
         self.notify = notify
@@ -34,29 +38,23 @@ class RejectAccessRequest:
         self.notification_hook = get_notification_hook()
 
     def execute(self) -> AccessRequest:
-        access_request_arg = self._access_request_arg
-        current_user_id = self._current_user_id_arg
-
         # Lock the request row so a reject can't race a concurrent approve/
         # reject; both serialize on this row and the loser hits the resolved
         # guard. No-op on SQLite.
-        request_id = access_request_arg if isinstance(access_request_arg, str) else access_request_arg.id
         access_request = db.session.scalars(
-            select(AccessRequest).where(AccessRequest.id == request_id).with_for_update()
+            select(AccessRequest).where(AccessRequest.id == self.access_request_id).with_for_update()
         ).first()
 
-        if current_user_id is None:
+        if self.current_user_id is None:
             rejecter_id = None
-        elif isinstance(current_user_id, str):
+        else:
             rejecter_id = getattr(
                 db.session.scalars(
-                    select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                    select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self.current_user_id)
                 ).first(),
                 "id",
                 None,
             )
-        else:
-            rejecter_id = current_user_id.id
 
         # Don't allow rejecting a request that is already resolved. Raise
         # rather than silently no-op so a stale/concurrent rejection surfaces

--- a/api/operations/reject_access_request.py
+++ b/api/operations/reject_access_request.py
@@ -24,6 +24,19 @@ class RejectAccessRequest:
         notify_requester: bool = True,
         current_user_id: Optional[str | OktaUser] = None,
     ):
+        self._access_request_arg = access_request
+        self._current_user_id_arg = current_user_id
+
+        self.rejection_reason = rejection_reason
+        self.notify = notify
+        self.notify_requester = notify_requester
+
+        self.notification_hook = get_notification_hook()
+
+    def _resolve(self) -> None:
+        access_request = self._access_request_arg
+        current_user_id = self._current_user_id_arg
+
         # Lock the request row so a reject can't race a concurrent approve/
         # reject; both serialize on this row and the loser hits the resolved
         # guard. No-op on SQLite.
@@ -45,13 +58,8 @@ class RejectAccessRequest:
         else:
             self.rejecter_id = current_user_id.id
 
-        self.rejection_reason = rejection_reason
-        self.notify = notify
-        self.notify_requester = notify_requester
-
-        self.notification_hook = get_notification_hook()
-
     def execute(self) -> AccessRequest:
+        self._resolve()
         # Don't allow rejecting a request that is already resolved. Raise
         # rather than silently no-op so a stale/concurrent rejection surfaces
         # as a conflict instead of looking like a success.

--- a/api/operations/reject_group_request.py
+++ b/api/operations/reject_group_request.py
@@ -24,8 +24,12 @@ class RejectGroupRequest:
         notify_requester: bool = True,
         current_user_id: Optional[str | OktaUser] = None,
     ):
-        self._group_request_arg = group_request
-        self._current_user_id_arg = current_user_id
+        self.group_request_id = group_request if isinstance(group_request, str) else group_request.id
+        self.current_user_id = (
+            current_user_id.id
+            if current_user_id is not None and not isinstance(current_user_id, str)
+            else current_user_id
+        )
 
         self.rejection_reason = rejection_reason
         self.notify = notify
@@ -34,26 +38,20 @@ class RejectGroupRequest:
         self.notification_hook = get_notification_hook()
 
     def execute(self) -> GroupRequest:
-        group_request_arg = self._group_request_arg
-        current_user_id = self._current_user_id_arg
-
         # Lock the request row so a reject can't race a concurrent approve/
         # reject; both serialize on this row and the loser hits the resolved
         # guard. No-op on SQLite.
-        request_id = group_request_arg if isinstance(group_request_arg, str) else group_request_arg.id
         group_request = db.session.scalars(
-            select(GroupRequest).where(GroupRequest.id == request_id).with_for_update()
+            select(GroupRequest).where(GroupRequest.id == self.group_request_id).with_for_update()
         ).first()
 
-        if current_user_id is None:
+        if self.current_user_id is None:
             rejecter_id = None
-        elif isinstance(current_user_id, str):
+        else:
             user = db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self.current_user_id)
             ).first()
             rejecter_id = user.id if user else None
-        else:
-            rejecter_id = current_user_id.id
 
         # Already resolved — raise rather than silently no-op so a stale/
         # concurrent rejection surfaces as a conflict instead of a success.

--- a/api/operations/reject_group_request.py
+++ b/api/operations/reject_group_request.py
@@ -24,6 +24,19 @@ class RejectGroupRequest:
         notify_requester: bool = True,
         current_user_id: Optional[str | OktaUser] = None,
     ):
+        self._group_request_arg = group_request
+        self._current_user_id_arg = current_user_id
+
+        self.rejection_reason = rejection_reason
+        self.notify = notify
+        self.notify_requester = notify_requester
+
+        self.notification_hook = get_notification_hook()
+
+    def _resolve(self) -> None:
+        group_request = self._group_request_arg
+        current_user_id = self._current_user_id_arg
+
         # Lock the request row so a reject can't race a concurrent approve/
         # reject; both serialize on this row and the loser hits the resolved
         # guard. No-op on SQLite.
@@ -42,13 +55,8 @@ class RejectGroupRequest:
         else:
             self.rejecter_id = current_user_id.id
 
-        self.rejection_reason = rejection_reason
-        self.notify = notify
-        self.notify_requester = notify_requester
-
-        self.notification_hook = get_notification_hook()
-
     def execute(self) -> GroupRequest:
+        self._resolve()
         # Already resolved — raise rather than silently no-op so a stale/
         # concurrent rejection surfaces as a conflict instead of a success.
         if self.group_request.status != AccessRequestStatus.PENDING or self.group_request.resolved_at is not None:

--- a/api/operations/reject_group_request.py
+++ b/api/operations/reject_group_request.py
@@ -33,47 +33,43 @@ class RejectGroupRequest:
 
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
-        group_request = self._group_request_arg
+    def execute(self) -> GroupRequest:
+        group_request_arg = self._group_request_arg
         current_user_id = self._current_user_id_arg
 
         # Lock the request row so a reject can't race a concurrent approve/
         # reject; both serialize on this row and the loser hits the resolved
         # guard. No-op on SQLite.
-        request_id = group_request if isinstance(group_request, str) else group_request.id
-        self.group_request = db.session.scalars(
+        request_id = group_request_arg if isinstance(group_request_arg, str) else group_request_arg.id
+        group_request = db.session.scalars(
             select(GroupRequest).where(GroupRequest.id == request_id).with_for_update()
         ).first()
 
         if current_user_id is None:
-            self.rejecter_id = None
+            rejecter_id = None
         elif isinstance(current_user_id, str):
             user = db.session.scalars(
                 select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
             ).first()
-            self.rejecter_id = user.id if user else None
+            rejecter_id = user.id if user else None
         else:
-            self.rejecter_id = current_user_id.id
+            rejecter_id = current_user_id.id
 
-    def execute(self) -> GroupRequest:
-        self._resolve()
         # Already resolved — raise rather than silently no-op so a stale/
         # concurrent rejection surfaces as a conflict instead of a success.
-        if self.group_request.status != AccessRequestStatus.PENDING or self.group_request.resolved_at is not None:
+        if group_request.status != AccessRequestStatus.PENDING or group_request.resolved_at is not None:
             raise ConflictError("Group request is no longer pending")
 
         resolved_app_id = (
-            self.group_request.resolved_app_id
-            if self.group_request.resolved_app_id
-            else self.group_request.requested_app_id
+            group_request.resolved_app_id if group_request.resolved_app_id else group_request.requested_app_id
         )
 
-        if self.rejecter_id is not None:
-            is_self_rejection = self.group_request.requester_user_id == self.rejecter_id
+        if rejecter_id is not None:
+            is_self_rejection = group_request.requester_user_id == rejecter_id
 
             if not is_self_rejection:
                 access_owner_ids = {u.id for u in get_access_owners()}
-                is_global_admin = self.rejecter_id in access_owner_ids
+                is_global_admin = rejecter_id in access_owner_ids
 
                 if not is_global_admin:
                     # Check app ownership if this is an app group request
@@ -85,20 +81,20 @@ class RejectGroupRequest:
                                 AppGroup.app_id == resolved_app_id,
                                 AppGroup.is_owner.is_(True),
                                 AppGroup.deleted_at.is_(None),
-                                OktaUserGroupMember.user_id == self.rejecter_id,
+                                OktaUserGroupMember.user_id == rejecter_id,
                                 OktaUserGroupMember.is_owner.is_(True),
                                 OktaUserGroupMember.ended_at.is_(None),
                             )
                         ).first()
 
                         if not is_app_owner:
-                            return self.group_request
+                            return group_request
                     else:
                         # Non-app-group request: only global admins can reject
-                        return self.group_request
+                        return group_request
 
         # Audit logging
-        email = getattr(db.session.get(OktaUser, self.rejecter_id), "email", None) if self.rejecter_id else None
+        email = getattr(db.session.get(OktaUser, rejecter_id), "email", None) if rejecter_id else None
         _ctx = get_request_context()
         logging.getLogger("access.audit").info(
             AuditLogSchema().dumps(
@@ -106,32 +102,32 @@ class RejectGroupRequest:
                     "event_type": EventType.group_request_reject,
                     "user_agent": _ctx.user_agent if _ctx else None,
                     "ip": _ctx.ip if _ctx else None,
-                    "current_user_id": self.rejecter_id,
+                    "current_user_id": rejecter_id,
                     "current_user_email": email,
-                    "group_request": self.group_request,
-                    "requester": db.session.get(OktaUser, self.group_request.requester_user_id),
+                    "group_request": group_request,
+                    "requester": db.session.get(OktaUser, group_request.requester_user_id),
                 }
             )
         )
 
-        self.group_request.status = AccessRequestStatus.REJECTED
-        self.group_request.resolved_at = func.now()
-        self.group_request.resolver_user_id = self.rejecter_id
-        self.group_request.resolution_reason = self.rejection_reason
+        group_request.status = AccessRequestStatus.REJECTED
+        group_request.resolved_at = func.now()
+        group_request.resolver_user_id = rejecter_id
+        group_request.resolution_reason = self.rejection_reason
 
         db.session.commit()
 
         if self.notify:
-            requester = db.session.get(OktaUser, self.group_request.requester_user_id)
+            requester = db.session.get(OktaUser, group_request.requester_user_id)
 
-            approvers = get_all_possible_request_approvers(self.group_request)
+            approvers = get_all_possible_request_approvers(group_request)
 
             self.notification_hook.access_group_request_completed(
-                group_request=self.group_request,
+                group_request=group_request,
                 group=None,
                 requester=requester,
                 approvers=approvers,
                 notify_requester=self.notify_requester,
             )
 
-        return self.group_request
+        return group_request

--- a/api/operations/reject_role_request.py
+++ b/api/operations/reject_role_request.py
@@ -24,6 +24,19 @@ class RejectRoleRequest:
         notify_requester: bool = True,
         current_user_id: Optional[str | OktaUser] = None,
     ):
+        self._role_request_arg = role_request
+        self._current_user_id_arg = current_user_id
+
+        self.rejection_reason = rejection_reason
+        self.notify = notify
+        self.notify_requester = notify_requester
+
+        self.notification_hook = get_notification_hook()
+
+    def _resolve(self) -> None:
+        role_request = self._role_request_arg
+        current_user_id = self._current_user_id_arg
+
         # Lock the request row so a reject can't race a concurrent approve/
         # reject; both serialize on this row and the loser hits the resolved
         # guard. No-op on SQLite.
@@ -45,13 +58,8 @@ class RejectRoleRequest:
         else:
             self.rejecter_id = current_user_id.id
 
-        self.rejection_reason = rejection_reason
-        self.notify = notify
-        self.notify_requester = notify_requester
-
-        self.notification_hook = get_notification_hook()
-
     def execute(self) -> RoleRequest:
+        self._resolve()
         # Don't allow rejecting a request that is already resolved. Raise
         # rather than silently no-op so a stale/concurrent rejection surfaces
         # as a conflict instead of looking like a success.

--- a/api/operations/reject_role_request.py
+++ b/api/operations/reject_role_request.py
@@ -24,8 +24,12 @@ class RejectRoleRequest:
         notify_requester: bool = True,
         current_user_id: Optional[str | OktaUser] = None,
     ):
-        self._role_request_arg = role_request
-        self._current_user_id_arg = current_user_id
+        self.role_request_id = role_request if isinstance(role_request, str) else role_request.id
+        self.current_user_id = (
+            current_user_id.id
+            if current_user_id is not None and not isinstance(current_user_id, str)
+            else current_user_id
+        )
 
         self.rejection_reason = rejection_reason
         self.notify = notify
@@ -34,29 +38,23 @@ class RejectRoleRequest:
         self.notification_hook = get_notification_hook()
 
     def execute(self) -> RoleRequest:
-        role_request_arg = self._role_request_arg
-        current_user_id = self._current_user_id_arg
-
         # Lock the request row so a reject can't race a concurrent approve/
         # reject; both serialize on this row and the loser hits the resolved
         # guard. No-op on SQLite.
-        request_id = role_request_arg if isinstance(role_request_arg, str) else role_request_arg.id
         role_request = db.session.scalars(
-            select(RoleRequest).where(RoleRequest.id == request_id).with_for_update()
+            select(RoleRequest).where(RoleRequest.id == self.role_request_id).with_for_update()
         ).first()
 
-        if current_user_id is None:
+        if self.current_user_id is None:
             rejecter_id = None
-        elif isinstance(current_user_id, str):
+        else:
             rejecter_id = getattr(
                 db.session.scalars(
-                    select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                    select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self.current_user_id)
                 ).first(),
                 "id",
                 None,
             )
-        else:
-            rejecter_id = current_user_id.id
 
         # Don't allow rejecting a request that is already resolved. Raise
         # rather than silently no-op so a stale/concurrent rejection surfaces

--- a/api/operations/reject_role_request.py
+++ b/api/operations/reject_role_request.py
@@ -33,22 +33,22 @@ class RejectRoleRequest:
 
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
-        role_request = self._role_request_arg
+    def execute(self) -> RoleRequest:
+        role_request_arg = self._role_request_arg
         current_user_id = self._current_user_id_arg
 
         # Lock the request row so a reject can't race a concurrent approve/
         # reject; both serialize on this row and the loser hits the resolved
         # guard. No-op on SQLite.
-        request_id = role_request if isinstance(role_request, str) else role_request.id
-        self.role_request = db.session.scalars(
+        request_id = role_request_arg if isinstance(role_request_arg, str) else role_request_arg.id
+        role_request = db.session.scalars(
             select(RoleRequest).where(RoleRequest.id == request_id).with_for_update()
         ).first()
 
         if current_user_id is None:
-            self.rejecter_id = None
+            rejecter_id = None
         elif isinstance(current_user_id, str):
-            self.rejecter_id = getattr(
+            rejecter_id = getattr(
                 db.session.scalars(
                     select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
                 ).first(),
@@ -56,32 +56,30 @@ class RejectRoleRequest:
                 None,
             )
         else:
-            self.rejecter_id = current_user_id.id
+            rejecter_id = current_user_id.id
 
-    def execute(self) -> RoleRequest:
-        self._resolve()
         # Don't allow rejecting a request that is already resolved. Raise
         # rather than silently no-op so a stale/concurrent rejection surfaces
         # as a conflict instead of looking like a success.
-        if self.role_request.status != AccessRequestStatus.PENDING or self.role_request.resolved_at is not None:
+        if role_request.status != AccessRequestStatus.PENDING or role_request.resolved_at is not None:
             raise ConflictError("Role request is no longer pending")
 
-        self.role_request.status = AccessRequestStatus.REJECTED
-        self.role_request.resolved_at = func.now()
-        self.role_request.resolver_user_id = self.rejecter_id
-        self.role_request.resolution_reason = self.rejection_reason
+        role_request.status = AccessRequestStatus.REJECTED
+        role_request.resolved_at = func.now()
+        role_request.resolver_user_id = rejecter_id
+        role_request.resolution_reason = self.rejection_reason
 
         db.session.commit()
 
         # Audit logging
         email = None
-        if self.rejecter_id is not None:
-            email = getattr(db.session.get(OktaUser, self.rejecter_id), "email", None)
+        if rejecter_id is not None:
+            email = getattr(db.session.get(OktaUser, rejecter_id), "email", None)
 
         group = db.session.scalars(
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup]), joinedload(AppGroup.app))
-            .where(OktaGroup.id == self.role_request.requested_group_id)
+            .where(OktaGroup.id == role_request.requested_group_id)
             .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
         ).first()
 
@@ -93,23 +91,23 @@ class RejectRoleRequest:
                     "event_type": EventType.role_request_reject,
                     "user_agent": _ctx.user_agent if _ctx else None,
                     "ip": _ctx.ip if _ctx else None,
-                    "current_user_id": self.rejecter_id,
+                    "current_user_id": rejecter_id,
                     "current_user_email": email,
                     "group": group,
-                    "role_request": self.role_request,
-                    "requester": db.session.get(OktaUser, self.role_request.requester_user_id),
+                    "role_request": role_request,
+                    "requester": db.session.get(OktaUser, role_request.requester_user_id),
                 }
             )
         )
 
         if self.notify:
-            requester = db.session.get(OktaUser, self.role_request.requester_user_id)
-            requester_role = db.session.get(OktaGroup, self.role_request.requester_role_id)
+            requester = db.session.get(OktaUser, role_request.requester_user_id)
+            requester_role = db.session.get(OktaGroup, role_request.requester_role_id)
 
-            approvers = get_all_possible_request_approvers(self.role_request)
+            approvers = get_all_possible_request_approvers(role_request)
 
             self.notification_hook.access_role_request_completed(
-                role_request=self.role_request,
+                role_request=role_request,
                 role=requester_role,
                 group=group,
                 requester=requester,
@@ -117,4 +115,4 @@ class RejectRoleRequest:
                 notify_requester=self.notify_requester,
             )
 
-        return self.role_request
+        return role_request

--- a/api/operations/unmanage_group.py
+++ b/api/operations/unmanage_group.py
@@ -28,15 +28,15 @@ class UnmanageGroup:
         self._group_arg = group
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
-        group = self._group_arg
-        self.group = db.session.scalars(
+    def execute(self, dry_run: bool = False) -> None:
+        group_arg = self._group_arg
+        group = db.session.scalars(
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-            .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+            .where(OktaGroup.id == (group_arg if isinstance(group_arg, str) else group_arg.id))
         ).first()
 
-        self.current_user_id = getattr(
+        current_user_id = getattr(
             db.session.scalars(
                 select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
@@ -44,9 +44,7 @@ class UnmanageGroup:
             None,
         )
 
-    def execute(self, dry_run: bool = False) -> None:
-        self._resolve()
-        if self.group.is_managed:
+        if group.is_managed:
             return
 
         # TODO: End all direct ownerships of the group?
@@ -60,7 +58,7 @@ class UnmanageGroup:
                     OktaUserGroupMember.ended_at > func.now(),
                 )
             )
-            .where(OktaUserGroupMember.group_id == self.group.id)
+            .where(OktaUserGroupMember.group_id == group.id)
             .where(OktaUserGroupMember.role_group_map_id.isnot(None))
         )
 
@@ -68,7 +66,7 @@ class UnmanageGroup:
             logger.info(
                 f"User {active_access_via_role.user_id} has invalid "
                 f"{'ownership' if active_access_via_role.is_owner else 'membership'} "
-                f"to unmanaged group {self.group.id} via role"
+                f"to unmanaged group {group.id} via role"
             )
 
         if not dry_run:
@@ -80,7 +78,7 @@ class UnmanageGroup:
                         OktaUserGroupMember.ended_at > func.now(),
                     )
                 )
-                .where(OktaUserGroupMember.group_id == self.group.id)
+                .where(OktaUserGroupMember.group_id == group.id)
                 .where(OktaUserGroupMember.role_group_map_id.isnot(None))
                 .values({OktaUserGroupMember.ended_at: func.now()})
                 .execution_options(synchronize_session="fetch")
@@ -91,21 +89,21 @@ class UnmanageGroup:
         active_role_assignments_query = (
             select(RoleGroupMap)
             .where(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
-            .where(RoleGroupMap.group_id == self.group.id)
+            .where(RoleGroupMap.group_id == group.id)
         )
 
         for active_role_assignment in db.session.scalars(active_role_assignments_query).all():
             logger.info(
                 f"Role {active_role_assignment.role_group_id} has invalid "
                 f"{'ownership' if active_role_assignment.is_owner else 'membership'} "
-                f"to unmanaged group {self.group.id}"
+                f"to unmanaged group {group.id}"
             )
 
         if not dry_run:
             db.session.execute(
                 update(RoleGroupMap)
                 .where(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
-                .where(RoleGroupMap.group_id == self.group.id)
+                .where(RoleGroupMap.group_id == group.id)
                 .values({RoleGroupMap.ended_at: func.now()})
                 .execution_options(synchronize_session="fetch")
             )
@@ -117,20 +115,19 @@ class UnmanageGroup:
         # Reject all pending access requests for this group
         obsolete_access_requests = db.session.scalars(
             select(AccessRequest)
-            .where(AccessRequest.requested_group_id == self.group.id)
+            .where(AccessRequest.requested_group_id == group.id)
             .where(AccessRequest.status == AccessRequestStatus.PENDING)
             .where(AccessRequest.resolved_at.is_(None))
         ).all()
         for obsolete_access_request in obsolete_access_requests:
             logger.info(
-                f"Rejecting obsolete access request {obsolete_access_request.id} "
-                f"for unmanaged group {self.group.id}"
+                f"Rejecting obsolete access request {obsolete_access_request.id} " f"for unmanaged group {group.id}"
             )
             if not dry_run:
                 RejectAccessRequest(
                     access_request=obsolete_access_request,
                     rejection_reason="Closed because the requested group is no longer managed by Access",
-                    current_user_id=self.current_user_id,
+                    current_user_id=current_user_id,
                 ).execute()
 
         # Reject all pending role requests touching this group, either as the
@@ -139,20 +136,18 @@ class UnmanageGroup:
             select(RoleRequest)
             .where(
                 or_(
-                    RoleRequest.requested_group_id == self.group.id,
-                    RoleRequest.requester_role_id == self.group.id,
+                    RoleRequest.requested_group_id == group.id,
+                    RoleRequest.requester_role_id == group.id,
                 )
             )
             .where(RoleRequest.status == AccessRequestStatus.PENDING)
             .where(RoleRequest.resolved_at.is_(None))
         ).all()
         for obsolete_role_request in obsolete_role_requests:
-            logger.info(
-                f"Rejecting obsolete role request {obsolete_role_request.id} for unmanaged group {self.group.id}"
-            )
+            logger.info(f"Rejecting obsolete role request {obsolete_role_request.id} for unmanaged group {group.id}")
             if not dry_run:
                 RejectRoleRequest(
                     role_request=obsolete_role_request,
                     rejection_reason="Closed because a group in this role request is no longer managed by Access",
-                    current_user_id=self.current_user_id,
+                    current_user_id=current_user_id,
                 ).execute()

--- a/api/operations/unmanage_group.py
+++ b/api/operations/unmanage_group.py
@@ -25,15 +25,14 @@ logger = logging.getLogger(__name__)
 # Run this operation when a group becomes unmanaged by Access
 class UnmanageGroup:
     def __init__(self, *, group: OktaGroup | str, current_user_id: Optional[str] = None):
-        self._group_arg = group
+        self.group_id = group if isinstance(group, str) else group.id
         self._current_user_id_arg = current_user_id
 
     def execute(self, dry_run: bool = False) -> None:
-        group_arg = self._group_arg
         group = db.session.scalars(
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-            .where(OktaGroup.id == (group_arg if isinstance(group_arg, str) else group_arg.id))
+            .where(OktaGroup.id == self.group_id)
         ).first()
 
         current_user_id = getattr(

--- a/api/operations/unmanage_group.py
+++ b/api/operations/unmanage_group.py
@@ -25,6 +25,11 @@ logger = logging.getLogger(__name__)
 # Run this operation when a group becomes unmanaged by Access
 class UnmanageGroup:
     def __init__(self, *, group: OktaGroup | str, current_user_id: Optional[str] = None):
+        self._group_arg = group
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
+        group = self._group_arg
         self.group = db.session.scalars(
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
@@ -33,13 +38,14 @@ class UnmanageGroup:
 
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self, dry_run: bool = False) -> None:
+        self._resolve()
         if self.group.is_managed:
             return
 

--- a/api/operations/unmanage_group.py
+++ b/api/operations/unmanage_group.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 class UnmanageGroup:
     def __init__(self, *, group: OktaGroup | str, current_user_id: Optional[str] = None):
         self.group_id = group if isinstance(group, str) else group.id
-        self._current_user_id_arg = current_user_id
+        self.current_user_id = current_user_id
 
     def execute(self, dry_run: bool = False) -> None:
         group = db.session.scalars(
@@ -37,7 +37,7 @@ class UnmanageGroup:
 
         current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self.current_user_id)
             ).first(),
             "id",
             None,


### PR DESCRIPTION
Part of the async-SQLAlchemy migration stack; rebased directly on `main` (#475–#477 merged).

`__init__` can't be `async`, so the DB work it currently does must move behind `execute()` before the flip makes those queries awaitable. This PR relocates it — without the intermediate `_resolve()`/on-`self` scaffolding the first revision used (see review history below):

- **Lookups are local variables in the execute method.** Each `execute()` (or `_execute()` for the four `asyncio.run` ops, and each `execute_for_group()`/`execute_for_role()` for the constraint checks) performs its queries, row locks, and id lookups as locals. Nothing DB-loaded is stashed on `self`. Values genuinely read across methods stay on `self` (e.g. `ModifyGroupUsers.current_user_id`, `ModifyRoleGroups.role`/`current_user_id`, read by the notify/approve helpers).
- **`__init__` stores entity ids, not ORM model references.** Every `Model | str` constructor arg is reduced to its id in `__init__` (`self.x_id = x if isinstance(x, str) else x.id`, None-guarded for optional args); the execute method looks the entity up by that id. Holding an ORM reference across the `__init__` → `execute()` gap is fragile (it can expire/detach), and these args were only ever used to re-query by id. The few ops that previously trusted a passed-in object (the `create_*_request` requester/role/group args, the `approver_user` args) now always re-query by the stored id — equivalent, since those entities are always persisted before the op runs.

Every call site already chains `.execute()` immediately and uses the return value, so no caller reads operation state afterward — behavior is unchanged. Side benefit: the `with_for_update` row locks in the approve/reject ops now begin at execute time rather than construction time, narrowing the lock window to the actual mutation.

Full suite green (541 tests), ruff (format + check) + mypy clean.

### Review history
The first revision used a private `_resolve()` that stashed results on `self`. Per review (@somethingnew2-0, @Jeff-Rowell): dropped `_resolve()` in favor of locals-in-execute (commit `1d3bdd8`), then switched `__init__` to store ids instead of model references (commit `11237e2`). That also removes the shared-`_resolve()`-from-both-constraint-entry-points re-query concern.

## PR stack

Merge bottom-up; each PR retargets to `main` as predecessors merge.

1. ~~#475 — async dependency prep~~ ✅ merged
2. ~~#476 — legacy Query API → 2.0-style statements~~ ✅ merged
3. ~~#477 — eliminate lazy loading and commit-expiration from the ORM layer~~ ✅ merged
4. #478 — resolve operation DB lookups as locals in execute() ⬅️ **this PR** (on `main`)
5. #479 — keep `db.session` access out of spawned notification tasks (on `main`)
6. #480 — **the async flip** (production + tests + docs)
7. #481 — surface failed Okta/notification fan-out tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
