### PR TITLE
[async 8/8] test: reproduce the Flask-era lazy-load Sentry issues with polymorphic data

### DIFF
--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - python-version: "3.13"
             database: postgresql
-            database-uri: postgresql+pg8000://postgres:postgres@localhost:5432/postgres
+            database-uri: postgresql://postgres:postgres@localhost:5432/postgres
           - python-version: "3.13"
             database: sqlite
             database-uri: sqlite:///migrations_ci.db

--- a/POST_MIGRATION_TODO.md
+++ b/POST_MIGRATION_TODO.md
@@ -8,23 +8,6 @@ Items grouped roughly by surface area; ordering within each group is rough prior
 
 ## Database / SQLAlchemy
 
-### 2. Switch to async SQLAlchemy
-
-The migration kept SQLAlchemy synchronous. To go async:
-- Engine: `create_engine` → `create_async_engine`
-- Sessionmaker: `sessionmaker` → `async_sessionmaker`
-- `get_db`: `Generator[Session, …]` → `AsyncGenerator[AsyncSession, …]`
-- Operations: every `db.session.query(...).first()` → `await session.execute(select(...))`
-- Routers: `def` → `async def`
-
-Major lift — every operation file changes — but unlocks concurrent I/O and
-removes the sync-thread-pool overhead per request.
-
-### 3. Replace the `_session_scope` ContextVar dance with `async_scoped_session`
-
-Once #2 lands, SQLAlchemy's built-in `async_scoped_session` replaces the
-manual ContextVar plumbing in `api/extensions.py`.
-
 ### 4. Eager-loading hygiene
 
 **Strict serialization landed.** `api/schemas/_serialize.py` exposes
@@ -85,21 +68,27 @@ Care needed:
 - Tests that assert call-count of mocked Okta methods may need to await
   background tasks before asserting
 
-### 11. Async HTTP for Okta calls
+### 11a. Okta SDK v3 upgrade
 
-Replace synchronous `requests` calls in `api/services/okta_service.py` with
-`httpx.AsyncClient` and connection pooling. Pairs naturally with #2 (async
-SQLAlchemy).
+The async migration kept `okta==2.9.8` (aiohttp-based, async-native)
+behind the `OktaService` facade. The SDK's v3 line (3.x, late 2025+) is
+a ground-up openapi-generator rewrite: Pydantic models replace
+`OktaObject`, API methods move to `okta.api.*` classes, and the
+exception hierarchy changes. Still async, so nothing blocks on it — but
+v2 is in maintenance mode. The facade contains the blast radius:
+upgrading touches `api/services/okta_service.py` (retry/pagination/
+custom group-owners endpoint plumbing), `tests/factories.py` (Okta SDK
+model factories), and the okta service/retry tests. Verify rate-limit
+and pagination behavior against a live org when upgrading.
 
-**Important sequencing note.** The current `OktaService` sync wrappers
-each call `asyncio.run(...)` internally on an inner async helper. That
-works *today* because every router is `def` (sync) and runs on an
-`anyio.to_thread.run_sync` worker thread that has no event loop. The
-moment any router becomes `async def`, the same call breaks with
-`asyncio.run() cannot be called from a running event loop`. So this
-work is gated on #2 (async SQLAlchemy / async routers) and must land
-together — converting `OktaService` to async without converting the
-routers buys nothing and is risky.
+### 11b. Shared pooled Okta client
+
+`OktaService._okta_client()` creates a fresh SDK client (and aiohttp
+session) per call so CLI invocations and per-test event loops stay
+isolated. The FastAPI server loop could instead hold one client for
+connection pooling — e.g. created in a lifespan hook and reused when
+`asyncio.get_running_loop()` matches. Measure before bothering: Okta
+API latency dominates connection setup for most operations.
 
 (Note: the previous "Replace the in-process syncer.py loop with a
 proper task runner" entry was removed — the syncer already runs as a
@@ -122,14 +111,6 @@ violations in those directories.
 ---
 
 ## Test Ergonomics
-
-### 15. Async test client
-
-Once routers are async (#2), switch from `fastapi.testclient.TestClient`
-to `httpx.AsyncClient(transport=ASGITransport(app=app))` with
-`pytest-asyncio`. Lets tests exercise true async paths (e.g. concurrent
-DB calls in a single request) and avoids the sync-bridge in the current
-TestClient.
 
 ### 16. Replace `factory_boy` with Pydantic-based builders
 
@@ -158,8 +139,12 @@ clean `--snapshot-update` ergonomics.
 
 The four plugin types (`notifications`, `conditional_access`,
 `app_group_lifecycle`, `metrics_reporter`) currently expose synchronous
-hooks via `pluggy`. Once the application goes async (#2), plugins
-should follow.
+hooks via `pluggy`. The application is now async; the sync hooks are
+bridged at every call site — `app_group_lifecycle` hooks (which receive
+`session=`) run through `AsyncSession.run_sync` on the greenlet bridge,
+and `notifications`/`conditional_access` hooks run on a worker thread
+via `anyio.to_thread.run_sync` so plugin network I/O can't block the
+event loop. Plugins should eventually follow the app.
 
 Strategy mirrors the existing `DeprecationWarning` pattern in
 `api/plugins/notifications.py:48-74`:
@@ -172,6 +157,17 @@ Strategy mirrors the existing `DeprecationWarning` pattern in
 
 Plugins authored in this window can pick either flavor; the application
 prefers the async hook when both are registered.
+
+Rules to document with the async hook specs:
+- Hooks must not import `api.extensions.db` — they receive everything
+  they need (the lifecycle hooks' `session` argument is a sync
+  `Session` shim today and becomes an `AsyncSession` for the `_async`
+  variants).
+- **Plugin-contributed CLI commands** (the `access.commands` entry
+  point) now run inside the CLI's `asyncio.run` boundary; commands
+  written against the old sync `db.session` will break. They should
+  declare `async def` bodies and await session calls — document this
+  in the plugin guide alongside the async hook rollout.
 
 ### 19. Pre-2.0 release checklist: drop deprecated plugin parameters
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Create a `.env.production` file in the repo root with the following variables. A
 ```
 OKTA_DOMAIN=<YOUR_OKTA_DOMAIN> # For example, "mydomain.okta.com"
 OKTA_API_TOKEN=<YOUR_OKTA_API_TOKEN>
-DATABASE_URI=<YOUR_DATABASE_URI> # For example, "postgresql+pg8000://postgres:postgres@localhost:5432/access"
+DATABASE_URI=<YOUR_DATABASE_URI> # For example, "postgresql://postgres:postgres@localhost:5432/access"
 CLIENT_ORIGIN_URL=http://localhost:3000
 VITE_API_SERVER_URL=""
 FASTAPI_SENTRY_DSN=https://<key>@sentry.io/<project>
@@ -139,7 +139,7 @@ If you want to use the Cloud SQL Python Connector, set the following variables i
 
 ```
 CLOUDSQL_CONNECTION_NAME=<YOUR_CLOUDSQL_CONNECTION_NAME> # For example, "project:region:instance-name"
-DATABASE_URI="postgresql+pg8000://"
+DATABASE_URI="postgresql://"
 DATABASE_USER=<YOUR_DATABASE_USER> # For a service account, this is the service account's email without the .gserviceaccount.com domain suffix.
 DATABASE_NAME=<YOUR_DATABASE_NAME>
 DATABASE_USES_PUBLIC_IP=[True|False]
@@ -252,7 +252,7 @@ The `.env.production` file is where you configure the application.
 
 - `OKTA_DOMAIN`: Specifies the [Okta](https://okta.com) domain to use.
 - `OKTA_API_TOKEN`: Specifies the [Okta](https://okta.com) [API Token](https://developer.okta.com/docs/api/openapi/okta-management/management/tag/ApiToken/) to use.
-- `DATABASE_URI`: Specifies the Database connection URI. **Example:** `postgresql+pg8000://<POSTGRES_USER>:<POSTGRES_PASSWORD>@postgres:5432/<DB_NAME>`.
+- `DATABASE_URI`: Specifies the Database connection URI. **Example:** `postgresql://<POSTGRES_USER>:<POSTGRES_PASSWORD>@postgres:5432/<DB_NAME>`. The app runs on async SQLAlchemy: `postgresql://` (and legacy `postgresql+pg8000://`) URIs are normalized to the `asyncpg` driver, `sqlite://` to `aiosqlite`. Note that asyncpg does not accept `sslmode=` URL parameters (use `ssl=`), and deployments behind transaction-mode PgBouncer should disable asyncpg's prepared-statement cache (`statement_cache_size=0`).
 - `CLIENT_ORIGIN_URL`: Specifies the origin URL used by plugins (e.g. for building notification URLs).
 - `VITE_API_SERVER_URL`: Specifies the API base URL which is used by the frontend. Set to an empty string "" to use the same URL as the frontend.
 - `FASTAPI_SENTRY_DSN`: See the [Sentry documentation](https://docs.sentry.io/product/sentry-basics/concepts/dsn-explainer/). **[OPTIONAL] You can safely remove this from your env file**

--- a/api/app.py
+++ b/api/app.py
@@ -21,7 +21,7 @@ from starlette.middleware.cors import CORSMiddleware
 
 from api import exception_handlers, middleware
 from api.config import settings
-from api.database import build_engine
+from api.database import build_async_engine
 from api.extensions import db
 from api.log_filters import RedactingUvicornLogger, TokenSanitizingFilter
 from api.schemas.core_schemas import ProblemDetail
@@ -229,7 +229,7 @@ def create_app(testing: Optional[bool] = False) -> FastAPI:
     # fixture rebuilds with a sqlite-in-memory engine, so we only bind here
     # when not testing.
     if not testing and (settings.SQLALCHEMY_DATABASE_URI or settings.CLOUDSQL_CONNECTION_NAME):
-        db.init_app(engine=build_engine())
+        db.init_app(engine=build_async_engine())
 
     # OIDC: Authlib + SessionMiddleware. Only mounted if configured.
     if settings.OIDC_CLIENT_SECRETS is not None and settings.SECRET_KEY:

--- a/api/auth/dependencies.py
+++ b/api/auth/dependencies.py
@@ -19,7 +19,7 @@ from typing import Annotated
 from fastapi import Depends, HTTPException
 from sentry_sdk import set_user
 from sqlalchemy import func, select
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 
 from api.auth.cloudflare import extract_token, verify_cloudflare_token
@@ -30,9 +30,11 @@ from api.models import OktaUser
 logger = logging.getLogger(__name__)
 
 
-def _lookup_user_by_email(db: Session, email: str) -> OktaUser:
-    user = db.scalars(
-        select(OktaUser).where(func.lower(OktaUser.email) == func.lower(email)).where(OktaUser.deleted_at.is_(None))
+async def _lookup_user_by_email(db: AsyncSession, email: str) -> OktaUser:
+    user = (
+        await db.scalars(
+            select(OktaUser).where(func.lower(OktaUser.email) == func.lower(email)).where(OktaUser.deleted_at.is_(None))
+        )
     ).first()
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
@@ -55,7 +57,7 @@ class OIDCRedirectRequired(Exception):
         super().__init__(f"OIDC login required (next={next_path!r})")
 
 
-def get_current_user_id(request: Request, db: DbSession) -> str:
+async def get_current_user_id(request: Request, db: DbSession) -> str:
     """Resolve the current user id, raising 403 if unauthenticated."""
     if settings.ENV in ("development", "test"):
         email = _dev_user_email(request)
@@ -63,7 +65,7 @@ def get_current_user_id(request: Request, db: DbSession) -> str:
             # Health-check tests set this sentinel to opt out of having a
             # real OktaUser row resolved; the endpoint runs without auth.
             return ""
-        user = _lookup_user_by_email(db, email)
+        user = await _lookup_user_by_email(db, email)
         request.state.current_user_id = user.id
         if settings.FASTAPI_SENTRY_DSN:
             set_user({"id": user.id})
@@ -75,7 +77,7 @@ def get_current_user_id(request: Request, db: DbSession) -> str:
             raise HTTPException(status_code=403, detail="Missing required Cloudflare authorization token")
         payload = verify_cloudflare_token(token)
         if "email" in payload:
-            user = _lookup_user_by_email(db, payload["email"])
+            user = await _lookup_user_by_email(db, payload["email"])
             request.state.current_user_id = user.id
             if settings.FASTAPI_SENTRY_DSN:
                 set_user({"id": user.id})
@@ -95,7 +97,7 @@ def get_current_user_id(request: Request, db: DbSession) -> str:
             # Browser flow: the SPA should follow the 307 to the OIDC login
             # endpoint, which kicks off the authorization-code redirect.
             raise OIDCRedirectRequired(next_path=request.url.path)
-        user = _lookup_user_by_email(db, userinfo["email"])
+        user = await _lookup_user_by_email(db, userinfo["email"])
         request.state.current_user_id = user.id
         if settings.FASTAPI_SENTRY_DSN:
             set_user({"id": user.id})
@@ -104,12 +106,12 @@ def get_current_user_id(request: Request, db: DbSession) -> str:
     raise HTTPException(status_code=403, detail="No authentication method configured")
 
 
-def get_current_user(
+async def get_current_user(
     db: DbSession,
     current_user_id: Annotated[str, Depends(get_current_user_id)],
 ) -> OktaUser:
-    user = db.scalars(
-        select(OktaUser).where(OktaUser.id == current_user_id).where(OktaUser.deleted_at.is_(None))
+    user = (
+        await db.scalars(select(OktaUser).where(OktaUser.id == current_user_id).where(OktaUser.deleted_at.is_(None)))
     ).first()
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
@@ -129,7 +131,7 @@ CurrentUser = Annotated[OktaUser, Depends(get_current_user)]
 AUTH_ALLOWLIST_PREFIXES = ("/api/healthz", "/oidc/")
 
 
-def require_authenticated(request: Request, db: DbSession) -> None:
+async def require_authenticated(request: Request, db: DbSession) -> None:
     """Enforce authentication on every request except `/api/healthz` and
     the OIDC login endpoints. `/api/docs` and `/api/openapi.json` are
     intentionally inside the gate even though they're DEBUG-only, as is
@@ -137,4 +139,4 @@ def require_authenticated(request: Request, db: DbSession) -> None:
     path = request.url.path
     if any(path == p.rstrip("/") or path.startswith(p) for p in AUTH_ALLOWLIST_PREFIXES):
         return
-    get_current_user_id(request, db)
+    await get_current_user_id(request, db)

--- a/api/auth/permissions.py
+++ b/api/auth/permissions.py
@@ -12,7 +12,8 @@ from typing import Annotated, Optional
 
 from fastapi import Depends, HTTPException
 from sqlalchemy import func, or_, select
-from sqlalchemy.orm import Session, selectinload
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from api.auth.dependencies import CurrentUserId
 from api.config import settings
@@ -20,7 +21,7 @@ from api.database import DbSession
 from api.models import App, AppGroup, OktaGroup, OktaUserGroupMember
 
 
-def is_group_owner(db: Session, current_user_id: str, group: OktaGroup) -> bool:
+async def is_group_owner(db: AsyncSession, current_user_id: str, group: OktaGroup) -> bool:
     stmt = (
         select(OktaUserGroupMember)
         .where(OktaUserGroupMember.group_id == group.id)
@@ -33,11 +34,11 @@ def is_group_owner(db: Session, current_user_id: str, group: OktaGroup) -> bool:
             )
         )
     )
-    return (db.scalar(select(func.count()).select_from(stmt.subquery())) or 0) > 0
+    return (await db.scalar(select(func.count()).select_from(stmt.subquery())) or 0) > 0
 
 
-def is_app_owner_group_owner(
-    db: Session,
+async def is_app_owner_group_owner(
+    db: AsyncSession,
     current_user_id: str,
     *,
     app_group: Optional[AppGroup] = None,
@@ -56,12 +57,13 @@ def is_app_owner_group_owner(
         .where(AppGroup.app_id == app_id)
         .where(AppGroup.is_owner.is_(True))
     )
-    if (db.scalar(select(func.count()).select_from(owner_app_groups_stmt.subquery())) or 0) == 0:
+    if (await db.scalar(select(func.count()).select_from(owner_app_groups_stmt.subquery())) or 0) == 0:
         return False
 
+    owner_app_groups = (await db.scalars(owner_app_groups_stmt)).all()
     stmt = (
         select(OktaUserGroupMember)
-        .where(OktaUserGroupMember.group_id.in_([ag.id for ag in db.scalars(owner_app_groups_stmt)]))
+        .where(OktaUserGroupMember.group_id.in_([ag.id for ag in owner_app_groups]))
         .where(OktaUserGroupMember.user_id == current_user_id)
         .where(OktaUserGroupMember.is_owner.is_(True))
         .where(
@@ -71,15 +73,17 @@ def is_app_owner_group_owner(
             )
         )
     )
-    return (db.scalar(select(func.count()).select_from(stmt.subquery())) or 0) > 0
+    return (await db.scalar(select(func.count()).select_from(stmt.subquery())) or 0) > 0
 
 
-def is_access_admin(db: Session, current_user_id: str) -> bool:
-    access_app = db.scalars(
-        select(App)
-        .options(selectinload(App.active_owner_app_groups))
-        .where(App.deleted_at.is_(None))
-        .where(App.name == App.ACCESS_APP_RESERVED_NAME)
+async def is_access_admin(db: AsyncSession, current_user_id: str) -> bool:
+    access_app = (
+        await db.scalars(
+            select(App)
+            .options(selectinload(App.active_owner_app_groups))
+            .where(App.deleted_at.is_(None))
+            .where(App.name == App.ACCESS_APP_RESERVED_NAME)
+        )
     ).first()
     if access_app is None or len(access_app.active_owner_app_groups) == 0:
         return False
@@ -95,61 +99,61 @@ def is_access_admin(db: Session, current_user_id: str) -> bool:
             )
         )
     )
-    return (db.scalar(select(func.count()).select_from(stmt.subquery())) or 0) > 0
+    return (await db.scalar(select(func.count()).select_from(stmt.subquery())) or 0) > 0
 
 
-def can_manage_group(db: Session, current_user_id: str, group: OktaGroup) -> bool:
-    if is_group_owner(db, current_user_id, group):
+async def can_manage_group(db: AsyncSession, current_user_id: str, group: OktaGroup) -> bool:
+    if await is_group_owner(db, current_user_id, group):
         return True
-    if is_app_owner_group_owner(db, current_user_id, app_group=group):
+    if await is_app_owner_group_owner(db, current_user_id, app_group=group):
         return True
-    if is_access_admin(db, current_user_id):
+    if await is_access_admin(db, current_user_id):
         return True
     return False
 
 
-def can_delete_group(db: Session, current_user_id: str, group: OktaGroup) -> bool:
+async def can_delete_group(db: AsyncSession, current_user_id: str, group: OktaGroup) -> bool:
     if current_user_id in settings.app_group_deleter_ids and type(group) is AppGroup and group.is_managed:
         return True
-    return can_manage_group(db, current_user_id, group)
+    return await can_manage_group(db, current_user_id, group)
 
 
 # --- Depends factories -----------------------------------------------------
 
 
-def require_access_admin(
+async def require_access_admin(
     db: DbSession,
     current_user_id: CurrentUserId,
 ) -> str:
-    if not is_access_admin(db, current_user_id):
+    if not await is_access_admin(db, current_user_id):
         raise HTTPException(status_code=403, detail="Current user is not allowed to perform this action")
     return current_user_id
 
 
-def require_access_admin_or_app_creator(
+async def require_access_admin_or_app_creator(
     db: DbSession,
     current_user_id: CurrentUserId,
 ) -> str:
     if current_user_id in settings.app_creator_ids:
         return current_user_id
-    if is_access_admin(db, current_user_id):
+    if await is_access_admin(db, current_user_id):
         return current_user_id
     raise HTTPException(status_code=403, detail="Current user is not allowed to perform this action")
 
 
-def require_app_owner_or_access_admin_for_app(
+async def require_app_owner_or_access_admin_for_app(
     app_id: str,
     db: DbSession,
     current_user_id: CurrentUserId,
 ) -> App:
-    app_obj = db.scalars(
-        select(App).where(App.deleted_at.is_(None)).where(or_(App.id == app_id, App.name == app_id))
+    app_obj = (
+        await db.scalars(select(App).where(App.deleted_at.is_(None)).where(or_(App.id == app_id, App.name == app_id)))
     ).first()
     if app_obj is None:
         raise HTTPException(status_code=404, detail="Not Found")
-    if is_app_owner_group_owner(db, current_user_id, app=app_obj):
+    if await is_app_owner_group_owner(db, current_user_id, app=app_obj):
         return app_obj
-    if is_access_admin(db, current_user_id):
+    if await is_access_admin(db, current_user_id):
         return app_obj
     raise HTTPException(status_code=403, detail="Current user is not allowed to perform this action")
 

--- a/api/database.py
+++ b/api/database.py
@@ -1,4 +1,4 @@
-"""SQLAlchemy engine creation and the FastAPI `get_db` dependency.
+"""SQLAlchemy async engine creation and the FastAPI `get_db` dependency.
 
 `api.extensions` holds the `db` session/engine facade; this module wires the
 engine into it and provides the request-scoped session dependency.
@@ -6,45 +6,61 @@ engine into it and provides the request-scoped session dependency.
 
 from __future__ import annotations
 
-from collections.abc import Generator
+from collections.abc import AsyncGenerator
 from typing import Annotated, Any
 
 from fastapi import Depends, Request
-from sqlalchemy import Engine, create_engine
-from sqlalchemy.orm import Session
+from sqlalchemy import URL, make_url
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 
 from api.config import settings
-from api.extensions import db, get_cloudsql_conn
+from api.extensions import db, get_cloudsql_async_conn
+
+# Deployment URLs predating the async engine keep working: legacy sync driver
+# names are normalized to their async equivalents.
+_ASYNC_DRIVERS = {
+    "postgresql": "postgresql+asyncpg",
+    "postgres": "postgresql+asyncpg",
+    "postgresql+pg8000": "postgresql+asyncpg",
+    "postgresql+psycopg2": "postgresql+asyncpg",
+    "sqlite": "sqlite+aiosqlite",
+    "sqlite+pysqlite": "sqlite+aiosqlite",
+}
 
 
-def build_engine() -> Engine:
-    """Construct the SQLAlchemy engine from settings."""
+def to_async_url(url_str: str) -> URL:
+    """Normalize a database URL to an async driver."""
+    url = make_url(url_str)
+    if url.drivername in _ASYNC_DRIVERS:
+        url = url.set(drivername=_ASYNC_DRIVERS[url.drivername])
+    return url
+
+
+def build_async_engine() -> AsyncEngine:
+    """Construct the SQLAlchemy async engine from settings."""
     kwargs: dict[str, Any] = {}
     if settings.SQLALCHEMY_ECHO:
         kwargs["echo"] = True
     if settings.CLOUDSQL_CONNECTION_NAME:
-        kwargs["creator"] = get_cloudsql_conn(
+        kwargs["async_creator"] = get_cloudsql_async_conn(
             cloudsql_connection_name=settings.CLOUDSQL_CONNECTION_NAME,
             db_user=settings.DATABASE_USER,
             db_name=settings.DATABASE_NAME,
             uses_public_ip=settings.DATABASE_USES_PUBLIC_IP,
         )
         # CloudSQL connector creator handles connection details
-        url = "postgresql+pg8000://"
+        url = make_url("postgresql+asyncpg://")
     else:
-        url = settings.SQLALCHEMY_DATABASE_URI or "sqlite:///instance/access.db"
+        url = to_async_url(settings.SQLALCHEMY_DATABASE_URI or "sqlite:///instance/access.db")
 
-    if url.startswith("sqlite"):
-        kwargs.setdefault("connect_args", {"check_same_thread": False})
-
-    return create_engine(url, **kwargs)
+    return create_async_engine(url, **kwargs)
 
 
-def get_db(request: Request) -> Generator[Session, None, None]:
-    """FastAPI dependency that yields the request-scoped Session.
+async def get_db(request: Request) -> AsyncGenerator[AsyncSession, None]:
+    """FastAPI dependency that yields the request-scoped AsyncSession.
 
     `RequestIdMiddleware` is responsible for setting the `_session_scope`
-    contextvar (so each request gets its own scoped Session) and for
+    contextvar (so each request gets its own scoped AsyncSession) and for
     calling `db.remove()` when the response has been emitted. This
     dependency only commits or rolls back the session on the way out; it
     does not manipulate the scope or close the session, because the
@@ -55,16 +71,16 @@ def get_db(request: Request) -> Generator[Session, None, None]:
         yield db.session
     except Exception:
         try:
-            db.session.rollback()
+            await db.session.rollback()
         except Exception:
             pass
         raise
     else:
         try:
-            db.session.commit()
+            await db.session.commit()
         except Exception:
-            db.session.rollback()
+            await db.session.rollback()
             raise
 
 
-DbSession = Annotated[Session, Depends(get_db)]
+DbSession = Annotated[AsyncSession, Depends(get_db)]

--- a/api/extensions.py
+++ b/api/extensions.py
@@ -3,34 +3,48 @@
 Exposes:
 
 - `Base`: declarative base for all ORM models.
-- `db.session`: the request-scoped Session bound to the active `_session_scope`.
-- `db.engine`: the configured Engine.
+- `db.session`: the request-scoped AsyncSession bound to the active
+  `_session_scope`.
+- `db.engine`: the configured AsyncEngine.
 - `db.init_app(engine=...)`, `db.remove()`, `db.create_all()`, `db.drop_all()`.
 
-The session is bound to a `ContextVar` so each FastAPI request (or CLI
-invocation) gets its own Session. The dependency in `api.database.get_db`
-sets and clears this var per request.
+The session is scoped on a `ContextVar` so each FastAPI request (or CLI
+invocation) gets its own AsyncSession. The dependency in `api.database.get_db`
+yields it per request; `RequestIdMiddleware` sets and clears the scope.
+
+Concurrency rule: an AsyncSession must never be used concurrently. ContextVars
+propagate into tasks spawned with `asyncio.create_task`, so a spawned task
+sees the *same* session as its parent — tasks handed to `create_task` /
+`gather` / `wait` may only perform network I/O (Okta calls, notification
+hooks), never `db.session` access.
 """
 
 from __future__ import annotations
 
+import asyncio
 import contextvars
-from typing import Any, Callable, Optional
+from typing import Any, Awaitable, Callable, Optional
 
-from google.cloud.sql.connector import Connector, IPTypes
-from sqlalchemy import Engine, MetaData
-from sqlalchemy.orm import (
-    DeclarativeBase,
-    Session,
-    scoped_session,
-    sessionmaker,
+from sqlalchemy import MetaData
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_scoped_session,
+    async_sessionmaker,
 )
+from sqlalchemy.orm import DeclarativeBase
 
 
-# Per-request session scope. The FastAPI dependency sets this to a unique
+# Per-request session scope. The FastAPI middleware sets this to a unique
 # request id; CLI/syncer entrypoints set it to a per-run sentinel. Default
 # is a single process-global scope identifier so that ad-hoc usage (alembic,
 # scripts) just works without explicit setup.
+#
+# Scoping on the ContextVar (rather than `asyncio.current_task`) is load-
+# bearing: `BaseHTTPMiddleware.call_next` runs the downstream app in a child
+# task, and context copies propagate to child tasks while task identity does
+# not — task-scoping would register the handler's session under a key the
+# middleware teardown could never remove.
 _session_scope: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
     "access_session_scope", default="__default__"
 )
@@ -77,54 +91,56 @@ class Base(DeclarativeBase):
 
 
 class _DB:
-    """Session/engine facade. Provides per-request scoped session via
+    """Session/engine facade. Provides per-request scoped AsyncSession via
     `db.session`, plus startup/teardown plumbing (`init_app`, `remove`)."""
 
     def __init__(self) -> None:
-        self._engine: Optional[Engine] = None
-        self._sessionmaker: Optional[sessionmaker[Session]] = None
-        self._scoped: Optional[scoped_session[Session]] = None
+        self._engine: Optional[AsyncEngine] = None
+        self._sessionmaker: Optional[async_sessionmaker[AsyncSession]] = None
+        self._scoped: Optional[async_scoped_session[AsyncSession]] = None
 
-    def init_app(self, *, engine: Engine) -> None:
+    def init_app(self, *, engine: AsyncEngine) -> None:
         """Bind the session facade to a SQLAlchemy engine. Must be called
         once at app (or CLI) startup before any ORM operation."""
         self._engine = engine
-        self._sessionmaker = sessionmaker(
+        self._sessionmaker = async_sessionmaker(
             bind=engine,
             autoflush=False,
-            # Loaded state survives commits. Required for the async flip:
+            # Loaded state survives commits. Required under async:
             # expired-attribute access on an AsyncSession raises MissingGreenlet,
             # and operations/syncer keep using ORM objects across mid-flow
             # commits. Attributes assigned SQL expressions (e.g. func.now())
             # still expire at flush and need an explicit refresh before use.
             expire_on_commit=False,
         )
-        self._scoped = scoped_session(self._sessionmaker, scopefunc=lambda: _session_scope.get())
+        self._scoped = async_scoped_session(self._sessionmaker, scopefunc=lambda: _session_scope.get())
 
     @property
-    def engine(self) -> Engine:
+    def engine(self) -> AsyncEngine:
         if self._engine is None:
             raise RuntimeError("db.init_app(engine=...) was not called")
         return self._engine
 
     @property
-    def session(self) -> Session:
+    def session(self) -> AsyncSession:
         """Returns the current scoped session for the active scope."""
         if self._scoped is None:
             raise RuntimeError("db.init_app(engine=...) was not called")
         return self._scoped()
 
-    def remove(self) -> None:
-        """Removes the session for the current scope. Called by the FastAPI
-        dependency on request teardown and by CLI entrypoints on exit."""
+    async def remove(self) -> None:
+        """Removes (closes) the session for the current scope. Called by the
+        middleware on request teardown and by CLI entrypoints on exit."""
         if self._scoped is not None:
-            self._scoped.remove()
+            await self._scoped.remove()
 
-    def create_all(self) -> None:
-        Base.metadata.create_all(self.engine)
+    async def create_all(self) -> None:
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
 
-    def drop_all(self) -> None:
-        Base.metadata.drop_all(self.engine)
+    async def drop_all(self) -> None:
+        async with self.engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
 
 
 db = _DB()
@@ -134,23 +150,35 @@ db = _DB()
 Db = _DB
 
 
-def get_cloudsql_conn(
+def get_cloudsql_async_conn(
     cloudsql_connection_name: str,
     db_user: Optional[str] = "root",
     db_name: Optional[str] = "access",
     uses_public_ip: Optional[bool] = False,
-) -> Callable[[], Connector]:
-    def _get_conn() -> Connector:
-        with Connector() as connector:
-            conn = connector.connect(
-                cloudsql_connection_name,
-                "pg8000",
-                user=db_user,
-                db=db_name,
-                ip_type=IPTypes.PUBLIC if uses_public_ip else IPTypes.PRIVATE,
-                enable_iam_auth=True,
-            )
-            return conn
+) -> Callable[[], Awaitable[Any]]:
+    """Build an `async_creator` for `create_async_engine` that connects to
+    Cloud SQL over the Cloud SQL Python Connector with asyncpg + IAM auth.
+
+    A single Connector is created lazily on first connect and bound to the
+    running event loop, then reused for the engine's lifetime (the connector
+    maintains its own background refresh of ephemeral certificates).
+    """
+    from google.cloud.sql.connector import Connector, IPTypes
+
+    connector: Optional[Connector] = None
+
+    async def _get_conn() -> Any:
+        nonlocal connector
+        if connector is None:
+            connector = Connector(loop=asyncio.get_running_loop())
+        return await connector.connect_async(
+            cloudsql_connection_name,
+            "asyncpg",
+            user=db_user,
+            db=db_name,
+            ip_type=IPTypes.PUBLIC if uses_public_ip else IPTypes.PRIVATE,
+            enable_iam_auth=True,
+        )
 
     return _get_conn
 
@@ -160,5 +188,5 @@ __all__ = [
     "Db",
     "_session_scope",
     "db",
-    "get_cloudsql_conn",
+    "get_cloudsql_async_conn",
 ]

--- a/api/integrity.py
+++ b/api/integrity.py
@@ -9,20 +9,24 @@ from api.services import okta
 logger = logging.getLogger(__name__)
 
 
-def verify_and_fix_unmanaged_groups(dry_run: bool = False) -> None:
-    active_unmanaged_groups = db.session.scalars(
-        select(OktaGroup).where(OktaGroup.is_managed.is_(False)).where(OktaGroup.deleted_at.is_(None))
+async def verify_and_fix_unmanaged_groups(dry_run: bool = False) -> None:
+    active_unmanaged_groups = (
+        await db.session.scalars(
+            select(OktaGroup).where(OktaGroup.is_managed.is_(False)).where(OktaGroup.deleted_at.is_(None))
+        )
     ).all()
     for group in active_unmanaged_groups:
-        UnmanageGroup(group=group.id).execute(dry_run=dry_run)
+        await UnmanageGroup(group=group.id).execute(dry_run=dry_run)
 
 
-def verify_and_fix_role_memberships(dry_run: bool = False) -> None:
-    active_role_group_maps = db.session.scalars(
-        select(RoleGroupMap).where(
-            or_(
-                RoleGroupMap.ended_at.is_(None),
-                RoleGroupMap.ended_at > func.now(),
+async def verify_and_fix_role_memberships(dry_run: bool = False) -> None:
+    active_role_group_maps = (
+        await db.session.scalars(
+            select(RoleGroupMap).where(
+                or_(
+                    RoleGroupMap.ended_at.is_(None),
+                    RoleGroupMap.ended_at > func.now(),
+                )
             )
         )
     ).all()
@@ -38,17 +42,21 @@ def verify_and_fix_role_memberships(dry_run: bool = False) -> None:
             )
             .where(OktaUserGroupMember.is_owner.is_(False))
         )
-        active_role_group_members_ids = [m.user_id for m in db.session.scalars(active_role_group_members_query).all()]
+        active_role_group_members_ids = [
+            m.user_id for m in (await db.session.scalars(active_role_group_members_query)).all()
+        ]
 
-        active_group_users_for_role = db.session.scalars(
-            select(OktaUserGroupMember)
-            .where(
-                or_(
-                    OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > func.now(),
+        active_group_users_for_role = (
+            await db.session.scalars(
+                select(OktaUserGroupMember)
+                .where(
+                    or_(
+                        OktaUserGroupMember.ended_at.is_(None),
+                        OktaUserGroupMember.ended_at > func.now(),
+                    )
                 )
+                .where(OktaUserGroupMember.role_group_map_id == active_role_group_map.id)
             )
-            .where(OktaUserGroupMember.role_group_map_id == active_role_group_map.id)
         ).all()
         active_group_users_for_role_ids = [m.user_id for m in active_group_users_for_role]
 
@@ -62,8 +70,10 @@ def verify_and_fix_role_memberships(dry_run: bool = False) -> None:
             )
             if not dry_run:
                 for member in list(missing_group_users_for_role):
-                    role_group_membership = db.session.scalars(
-                        active_role_group_members_query.where(OktaUserGroupMember.user_id == member)
+                    role_group_membership = (
+                        await db.session.scalars(
+                            active_role_group_members_query.where(OktaUserGroupMember.user_id == member)
+                        )
                     ).first()
                     # `member` came out of `active_role_group_members_ids` which we
                     # just built from this same query, so the filter must return a
@@ -71,14 +81,14 @@ def verify_and_fix_role_memberships(dry_run: bool = False) -> None:
                     assert role_group_membership is not None
                     if not active_role_group_map.is_owner:
                         # Add user to okta group members
-                        okta.add_user_to_group(
+                        await okta.add_user_to_group(
                             active_role_group_map.group_id,
                             member,
                         )
                     else:
                         # Add user to okta group owners
                         # https://help.okta.com/en-us/Content/Topics/identity-governance/group-owner.htm
-                        okta.add_owner_to_group(
+                        await okta.add_owner_to_group(
                             active_role_group_map.group_id,
                             member,
                         )
@@ -99,7 +109,7 @@ def verify_and_fix_role_memberships(dry_run: bool = False) -> None:
                             ended_at=associated_users_ended_at,
                         )
                     )
-                db.session.commit()
+                await db.session.commit()
 
         # Fix extra group memberships/ownerships for the role by ending the membership and potentially
         # removing the user from the group
@@ -112,7 +122,7 @@ def verify_and_fix_role_memberships(dry_run: bool = False) -> None:
             )
             if not dry_run:
                 # End all extra OktaUserGroupMembers the users not members of the role group
-                db.session.execute(
+                await db.session.execute(
                     update(OktaUserGroupMember)
                     .where(
                         or_(
@@ -125,30 +135,32 @@ def verify_and_fix_role_memberships(dry_run: bool = False) -> None:
                     .values({OktaUserGroupMember.ended_at: func.now()})
                     .execution_options(synchronize_session="fetch")
                 )
-                db.session.commit()
+                await db.session.commit()
 
                 # Check if there are other OktaUserGroupMembers for this user/group
                 # combination before removing membership, there can be multiple role groups
                 # which allow group access for this user
-                removed_users_with_other_access = db.session.scalars(
-                    select(OktaUserGroupMember)
-                    .where(
-                        or_(
-                            OktaUserGroupMember.ended_at.is_(None),
-                            OktaUserGroupMember.ended_at > func.now(),
+                removed_users_with_other_access = (
+                    await db.session.scalars(
+                        select(OktaUserGroupMember)
+                        .where(
+                            or_(
+                                OktaUserGroupMember.ended_at.is_(None),
+                                OktaUserGroupMember.ended_at > func.now(),
+                            )
                         )
+                        .where(OktaUserGroupMember.is_owner == active_role_group_map.is_owner)
+                        .where(OktaUserGroupMember.group_id == active_role_group_map.group_id)
+                        .where(OktaUserGroupMember.user_id.in_(extra_group_users_for_role))
                     )
-                    .where(OktaUserGroupMember.is_owner == active_role_group_map.is_owner)
-                    .where(OktaUserGroupMember.group_id == active_role_group_map.group_id)
-                    .where(OktaUserGroupMember.user_id.in_(extra_group_users_for_role))
                 ).all()
                 removed_users_with_other_access_ids = [m.user_id for m in removed_users_with_other_access]
                 okta_users_to_remove_ids = set(extra_group_users_for_role) - set(removed_users_with_other_access_ids)
                 for user_id in okta_users_to_remove_ids:
                     if not active_role_group_map.is_owner:
                         # Remove user from okta group membership
-                        okta.remove_user_from_group(active_role_group_map.group_id, user_id)
+                        await okta.remove_user_from_group(active_role_group_map.group_id, user_id)
                     else:
                         # Remove user from okta group owners
                         # https://help.okta.com/en-us/Content/Topics/identity-governance/group-owner.htm
-                        okta.remove_owner_from_group(active_role_group_map.group_id, user_id)
+                        await okta.remove_owner_from_group(active_role_group_map.group_id, user_id)

--- a/api/manage.py
+++ b/api/manage.py
@@ -12,6 +12,7 @@ Run via:
 
 from __future__ import annotations
 
+import asyncio
 import functools
 import uuid
 from typing import Any, Callable, List, TypeVar
@@ -26,12 +27,16 @@ def _with_app_context(func: F) -> F:
     """Establish a per-invocation app context for a Click command: bind the
     SQLAlchemy engine, eagerly load every plugin type, and set up a
     request-scoped session keyed to the CLI run. Mirrors the spirit of the
-    pre-migration `with app.app_context()` block."""
+    pre-migration `with app.app_context()` block.
+
+    This decorator is the sync/async boundary for the CLI: Click commands
+    stay synchronous entry points, while the decorated command body is an
+    `async def` driven by a single `asyncio.run` per invocation."""
 
     @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         from api.app import _configure_logging, _configure_okta, _configure_sentry
-        from api.database import build_engine
+        from api.database import build_async_engine
         from api.extensions import _session_scope, db
         from api.plugins import load_plugins
 
@@ -44,23 +49,38 @@ def _with_app_context(func: F) -> F:
         _configure_sentry()
         _configure_okta()
 
-        if db._engine is None:
-            db.init_app(engine=build_engine())
-        # Trigger plugin discovery once per CLI run. Notification, conditional
-        # access, and app-group-lifecycle hooks are all consumed by the
-        # `sync` / `notify` / `sync-app-group-memberships` commands; the
-        # `init` family doesn't need them but the call is cheap (memoized).
-        load_plugins()
-        token = _session_scope.set(f"cli-{uuid.uuid4().hex}")
-        try:
-            return func(*args, **kwargs)
-        finally:
+        async def _run() -> Any:
+            # The async engine (and any asyncpg/aiosqlite connections it
+            # creates) must be created and disposed on the event loop that
+            # uses it, so engine binding happens inside asyncio.run.
+            created_engine = False
+            if db._engine is None:
+                db.init_app(engine=build_async_engine())
+                created_engine = True
+            # Trigger plugin discovery once per CLI run. Notification,
+            # conditional access, and app-group-lifecycle hooks are all
+            # consumed by the `sync` / `notify` / `sync-app-group-memberships`
+            # commands; the `init` family doesn't need them but the call is
+            # cheap (memoized).
+            load_plugins()
+            token = _session_scope.set(f"cli-{uuid.uuid4().hex}")
             try:
-                db.session.commit()
-            except Exception:
-                db.session.rollback()
-            db.remove()
-            _session_scope.reset(token)
+                return await func(*args, **kwargs)
+            finally:
+                try:
+                    await db.session.commit()
+                except Exception:
+                    await db.session.rollback()
+                await db.remove()
+                _session_scope.reset(token)
+                # Connections opened by the async drivers must be closed on
+                # the loop that created them. Only dispose when this
+                # invocation created the engine — if it was already bound
+                # (tests), the owner is responsible for disposal.
+                if created_engine:
+                    await db.engine.dispose()
+
+        return asyncio.run(_run())
 
     return wrapper  # type: ignore[return-value]
 
@@ -100,97 +120,101 @@ _load_plugin_commands()
 @cli.command("init")
 @click.argument("admin_okta_user_email")
 @_with_app_context
-def init(admin_okta_user_email: str) -> None:
+async def init(admin_okta_user_email: str) -> None:
     """Import users/groups/memberships from Okta and create the built-in Access app."""
-    _import_from_okta()
-    _init_builtin_apps(admin_okta_user_email)
+    await _import_from_okta()
+    await _init_builtin_apps(admin_okta_user_email)
 
 
 @cli.command("import-from-okta")
 @_with_app_context
-def import_from_okta() -> None:
+async def import_from_okta() -> None:
     """Import users/groups/memberships from Okta."""
-    _import_from_okta()
+    await _import_from_okta()
 
 
-def _import_from_okta() -> None:
+async def _import_from_okta() -> None:
     from api.extensions import db
     from api.models import OktaGroup, OktaUser, OktaUserGroupMember
     from api.services import okta
 
     click.echo("Starting Okta Import")
-    if (db.session.scalar(select(func.count(OktaUser.id))) or 0) > 0:
+    if (await db.session.scalar(select(func.count(OktaUser.id))) or 0) > 0:
         click.echo("Skipping import of Okta Users as they were previously imported")
     else:
         click.echo("Importing Okta Users")
         user_type_to_user_attrs_to_titles: dict[str, Any] = {}
 
-        users = okta.list_users()
+        users = await okta.list_users()
         for user in users:
             if user.type.id not in user_type_to_user_attrs_to_titles:
-                user_type_to_user_attrs_to_titles[user.type.id] = okta.get_user_schema(
-                    user.type.id
+                user_type_to_user_attrs_to_titles[user.type.id] = (
+                    await okta.get_user_schema(user.type.id)
                 ).user_attrs_to_titles()
 
             user_attrs_to_titles = user_type_to_user_attrs_to_titles[user.type.id]
 
             db.session.add(user.update_okta_user(OktaUser(), user_attrs_to_titles))
 
-        db.session.commit()
+        await db.session.commit()
 
-    if (db.session.scalar(select(func.count(OktaGroup.id))) or 0) > 0:
+    if (await db.session.scalar(select(func.count(OktaGroup.id))) or 0) > 0:
         click.echo("Skipping import of Okta Groups as they were previously imported")
     else:
         click.echo("Importing Okta Groups")
 
         # Consider groups with group rules assigning to them as unmanaged by Access
-        group_ids_with_group_rules = okta.list_groups_with_active_rules()
-        groups = okta.list_groups()
+        group_ids_with_group_rules = await okta.list_groups_with_active_rules()
+        groups = await okta.list_groups()
         for group in groups:
             db.session.add(group.update_okta_group(OktaGroup(), group_ids_with_group_rules))
-        db.session.commit()
+        await db.session.commit()
 
-    if (db.session.scalar(select(func.count(OktaUserGroupMember.id))) or 0) > 0:
+    if (await db.session.scalar(select(func.count(OktaUserGroupMember.id))) or 0) > 0:
         click.echo("Skipping import of Okta Group Memberships as they were previously imported")
     else:
         click.echo("Importing Okta Group Memberships")
-        groups = okta.list_groups()
+        groups = await okta.list_groups()
         for group in groups:
-            members = okta.list_users_for_group(group.id)
+            members = await okta.list_users_for_group(group.id)
             for member in members:
                 if member.get_deleted_at() is None:
                     db.session.add(OktaUserGroupMember(user_id=member.id, group_id=group.id))
-        db.session.commit()
+        await db.session.commit()
     click.echo("Completed Okta Import")
 
 
 @cli.command("init-builtin-apps")
 @click.argument("admin_okta_user_email")
 @_with_app_context
-def init_builtin_apps(admin_okta_user_email: str) -> None:
+async def init_builtin_apps(admin_okta_user_email: str) -> None:
     """Create the built-in Access app and owner group."""
-    _init_builtin_apps(admin_okta_user_email)
+    await _init_builtin_apps(admin_okta_user_email)
 
 
-def _init_builtin_apps(admin_okta_user_email: str) -> None:
+async def _init_builtin_apps(admin_okta_user_email: str) -> None:
     from api.extensions import db
     from api.models import App, OktaUser
     from api.operations import CreateApp
 
-    existing_app = db.session.scalars(
-        select(App).where(App.name == App.ACCESS_APP_RESERVED_NAME).where(App.deleted_at.is_(None))
+    existing_app = (
+        await db.session.scalars(
+            select(App).where(App.name == App.ACCESS_APP_RESERVED_NAME).where(App.deleted_at.is_(None))
+        )
     ).first()
     if existing_app is not None:
         click.echo("Access app and groups already exist, skipping init of built-in apps")
         return
 
-    admin_okta_user = db.session.scalars(
-        select(OktaUser)
-        .where(OktaUser.deleted_at.is_(None))
-        .where(
-            or_(
-                OktaUser.id == admin_okta_user_email,
-                OktaUser.email.ilike(admin_okta_user_email),
+    admin_okta_user = (
+        await db.session.scalars(
+            select(OktaUser)
+            .where(OktaUser.deleted_at.is_(None))
+            .where(
+                or_(
+                    OktaUser.id == admin_okta_user_email,
+                    OktaUser.email.ilike(admin_okta_user_email),
+                )
             )
         )
     ).first()
@@ -200,7 +224,7 @@ def _init_builtin_apps(admin_okta_user_email: str) -> None:
         return
 
     click.echo("Creating Access app and groups")
-    CreateApp(
+    await CreateApp(
         owner_id=admin_okta_user.id,
         app={"name": App.ACCESS_APP_RESERVED_NAME, "description": f"The {App.ACCESS_APP_RESERVED_NAME} Portal"},
     ).execute()
@@ -222,7 +246,7 @@ def _init_builtin_apps(admin_okta_user_email: str) -> None:
     help="Sync group memberships from Access to Okta",
 )
 @_with_app_context
-def sync(sync_groups_authoritatively: bool, sync_group_memberships_authoritatively: bool) -> None:
+async def sync(sync_groups_authoritatively: bool, sync_group_memberships_authoritatively: bool) -> None:
     """Sync users/groups/memberships from Okta to Access and expire stale requests."""
     from sentry_sdk import start_transaction
 
@@ -236,12 +260,12 @@ def sync(sync_groups_authoritatively: bool, sync_group_memberships_authoritative
     )
 
     with start_transaction(op="sync"):
-        sync_users()
-        sync_groups(act_as_authority=sync_groups_authoritatively)
-        sync_group_memberships(act_as_authority=sync_group_memberships_authoritatively)
+        await sync_users()
+        await sync_groups(act_as_authority=sync_groups_authoritatively)
+        await sync_group_memberships(act_as_authority=sync_group_memberships_authoritatively)
         if settings.OKTA_USE_GROUP_OWNERS_API:
-            sync_group_ownerships(act_as_authority=sync_group_memberships_authoritatively)
-        expire_access_requests()
+            await sync_group_ownerships(act_as_authority=sync_group_memberships_authoritatively)
+        await expire_access_requests()
 
 
 @cli.command("fix-unmanaged-groups")
@@ -253,11 +277,11 @@ def sync(sync_groups_authoritatively: bool, sync_group_memberships_authoritative
     help="If set will run as dry run and not make any changes",
 )
 @_with_app_context
-def fix_unmanaged_groups(dry_run: bool) -> None:
+async def fix_unmanaged_groups(dry_run: bool) -> None:
     """Verify and fix unmanaged-group state in Access against Okta."""
     from api.integrity import verify_and_fix_unmanaged_groups
 
-    verify_and_fix_unmanaged_groups(dry_run=dry_run)
+    await verify_and_fix_unmanaged_groups(dry_run=dry_run)
 
 
 @cli.command("fix-role-memberships")
@@ -269,11 +293,11 @@ def fix_unmanaged_groups(dry_run: bool) -> None:
     help="If set will run as dry run and not make any changes",
 )
 @_with_app_context
-def fix_role_memberships(dry_run: bool) -> None:
+async def fix_role_memberships(dry_run: bool) -> None:
     """Verify and fix role-membership state in Access."""
     from api.integrity import verify_and_fix_role_memberships
 
-    verify_and_fix_role_memberships(dry_run=dry_run)
+    await verify_and_fix_role_memberships(dry_run=dry_run)
 
 
 @cli.command("notify")
@@ -292,7 +316,7 @@ def fix_role_memberships(dry_run: bool) -> None:
     help="If set will notify role owners instead of individuals",
 )
 @_with_app_context
-def notify(owner: bool, role_owner: bool) -> None:
+async def notify(owner: bool, role_owner: bool) -> None:
     """Send expiring-access notifications."""
     from api.syncer import (
         expiring_access_notifications_owner,
@@ -301,16 +325,16 @@ def notify(owner: bool, role_owner: bool) -> None:
     )
 
     if owner:
-        expiring_access_notifications_owner()
+        await expiring_access_notifications_owner()
     elif role_owner:
-        expiring_access_notifications_role_owner()
+        await expiring_access_notifications_role_owner()
     else:
-        expiring_access_notifications_user()
+        await expiring_access_notifications_user()
 
 
 @cli.command("sync-app-group-memberships")
 @_with_app_context
-def sync_app_group_memberships() -> None:
+async def sync_app_group_memberships() -> None:
     """Invoke the periodic membership sync hook for all apps with app group lifecycle plugins configured."""
     from api.extensions import db
     from api.models import App
@@ -319,8 +343,10 @@ def sync_app_group_memberships() -> None:
     click.echo("Starting app group lifecycle plugin sync")
 
     apps: List[App] = list(
-        db.session.scalars(
-            select(App).where(App.deleted_at.is_(None)).where(App.app_group_lifecycle_plugin.isnot(None))
+        (
+            await db.session.scalars(
+                select(App).where(App.deleted_at.is_(None)).where(App.app_group_lifecycle_plugin.isnot(None))
+            )
         ).all()
     )
 
@@ -335,11 +361,17 @@ def sync_app_group_memberships() -> None:
     for app in apps:
         click.echo(f"Syncing app '{app.name}' (plugin: {app.app_group_lifecycle_plugin})")
         try:
-            hook.sync_all_group_membership(session=db.session, app=app, plugin_id=app.app_group_lifecycle_plugin)
-            db.session.commit()
+            # App-group-lifecycle hooks are sync plugin code that expects a
+            # sync Session; run them through the session's greenlet bridge.
+            await db.session.run_sync(
+                lambda session, app=app: hook.sync_all_group_membership(  # type: ignore[misc]
+                    session=session, app=app, plugin_id=app.app_group_lifecycle_plugin
+                )
+            )
+            await db.session.commit()
             click.echo(f"  ✓ Synced app '{app.name}'")
         except Exception as e:
-            db.session.rollback()
+            await db.session.rollback()
             click.echo(f"  ✗ Failed to sync app '{app.name}': {e}", err=True)
 
     click.echo("Completed app group lifecycle plugin sync")

--- a/api/mcp/auth/__init__.py
+++ b/api/mcp/auth/__init__.py
@@ -20,7 +20,7 @@ import contextvars
 import functools
 import json
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Awaitable, Callable, Optional, TypeVar
 
 # Scope strings used by the v1 tool surface. Tools declare a required
 # scope via ``@require_scope(MCP_SCOPE_READ_ALL)`` etc.; the
@@ -127,7 +127,7 @@ def require_scope(scope: str) -> None:
         raise MCPScopeError(f"This tool requires the '{scope}' scope; the active token does not carry it.")
 
 
-F = TypeVar("F", bound=Callable[..., str])
+F = TypeVar("F", bound=Callable[..., Awaitable[str]])
 
 
 def requires_scope(scope: str) -> Callable[[F], F]:
@@ -146,7 +146,7 @@ def requires_scope(scope: str) -> Callable[[F], F]:
 
         @mcp.tool(name="list_groups", ...)
         @requires_scope(MCP_SCOPE_READ_ALL)
-        def list_groups(...): ...
+        async def list_groups(...): ...
 
     ``functools.wraps`` preserves the wrapped function's signature so
     FastMCP's schema introspection sees the original parameter list.
@@ -154,12 +154,12 @@ def requires_scope(scope: str) -> Callable[[F], F]:
 
     def decorator(fn: F) -> F:
         @functools.wraps(fn)
-        def wrapper(*args: Any, **kwargs: Any) -> str:
+        async def wrapper(*args: Any, **kwargs: Any) -> str:
             try:
                 require_scope(scope)
             except MCPScopeError as e:
                 return json.dumps({"error": str(e)})
-            return fn(*args, **kwargs)
+            return await fn(*args, **kwargs)
 
         return wrapper  # type: ignore[return-value]
 

--- a/api/mcp/auth/cloudflare.py
+++ b/api/mcp/auth/cloudflare.py
@@ -109,7 +109,7 @@ def _parse_scopes(claim: object) -> frozenset[str]:
     return frozenset()
 
 
-def resolve_identity(scope: Scope) -> Optional[MCPIdentity]:
+async def resolve_identity(scope: Scope) -> Optional[MCPIdentity]:
     """Resolve an ``MCPIdentity`` from a Cloudflare Access JWT.
 
     Returns ``None`` (defers to the next provider) when:
@@ -157,10 +157,12 @@ def resolve_identity(scope: Scope) -> Optional[MCPIdentity]:
     if "email" not in payload:
         logger.warning("CF Access JWT verified but carries no 'email' claim")
         return None
-    user = db.scalars(
-        select(OktaUser)
-        .where(func.lower(OktaUser.email) == func.lower(payload["email"]))
-        .where(OktaUser.deleted_at.is_(None))
+    user = (
+        await db.scalars(
+            select(OktaUser)
+            .where(func.lower(OktaUser.email) == func.lower(payload["email"]))
+            .where(OktaUser.deleted_at.is_(None))
+        )
     ).first()
     if user is None:
         logger.warning(f"CF Access JWT verified for email={payload['email']!r} but no matching active OktaUser exists")

--- a/api/mcp/auth/dev.py
+++ b/api/mcp/auth/dev.py
@@ -28,7 +28,7 @@ from api.models import OktaUser
 logger = logging.getLogger(__name__)
 
 
-def resolve_identity(scope: Scope) -> Optional[MCPIdentity]:
+async def resolve_identity(scope: Scope) -> Optional[MCPIdentity]:
     if settings.ENV not in ("development", "test"):
         return None
 
@@ -37,8 +37,10 @@ def resolve_identity(scope: Scope) -> Optional[MCPIdentity]:
         return None
 
     db = _db_shim.session
-    user = db.scalars(
-        select(OktaUser).where(func.lower(OktaUser.email) == func.lower(email)).where(OktaUser.deleted_at.is_(None))
+    user = (
+        await db.scalars(
+            select(OktaUser).where(func.lower(OktaUser.email) == func.lower(email)).where(OktaUser.deleted_at.is_(None))
+        )
     ).first()
     if user is None:
         logger.warning(

--- a/api/mcp/auth/oidc.py
+++ b/api/mcp/auth/oidc.py
@@ -97,7 +97,7 @@ def _configured_fallback_scopes() -> frozenset[str]:
     return frozenset(s.strip() for s in raw.split(",") if s.strip())
 
 
-def resolve_identity(scope: Scope) -> Optional[MCPIdentity]:
+async def resolve_identity(scope: Scope) -> Optional[MCPIdentity]:
     """Return an ``MCPIdentity`` for an OIDC-authenticated request, or
     ``None`` to defer (no OIDC config, no Bearer token, verification
     failure). Never raises for a missing credential — the middleware
@@ -144,8 +144,10 @@ def resolve_identity(scope: Scope) -> Optional[MCPIdentity]:
         return None
 
     db = _db_shim.session
-    user = db.scalars(
-        select(OktaUser).where(func.lower(OktaUser.email) == func.lower(email)).where(OktaUser.deleted_at.is_(None))
+    user = (
+        await db.scalars(
+            select(OktaUser).where(func.lower(OktaUser.email) == func.lower(email)).where(OktaUser.deleted_at.is_(None))
+        )
     ).first()
     if user is None:
         logger.warning(f"OIDC token verified for email={email!r} but no matching active OktaUser exists")

--- a/api/mcp/db.py
+++ b/api/mcp/db.py
@@ -15,16 +15,16 @@ discipline a write operation requires.
 
 from __future__ import annotations
 
-from contextlib import contextmanager
-from typing import Iterator
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
 
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.extensions import db as _db_shim
 
 
-@contextmanager
-def mcp_db_session() -> Iterator[Session]:
+@asynccontextmanager
+async def mcp_db_session() -> AsyncIterator[AsyncSession]:
     """Yield the request-scoped DB session, committing on success and
     rolling back on exception. Matches the contract of
     ``api/database.py::get_db`` so write tools behave the same way as
@@ -34,13 +34,13 @@ def mcp_db_session() -> Iterator[Session]:
         yield session
     except Exception:
         try:
-            session.rollback()
+            await session.rollback()
         except Exception:
             pass
         raise
     else:
         try:
-            session.commit()
+            await session.commit()
         except Exception:
-            session.rollback()
+            await session.rollback()
             raise

--- a/api/mcp/server.py
+++ b/api/mcp/server.py
@@ -316,7 +316,7 @@ class MCPAuthMiddleware:
         identity: Optional[MCPIdentity] = None
         for provider in (dev_provider, cloudflare_provider, oidc_provider):
             try:
-                identity = provider.resolve_identity(scope)
+                identity = await provider.resolve_identity(scope)
             except Exception:
                 # Providers shouldn't raise — they return None on
                 # missing or invalid credentials. A raised exception is

--- a/api/mcp/tools.py
+++ b/api/mcp/tools.py
@@ -1235,12 +1235,13 @@ def _register_write_tools(mcp: "FastMCP") -> None:
 
             # Drop cached ORM state so the response reflects what the operation
             # committed (expire_on_commit=False keeps pre-operation state otherwise).
+            ar_id = ar.id
             db.expire_all()
             refreshed = (
                 await db.scalars(
                     select(AccessRequest)
                     .options(*_access_request_summary_load_options())
-                    .where(AccessRequest.id == ar.id)
+                    .where(AccessRequest.id == ar_id)
                 )
             ).first()
             # Log the MCP-origin tag onto the audit channel separately
@@ -1362,10 +1363,11 @@ def _register_write_tools(mcp: "FastMCP") -> None:
                 return _error("Role request could not be created")
             # Drop cached ORM state so the response reflects what the operation
             # committed (expire_on_commit=False keeps pre-operation state otherwise).
+            rr_id = rr.id
             db.expire_all()
             refreshed = (
                 await db.scalars(
-                    select(RoleRequest).options(*_role_request_summary_load_options()).where(RoleRequest.id == rr.id)
+                    select(RoleRequest).options(*_role_request_summary_load_options()).where(RoleRequest.id == rr_id)
                 )
             ).first()
             _ctx = get_request_context()
@@ -1493,10 +1495,11 @@ def _register_write_tools(mcp: "FastMCP") -> None:
                 return _error("Group request could not be created")
             # Drop cached ORM state so the response reflects what the operation
             # committed (expire_on_commit=False keeps pre-operation state otherwise).
+            gr_id = gr.id
             db.expire_all()
             refreshed = (
                 await db.scalars(
-                    select(GroupRequest).options(*_group_request_load_options()).where(GroupRequest.id == gr.id)
+                    select(GroupRequest).options(*_group_request_load_options()).where(GroupRequest.id == gr_id)
                 )
             ).first()
             _ctx = get_request_context()

--- a/api/mcp/tools.py
+++ b/api/mcp/tools.py
@@ -44,10 +44,9 @@ returned as ``{"error": "..."}`` strings rather than raised — FastMCP's
 exception-to-tool-error path is non-deterministic across versions and a
 JSON string keeps the error contract stable.
 
-Tool handlers are sync (``def``, not ``async def``). FastMCP runs them
-on its threadpool, the same way FastAPI does for sync route handlers,
-which keeps the sync SQLAlchemy ORM happy. Do not change tools to async
-without first porting the ORM.
+Tool handlers are async (``async def``) — FastMCP runs them natively on
+the event loop, and every DB touch goes through the request-scoped
+AsyncSession exposed by ``api.extensions.db``.
 """
 
 from __future__ import annotations
@@ -189,12 +188,14 @@ def _clamp_pagination(page: int, size: int) -> tuple[int, int, Optional[str]]:
     return page, size, None
 
 
-def _paginate_query(db: Any, query: Any, page: int, size: int) -> dict[str, Any]:
+async def _paginate_query(db: Any, query: Any, page: int, size: int) -> dict[str, Any]:
     """Run ``query`` and return the standard envelope. ``page`` is
     zero-indexed."""
-    total = db.scalar(select(func.count()).select_from(query.order_by(None).options(noload("*")).subquery())) or 0
+    total = (
+        await db.scalar(select(func.count()).select_from(query.order_by(None).options(noload("*")).subquery()))
+    ) or 0
     pages = max(1, (total + size - 1) // size)
-    items = db.scalars(query.limit(size).offset(page * size)).all()
+    items = (await db.scalars(query.limit(size).offset(page * size))).all()
     return {"total": total, "pages": pages, "page": page, "size": size, "items": items}
 
 
@@ -342,8 +343,8 @@ def register_tools(mcp: "FastMCP") -> None:
         regardless of which auth provider resolved the request.
       - ``get_mcp_user_id()`` returns the authenticated user id.
       - Reads use ``_db_shim.session`` directly (no commit).
-      - Writes use ``with mcp_db_session() as session:`` (commits on
-        success).
+      - Writes use ``async with mcp_db_session() as session:`` (commits
+        on success).
       - Output is JSON. Errors are ``{"error": "..."}`` strings.
     """
 
@@ -375,7 +376,7 @@ def _register_group_tools(mcp: "FastMCP") -> None:
         annotations=_READ_ANNOTATIONS,
     )
     @requires_scope(MCP_SCOPE_READ_ALL)
-    def list_groups(
+    async def list_groups(
         q: str = "", managed: Optional[bool] = None, page: int = 0, size: int = MCP_DEFAULT_PAGE_SIZE
     ) -> str:
         page, size, err = _clamp_pagination(page, size)
@@ -400,7 +401,7 @@ def _register_group_tools(mcp: "FastMCP") -> None:
         if managed is not None:
             query = query.where(OktaGroup.is_managed == managed)
 
-        page_data = _paginate_query(db, query, page, size)
+        page_data = await _paginate_query(db, query, page, size)
         adapter: TypeAdapter[Any] = TypeAdapter(GroupSummary)
         results = [_serialize_model(adapter.validate_python(row, from_attributes=True)) for row in page_data["items"]]
         return json.dumps(
@@ -435,13 +436,15 @@ def _register_group_tools(mcp: "FastMCP") -> None:
         annotations=_READ_ANNOTATIONS,
     )
     @requires_scope(MCP_SCOPE_READ_ALL)
-    def get_group(group_id_or_name: str) -> str:
+    async def get_group(group_id_or_name: str) -> str:
         db = _db_shim.session
-        group = db.scalars(
-            select(OktaGroup)
-            .options(*_group_load_options())
-            .where(or_(OktaGroup.id == group_id_or_name, OktaGroup.name == group_id_or_name))
-            .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
+        group = (
+            await db.scalars(
+                select(OktaGroup)
+                .options(*_group_load_options())
+                .where(or_(OktaGroup.id == group_id_or_name, OktaGroup.name == group_id_or_name))
+                .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
+            )
         ).first()
         if group is None:
             return _error("Group not found")
@@ -460,25 +463,29 @@ def _register_group_tools(mcp: "FastMCP") -> None:
         annotations=_READ_ANNOTATIONS,
     )
     @requires_scope(MCP_SCOPE_READ_ALL)
-    def list_group_memberships(group_id_or_name: str) -> str:
+    async def list_group_memberships(group_id_or_name: str) -> str:
         db = _db_shim.session
-        group = db.scalars(
-            select(OktaGroup)
-            .where(OktaGroup.deleted_at.is_(None))
-            .where(or_(OktaGroup.id == group_id_or_name, OktaGroup.name == group_id_or_name))
+        group = (
+            await db.scalars(
+                select(OktaGroup)
+                .where(OktaGroup.deleted_at.is_(None))
+                .where(or_(OktaGroup.id == group_id_or_name, OktaGroup.name == group_id_or_name))
+            )
         ).first()
         if group is None:
             return _error("Group not found")
-        rows = db.execute(
-            select(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
-            .where(
-                or_(
-                    OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > func.now(),
+        rows = (
+            await db.execute(
+                select(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
+                .where(
+                    or_(
+                        OktaUserGroupMember.ended_at.is_(None),
+                        OktaUserGroupMember.ended_at > func.now(),
+                    )
                 )
+                .where(OktaUserGroupMember.group_id == group.id)
+                .group_by(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
             )
-            .where(OktaUserGroupMember.group_id == group.id)
-            .group_by(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
         ).all()
         result = GroupMembersSummary(
             members=[r.user_id for r in rows if not r.is_owner],
@@ -503,28 +510,32 @@ def _register_role_tools(mcp: "FastMCP") -> None:
         annotations=_READ_ANNOTATIONS,
     )
     @requires_scope(MCP_SCOPE_READ_ALL)
-    def list_roles(q: str = "", owner_id: str = "", page: int = 0, size: int = MCP_DEFAULT_PAGE_SIZE) -> str:
+    async def list_roles(q: str = "", owner_id: str = "", page: int = 0, size: int = MCP_DEFAULT_PAGE_SIZE) -> str:
         page, size, err = _clamp_pagination(page, size)
         if err:
             return _error(err)
         db = _db_shim.session
         query = select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).order_by(func.lower(RoleGroup.name))
         if owner_id:
-            owner = db.scalars(
-                select(OktaUser)
-                .where(or_(OktaUser.id == owner_id, OktaUser.email.ilike(owner_id)))
-                .order_by(nullsfirst(OktaUser.deleted_at.desc()))
+            owner = (
+                await db.scalars(
+                    select(OktaUser)
+                    .where(or_(OktaUser.id == owner_id, OktaUser.email.ilike(owner_id)))
+                    .order_by(nullsfirst(OktaUser.deleted_at.desc()))
+                )
             ).first()
             if owner is None:
                 return _error(f"Owner not found: {owner_id}")
-            owned_role_ids = db.scalars(
-                select(OktaUserGroupMember.group_id)
-                .where(OktaUserGroupMember.user_id == owner.id)
-                .where(OktaUserGroupMember.is_owner.is_(True))
-                .where(
-                    or_(
-                        OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > func.now(),
+            owned_role_ids = (
+                await db.scalars(
+                    select(OktaUserGroupMember.group_id)
+                    .where(OktaUserGroupMember.user_id == owner.id)
+                    .where(OktaUserGroupMember.is_owner.is_(True))
+                    .where(
+                        or_(
+                            OktaUserGroupMember.ended_at.is_(None),
+                            OktaUserGroupMember.ended_at > func.now(),
+                        )
                     )
                 )
             ).all()
@@ -532,7 +543,7 @@ def _register_role_tools(mcp: "FastMCP") -> None:
         if q:
             like = f"%{q}%"
             query = query.where(or_(RoleGroup.name.ilike(like), RoleGroup.description.ilike(like)))
-        page_data = _paginate_query(db, query, page, size)
+        page_data = await _paginate_query(db, query, page, size)
         adapter: TypeAdapter[Any] = TypeAdapter(RoleGroupListItem)
         results = [_serialize_model(adapter.validate_python(row, from_attributes=True)) for row in page_data["items"]]
         return json.dumps(
@@ -560,13 +571,15 @@ def _register_role_tools(mcp: "FastMCP") -> None:
         annotations=_READ_ANNOTATIONS,
     )
     @requires_scope(MCP_SCOPE_READ_ALL)
-    def get_role(role_id_or_name: str) -> str:
+    async def get_role(role_id_or_name: str) -> str:
         db = _db_shim.session
-        role = db.scalars(
-            select(RoleGroup)
-            .options(*_group_load_options())
-            .where(or_(RoleGroup.id == role_id_or_name, RoleGroup.name == role_id_or_name))
-            .order_by(nullsfirst(RoleGroup.deleted_at.desc()))
+        role = (
+            await db.scalars(
+                select(RoleGroup)
+                .options(*_group_load_options())
+                .where(or_(RoleGroup.id == role_id_or_name, RoleGroup.name == role_id_or_name))
+                .order_by(nullsfirst(RoleGroup.deleted_at.desc()))
+            )
         ).first()
         if role is None:
             return _error("Role not found")
@@ -589,7 +602,7 @@ def _register_app_tools(mcp: "FastMCP") -> None:
         annotations=_READ_ANNOTATIONS,
     )
     @requires_scope(MCP_SCOPE_READ_ALL)
-    def list_apps(q: str = "", page: int = 0, size: int = MCP_DEFAULT_PAGE_SIZE) -> str:
+    async def list_apps(q: str = "", page: int = 0, size: int = MCP_DEFAULT_PAGE_SIZE) -> str:
         page, size, err = _clamp_pagination(page, size)
         if err:
             return _error(err)
@@ -598,7 +611,7 @@ def _register_app_tools(mcp: "FastMCP") -> None:
         if q:
             like = f"%{q}%"
             query = query.where(or_(App.name.ilike(like), App.description.ilike(like)))
-        page_data = _paginate_query(db, query, page, size)
+        page_data = await _paginate_query(db, query, page, size)
         adapter: TypeAdapter[Any] = TypeAdapter(AppSummary)
         results = [_serialize_model(adapter.validate_python(row, from_attributes=True)) for row in page_data["items"]]
         return json.dumps(
@@ -623,13 +636,15 @@ def _register_app_tools(mcp: "FastMCP") -> None:
         annotations=_READ_ANNOTATIONS,
     )
     @requires_scope(MCP_SCOPE_READ_ALL)
-    def get_app(app_id_or_name: str) -> str:
+    async def get_app(app_id_or_name: str) -> str:
         db = _db_shim.session
-        app = db.scalars(
-            select(App)
-            .options(*_app_load_options())
-            .where(App.deleted_at.is_(None))
-            .where(or_(App.id == app_id_or_name, App.name == app_id_or_name))
+        app = (
+            await db.scalars(
+                select(App)
+                .options(*_app_load_options())
+                .where(App.deleted_at.is_(None))
+                .where(or_(App.id == app_id_or_name, App.name == app_id_or_name))
+            )
         ).first()
         if app is None:
             return _error("App not found")
@@ -651,7 +666,7 @@ def _register_user_tools(mcp: "FastMCP") -> None:
         annotations=_READ_ANNOTATIONS,
     )
     @requires_scope(MCP_SCOPE_READ_ALL)
-    def list_users(q: str = "", page: int = 0, size: int = MCP_DEFAULT_PAGE_SIZE) -> str:
+    async def list_users(q: str = "", page: int = 0, size: int = MCP_DEFAULT_PAGE_SIZE) -> str:
         page, size, err = _clamp_pagination(page, size)
         if err:
             return _error(err)
@@ -668,7 +683,7 @@ def _register_user_tools(mcp: "FastMCP") -> None:
                     (OktaUser.first_name + " " + OktaUser.last_name).ilike(like),
                 )
             )
-        page_data = _paginate_query(db, query, page, size)
+        page_data = await _paginate_query(db, query, page, size)
         adapter: TypeAdapter[Any] = TypeAdapter(OktaUserSummary)
         results = [_serialize_model(adapter.validate_python(row, from_attributes=True)) for row in page_data["items"]]
         return json.dumps(
@@ -693,19 +708,21 @@ def _register_user_tools(mcp: "FastMCP") -> None:
         annotations=_READ_ANNOTATIONS,
     )
     @requires_scope(MCP_SCOPE_READ_ALL)
-    def get_user(user_id_or_email: str) -> str:
+    async def get_user(user_id_or_email: str) -> str:
         if user_id_or_email == "@me":
             user_id_or_email = get_mcp_user_id()
         db = _db_shim.session
-        user = db.scalars(
-            select(OktaUser)
-            .options(
-                selectinload(OktaUser.active_group_memberships).options(*user_group_member_options()),
-                selectinload(OktaUser.active_group_ownerships).options(*user_group_member_options()),
-                joinedload(OktaUser.manager),
+        user = (
+            await db.scalars(
+                select(OktaUser)
+                .options(
+                    selectinload(OktaUser.active_group_memberships).options(*user_group_member_options()),
+                    selectinload(OktaUser.active_group_ownerships).options(*user_group_member_options()),
+                    joinedload(OktaUser.manager),
+                )
+                .where(or_(OktaUser.id == user_id_or_email, OktaUser.email.ilike(user_id_or_email)))
+                .order_by(nullsfirst(OktaUser.deleted_at.desc()))
             )
-            .where(or_(OktaUser.id == user_id_or_email, OktaUser.email.ilike(user_id_or_email)))
-            .order_by(nullsfirst(OktaUser.deleted_at.desc()))
         ).first()
         if user is None:
             return _error("User not found")
@@ -729,7 +746,7 @@ def _register_tag_tools(mcp: "FastMCP") -> None:
         annotations=_READ_ANNOTATIONS,
     )
     @requires_scope(MCP_SCOPE_READ_ALL)
-    def list_tags(q: str = "", page: int = 0, size: int = MCP_DEFAULT_PAGE_SIZE) -> str:
+    async def list_tags(q: str = "", page: int = 0, size: int = MCP_DEFAULT_PAGE_SIZE) -> str:
         page, size, err = _clamp_pagination(page, size)
         if err:
             return _error(err)
@@ -738,7 +755,7 @@ def _register_tag_tools(mcp: "FastMCP") -> None:
         if q:
             like = f"%{q}%"
             query = query.where(or_(Tag.name.ilike(like), Tag.description.ilike(like)))
-        page_data = _paginate_query(db, query, page, size)
+        page_data = await _paginate_query(db, query, page, size)
         adapter: TypeAdapter[Any] = TypeAdapter(TagListItem)
         results = [_serialize_model(adapter.validate_python(row, from_attributes=True)) for row in page_data["items"]]
         return json.dumps(
@@ -756,13 +773,15 @@ def _register_tag_tools(mcp: "FastMCP") -> None:
         annotations=_READ_ANNOTATIONS,
     )
     @requires_scope(MCP_SCOPE_READ_ALL)
-    def get_tag(tag_id_or_name: str) -> str:
+    async def get_tag(tag_id_or_name: str) -> str:
         db = _db_shim.session
-        tag = db.scalars(
-            select(Tag)
-            .options(*_tag_load_options())
-            .where(or_(Tag.id == tag_id_or_name, Tag.name == tag_id_or_name))
-            .order_by(nullsfirst(Tag.deleted_at.desc()))
+        tag = (
+            await db.scalars(
+                select(Tag)
+                .options(*_tag_load_options())
+                .where(or_(Tag.id == tag_id_or_name, Tag.name == tag_id_or_name))
+                .order_by(nullsfirst(Tag.deleted_at.desc()))
+            )
         ).first()
         if tag is None:
             return _error("Tag not found")
@@ -786,7 +805,7 @@ def _register_access_request_tools(mcp: "FastMCP") -> None:
         annotations=_READ_ANNOTATIONS,
     )
     @requires_scope(MCP_SCOPE_READ_ALL)
-    def list_access_requests(
+    async def list_access_requests(
         q: str = "",
         status: str = "",
         requester_user_id: str = "",
@@ -827,7 +846,7 @@ def _register_access_request_tools(mcp: "FastMCP") -> None:
                     AccessRequest.request_reason.ilike(like),
                 )
             )
-        page_data = _paginate_query(db, query, page, size)
+        page_data = await _paginate_query(db, query, page, size)
         adapter: TypeAdapter[Any] = TypeAdapter(AccessRequestSummary)
         results = [_serialize_model(adapter.validate_python(row, from_attributes=True)) for row in page_data["items"]]
         return json.dumps(
@@ -846,12 +865,14 @@ def _register_access_request_tools(mcp: "FastMCP") -> None:
         annotations=_READ_ANNOTATIONS,
     )
     @requires_scope(MCP_SCOPE_READ_ALL)
-    def get_access_request(access_request_id: str) -> str:
+    async def get_access_request(access_request_id: str) -> str:
         db = _db_shim.session
-        ar = db.scalars(
-            select(AccessRequest)
-            .options(*_access_request_detail_load_options())
-            .where(AccessRequest.id == access_request_id)
+        ar = (
+            await db.scalars(
+                select(AccessRequest)
+                .options(*_access_request_detail_load_options())
+                .where(AccessRequest.id == access_request_id)
+            )
         ).first()
         if ar is None:
             return _error("Access request not found")
@@ -874,7 +895,7 @@ def _register_role_request_tools(mcp: "FastMCP") -> None:
         annotations=_READ_ANNOTATIONS,
     )
     @requires_scope(MCP_SCOPE_READ_ALL)
-    def list_role_requests(
+    async def list_role_requests(
         q: str = "",
         status: str = "",
         requester_user_id: str = "",
@@ -905,7 +926,7 @@ def _register_role_request_tools(mcp: "FastMCP") -> None:
         if q:
             like = f"%{q}%"
             query = query.where(or_(RoleRequest.id.like(f"{q}%"), RoleRequest.request_reason.ilike(like)))
-        page_data = _paginate_query(db, query, page, size)
+        page_data = await _paginate_query(db, query, page, size)
         adapter: TypeAdapter[Any] = TypeAdapter(RoleRequestSummary)
         results = [_serialize_model(adapter.validate_python(row, from_attributes=True)) for row in page_data["items"]]
         return json.dumps(
@@ -923,10 +944,14 @@ def _register_role_request_tools(mcp: "FastMCP") -> None:
         annotations=_READ_ANNOTATIONS,
     )
     @requires_scope(MCP_SCOPE_READ_ALL)
-    def get_role_request(role_request_id: str) -> str:
+    async def get_role_request(role_request_id: str) -> str:
         db = _db_shim.session
-        rr = db.scalars(
-            select(RoleRequest).options(*_role_request_detail_load_options()).where(RoleRequest.id == role_request_id)
+        rr = (
+            await db.scalars(
+                select(RoleRequest)
+                .options(*_role_request_detail_load_options())
+                .where(RoleRequest.id == role_request_id)
+            )
         ).first()
         if rr is None:
             return _error("Role request not found")
@@ -949,7 +974,7 @@ def _register_group_request_tools(mcp: "FastMCP") -> None:
         annotations=_READ_ANNOTATIONS,
     )
     @requires_scope(MCP_SCOPE_READ_ALL)
-    def list_group_requests(
+    async def list_group_requests(
         q: str = "",
         status: str = "",
         requester_user_id: str = "",
@@ -984,7 +1009,7 @@ def _register_group_request_tools(mcp: "FastMCP") -> None:
                     GroupRequest.request_reason.ilike(like),
                 )
             )
-        page_data = _paginate_query(db, query, page, size)
+        page_data = await _paginate_query(db, query, page, size)
         adapter: TypeAdapter[Any] = TypeAdapter(GroupRequestDetail)
         results = [_serialize_model(adapter.validate_python(row, from_attributes=True)) for row in page_data["items"]]
         return json.dumps(
@@ -998,10 +1023,12 @@ def _register_group_request_tools(mcp: "FastMCP") -> None:
         annotations=_READ_ANNOTATIONS,
     )
     @requires_scope(MCP_SCOPE_READ_ALL)
-    def get_group_request(group_request_id: str) -> str:
+    async def get_group_request(group_request_id: str) -> str:
         db = _db_shim.session
-        gr = db.scalars(
-            select(GroupRequest).options(*_group_request_load_options()).where(GroupRequest.id == group_request_id)
+        gr = (
+            await db.scalars(
+                select(GroupRequest).options(*_group_request_load_options()).where(GroupRequest.id == group_request_id)
+            )
         ).first()
         if gr is None:
             return _error("Group request not found")
@@ -1026,7 +1053,7 @@ def _register_audit_tool(mcp: "FastMCP") -> None:
         annotations=_READ_ANNOTATIONS,
     )
     @requires_scope(MCP_SCOPE_READ_ALL)
-    def list_audit_entries(
+    async def list_audit_entries(
         user_id: str = "",
         group_id: str = "",
         is_owner: Optional[bool] = None,
@@ -1045,20 +1072,24 @@ def _register_audit_tool(mcp: "FastMCP") -> None:
         if user_id:
             resolved_user_id = current_user_id if user_id == "@me" else user_id
             # Accept email too — match by id or email.
-            user = db.scalars(
-                select(OktaUser)
-                .where(or_(OktaUser.id == resolved_user_id, OktaUser.email.ilike(resolved_user_id)))
-                .order_by(nullsfirst(OktaUser.deleted_at.desc()))
+            user = (
+                await db.scalars(
+                    select(OktaUser)
+                    .where(or_(OktaUser.id == resolved_user_id, OktaUser.email.ilike(resolved_user_id)))
+                    .order_by(nullsfirst(OktaUser.deleted_at.desc()))
+                )
             ).first()
             if user is None:
                 return _error(f"User not found: {user_id}")
             query = query.where(OktaUserGroupMember.user_id == user.id)
 
         if group_id:
-            group = db.scalars(
-                select(OktaGroup)
-                .where(or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
-                .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
+            group = (
+                await db.scalars(
+                    select(OktaGroup)
+                    .where(or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
+                    .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
+                )
             ).first()
             if group is None:
                 return _error(f"Group not found: {group_id}")
@@ -1080,9 +1111,9 @@ def _register_audit_tool(mcp: "FastMCP") -> None:
         # related model. For MCP we keep it simple and return only the
         # scalar columns + user_id / group_id; clients that need richer
         # data can call get_user / get_group on the id values.
-        total = db.scalar(select(func.count()).select_from(query.order_by(None).subquery())) or 0
+        total = (await db.scalar(select(func.count()).select_from(query.order_by(None).subquery()))) or 0
         pages = max(1, (total + size - 1) // size)
-        items = db.scalars(query.limit(size).offset(page * size)).all()
+        items = (await db.scalars(query.limit(size).offset(page * size))).all()
         results = [
             {
                 "id": m.id,
@@ -1125,7 +1156,7 @@ def _register_write_tools(mcp: "FastMCP") -> None:
         annotations=_WRITE_PROPOSAL_ANNOTATIONS,
     )
     @requires_scope(MCP_SCOPE_CREATE_REQUESTS)
-    def create_access_request(
+    async def create_access_request(
         group_id: str,
         reason: str = "",
         group_owner: bool = False,
@@ -1148,9 +1179,11 @@ def _register_write_tools(mcp: "FastMCP") -> None:
         # graph until a write tool actually fires. Reads don't need it.
         from api.operations import CreateAccessRequest, RejectAccessRequest
 
-        with mcp_db_session() as db:
-            requester = db.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+        async with mcp_db_session() as db:
+            requester = (
+                await db.scalars(
+                    select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                )
             ).first()
             if requester is None:
                 # No active OktaUser for the resolved id — typically a
@@ -1158,8 +1191,10 @@ def _register_write_tools(mcp: "FastMCP") -> None:
                 # a real human identity. The REST handler returns 403
                 # here; we mirror that.
                 return _error("Current user is not allowed to perform this action")
-            group = db.scalars(
-                select(OktaGroup).where(OktaGroup.id == body.group_id).where(OktaGroup.deleted_at.is_(None))
+            group = (
+                await db.scalars(
+                    select(OktaGroup).where(OktaGroup.id == body.group_id).where(OktaGroup.deleted_at.is_(None))
+                )
             ).first()
             if group is None:
                 return _error("Group not found")
@@ -1167,16 +1202,18 @@ def _register_write_tools(mcp: "FastMCP") -> None:
                 return _error("Groups not managed by Access cannot be modified")
 
             # Same supersede-prior-pending behavior as POST /api/requests.
-            existing_pending = db.scalars(
-                select(AccessRequest)
-                .where(AccessRequest.status == AccessRequestStatus.PENDING)
-                .where(AccessRequest.requester_user_id == requester.id)
-                .where(AccessRequest.requested_group_id == group.id)
-                .where(AccessRequest.request_ownership.is_(body.group_owner))
-                .where(AccessRequest.resolved_at.is_(None))
+            existing_pending = (
+                await db.scalars(
+                    select(AccessRequest)
+                    .where(AccessRequest.status == AccessRequestStatus.PENDING)
+                    .where(AccessRequest.requester_user_id == requester.id)
+                    .where(AccessRequest.requested_group_id == group.id)
+                    .where(AccessRequest.request_ownership.is_(body.group_owner))
+                    .where(AccessRequest.resolved_at.is_(None))
+                )
             ).all()
             for prior in existing_pending:
-                RejectAccessRequest(
+                await RejectAccessRequest(
                     access_request=prior,
                     current_user_id=current_user_id,
                     rejection_reason="Superseded by a newer request from the same user",
@@ -1186,7 +1223,7 @@ def _register_write_tools(mcp: "FastMCP") -> None:
             # Execute the operation. Audit-log emission, conditional
             # access hooks, and notification hooks all fire from inside
             # `execute()` — the per-operation contract handles the rest.
-            ar = CreateAccessRequest(
+            ar = await CreateAccessRequest(
                 requester_user=requester,
                 requested_group=group,
                 request_ownership=body.group_owner,
@@ -1199,8 +1236,12 @@ def _register_write_tools(mcp: "FastMCP") -> None:
             # Drop cached ORM state so the response reflects what the operation
             # committed (expire_on_commit=False keeps pre-operation state otherwise).
             db.expire_all()
-            refreshed = db.scalars(
-                select(AccessRequest).options(*_access_request_summary_load_options()).where(AccessRequest.id == ar.id)
+            refreshed = (
+                await db.scalars(
+                    select(AccessRequest)
+                    .options(*_access_request_summary_load_options())
+                    .where(AccessRequest.id == ar.id)
+                )
             ).first()
             # Log the MCP-origin tag onto the audit channel separately
             # from the operation's own audit emission, which already
@@ -1230,7 +1271,7 @@ def _register_write_tools(mcp: "FastMCP") -> None:
         annotations=_WRITE_PROPOSAL_ANNOTATIONS,
     )
     @requires_scope(MCP_SCOPE_CREATE_REQUESTS)
-    def create_role_request(
+    async def create_role_request(
         role_id: str,
         group_id: str,
         reason: str = "",
@@ -1254,12 +1295,16 @@ def _register_write_tools(mcp: "FastMCP") -> None:
 
         from api.operations import CreateRoleRequest, RejectRoleRequest
 
-        with mcp_db_session() as db:
-            requester = db.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+        async with mcp_db_session() as db:
+            requester = (
+                await db.scalars(
+                    select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                )
             ).first()
-            role = db.scalars(
-                select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == body.role_id)
+            role = (
+                await db.scalars(
+                    select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == body.role_id)
+                )
             ).first()
             if role is None:
                 return _error("Role not found")
@@ -1269,10 +1314,12 @@ def _register_write_tools(mcp: "FastMCP") -> None:
             # If the requester has no active OktaUser row at all (e.g.
             # service-token traffic), can_manage_group returns False and
             # we surface the same 403 message the REST handler does.
-            if requester is None or not can_manage_group(db, current_user_id, role):
+            if requester is None or not await can_manage_group(db, current_user_id, role):
                 return _error("Current user is not allowed to perform this action")
-            group = db.scalars(
-                select(OktaGroup).where(OktaGroup.deleted_at.is_(None)).where(OktaGroup.id == body.group_id)
+            group = (
+                await db.scalars(
+                    select(OktaGroup).where(OktaGroup.deleted_at.is_(None)).where(OktaGroup.id == body.group_id)
+                )
             ).first()
             if group is None:
                 return _error("Group not found")
@@ -1284,24 +1331,26 @@ def _register_write_tools(mcp: "FastMCP") -> None:
                 # error surfaces before we hit the operation.
                 return _error("Role requests may only be made for groups and app groups (not roles).")
 
-            existing = db.scalars(
-                select(RoleRequest)
-                .where(RoleRequest.requester_user_id == current_user_id)
-                .where(RoleRequest.requester_role_id == body.role_id)
-                .where(RoleRequest.requested_group_id == body.group_id)
-                .where(RoleRequest.request_ownership == body.group_owner)
-                .where(RoleRequest.status == AccessRequestStatus.PENDING)
-                .where(RoleRequest.resolved_at.is_(None))
+            existing = (
+                await db.scalars(
+                    select(RoleRequest)
+                    .where(RoleRequest.requester_user_id == current_user_id)
+                    .where(RoleRequest.requester_role_id == body.role_id)
+                    .where(RoleRequest.requested_group_id == body.group_id)
+                    .where(RoleRequest.request_ownership == body.group_owner)
+                    .where(RoleRequest.status == AccessRequestStatus.PENDING)
+                    .where(RoleRequest.resolved_at.is_(None))
+                )
             ).all()
             for old in existing:
-                RejectRoleRequest(
+                await RejectRoleRequest(
                     role_request=old,
                     rejection_reason="Closed due to duplicate role request creation",
                     notify_requester=False,
                     current_user_id=current_user_id,
                 ).execute()
 
-            rr = CreateRoleRequest(
+            rr = await CreateRoleRequest(
                 requester_user=requester,
                 requester_role=role,
                 requested_group=group,
@@ -1314,8 +1363,10 @@ def _register_write_tools(mcp: "FastMCP") -> None:
             # Drop cached ORM state so the response reflects what the operation
             # committed (expire_on_commit=False keeps pre-operation state otherwise).
             db.expire_all()
-            refreshed = db.scalars(
-                select(RoleRequest).options(*_role_request_summary_load_options()).where(RoleRequest.id == rr.id)
+            refreshed = (
+                await db.scalars(
+                    select(RoleRequest).options(*_role_request_summary_load_options()).where(RoleRequest.id == rr.id)
+                )
             ).first()
             _ctx = get_request_context()
             if _ctx is not None and _ctx.source == "mcp":
@@ -1342,7 +1393,7 @@ def _register_write_tools(mcp: "FastMCP") -> None:
         annotations=_WRITE_PROPOSAL_ANNOTATIONS,
     )
     @requires_scope(MCP_SCOPE_CREATE_REQUESTS)
-    def create_group_request(
+    async def create_group_request(
         group_name: str,
         group_type: str,
         description: str = "",
@@ -1378,14 +1429,16 @@ def _register_write_tools(mcp: "FastMCP") -> None:
 
         requested_app_id: Optional[str] = body.requested_app_id if isinstance(body, _AppGroupRequestBody) else None
 
-        with mcp_db_session() as db:
+        async with mcp_db_session() as db:
             # Same gate as POST /api/group-requests: an active OktaUser
             # row is required. No additional role/admin check — anyone
             # authenticated can ask Access to create a group; the
             # approval step (not exposed here) is where the gating
             # happens.
-            requester = db.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+            requester = (
+                await db.scalars(
+                    select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                )
             ).first()
             if requester is None:
                 return _error("Current user is not allowed to perform this action")
@@ -1394,13 +1447,17 @@ def _register_write_tools(mcp: "FastMCP") -> None:
             if body.requested_group_type == "app_group":
                 if requested_app_id is None:
                     return _error("app_id is required for app group requests")
-                app = db.scalars(select(App).where(App.deleted_at.is_(None)).where(App.id == requested_app_id)).first()
+                app = (
+                    await db.scalars(select(App).where(App.deleted_at.is_(None)).where(App.id == requested_app_id))
+                ).first()
                 if app is None:
                     return _error("App not found")
 
             if body.requested_group_tags:
-                tags = db.scalars(
-                    select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(body.requested_group_tags))
+                tags = (
+                    await db.scalars(
+                        select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(body.requested_group_tags))
+                    )
                 ).all()
                 if len(tags) != len(body.requested_group_tags):
                     return _error("One or more tags not found")
@@ -1414,15 +1471,15 @@ def _register_write_tools(mcp: "FastMCP") -> None:
             )
             if body.requested_group_type == "app_group":
                 existing_query = existing_query.where(GroupRequest.requested_app_id == requested_app_id)
-            for prior in db.scalars(existing_query).all():
-                RejectGroupRequest(
+            for prior in (await db.scalars(existing_query)).all():
+                await RejectGroupRequest(
                     group_request=prior,
                     rejection_reason="Closed due to duplicate group request creation",
                     notify_requester=False,
                     current_user_id=current_user_id,
                 ).execute()
 
-            gr = CreateGroupRequest(
+            gr = await CreateGroupRequest(
                 requester_user=requester,
                 requested_group_name=body.requested_group_name,
                 requested_group_description=body.requested_group_description or "",
@@ -1437,8 +1494,10 @@ def _register_write_tools(mcp: "FastMCP") -> None:
             # Drop cached ORM state so the response reflects what the operation
             # committed (expire_on_commit=False keeps pre-operation state otherwise).
             db.expire_all()
-            refreshed = db.scalars(
-                select(GroupRequest).options(*_group_request_load_options()).where(GroupRequest.id == gr.id)
+            refreshed = (
+                await db.scalars(
+                    select(GroupRequest).options(*_group_request_load_options()).where(GroupRequest.id == gr.id)
+                )
             ).first()
             _ctx = get_request_context()
             if _ctx is not None and _ctx.source == "mcp":

--- a/api/middleware.py
+++ b/api/middleware.py
@@ -101,15 +101,15 @@ class RequestIdMiddleware(BaseHTTPMiddleware):
         finally:
             if owns_scope:
                 try:
-                    db.remove()
+                    await db.remove()
                 except Exception:
                     pass
                 if token is not None:
                     try:
                         _session_scope.reset(token)
                     except ValueError:
-                        # scoped_session ran on a copied context (FastAPI's
-                        # threadpool); the original token isn't valid here.
+                        # the scope was set on a copied context; the original
+                        # token isn't valid here.
                         _session_scope.set("__default__")
         response.headers["X-Request-Id"] = request_id
         return response

--- a/api/models/access_request.py
+++ b/api/models/access_request.py
@@ -5,7 +5,9 @@ from api.models.core_models import AccessRequest, AppGroup, GroupRequest, OktaUs
 from api.models.okta_group import get_group_managers
 
 
-def get_all_possible_request_approvers(access_request: AccessRequest | RoleRequest | GroupRequest) -> Set[OktaUser]:
+async def get_all_possible_request_approvers(
+    access_request: AccessRequest | RoleRequest | GroupRequest,
+) -> Set[OktaUser]:
     # This will return the entire set of possible access request approvers
     # to ensure that even if the resolved set of approvers changes
     # we still are able to mark the request as resolved for any users
@@ -18,16 +20,16 @@ def get_all_possible_request_approvers(access_request: AccessRequest | RoleReque
     # fields, since the group hasn't been created yet). Branch on the type so
     # mypy narrows the union accurately.
     if isinstance(access_request, (AccessRequest, RoleRequest)):
-        group_owners = get_group_managers(access_request.requested_group_id)
+        group_owners = await get_group_managers(access_request.requested_group_id)
         if isinstance(access_request.requested_group, AppGroup):
-            app_managers = get_app_managers(access_request.requested_group.app_id)
+            app_managers = await get_app_managers(access_request.requested_group.app_id)
     elif (
         isinstance(access_request, GroupRequest)
         and access_request.requested_group_type == "app_group"
         and access_request.requested_app_id is not None
     ):
-        app_managers = get_app_managers(access_request.requested_app_id)
+        app_managers = await get_app_managers(access_request.requested_app_id)
 
-    access_app_owners = get_access_owners()
+    access_app_owners = await get_access_owners()
 
     return set(group_owners + access_app_owners + app_managers)

--- a/api/models/app_group.py
+++ b/api/models/app_group.py
@@ -6,7 +6,7 @@ from api.extensions import db
 from api.models.core_models import App, AppGroup, OktaGroup, OktaUser, OktaUserGroupMember
 
 
-def get_app_managers(app_id: str) -> List[OktaUser]:
+async def get_app_managers(app_id: str) -> List[OktaUser]:
     """Returns the users that can manage members of the app"""
     owner_app_groups_stmt = (
         select(AppGroup)
@@ -15,30 +15,32 @@ def get_app_managers(app_id: str) -> List[OktaUser]:
         .where(AppGroup.is_owner.is_(True))
     )
 
-    if (db.session.scalar(select(func.count()).select_from(owner_app_groups_stmt.subquery())) or 0) > 0:
-        return list(
-            db.session.scalars(
-                select(OktaUser)
-                .join(OktaUser.all_group_memberships_and_ownerships)
-                .where(OktaUserGroupMember.group_id.in_([ag.id for ag in db.session.scalars(owner_app_groups_stmt)]))
-                .where(OktaUserGroupMember.is_owner.is_(True))
-                .where(
-                    or_(
-                        OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > func.now(),
-                    )
+    if ((await db.session.scalar(select(func.count()).select_from(owner_app_groups_stmt.subquery()))) or 0) > 0:
+        owner_app_group_ids = [ag.id for ag in await db.session.scalars(owner_app_groups_stmt)]
+        result = await db.session.scalars(
+            select(OktaUser)
+            .join(OktaUser.all_group_memberships_and_ownerships)
+            .where(OktaUserGroupMember.group_id.in_(owner_app_group_ids))
+            .where(OktaUserGroupMember.is_owner.is_(True))
+            .where(
+                or_(
+                    OktaUserGroupMember.ended_at.is_(None),
+                    OktaUserGroupMember.ended_at > func.now(),
                 )
-            ).all()
+            )
         )
+        return list(result.all())
 
     return []
 
 
-def get_access_owners() -> List[OktaUser]:
+async def get_access_owners() -> List[OktaUser]:
     """Returns the access super admins that are members of the owners group"""
 
-    access_app = db.session.scalars(
-        select(App).where(App.deleted_at.is_(None)).where(App.name == App.ACCESS_APP_RESERVED_NAME)
+    access_app = (
+        await db.session.scalars(
+            select(App).where(App.deleted_at.is_(None)).where(App.name == App.ACCESS_APP_RESERVED_NAME)
+        )
     ).first()
 
     if access_app is None:
@@ -51,21 +53,21 @@ def get_access_owners() -> List[OktaUser]:
         .where(AppGroup.is_owner.is_(True))
     )
 
-    if (db.session.scalar(select(func.count()).select_from(owner_app_groups_stmt.subquery())) or 0) > 0:
-        return list(
-            db.session.scalars(
-                select(OktaUser)
-                .join(OktaUser.all_group_memberships_and_ownerships)
-                .where(OktaUserGroupMember.group_id.in_([ag.id for ag in db.session.scalars(owner_app_groups_stmt)]))
-                .where(OktaUserGroupMember.is_owner.is_(False))
-                .where(
-                    or_(
-                        OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > func.now(),
-                    )
+    if ((await db.session.scalar(select(func.count()).select_from(owner_app_groups_stmt.subquery()))) or 0) > 0:
+        owner_app_group_ids = [ag.id for ag in await db.session.scalars(owner_app_groups_stmt)]
+        result = await db.session.scalars(
+            select(OktaUser)
+            .join(OktaUser.all_group_memberships_and_ownerships)
+            .where(OktaUserGroupMember.group_id.in_(owner_app_group_ids))
+            .where(OktaUserGroupMember.is_owner.is_(False))
+            .where(
+                or_(
+                    OktaUserGroupMember.ended_at.is_(None),
+                    OktaUserGroupMember.ended_at > func.now(),
                 )
-            ).all()
+            )
         )
+        return list(result.all())
 
     return []
 

--- a/api/models/okta_group.py
+++ b/api/models/okta_group.py
@@ -6,18 +6,17 @@ from api.extensions import db
 from api.models.core_models import OktaUser, OktaUserGroupMember
 
 
-def get_group_managers(group_id: str) -> List[OktaUser]:
-    return list(
-        db.session.scalars(
-            select(OktaUser)
-            .join(OktaUserGroupMember, OktaUser.id == OktaUserGroupMember.user_id)
-            .where(OktaUserGroupMember.group_id == group_id)
-            .where(OktaUserGroupMember.is_owner.is_(True))
-            .where(
-                or_(
-                    OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > func.now(),
-                )
+async def get_group_managers(group_id: str) -> List[OktaUser]:
+    result = await db.session.scalars(
+        select(OktaUser)
+        .join(OktaUserGroupMember, OktaUser.id == OktaUserGroupMember.user_id)
+        .where(OktaUserGroupMember.group_id == group_id)
+        .where(OktaUserGroupMember.is_owner.is_(True))
+        .where(
+            or_(
+                OktaUserGroupMember.ended_at.is_(None),
+                OktaUserGroupMember.ended_at > func.now(),
             )
-        ).all()
+        )
     )
+    return list(result.all())

--- a/api/operations/_fan_out.py
+++ b/api/operations/_fan_out.py
@@ -1,0 +1,41 @@
+"""Draining helper for the Okta/notification task fan-out in operations.
+
+The fan-out operations (`ModifyGroupUsers`, `ModifyRoleGroups`, `DeleteUser`,
+`DeleteGroup`) spawn Okta API calls and notification dispatch with
+`asyncio.create_task` and drain them here after the local DB state has
+committed. A failed task therefore must not fail the request — the
+authoritative state change already happened — but it must not vanish either:
+`asyncio.wait` (the previous idiom) drops task exceptions on the floor, which
+made partial Okta failures during membership changes invisible.
+
+Per the concurrency rule in `api/extensions.py`, these tasks only perform
+network I/O (Okta calls, notification hooks) — never `db.session` access.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+logger = logging.getLogger("api")
+
+
+async def drain_fan_out_tasks(tasks: list[asyncio.Task[Any]], context: str) -> None:
+    """Await every fan-out task and log each failure with its context.
+
+    Failures are logged at ERROR (with the traceback) and swallowed: the
+    DB commit these tasks trail behind has already happened, so raising
+    would turn an Okta/notification straggler into a misleading request
+    failure. The syncer reconciles Okta drift on its next run.
+    """
+    if not tasks:
+        return
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+    for result in results:
+        if isinstance(result, BaseException):
+            logger.error(
+                "Okta/notification task failed during %s; local DB state is already committed",
+                context,
+                exc_info=result,
+            )

--- a/api/operations/approve_access_request.py
+++ b/api/operations/approve_access_request.py
@@ -27,6 +27,21 @@ class ApproveAccessRequest:
         ending_at: Optional[datetime] = None,
         notify: bool = True,
     ):
+        self._access_request_arg = access_request
+        self._approver_user_arg = approver_user
+
+        self.approval_reason = approval_reason
+
+        self.ending_at = ending_at
+
+        self.notify = notify
+
+        self.notification_hook = get_notification_hook()
+
+    def _resolve(self) -> None:
+        access_request = self._access_request_arg
+        approver_user = self._approver_user_arg
+
         # Lock the request row for the duration of the transaction so two
         # concurrent approvers can't both pass the pending-state guard below
         # and double-grant. `of=AccessRequest` keeps FOR UPDATE off the
@@ -50,15 +65,8 @@ class ApproveAccessRequest:
             self.approver_id = approver_user.id
             self.approver_email = approver_user.email
 
-        self.approval_reason = approval_reason
-
-        self.ending_at = ending_at
-
-        self.notify = notify
-
-        self.notification_hook = get_notification_hook()
-
     def execute(self) -> AccessRequest:
+        self._resolve()
         # Don't allow approving a request that is already resolved. Raise
         # rather than silently no-op so a stale/concurrent approval surfaces
         # as a conflict instead of looking like a success.

--- a/api/operations/approve_access_request.py
+++ b/api/operations/approve_access_request.py
@@ -38,7 +38,7 @@ class ApproveAccessRequest:
 
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         access_request = self._access_request_arg
         approver_user = self._approver_user_arg
 
@@ -47,26 +47,27 @@ class ApproveAccessRequest:
         # and double-grant. `of=AccessRequest` keeps FOR UPDATE off the
         # joinedload's nullable outer-join side (Postgres rejects that); it's
         # a no-op on SQLite.
-        self.access_request = db.session.scalars(
+        request_result = await db.session.scalars(
             select(AccessRequest)
             .options(joinedload(AccessRequest.active_requested_group))
             .where(AccessRequest.id == (access_request if isinstance(access_request, str) else access_request.id))
             .with_for_update(of=AccessRequest)
-        ).first()
+        )
+        self.access_request = request_result.first()
 
         if approver_user is None:
             self.approver_id = None
             self.approver_email = None
         elif isinstance(approver_user, str):
-            approver = db.session.get(OktaUser, approver_user)
+            approver = await db.session.get(OktaUser, approver_user)
             self.approver_id = approver.id
             self.approver_email = approver.email
         else:
             self.approver_id = approver_user.id
             self.approver_email = approver_user.email
 
-    def execute(self) -> AccessRequest:
-        self._resolve()
+    async def execute(self) -> AccessRequest:
+        await self._resolve()
         # Don't allow approving a request that is already resolved. Raise
         # rather than silently no-op so a stale/concurrent approval surfaces
         # as a conflict instead of looking like a success.
@@ -78,7 +79,7 @@ class ApproveAccessRequest:
             return self.access_request
 
         # Don't allow approving a request if the reason is invalid and required
-        valid, _ = CheckForReason(
+        valid, _ = await CheckForReason(
             group=self.access_request.requested_group,
             reason=self.approval_reason,
             members_to_add=[self.access_request.requester_user_id] if not self.access_request.request_ownership else [],
@@ -88,7 +89,7 @@ class ApproveAccessRequest:
             return self.access_request
 
         # Don't allow approving a request if the requester is deleted
-        requester = db.session.get(OktaUser, self.access_request.requester_user_id)
+        requester = await db.session.get(OktaUser, self.access_request.requester_user_id)
         if requester is None or requester.deleted_at is not None:
             raise ResourceGoneError("The requester no longer exists")
 
@@ -106,11 +107,13 @@ class ApproveAccessRequest:
         # self.access_request.approval_ending_at = self.ending_at
 
         # Audit logging
-        group = db.session.scalars(
-            select(OktaGroup)
-            .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
-            .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == self.access_request.requested_group_id)
+        group = (
+            await db.session.scalars(
+                select(OktaGroup)
+                .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
+                .where(OktaGroup.deleted_at.is_(None))
+                .where(OktaGroup.id == self.access_request.requested_group_id)
+            )
         ).first()
 
         _ctx = get_request_context()
@@ -125,13 +128,13 @@ class ApproveAccessRequest:
                     "current_user_email": self.approver_email,
                     "group": group,
                     "request": self.access_request,
-                    "requester": db.session.get(OktaUser, self.access_request.requester_user_id),
+                    "requester": await db.session.get(OktaUser, self.access_request.requester_user_id),
                 }
             )
         )
 
         if self.access_request.request_ownership:
-            ModifyGroupUsers(
+            await ModifyGroupUsers(
                 group=self.access_request.requested_group_id,
                 current_user_id=self.approver_id,
                 users_added_ended_at=self.ending_at,
@@ -140,7 +143,7 @@ class ApproveAccessRequest:
                 notify=self.notify,
             ).execute()
         else:
-            ModifyGroupUsers(
+            await ModifyGroupUsers(
                 group=self.access_request.requested_group_id,
                 current_user_id=self.approver_id,
                 users_added_ended_at=self.ending_at,

--- a/api/operations/approve_group_request.py
+++ b/api/operations/approve_group_request.py
@@ -1,6 +1,9 @@
+import functools
 from typing import Optional
 
 import logging
+
+import anyio.to_thread
 
 from api.context import get_request_context
 from sqlalchemy import func, select
@@ -47,7 +50,7 @@ class ApproveGroupRequest:
         self.bypass_self_approval = bypass_self_approval
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         group_request = self._group_request_arg
         approver_user = self._approver_user_arg
 
@@ -55,26 +58,27 @@ class ApproveGroupRequest:
         # can't both pass the pending-state guard and double-create the group.
         # `of=` keeps FOR UPDATE off the joinedload's nullable outer-join side
         # (Postgres rejects that); no-op on SQLite.
-        self.group_request = db.session.scalars(
+        request_result = await db.session.scalars(
             select(GroupRequest)
             .options(joinedload(GroupRequest.active_requester))
             .where(GroupRequest.id == (group_request if isinstance(group_request, str) else group_request.id))
             .with_for_update(of=GroupRequest)
-        ).first()
+        )
+        self.group_request = request_result.first()
 
         self.approver_id: str | None = None
         if approver_user is None:
             self.approver_email = None
         elif isinstance(approver_user, str):
-            approver = db.session.get(OktaUser, approver_user)
+            approver = await db.session.get(OktaUser, approver_user)
             self.approver_id = approver.id
             self.approver_email = approver.email
         else:
             self.approver_id = approver_user.id
             self.approver_email = approver_user.email
 
-    def execute(self) -> Optional[GroupRequest]:
-        self._resolve()
+    async def execute(self) -> Optional[GroupRequest]:
+        await self._resolve()
         # Guard against missing group_request
         if self.group_request is None:
             return None
@@ -93,7 +97,7 @@ class ApproveGroupRequest:
         # a deleted requester usually can't even load above — active_requester
         # is an inner join filtering deleted_at — so this is a belt-and-braces
         # check that mirrors the historical no-op rather than a 4xx path.)
-        requester = db.session.get(OktaUser, self.group_request.requester_user_id)
+        requester = await db.session.get(OktaUser, self.group_request.requester_user_id)
         if requester is None or requester.deleted_at is not None:
             return self.group_request
 
@@ -125,7 +129,7 @@ class ApproveGroupRequest:
         )
 
         # authorization
-        access_owner_ids = {u.id for u in get_access_owners()}
+        access_owner_ids = {u.id for u in await get_access_owners()}
         is_admin = self.approver_id in access_owner_ids
 
         if not is_admin:
@@ -137,16 +141,18 @@ class ApproveGroupRequest:
         if resolved_app_id is not None:
             # App group request: admins OR owners of that specific app can approve
             if not is_admin:
-                is_app_owner = db.session.scalars(
-                    select(OktaUserGroupMember)
-                    .join(AppGroup, OktaUserGroupMember.group_id == AppGroup.id)
-                    .where(
-                        AppGroup.app_id == resolved_app_id,
-                        AppGroup.is_owner.is_(True),
-                        AppGroup.deleted_at.is_(None),
-                        OktaUserGroupMember.user_id == self.approver_id,
-                        OktaUserGroupMember.is_owner.is_(True),
-                        OktaUserGroupMember.ended_at.is_(None),
+                is_app_owner = (
+                    await db.session.scalars(
+                        select(OktaUserGroupMember)
+                        .join(AppGroup, OktaUserGroupMember.group_id == AppGroup.id)
+                        .where(
+                            AppGroup.app_id == resolved_app_id,
+                            AppGroup.is_owner.is_(True),
+                            AppGroup.deleted_at.is_(None),
+                            OktaUserGroupMember.user_id == self.approver_id,
+                            OktaUserGroupMember.is_owner.is_(True),
+                            OktaUserGroupMember.ended_at.is_(None),
+                        )
                     )
                 ).first()
 
@@ -168,15 +174,17 @@ class ApproveGroupRequest:
         ):
             return self.group_request
 
-        existing_group = db.session.scalars(
-            select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-            .where(func.lower(OktaGroup.name) == func.lower(resolved_name))
-            .where(OktaGroup.deleted_at.is_(None))
+        existing_group = (
+            await db.session.scalars(
+                select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+                .where(func.lower(OktaGroup.name) == func.lower(resolved_name))
+                .where(OktaGroup.deleted_at.is_(None))
+            )
         ).first()
         if existing_group is not None:
             return self.group_request
 
-        db.session.commit()
+        await db.session.commit()
 
         # Audit logging
         _ctx = get_request_context()
@@ -190,7 +198,7 @@ class ApproveGroupRequest:
                     "current_user_id": self.approver_id,
                     "current_user_email": self.approver_email,
                     "group_request": self.group_request,
-                    "requester": db.session.get(OktaUser, self.group_request.requester_user_id),
+                    "requester": await db.session.get(OktaUser, self.group_request.requester_user_id),
                 }
             )
         )
@@ -213,21 +221,23 @@ class ApproveGroupRequest:
                 description=resolved_description,
             )
 
-        created_group: AppGroup | OktaGroup | RoleGroup = CreateGroup(
+        created_group: AppGroup | OktaGroup | RoleGroup = await CreateGroup(
             group=new_group,
             tags=resolved_tags,
             current_user_id=self.approver_id,
         ).execute()
 
         # Check tags on created group for ownership length constraints including propagated app tags
-        created_group_with_tags = db.session.scalars(
-            select(OktaGroup)
-            .options(
-                selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
-                selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
+        created_group_with_tags = (
+            await db.session.scalars(
+                select(OktaGroup)
+                .options(
+                    selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
+                    selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
+                )
+                .where(OktaGroup.id == created_group.id)
+                .where(OktaGroup.deleted_at.is_(None))
             )
-            .where(OktaGroup.id == created_group.id)
-            .where(OktaGroup.deleted_at.is_(None))
         ).first()
 
         tags = [tag_map.active_tag for tag_map in created_group_with_tags.active_group_tags]
@@ -253,12 +263,12 @@ class ApproveGroupRequest:
         # If app owner auto approval, skip if group has owner add constraint (will inherit ownership via app)
         can_add_owner = True
         if self.bypass_self_approval and self.approver_id is not None:
-            can_add_owner, _ = CheckForSelfAdd(
+            can_add_owner, _ = await CheckForSelfAdd(
                 group=created_group_with_tags, current_user=self.approver_id, owners_to_add=[self.approver_id]
             ).execute_for_group()
 
         if can_add_owner:
-            ModifyGroupUsers(
+            await ModifyGroupUsers(
                 group=created_group_with_tags,
                 owners_to_add=[self.group_request.requester_user_id],
                 users_added_ended_at=coalesced_ownership_ending_at,
@@ -273,17 +283,22 @@ class ApproveGroupRequest:
         self.group_request.resolution_reason = self.approval_reason
         self.group_request.approved_group_id = created_group.id
 
-        db.session.commit()
+        await db.session.commit()
 
         if self.notify:
-            requester = db.session.get(OktaUser, self.group_request.requester_user_id)
-            approvers = get_all_possible_request_approvers(self.group_request)
-            self.notification_hook.access_group_request_completed(
-                group_request=self.group_request,
-                group=created_group,
-                requester=requester,
-                approvers=approvers,
-                notify_requester=True,
+            requester = await db.session.get(OktaUser, self.group_request.requester_user_id)
+            approvers = await get_all_possible_request_approvers(self.group_request)
+            # Sync notification hook may do network I/O; run it on a worker
+            # thread so it doesn't block the event loop.
+            await anyio.to_thread.run_sync(
+                functools.partial(
+                    self.notification_hook.access_group_request_completed,
+                    group_request=self.group_request,
+                    group=created_group,
+                    requester=requester,
+                    approvers=approvers,
+                    notify_requester=True,
+                )
             )
 
         return self.group_request

--- a/api/operations/approve_group_request.py
+++ b/api/operations/approve_group_request.py
@@ -39,6 +39,18 @@ class ApproveGroupRequest:
         notify: bool = True,
         bypass_self_approval: bool = False,
     ):
+        self._group_request_arg = group_request
+        self._approver_user_arg = approver_user
+
+        self.approval_reason = approval_reason
+        self.notify = notify
+        self.bypass_self_approval = bypass_self_approval
+        self.notification_hook = get_notification_hook()
+
+    def _resolve(self) -> None:
+        group_request = self._group_request_arg
+        approver_user = self._approver_user_arg
+
         # Lock the request row for the transaction so concurrent approvers
         # can't both pass the pending-state guard and double-create the group.
         # `of=` keeps FOR UPDATE off the joinedload's nullable outer-join side
@@ -61,12 +73,8 @@ class ApproveGroupRequest:
             self.approver_id = approver_user.id
             self.approver_email = approver_user.email
 
-        self.approval_reason = approval_reason
-        self.notify = notify
-        self.bypass_self_approval = bypass_self_approval
-        self.notification_hook = get_notification_hook()
-
     def execute(self) -> Optional[GroupRequest]:
+        self._resolve()
         # Guard against missing group_request
         if self.group_request is None:
             return None

--- a/api/operations/approve_role_request.py
+++ b/api/operations/approve_role_request.py
@@ -27,6 +27,21 @@ class ApproveRoleRequest:
         ending_at: Optional[datetime] = None,
         notify: bool = True,
     ):
+        self._role_request_arg = role_request
+        self._approver_user_arg = approver_user
+
+        self.approval_reason = approval_reason
+
+        self.ending_at = ending_at
+
+        self.notify = notify
+
+        self.notification_hook = get_notification_hook()
+
+    def _resolve(self) -> None:
+        role_request = self._role_request_arg
+        approver_user = self._approver_user_arg
+
         # Lock the request row for the transaction so concurrent approvers
         # can't both pass the pending-state guard and double-grant. `of=` keeps
         # FOR UPDATE off the joinedloads' nullable outer-join sides (Postgres
@@ -49,15 +64,8 @@ class ApproveRoleRequest:
             self.approver_id = approver_user.id
             self.approver_email = approver_user.email
 
-        self.approval_reason = approval_reason
-
-        self.ending_at = ending_at
-
-        self.notify = notify
-
-        self.notification_hook = get_notification_hook()
-
     def execute(self) -> RoleRequest:
+        self._resolve()
         # Don't allow approving a request that is already resolved. Raise
         # rather than silently no-op so a stale/concurrent approval surfaces
         # as a conflict instead of looking like a success.

--- a/api/operations/approve_role_request.py
+++ b/api/operations/approve_role_request.py
@@ -38,7 +38,7 @@ class ApproveRoleRequest:
 
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         role_request = self._role_request_arg
         approver_user = self._approver_user_arg
 
@@ -46,26 +46,27 @@ class ApproveRoleRequest:
         # can't both pass the pending-state guard and double-grant. `of=` keeps
         # FOR UPDATE off the joinedloads' nullable outer-join sides (Postgres
         # rejects that); no-op on SQLite.
-        self.role_request = db.session.scalars(
+        request_result = await db.session.scalars(
             select(RoleRequest)
             .options(joinedload(RoleRequest.active_requested_group), joinedload(RoleRequest.active_requester_role))
             .where(RoleRequest.id == (role_request if isinstance(role_request, str) else role_request.id))
             .with_for_update(of=RoleRequest)
-        ).first()
+        )
+        self.role_request = request_result.first()
 
         if approver_user is None:
             self.approver_id = None
             self.approver_email = None
         elif isinstance(approver_user, str):
-            approver = db.session.get(OktaUser, approver_user)
+            approver = await db.session.get(OktaUser, approver_user)
             self.approver_id = approver.id
             self.approver_email = approver.email
         else:
             self.approver_id = approver_user.id
             self.approver_email = approver_user.email
 
-    def execute(self) -> RoleRequest:
-        self._resolve()
+    async def execute(self) -> RoleRequest:
+        await self._resolve()
         # Don't allow approving a request that is already resolved. Raise
         # rather than silently no-op so a stale/concurrent approval surfaces
         # as a conflict instead of looking like a success.
@@ -77,7 +78,7 @@ class ApproveRoleRequest:
             return self.role_request
 
         # Don't allow approving a request if the reason is invalid and required
-        valid, _ = CheckForReason(
+        valid, _ = await CheckForReason(
             group=self.role_request.requester_role_id,
             reason=self.approval_reason,
             members_to_add=[self.role_request.requested_group_id] if not self.role_request.request_ownership else [],
@@ -87,7 +88,7 @@ class ApproveRoleRequest:
             return self.role_request
 
         # Don't allow approving a request if the requester role is deleted
-        requester = db.session.get(RoleGroup, self.role_request.requester_role_id)
+        requester = await db.session.get(RoleGroup, self.role_request.requester_role_id)
         if requester is None or requester.deleted_at is not None:
             raise ResourceGoneError("The requester role no longer exists")
 
@@ -97,14 +98,16 @@ class ApproveRoleRequest:
         if not self.role_request.active_requested_group.is_managed:
             raise InvalidRequestError("Groups not managed by Access cannot be modified")
 
-        db.session.commit()
+        await db.session.commit()
 
         # Audit logging
-        group = db.session.scalars(
-            select(OktaGroup)
-            .options(selectin_polymorphic(OktaGroup, [AppGroup]), joinedload(AppGroup.app))
-            .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == self.role_request.requested_group_id)
+        group = (
+            await db.session.scalars(
+                select(OktaGroup)
+                .options(selectin_polymorphic(OktaGroup, [AppGroup]), joinedload(AppGroup.app))
+                .where(OktaGroup.deleted_at.is_(None))
+                .where(OktaGroup.id == self.role_request.requested_group_id)
+            )
         ).first()
 
         _ctx = get_request_context()
@@ -119,13 +122,13 @@ class ApproveRoleRequest:
                     "current_user_email": self.approver_email,
                     "group": group,
                     "role_request": self.role_request,
-                    "requester": db.session.get(OktaUser, self.role_request.requester_user_id),
+                    "requester": await db.session.get(OktaUser, self.role_request.requester_user_id),
                 }
             )
         )
 
         if self.role_request.request_ownership:
-            ModifyRoleGroups(
+            await ModifyRoleGroups(
                 role_group=self.role_request.requester_role,
                 groups_added_ended_at=self.ending_at,
                 owner_groups_to_add=[self.role_request.requested_group_id],
@@ -134,7 +137,7 @@ class ApproveRoleRequest:
                 notify=self.notify,
             ).execute()
         else:
-            ModifyRoleGroups(
+            await ModifyRoleGroups(
                 role_group=self.role_request.requester_role,
                 groups_added_ended_at=self.ending_at,
                 groups_to_add=[self.role_request.requested_group_id],

--- a/api/operations/constraints/check_for_reason.py
+++ b/api/operations/constraints/check_for_reason.py
@@ -19,6 +19,15 @@ class CheckForReason:
         members_to_add: list[str] = [],
         owners_to_add: list[str] = [],
     ):
+        self._group_arg = group
+
+        self.reason = reason
+
+        self.members_to_add = members_to_add
+        self.owners_to_add = owners_to_add
+
+    def _resolve(self) -> None:
+        group = self._group_arg
         self.group = db.session.scalars(
             select(OktaGroup)
             .options(
@@ -37,16 +46,12 @@ class CheckForReason:
             .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
         ).first()
 
-        self.reason = reason
-
-        self.members_to_add = members_to_add
-        self.owners_to_add = owners_to_add
-
     @staticmethod
     def invalid_reason(reason: Optional[str]) -> bool:
         return reason is None or reason.strip() == ""
 
     def execute_for_group(self) -> Tuple[bool, str]:
+        self._resolve()
         if self.invalid_reason(self.reason):
             tags = [tag_map.active_tag for tag_map in self.group.active_group_tags]
             if len(self.owners_to_add) > 0:
@@ -92,6 +97,7 @@ class CheckForReason:
         return True, ""
 
     def execute_for_role(self) -> Tuple[bool, str]:
+        self._resolve()
         if type(self.group) is not RoleGroup:
             return True, ""
 

--- a/api/operations/constraints/check_for_reason.py
+++ b/api/operations/constraints/check_for_reason.py
@@ -26,9 +26,9 @@ class CheckForReason:
         self.members_to_add = members_to_add
         self.owners_to_add = owners_to_add
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         group = self._group_arg
-        self.group = db.session.scalars(
+        result = await db.session.scalars(
             select(OktaGroup)
             .options(
                 selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
@@ -44,14 +44,15 @@ class CheckForReason:
             )
             .where(OktaGroup.deleted_at.is_(None))
             .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
-        ).first()
+        )
+        self.group = result.first()
 
     @staticmethod
     def invalid_reason(reason: Optional[str]) -> bool:
         return reason is None or reason.strip() == ""
 
-    def execute_for_group(self) -> Tuple[bool, str]:
-        self._resolve()
+    async def execute_for_group(self) -> Tuple[bool, str]:
+        await self._resolve()
         if self.invalid_reason(self.reason):
             tags = [tag_map.active_tag for tag_map in self.group.active_group_tags]
             if len(self.owners_to_add) > 0:
@@ -96,19 +97,21 @@ class CheckForReason:
                             )
         return True, ""
 
-    def execute_for_role(self) -> Tuple[bool, str]:
-        self._resolve()
+    async def execute_for_role(self) -> Tuple[bool, str]:
+        await self._resolve()
         if type(self.group) is not RoleGroup:
             return True, ""
 
         if self.invalid_reason(self.reason):
             if len(self.members_to_add) > 0:
-                new_member_groups = db.session.scalars(
-                    select(OktaGroup)
-                    .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
-                    .where(OktaGroup.is_managed.is_(True))
-                    .where(OktaGroup.id.in_(self.members_to_add))
-                    .where(OktaGroup.deleted_at.is_(None))
+                new_member_groups = (
+                    await db.session.scalars(
+                        select(OktaGroup)
+                        .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
+                        .where(OktaGroup.is_managed.is_(True))
+                        .where(OktaGroup.id.in_(self.members_to_add))
+                        .where(OktaGroup.deleted_at.is_(None))
+                    )
                 ).all()
                 for member_group in new_member_groups:
                     require_member_reason = coalesce_constraints(
@@ -123,12 +126,14 @@ class CheckForReason:
                         )
 
             if len(self.owners_to_add) > 0:
-                new_owner_groups = db.session.scalars(
-                    select(OktaGroup)
-                    .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
-                    .where(OktaGroup.is_managed.is_(True))
-                    .where(OktaGroup.id.in_(self.owners_to_add))
-                    .where(OktaGroup.deleted_at.is_(None))
+                new_owner_groups = (
+                    await db.session.scalars(
+                        select(OktaGroup)
+                        .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
+                        .where(OktaGroup.is_managed.is_(True))
+                        .where(OktaGroup.id.in_(self.owners_to_add))
+                        .where(OktaGroup.deleted_at.is_(None))
+                    )
                 ).all()
                 for owner_group in new_owner_groups:
                     require_owner_reason = coalesce_constraints(

--- a/api/operations/constraints/check_for_self_add.py
+++ b/api/operations/constraints/check_for_self_add.py
@@ -20,6 +20,16 @@ class CheckForSelfAdd:
         members_to_add: list[str] = [],
         owners_to_add: list[str] = [],
     ):
+        self._group_arg = group
+        self._current_user_arg = current_user
+
+        self.members_to_add = members_to_add
+        self.owners_to_add = owners_to_add
+
+    def _resolve(self) -> None:
+        group = self._group_arg
+        current_user = self._current_user_arg
+
         self.group = db.session.scalars(
             select(OktaGroup)
             .options(
@@ -47,10 +57,8 @@ class CheckForSelfAdd:
                 .where(OktaUser.id == (current_user if isinstance(current_user, str) else current_user.id))
             ).first()
 
-        self.members_to_add = members_to_add
-        self.owners_to_add = owners_to_add
-
     def execute_for_group(self) -> Tuple[bool, str]:
+        self._resolve()
         if self.current_user is None or _is_access_admin(db.session, self.current_user.id):
             return True, ""
 
@@ -109,6 +117,7 @@ class CheckForSelfAdd:
         return True, ""
 
     def execute_for_role(self) -> Tuple[bool, str]:
+        self._resolve()
         if self.current_user is None or _is_access_admin(db.session, self.current_user.id):
             return True, ""
 

--- a/api/operations/constraints/check_for_self_add.py
+++ b/api/operations/constraints/check_for_self_add.py
@@ -26,11 +26,11 @@ class CheckForSelfAdd:
         self.members_to_add = members_to_add
         self.owners_to_add = owners_to_add
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         group = self._group_arg
         current_user = self._current_user_arg
 
-        self.group = db.session.scalars(
+        group_result = await db.session.scalars(
             select(OktaGroup)
             .options(
                 selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
@@ -46,20 +46,22 @@ class CheckForSelfAdd:
             )
             .where(OktaGroup.deleted_at.is_(None))
             .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
-        ).first()
+        )
+        self.group = group_result.first()
 
         if current_user is None:
             self.current_user = None
         else:
-            self.current_user = db.session.scalars(
+            user_result = await db.session.scalars(
                 select(OktaUser)
                 .where(OktaUser.deleted_at.is_(None))
                 .where(OktaUser.id == (current_user if isinstance(current_user, str) else current_user.id))
-            ).first()
+            )
+            self.current_user = user_result.first()
 
-    def execute_for_group(self) -> Tuple[bool, str]:
-        self._resolve()
-        if self.current_user is None or _is_access_admin(db.session, self.current_user.id):
+    async def execute_for_group(self) -> Tuple[bool, str]:
+        await self._resolve()
+        if self.current_user is None or await _is_access_admin(db.session, self.current_user.id):
             return True, ""
 
         if len(self.owners_to_add) > 0 and self.current_user.id in self.owners_to_add:
@@ -116,9 +118,9 @@ class CheckForSelfAdd:
                         )
         return True, ""
 
-    def execute_for_role(self) -> Tuple[bool, str]:
-        self._resolve()
-        if self.current_user is None or _is_access_admin(db.session, self.current_user.id):
+    async def execute_for_role(self) -> Tuple[bool, str]:
+        await self._resolve()
+        if self.current_user is None or await _is_access_admin(db.session, self.current_user.id):
             return True, ""
 
         if type(self.group) is not RoleGroup:
@@ -127,7 +129,7 @@ class CheckForSelfAdd:
         # Check to see if the current user is a member of the role,
         # which would grant them access to the newly added groups associated with the role
         if (
-            db.session.scalar(
+            await db.session.scalar(
                 select(func.count()).select_from(
                     select(OktaUserGroupMember)
                     .where(OktaUserGroupMember.group_id == self.group.id)
@@ -145,12 +147,14 @@ class CheckForSelfAdd:
             or 0
         ) > 0:
             if len(self.members_to_add) > 0:
-                new_member_groups = db.session.scalars(
-                    select(OktaGroup)
-                    .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
-                    .where(OktaGroup.is_managed.is_(True))
-                    .where(OktaGroup.id.in_(self.members_to_add))
-                    .where(OktaGroup.deleted_at.is_(None))
+                new_member_groups = (
+                    await db.session.scalars(
+                        select(OktaGroup)
+                        .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
+                        .where(OktaGroup.is_managed.is_(True))
+                        .where(OktaGroup.id.in_(self.members_to_add))
+                        .where(OktaGroup.deleted_at.is_(None))
+                    )
                 ).all()
                 for member_group in new_member_groups:
                     require_member_reason = coalesce_constraints(
@@ -166,12 +170,14 @@ class CheckForSelfAdd:
                         )
 
             if len(self.owners_to_add) > 0:
-                new_owner_groups = db.session.scalars(
-                    select(OktaGroup)
-                    .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
-                    .where(OktaGroup.is_managed.is_(True))
-                    .where(OktaGroup.id.in_(self.owners_to_add))
-                    .where(OktaGroup.deleted_at.is_(None))
+                new_owner_groups = (
+                    await db.session.scalars(
+                        select(OktaGroup)
+                        .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
+                        .where(OktaGroup.is_managed.is_(True))
+                        .where(OktaGroup.id.in_(self.owners_to_add))
+                        .where(OktaGroup.deleted_at.is_(None))
+                    )
                 ).all()
                 for owner_group in new_owner_groups:
                     require_owner_reason = coalesce_constraints(

--- a/api/operations/create_access_request.py
+++ b/api/operations/create_access_request.py
@@ -1,9 +1,12 @@
+import functools
 import random
 import string
 from datetime import datetime
 from typing import Optional
 
 import logging
+
+import anyio.to_thread
 
 from api.context import get_request_context
 from sqlalchemy import select
@@ -51,24 +54,26 @@ class CreateAccessRequest:
         self.conditional_access_hook = get_conditional_access_hook()
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         requester_user = self._requester_user_arg
         requested_group = self._requested_group_arg
 
         if isinstance(requester_user, str):
-            self.requester = db.session.get(OktaUser, requester_user)
+            self.requester = await db.session.get(OktaUser, requester_user)
         else:
             self.requester = requester_user
 
-        self.requested_group = db.session.scalars(
-            select(OktaGroup)
-            .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
-            .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == (requested_group if isinstance(requested_group, str) else requested_group.id))
+        self.requested_group = (
+            await db.session.scalars(
+                select(OktaGroup)
+                .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
+                .where(OktaGroup.deleted_at.is_(None))
+                .where(OktaGroup.id == (requested_group if isinstance(requested_group, str) else requested_group.id))
+            )
         ).first()
 
-    def execute(self) -> Optional[AccessRequest]:
-        self._resolve()
+    async def execute(self) -> Optional[AccessRequest]:
+        await self._resolve()
         # Don't allow creating a request for an unmanaged group
         if not self.requested_group.is_managed:
             return None
@@ -84,10 +89,10 @@ class CreateAccessRequest:
         )
 
         db.session.add(access_request)
-        db.session.commit()
+        await db.session.commit()
 
         # Fetch the users to notify
-        approvers = get_group_managers(self.requested_group.id)
+        approvers = await get_group_managers(self.requested_group.id)
 
         # If there are no approvers, try to get the app managers
         # or if the only approver is the requester, try to get the app managers
@@ -96,23 +101,26 @@ class CreateAccessRequest:
             or (len(approvers) == 1 and approvers[0].id == self.requester.id)
             and type(self.requested_group) is AppGroup
         ):
-            approvers = get_app_managers(self.requested_group.app_id)
+            approvers = await get_app_managers(self.requested_group.app_id)
 
         # If there are still no approvers, try to get the access owners
         if len(approvers) == 0 or (len(approvers) == 1 and approvers[0].id == self.requester.id):
-            approvers = get_access_owners()
+            approvers = await get_access_owners()
 
-        group = db.session.scalars(
-            select(OktaGroup)
-            .options(
-                selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
-                joinedload(AppGroup.app),
-                selectinload(OktaGroup.active_group_tags).options(
-                    joinedload(OktaGroupTagMap.active_app_tag_mapping), joinedload(OktaGroupTagMap.enabled_active_tag)
-                ),
+        group = (
+            await db.session.scalars(
+                select(OktaGroup)
+                .options(
+                    selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
+                    joinedload(AppGroup.app),
+                    selectinload(OktaGroup.active_group_tags).options(
+                        joinedload(OktaGroupTagMap.active_app_tag_mapping),
+                        joinedload(OktaGroupTagMap.enabled_active_tag),
+                    ),
+                )
+                .where(OktaGroup.deleted_at.is_(None))
+                .where(OktaGroup.id == self.requested_group.id)
             )
-            .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == self.requested_group.id)
         ).first()
 
         # Audit logging
@@ -134,24 +142,29 @@ class CreateAccessRequest:
             )
         )
 
-        conditional_access_responses = self.conditional_access_hook.access_request_created(
-            access_request=access_request,
-            group=group,
-            group_tags=[active_tag_map.enabled_active_tag for active_tag_map in group.active_group_tags],
-            requester=self.requester,
+        # Sync plugin hooks may do network I/O; run them on a worker thread so
+        # they don't block the event loop.
+        conditional_access_responses = await anyio.to_thread.run_sync(
+            functools.partial(
+                self.conditional_access_hook.access_request_created,
+                access_request=access_request,
+                group=group,
+                group_tags=[active_tag_map.enabled_active_tag for active_tag_map in group.active_group_tags],
+                requester=self.requester,
+            )
         )
 
         for response in conditional_access_responses:
             if response is not None:
                 if response.approved:
-                    ApproveAccessRequest(
+                    await ApproveAccessRequest(
                         access_request=access_request,
                         approval_reason=response.reason,
                         ending_at=response.ending_at,
                         notify=False,
                     ).execute()
                 else:
-                    RejectAccessRequest(
+                    await RejectAccessRequest(
                         access_request=access_request,
                         rejection_reason=response.reason,
                         notify=False,
@@ -159,11 +172,14 @@ class CreateAccessRequest:
 
                 return access_request
 
-        self.notification_hook.access_request_created(
-            access_request=access_request,
-            group=group,
-            requester=self.requester,
-            approvers=approvers,
+        await anyio.to_thread.run_sync(
+            functools.partial(
+                self.notification_hook.access_request_created,
+                access_request=access_request,
+                group=group,
+                requester=self.requester,
+                approvers=approvers,
+            )
         )
 
         return access_request

--- a/api/operations/create_access_request.py
+++ b/api/operations/create_access_request.py
@@ -39,6 +39,22 @@ class CreateAccessRequest:
     ):
         self.id = self.__generate_id()
 
+        self._requester_user_arg = requester_user
+        self._requested_group_arg = requested_group
+
+        self.request_ownership = request_ownership
+        self.request_reason = request_reason
+        self.request_ending_at = request_ending_at
+
+        self.request_approvers = select()
+
+        self.conditional_access_hook = get_conditional_access_hook()
+        self.notification_hook = get_notification_hook()
+
+    def _resolve(self) -> None:
+        requester_user = self._requester_user_arg
+        requested_group = self._requested_group_arg
+
         if isinstance(requester_user, str):
             self.requester = db.session.get(OktaUser, requester_user)
         else:
@@ -51,16 +67,8 @@ class CreateAccessRequest:
             .where(OktaGroup.id == (requested_group if isinstance(requested_group, str) else requested_group.id))
         ).first()
 
-        self.request_ownership = request_ownership
-        self.request_reason = request_reason
-        self.request_ending_at = request_ending_at
-
-        self.request_approvers = select()
-
-        self.conditional_access_hook = get_conditional_access_hook()
-        self.notification_hook = get_notification_hook()
-
     def execute(self) -> Optional[AccessRequest]:
+        self._resolve()
         # Don't allow creating a request for an unmanaged group
         if not self.requested_group.is_managed:
             return None

--- a/api/operations/create_app.py
+++ b/api/operations/create_app.py
@@ -67,17 +67,19 @@ class CreateApp:
                 self.additional_app_groups.append(AppGroup(is_owner=False, name=name, description=description))
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         self.tag_ids = [
             tag.id
-            for tag in db.session.scalars(
-                select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_arg))
+            for tag in (
+                await db.session.scalars(select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_arg)))
             ).all()
         ]
 
         self.owner_id = getattr(
-            db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._owner_id_arg)
+            (
+                await db.session.scalars(
+                    select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._owner_id_arg)
+                )
             ).first(),
             "id",
             None,
@@ -85,24 +87,32 @@ class CreateApp:
         owner_role_ids = self._owner_role_ids_arg
         self.owner_role_ids = None
         if owner_role_ids is not None:
-            self.owner_roles = db.session.scalars(
-                select(RoleGroup).where(RoleGroup.id.in_(owner_role_ids)).where(RoleGroup.deleted_at.is_(None))
+            self.owner_roles = (
+                await db.session.scalars(
+                    select(RoleGroup).where(RoleGroup.id.in_(owner_role_ids)).where(RoleGroup.deleted_at.is_(None))
+                )
             ).all()
             self.owner_role_ids = [role.id for role in self.owner_roles]
 
         self.current_user_id = getattr(
-            db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+            (
+                await db.session.scalars(
+                    select(OktaUser)
+                    .where(OktaUser.deleted_at.is_(None))
+                    .where(OktaUser.id == self._current_user_id_arg)
+                )
             ).first(),
             "id",
             None,
         )
 
-    def execute(self) -> App:
-        self._resolve()
+    async def execute(self) -> App:
+        await self._resolve()
         # Do not allow non-deleted apps with the same name
-        existing_app = db.session.scalars(
-            select(App).where(func.lower(App.name) == func.lower(self.app.name)).where(App.deleted_at.is_(None))
+        existing_app = (
+            await db.session.scalars(
+                select(App).where(func.lower(App.name) == func.lower(self.app.name)).where(App.deleted_at.is_(None))
+            )
         ).first()
         if existing_app is not None:
             return existing_app
@@ -110,7 +120,7 @@ class CreateApp:
         # Audit logging
         email = None
         if self.current_user_id is not None:
-            email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
+            email = getattr(await db.session.get(OktaUser, self.current_user_id), "email", None)
 
         _ctx = get_request_context()
 
@@ -129,14 +139,16 @@ class CreateApp:
         )
 
         db.session.add(self.app)
-        db.session.commit()
+        await db.session.commit()
 
         app_id = self.app.id
 
-        existing_owner_group = db.session.scalars(
-            select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-            .where(func.lower(OktaGroup.name) == func.lower(self.owner_group_name))
-            .where(OktaGroup.deleted_at.is_(None))
+        existing_owner_group = (
+            await db.session.scalars(
+                select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+                .where(func.lower(OktaGroup.name) == func.lower(self.owner_group_name))
+                .where(OktaGroup.deleted_at.is_(None))
+            )
         ).first()
 
         if existing_owner_group is None:
@@ -146,23 +158,23 @@ class CreateApp:
                 name=self.owner_group_name,
                 description=app_owners_group_description(self.app.name),
             )
-            owner_app_group = CreateGroup(group=owner_app_group, current_user_id=self.current_user_id).execute()
+            owner_app_group = await CreateGroup(group=owner_app_group, current_user_id=self.current_user_id).execute()
         else:
             group_id = existing_owner_group.id
             if type(existing_owner_group) is not AppGroup:
-                ModifyGroupType(
+                await ModifyGroupType(
                     group=existing_owner_group,
                     group_changes=AppGroup(app_id=app_id, is_owner=True),
                     current_user_id=self.current_user_id,
                 ).execute()
-            owner_app_group = db.session.scalars(select(AppGroup).where(AppGroup.id == group_id)).first()
+            owner_app_group = (await db.session.scalars(select(AppGroup).where(AppGroup.id == group_id))).first()
             owner_app_group.app_id = app_id
             owner_app_group.is_owner = True
-            db.session.commit()
+            await db.session.commit()
 
         if self.owner_id is not None:
             # Add the app owner to the app owner group as members and owners
-            ModifyGroupUsers(
+            await ModifyGroupUsers(
                 group=owner_app_group,
                 current_user_id=self.current_user_id,
                 members_to_add=[self.owner_id],
@@ -171,7 +183,7 @@ class CreateApp:
 
         if self.owner_role_ids is not None:
             for role_id in self.owner_role_ids:
-                ModifyRoleGroups(
+                await ModifyRoleGroups(
                     role_group=role_id,
                     current_user_id=self.current_user_id,
                     groups_to_add=[owner_app_group.id],
@@ -179,11 +191,13 @@ class CreateApp:
                 ).execute()
 
         # Find other app groups with the same app name prefix and update them
-        other_existing_app_groups = db.session.scalars(
-            select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-            .where(OktaGroup.name.ilike(f"{self.app_group_prefix}%"))
-            .where(func.lower(OktaGroup.name) != func.lower(self.owner_group_name))
-            .where(OktaGroup.deleted_at.is_(None))
+        other_existing_app_groups = (
+            await db.session.scalars(
+                select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+                .where(OktaGroup.name.ilike(f"{self.app_group_prefix}%"))
+                .where(func.lower(OktaGroup.name) != func.lower(self.owner_group_name))
+                .where(OktaGroup.deleted_at.is_(None))
+            )
         ).all()
         existing_app_group_ids_to_update = []
         for existing_app_group in other_existing_app_groups:
@@ -191,7 +205,7 @@ class CreateApp:
                 existing_app_group_ids_to_update.append(existing_app_group.id)
 
         for existing_app_group_id in existing_app_group_ids_to_update:
-            ModifyGroupType(
+            await ModifyGroupType(
                 group=existing_app_group_id,
                 group_changes=AppGroup(app_id=app_id, is_owner=False),
                 current_user_id=self.current_user_id,
@@ -202,30 +216,34 @@ class CreateApp:
             for app_group in self.additional_app_groups:
                 app_group.app_id = app_id
 
-                existing_group = db.session.scalars(
-                    select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-                    .where(func.lower(OktaGroup.name) == func.lower(app_group.name))
-                    .where(OktaGroup.deleted_at.is_(None))
+                existing_group = (
+                    await db.session.scalars(
+                        select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+                        .where(func.lower(OktaGroup.name) == func.lower(app_group.name))
+                        .where(OktaGroup.deleted_at.is_(None))
+                    )
                 ).first()
 
                 if existing_group is None:
-                    CreateGroup(group=app_group, current_user_id=self.current_user_id).execute()
+                    await CreateGroup(group=app_group, current_user_id=self.current_user_id).execute()
                 else:
                     group_id = existing_group.id
                     if type(existing_owner_group) is not AppGroup:
-                        ModifyGroupType(
+                        await ModifyGroupType(
                             group=existing_owner_group,
                             group_changes=AppGroup(app_id=app_id, is_owner=False),
                             current_user_id=self.current_user_id,
                         ).execute()
-                    app_group = db.session.scalars(select(AppGroup).where(AppGroup.id == group_id)).first()
+                    app_group = (await db.session.scalars(select(AppGroup).where(AppGroup.id == group_id))).first()
                     app_group.app_id = app_id
                     app_group.is_owner = False
-                    db.session.commit()
+                    await db.session.commit()
 
         if len(self.tag_ids) > 0:
-            all_app_groups = db.session.scalars(
-                select(AppGroup).where(AppGroup.app_id == app_id).where(AppGroup.deleted_at.is_(None))
+            all_app_groups = (
+                await db.session.scalars(
+                    select(AppGroup).where(AppGroup.app_id == app_id).where(AppGroup.deleted_at.is_(None))
+                )
             ).all()
 
             for tag_id in self.tag_ids:
@@ -235,15 +253,17 @@ class CreateApp:
                         app_id=app_id,
                     )
                 )
-            db.session.commit()
+            await db.session.commit()
 
-            new_app_tag_maps = db.session.scalars(
-                select(AppTagMap)
-                .where(AppTagMap.app_id == app_id)
-                .where(
-                    or_(
-                        AppTagMap.ended_at.is_(None),
-                        AppTagMap.ended_at > func.now(),
+            new_app_tag_maps = (
+                await db.session.scalars(
+                    select(AppTagMap)
+                    .where(AppTagMap.app_id == app_id)
+                    .where(
+                        or_(
+                            AppTagMap.ended_at.is_(None),
+                            AppTagMap.ended_at > func.now(),
+                        )
                     )
                 )
             ).all()
@@ -257,9 +277,9 @@ class CreateApp:
                             app_tag_map_id=app_tag_map.id,
                         )
                     )
-            db.session.commit()
+            await db.session.commit()
 
-        return db.session.get(App, app_id)
+        return await db.session.get(App, app_id)
 
     # Generate a 20 character alphanumeric ID similar to Okta IDs for users and groups
     def __generate_id(self) -> str:

--- a/api/operations/create_app.py
+++ b/api/operations/create_app.py
@@ -41,24 +41,9 @@ class CreateApp:
             app.id = id
             self.app = app
 
-        self.tag_ids = [
-            tag.id
-            for tag in db.session.scalars(select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(tags))).all()
-        ]
-
-        self.owner_id = getattr(
-            db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == owner_id)
-            ).first(),
-            "id",
-            None,
-        )
-        self.owner_role_ids = None
-        if owner_role_ids is not None:
-            self.owner_roles = db.session.scalars(
-                select(RoleGroup).where(RoleGroup.id.in_(owner_role_ids)).where(RoleGroup.deleted_at.is_(None))
-            ).all()
-            self.owner_role_ids = [role.id for role in self.owner_roles]
+        self._tags_arg = tags
+        self._owner_id_arg = owner_id
+        self._owner_role_ids_arg = owner_role_ids
 
         self.app_group_prefix = (
             f"{AppGroup.APP_GROUP_NAME_PREFIX}{self.app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}"
@@ -80,15 +65,41 @@ class CreateApp:
                 if name == self.owner_group_name:
                     continue
                 self.additional_app_groups.append(AppGroup(is_owner=False, name=name, description=description))
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
+        self.tag_ids = [
+            tag.id
+            for tag in db.session.scalars(
+                select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_arg))
+            ).all()
+        ]
+
+        self.owner_id = getattr(
+            db.session.scalars(
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._owner_id_arg)
+            ).first(),
+            "id",
+            None,
+        )
+        owner_role_ids = self._owner_role_ids_arg
+        self.owner_role_ids = None
+        if owner_role_ids is not None:
+            self.owner_roles = db.session.scalars(
+                select(RoleGroup).where(RoleGroup.id.in_(owner_role_ids)).where(RoleGroup.deleted_at.is_(None))
+            ).all()
+            self.owner_role_ids = [role.id for role in self.owner_roles]
+
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self) -> App:
+        self._resolve()
         # Do not allow non-deleted apps with the same name
         existing_app = db.session.scalars(
             select(App).where(func.lower(App.name) == func.lower(self.app.name)).where(App.deleted_at.is_(None))

--- a/api/operations/create_group.py
+++ b/api/operations/create_group.py
@@ -30,26 +30,32 @@ class CreateGroup:
         self._tags_arg = tags
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
-        self.tags = db.session.scalars(
-            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_arg))
+    async def _resolve(self) -> None:
+        self.tags = (
+            await db.session.scalars(select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_arg)))
         ).all()
 
         self.current_user_id = getattr(
-            db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+            (
+                await db.session.scalars(
+                    select(OktaUser)
+                    .where(OktaUser.deleted_at.is_(None))
+                    .where(OktaUser.id == self._current_user_id_arg)
+                )
             ).first(),
             "id",
             None,
         )
 
-    def execute(self, *, _group: Optional[T] = None) -> T:
-        self._resolve()
+    async def execute(self, *, _group: Optional[T] = None) -> T:
+        await self._resolve()
         # Do not allow non-deleted groups with the same name (case-insensitive)
-        existing_group = db.session.scalars(
-            select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-            .where(func.lower(OktaGroup.name) == func.lower(self.group.name))
-            .where(OktaGroup.deleted_at.is_(None))
+        existing_group = (
+            await db.session.scalars(
+                select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+                .where(func.lower(OktaGroup.name) == func.lower(self.group.name))
+                .where(OktaGroup.deleted_at.is_(None))
+            )
         ).first()
         if existing_group is not None:
             return existing_group
@@ -57,29 +63,31 @@ class CreateGroup:
         # Make sure the app exists if we're creating an app group
         if (
             type(self.group) is AppGroup
-            and db.session.scalars(
-                select(App).where(App.id == self.group.app_id).where(App.deleted_at.is_(None))
+            and (
+                await db.session.scalars(select(App).where(App.id == self.group.app_id).where(App.deleted_at.is_(None)))
             ).first()
             is None
         ):
             raise ValueError("App for AppGroup does not exist")
 
-        okta_group = okta.create_group(self.group.name, self.group.description)
+        okta_group = await okta.create_group(self.group.name, self.group.description)
         if okta_group is None:
-            okta_group = okta.list_groups(query_params={"q": self.group.name})[0]
+            okta_group = (await okta.list_groups(query_params={"q": self.group.name}))[0]
         self.group.id = okta_group.id
         db.session.add(self.group)
-        db.session.commit()
+        await db.session.commit()
 
         # If this is an app group, add any app tags
         if type(self.group) is AppGroup:
-            app_tag_maps = db.session.scalars(
-                select(AppTagMap)
-                .where(AppTagMap.app_id == self.group.app_id)
-                .where(
-                    or_(
-                        AppTagMap.ended_at.is_(None),
-                        AppTagMap.ended_at > func.now(),
+            app_tag_maps = (
+                await db.session.scalars(
+                    select(AppTagMap)
+                    .where(AppTagMap.app_id == self.group.app_id)
+                    .where(
+                        or_(
+                            AppTagMap.ended_at.is_(None),
+                            AppTagMap.ended_at > func.now(),
+                        )
                     )
                 )
             ).all()
@@ -92,7 +100,7 @@ class CreateGroup:
                         app_tag_map_id=app_tag_map.id,
                     )
                 )
-            db.session.commit()
+            await db.session.commit()
 
         # Add direct tags
         if len(self.tags) > 0:
@@ -103,31 +111,36 @@ class CreateGroup:
                         group_id=self.group.id,
                     )
                 )
-            db.session.commit()
+            await db.session.commit()
 
         # Invoke app group lifecycle plugin hook, if configured
         plugin_id = get_app_group_lifecycle_plugin_to_invoke(self.group)
         if plugin_id is not None:
             try:
                 hook = get_app_group_lifecycle_hook()
-                hook.group_created(session=db.session, group=self.group, plugin_id=plugin_id)
-                db.session.commit()
+                # sync plugin hook: session-bound, runs on the greenlet bridge
+                await db.session.run_sync(
+                    lambda s: hook.group_created(session=s, group=self.group, plugin_id=plugin_id)
+                )
+                await db.session.commit()
             except Exception:
                 logging.getLogger("api").exception(
                     f"Failed to invoke group_created hook for group {self.group.id} with plugin '{plugin_id}'"
                 )
-                db.session.rollback()
+                await db.session.rollback()
 
         # Audit logging
         email = None
         if self.current_user_id is not None:
-            email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
+            email = getattr(await db.session.get(OktaUser, self.current_user_id), "email", None)
 
-        group = db.session.scalars(
-            select(OktaGroup)
-            .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
-            .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == self.group.id)
+        group = (
+            await db.session.scalars(
+                select(OktaGroup)
+                .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
+                .where(OktaGroup.deleted_at.is_(None))
+                .where(OktaGroup.id == self.group.id)
+            )
         ).first()
 
         _ctx = get_request_context()

--- a/api/operations/create_group.py
+++ b/api/operations/create_group.py
@@ -27,17 +27,24 @@ class CreateGroup:
         else:
             self.group = group
 
-        self.tags = db.session.scalars(select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(tags))).all()
+        self._tags_arg = tags
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
+        self.tags = db.session.scalars(
+            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_arg))
+        ).all()
 
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self, *, _group: Optional[T] = None) -> T:
+        self._resolve()
         # Do not allow non-deleted groups with the same name (case-insensitive)
         existing_group = db.session.scalars(
             select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))

--- a/api/operations/create_group_request.py
+++ b/api/operations/create_group_request.py
@@ -1,9 +1,12 @@
+import functools
 import random
 import string
 from datetime import datetime
 from typing import List, Optional
 
 import logging
+
+import anyio.to_thread
 
 from api.context import get_request_context
 from sqlalchemy import select
@@ -54,15 +57,15 @@ class CreateGroupRequest:
         self.conditional_access_hook = get_conditional_access_hook()
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         requester_user = self._requester_user_arg
         if isinstance(requester_user, str):
-            self.requester = db.session.get(OktaUser, requester_user)
+            self.requester = await db.session.get(OktaUser, requester_user)
         else:
             self.requester = requester_user
 
-    def execute(self) -> Optional[GroupRequest]:
-        self._resolve()
+    async def execute(self) -> Optional[GroupRequest]:
+        await self._resolve()
         # Don't allow creating groups with -Owners suffix (reserved for app owner groups)
         if self.requested_group_name.endswith(f"-{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"):
             return None
@@ -89,10 +92,12 @@ class CreateGroupRequest:
         # Validate app exists if app_id provided and desired group name prefix is correct
         app = None
         if self.requested_app_id is not None:
-            app = db.session.scalars(
-                select(App).where(
-                    App.id == self.requested_app_id,
-                    App.deleted_at.is_(None),
+            app = (
+                await db.session.scalars(
+                    select(App).where(
+                        App.id == self.requested_app_id,
+                        App.deleted_at.is_(None),
+                    )
                 )
             ).first()
 
@@ -104,8 +109,10 @@ class CreateGroupRequest:
         # Validate tags exist and load them
         tags = []
         if self.requested_group_tags:
-            tags = db.session.scalars(
-                select(Tag).where(Tag.id.in_(self.requested_group_tags)).where(Tag.deleted_at.is_(None))
+            tags = (
+                await db.session.scalars(
+                    select(Tag).where(Tag.id.in_(self.requested_group_tags)).where(Tag.deleted_at.is_(None))
+                )
             ).all()
             if len(tags) != len(self.requested_group_tags):
                 return None
@@ -133,15 +140,15 @@ class CreateGroupRequest:
         )
 
         db.session.add(group_request)
-        db.session.commit()
+        await db.session.commit()
 
         # If the requested group is an app group and the requester is the app owner, approve the request
         if self.requested_group_type == "app_group" and app is not None:
             # Get app owners by checking active owner app groups
-            app_owner_user_ids = {u.id for u in get_app_managers(app.id)}
+            app_owner_user_ids = {u.id for u in await get_app_managers(app.id)}
 
             if self.requester.id in app_owner_user_ids:
-                ApproveGroupRequest(
+                await ApproveGroupRequest(
                     group_request=group_request,
                     approver_user=self.requester,
                     approval_reason="Requester owns parent app and can create app groups",
@@ -153,9 +160,9 @@ class CreateGroupRequest:
         # Fetch the users to notify
         # If app group, notify app managers; otherwise notify access owners
         if self.requested_app_id is not None:
-            approvers = get_app_managers(self.requested_app_id)
+            approvers = await get_app_managers(self.requested_app_id)
         else:
-            approvers = get_access_owners()
+            approvers = await get_access_owners()
 
         # Audit logging
         _ctx = get_request_context()
@@ -184,22 +191,26 @@ class CreateGroupRequest:
             )
         )
 
-        # Check conditional access hook
-        conditional_access_responses = self.conditional_access_hook.group_request_created(
-            group_request=group_request,
-            requester=self.requester,
+        # Check conditional access hook. Sync plugin hooks may do network I/O;
+        # run them on a worker thread so they don't block the event loop.
+        conditional_access_responses = await anyio.to_thread.run_sync(
+            functools.partial(
+                self.conditional_access_hook.group_request_created,
+                group_request=group_request,
+                requester=self.requester,
+            )
         )
 
         for response in conditional_access_responses:
             if response is not None:
                 if response.approved:
-                    ApproveGroupRequest(
+                    await ApproveGroupRequest(
                         group_request=group_request,
                         approval_reason=response.reason,
                         notify=False,
                     ).execute()
                 else:
-                    RejectGroupRequest(
+                    await RejectGroupRequest(
                         group_request=group_request,
                         rejection_reason=response.reason,
                         notify=False,
@@ -208,10 +219,13 @@ class CreateGroupRequest:
                 return group_request
 
         # Send notification to approvers
-        self.notification_hook.access_group_request_created(
-            group_request=group_request,
-            requester=self.requester,
-            approvers=approvers,
+        await anyio.to_thread.run_sync(
+            functools.partial(
+                self.notification_hook.access_group_request_created,
+                group_request=group_request,
+                requester=self.requester,
+                approvers=approvers,
+            )
         )
 
         return group_request

--- a/api/operations/create_group_request.py
+++ b/api/operations/create_group_request.py
@@ -41,10 +41,7 @@ class CreateGroupRequest:
     ):
         self.id = self.__generate_id()
 
-        if isinstance(requester_user, str):
-            self.requester = db.session.get(OktaUser, requester_user)
-        else:
-            self.requester = requester_user
+        self._requester_user_arg = requester_user
 
         self.requested_group_name = requested_group_name
         self.requested_group_description = requested_group_description
@@ -57,7 +54,15 @@ class CreateGroupRequest:
         self.conditional_access_hook = get_conditional_access_hook()
         self.notification_hook = get_notification_hook()
 
+    def _resolve(self) -> None:
+        requester_user = self._requester_user_arg
+        if isinstance(requester_user, str):
+            self.requester = db.session.get(OktaUser, requester_user)
+        else:
+            self.requester = requester_user
+
     def execute(self) -> Optional[GroupRequest]:
+        self._resolve()
         # Don't allow creating groups with -Owners suffix (reserved for app owner groups)
         if self.requested_group_name.endswith(f"-{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"):
             return None

--- a/api/operations/create_role_request.py
+++ b/api/operations/create_role_request.py
@@ -43,6 +43,22 @@ class CreateRoleRequest:
     ):
         self.id = self.__generate_id()
 
+        self._requester_user_arg = requester_user
+        self._requester_role_arg = requester_role
+        self._requested_group_arg = requested_group
+
+        self.request_ownership = request_ownership
+        self.request_reason = request_reason
+        self.request_ending_at = request_ending_at
+
+        self.conditional_access_hook = get_conditional_access_hook()
+        self.notification_hook = get_notification_hook()
+
+    def _resolve(self) -> None:
+        requester_user = self._requester_user_arg
+        requester_role = self._requester_role_arg
+        requested_group = self._requested_group_arg
+
         if isinstance(requester_user, str):
             self.requester = db.session.get(OktaUser, requester_user)
         else:
@@ -73,14 +89,8 @@ class CreateRoleRequest:
             .where(OktaGroup.id == (requested_group if isinstance(requested_group, str) else requested_group.id))
         ).first()
 
-        self.request_ownership = request_ownership
-        self.request_reason = request_reason
-        self.request_ending_at = request_ending_at
-
-        self.conditional_access_hook = get_conditional_access_hook()
-        self.notification_hook = get_notification_hook()
-
     def execute(self) -> Optional[RoleRequest]:
+        self._resolve()
         # Don't allow creating a request for an unmanaged group
         if not self.requested_group.is_managed:
             return None

--- a/api/operations/create_role_request.py
+++ b/api/operations/create_role_request.py
@@ -1,3 +1,4 @@
+import functools
 import random
 import string
 from datetime import datetime
@@ -5,6 +6,7 @@ from typing import Optional
 
 import logging
 
+import anyio.to_thread
 from sqlalchemy import func, or_, select
 from api.context import get_request_context
 from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload
@@ -54,20 +56,21 @@ class CreateRoleRequest:
         self.conditional_access_hook = get_conditional_access_hook()
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         requester_user = self._requester_user_arg
         requester_role = self._requester_role_arg
         requested_group = self._requested_group_arg
 
         if isinstance(requester_user, str):
-            self.requester = db.session.get(OktaUser, requester_user)
+            self.requester = await db.session.get(OktaUser, requester_user)
         else:
             self.requester = requester_user
 
         if isinstance(requester_role, str):
-            self.requester_role = db.session.scalars(
+            role_result = await db.session.scalars(
                 select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == requester_role)
-            ).first()
+            )
+            self.requester_role = role_result.first()
             # self.requester_role = (
             #     db.session.query(RoleGroup)
             #     .options(joinedload(OktaUserGroupMember.user))
@@ -78,19 +81,21 @@ class CreateRoleRequest:
         else:
             self.requester_role = requester_role
 
-        self.requested_group = db.session.scalars(
-            select(OktaGroup)
-            .options(
-                selectin_polymorphic(OktaGroup, [AppGroup]),
-                joinedload(AppGroup.app),
-                selectinload(OktaGroup.active_group_tags).options(joinedload(OktaGroupTagMap.active_tag)),
+        self.requested_group = (
+            await db.session.scalars(
+                select(OktaGroup)
+                .options(
+                    selectin_polymorphic(OktaGroup, [AppGroup]),
+                    joinedload(AppGroup.app),
+                    selectinload(OktaGroup.active_group_tags).options(joinedload(OktaGroupTagMap.active_tag)),
+                )
+                .where(OktaGroup.deleted_at.is_(None))
+                .where(OktaGroup.id == (requested_group if isinstance(requested_group, str) else requested_group.id))
             )
-            .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == (requested_group if isinstance(requested_group, str) else requested_group.id))
         ).first()
 
-    def execute(self) -> Optional[RoleRequest]:
-        self._resolve()
+    async def execute(self) -> Optional[RoleRequest]:
+        await self._resolve()
         # Don't allow creating a request for an unmanaged group
         if not self.requested_group.is_managed:
             return None
@@ -111,23 +116,25 @@ class CreateRoleRequest:
         )
 
         db.session.add(role_request)
-        db.session.commit()
+        await db.session.commit()
 
         # Fetch the users to notify
-        approvers = get_group_managers(self.requested_group.id)
+        approvers = await get_group_managers(self.requested_group.id)
 
         requested_group_tags = [tm.active_tag for tm in self.requested_group.active_group_tags]
 
         role_memberships = [
             u.user_id
-            for u in db.session.scalars(
-                select(OktaUserGroupMember)
-                .where(OktaUserGroupMember.group_id == self.requester_role.id)
-                .where(OktaUserGroupMember.is_owner.is_(False))
-                .where(
-                    or_(
-                        OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > func.now(),
+            for u in (
+                await db.session.scalars(
+                    select(OktaUserGroupMember)
+                    .where(OktaUserGroupMember.group_id == self.requester_role.id)
+                    .where(OktaUserGroupMember.is_owner.is_(False))
+                    .where(
+                        or_(
+                            OktaUserGroupMember.ended_at.is_(None),
+                            OktaUserGroupMember.ended_at > func.now(),
+                        )
                     )
                 )
             ).all()
@@ -156,23 +163,26 @@ class CreateRoleRequest:
             or (len(approvers) == 1 and approvers[0].id == self.requester.id)
             and type(self.requested_group) is AppGroup
         ):
-            approvers = get_app_managers(self.requested_group.app_id)
+            approvers = await get_app_managers(self.requested_group.app_id)
 
         # If there are still no approvers, try to get the access owners
         if len(approvers) == 0 or (len(approvers) == 1 and approvers[0].id == self.requester.id):
-            approvers = get_access_owners()
+            approvers = await get_access_owners()
 
-        group = db.session.scalars(
-            select(OktaGroup)
-            .options(
-                selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
-                joinedload(AppGroup.app),
-                selectinload(OktaGroup.active_group_tags).options(
-                    joinedload(OktaGroupTagMap.active_app_tag_mapping), joinedload(OktaGroupTagMap.enabled_active_tag)
-                ),
+        group = (
+            await db.session.scalars(
+                select(OktaGroup)
+                .options(
+                    selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
+                    joinedload(AppGroup.app),
+                    selectinload(OktaGroup.active_group_tags).options(
+                        joinedload(OktaGroupTagMap.active_app_tag_mapping),
+                        joinedload(OktaGroupTagMap.enabled_active_tag),
+                    ),
+                )
+                .where(OktaGroup.deleted_at.is_(None))
+                .where(OktaGroup.id == self.requested_group.id)
             )
-            .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == self.requested_group.id)
         ).first()
 
         # Audit logging
@@ -194,26 +204,31 @@ class CreateRoleRequest:
             )
         )
 
-        conditional_access_responses = self.conditional_access_hook.role_request_created(
-            role_request=role_request,
-            role=self.requester_role,
-            group=self.requested_group,
-            group_tags=[active_tag_map.enabled_active_tag for active_tag_map in group.active_group_tags],
-            requester=self.requester,
-            requester_role=self.requester_role,
+        # Sync plugin hooks may do network I/O; run them on a worker thread so
+        # they don't block the event loop.
+        conditional_access_responses = await anyio.to_thread.run_sync(
+            functools.partial(
+                self.conditional_access_hook.role_request_created,
+                role_request=role_request,
+                role=self.requester_role,
+                group=self.requested_group,
+                group_tags=[active_tag_map.enabled_active_tag for active_tag_map in group.active_group_tags],
+                requester=self.requester,
+                requester_role=self.requester_role,
+            )
         )
 
         for response in conditional_access_responses:
             if response is not None:
                 if response.approved:
-                    ApproveRoleRequest(
+                    await ApproveRoleRequest(
                         role_request=role_request,
                         approval_reason=response.reason,
                         ending_at=response.ending_at,
                         notify=False,
                     ).execute()
                 else:
-                    RejectRoleRequest(
+                    await RejectRoleRequest(
                         role_request=role_request,
                         rejection_reason=response.reason,
                         notify=False,
@@ -221,12 +236,15 @@ class CreateRoleRequest:
 
                 return role_request
 
-        self.notification_hook.access_role_request_created(
-            role_request=role_request,
-            role=self.requester_role,
-            group=self.requested_group,
-            requester=self.requester,
-            approvers=approvers,
+        await anyio.to_thread.run_sync(
+            functools.partial(
+                self.notification_hook.access_role_request_created,
+                role_request=role_request,
+                role=self.requester_role,
+                group=self.requested_group,
+                requester=self.requester,
+                approvers=approvers,
+            )
         )
 
         return role_request

--- a/api/operations/create_tag.py
+++ b/api/operations/create_tag.py
@@ -27,15 +27,19 @@ class CreateTag:
             tag.id = id
             self.tag = tag
 
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self) -> Tag:
+        self._resolve()
         # Do not allow non-deleted groups with the same name (case-insensitive)
         existing_tag = db.session.scalars(
             select(Tag).where(func.lower(Tag.name) == func.lower(self.tag.name)).where(Tag.deleted_at.is_(None))

--- a/api/operations/create_tag.py
+++ b/api/operations/create_tag.py
@@ -29,31 +29,37 @@ class CreateTag:
 
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         self.current_user_id = getattr(
-            db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+            (
+                await db.session.scalars(
+                    select(OktaUser)
+                    .where(OktaUser.deleted_at.is_(None))
+                    .where(OktaUser.id == self._current_user_id_arg)
+                )
             ).first(),
             "id",
             None,
         )
 
-    def execute(self) -> Tag:
-        self._resolve()
+    async def execute(self) -> Tag:
+        await self._resolve()
         # Do not allow non-deleted groups with the same name (case-insensitive)
-        existing_tag = db.session.scalars(
-            select(Tag).where(func.lower(Tag.name) == func.lower(self.tag.name)).where(Tag.deleted_at.is_(None))
+        existing_tag = (
+            await db.session.scalars(
+                select(Tag).where(func.lower(Tag.name) == func.lower(self.tag.name)).where(Tag.deleted_at.is_(None))
+            )
         ).first()
         if existing_tag is not None:
             return existing_tag
 
         db.session.add(self.tag)
-        db.session.commit()
+        await db.session.commit()
 
         # Audit logging
         email = None
         if self.current_user_id is not None:
-            email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
+            email = getattr(await db.session.get(OktaUser, self.current_user_id), "email", None)
 
         _ctx = get_request_context()
 

--- a/api/operations/delete_app.py
+++ b/api/operations/delete_app.py
@@ -13,6 +13,11 @@ from api.schemas import AuditLogSchema, EventType
 
 class DeleteApp:
     def __init__(self, *, app: App | str, current_user_id: Optional[str] = None):
+        self._app_arg = app
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
+        app = self._app_arg
         if isinstance(app, str):
             self.app = db.session.scalars(select(App).where(App.deleted_at.is_(None)).where(App.id == app)).first()
         else:
@@ -20,13 +25,14 @@ class DeleteApp:
 
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self) -> None:
+        self._resolve()
         # Prevent access app deletion
         if self.app.name == App.ACCESS_APP_RESERVED_NAME:
             raise ValueError("The Access Application cannot be deleted")

--- a/api/operations/delete_app.py
+++ b/api/operations/delete_app.py
@@ -16,23 +16,28 @@ class DeleteApp:
         self._app_arg = app
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         app = self._app_arg
         if isinstance(app, str):
-            self.app = db.session.scalars(select(App).where(App.deleted_at.is_(None)).where(App.id == app)).first()
+            app_result = await db.session.scalars(select(App).where(App.deleted_at.is_(None)).where(App.id == app))
+            self.app = app_result.first()
         else:
             self.app = app
 
         self.current_user_id = getattr(
-            db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+            (
+                await db.session.scalars(
+                    select(OktaUser)
+                    .where(OktaUser.deleted_at.is_(None))
+                    .where(OktaUser.id == self._current_user_id_arg)
+                )
             ).first(),
             "id",
             None,
         )
 
-    def execute(self) -> None:
-        self._resolve()
+    async def execute(self) -> None:
+        await self._resolve()
         # Prevent access app deletion
         if self.app.name == App.ACCESS_APP_RESERVED_NAME:
             raise ValueError("The Access Application cannot be deleted")
@@ -40,7 +45,7 @@ class DeleteApp:
         # Audit logging
         email = None
         if self.current_user_id is not None:
-            email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
+            email = getattr(await db.session.get(OktaUser, self.current_user_id), "email", None)
 
         _ctx = get_request_context()
 
@@ -58,18 +63,20 @@ class DeleteApp:
         )
 
         self.app.deleted_at = func.now()
-        db.session.commit()
+        await db.session.commit()
 
         # Delete all associated Okta App Groups and end their membership
-        app_groups = db.session.scalars(
-            select(AppGroup).where(AppGroup.deleted_at.is_(None)).where(AppGroup.app_id == self.app.id)
+        app_groups = (
+            await db.session.scalars(
+                select(AppGroup).where(AppGroup.deleted_at.is_(None)).where(AppGroup.app_id == self.app.id)
+            )
         ).all()
         app_group_ids = [ag.id for ag in app_groups]
         for app_group_id in app_group_ids:
-            DeleteGroup(group=app_group_id, current_user_id=self.current_user_id).execute()
+            await DeleteGroup(group=app_group_id, current_user_id=self.current_user_id).execute()
 
         # End all tag mappings for this app (OktaGroupTagMaps are ended by the DeleteGroup operation above)
-        db.session.execute(
+        await db.session.execute(
             update(AppTagMap)
             .where(AppTagMap.app_id == self.app.id)
             .where(
@@ -81,4 +88,4 @@ class DeleteApp:
             .values({AppTagMap.ended_at: func.now()})
             .execution_options(synchronize_session="fetch")
         )
-        db.session.commit()
+        await db.session.commit()

--- a/api/operations/delete_group.py
+++ b/api/operations/delete_group.py
@@ -30,23 +30,30 @@ from api.schemas import AuditLogSchema, EventType
 
 class DeleteGroup:
     def __init__(self, *, group: OktaGroup | str, sync_to_okta: bool = True, current_user_id: Optional[str] = None):
+        self._group_arg = group
+
+        self.sync_to_okta = sync_to_okta
+
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
+        group = self._group_arg
         self.group = db.session.scalars(
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
             .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
         ).first()
 
-        self.sync_to_okta = sync_to_okta
-
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self) -> None:
+        self._resolve()
         # Run asychronously to parallelize Okta API requests
         asyncio.run(self._execute())
 

--- a/api/operations/delete_group.py
+++ b/api/operations/delete_group.py
@@ -8,6 +8,7 @@ from api.context import get_request_context
 from sqlalchemy.orm import joinedload, selectin_polymorphic
 
 from api.extensions import db
+from api.operations._fan_out import drain_fan_out_tasks
 from api.models import (
     AccessRequest,
     AccessRequestStatus,
@@ -329,5 +330,4 @@ class DeleteGroup:
                 )
                 await db.session.rollback()
 
-        if len(okta_tasks) > 0:
-            await asyncio.wait(okta_tasks)
+        await drain_fan_out_tasks(okta_tasks, f"DeleteGroup for group {self.group.id}")

--- a/api/operations/delete_group.py
+++ b/api/operations/delete_group.py
@@ -36,35 +36,37 @@ class DeleteGroup:
 
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         group = self._group_arg
-        self.group = db.session.scalars(
-            select(OktaGroup)
-            .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
-            .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+        self.group = (
+            await db.session.scalars(
+                select(OktaGroup)
+                .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
+                .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+            )
         ).first()
 
         self.current_user_id = getattr(
-            db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+            (
+                await db.session.scalars(
+                    select(OktaUser)
+                    .where(OktaUser.deleted_at.is_(None))
+                    .where(OktaUser.id == self._current_user_id_arg)
+                )
             ).first(),
             "id",
             None,
         )
 
-    def execute(self) -> None:
-        self._resolve()
-        # Run asychronously to parallelize Okta API requests
-        asyncio.run(self._execute())
-
-    async def _execute(self) -> None:
+    async def execute(self) -> None:
+        await self._resolve()
         # Create a list of okta asyncio tasks to wait to completion on at the end of this function
         okta_tasks = []
 
         # Prevent deletion of the Access owner group
         if type(self.group) is AppGroup and self.group.is_owner:
-            app = db.session.scalars(
-                select(App).where(App.id == self.group.app_id).where(App.deleted_at.is_(None))
+            app = (
+                await db.session.scalars(select(App).where(App.id == self.group.app_id).where(App.deleted_at.is_(None)))
             ).first()
             if app is not None and app.name == App.ACCESS_APP_RESERVED_NAME:
                 raise ValueError("Access application owner group cannot be deleted")
@@ -72,7 +74,7 @@ class DeleteGroup:
         # Audit logging
         email = None
         if self.current_user_id is not None:
-            email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
+            email = getattr(await db.session.get(OktaUser, self.current_user_id), "email", None)
 
         _ctx = get_request_context()
 
@@ -90,7 +92,7 @@ class DeleteGroup:
         )
 
         if self.sync_to_okta:
-            okta_tasks.append(asyncio.create_task(okta.async_delete_group(self.group.id)))
+            okta_tasks.append(asyncio.create_task(okta.delete_group(self.group.id)))
 
         self.group.deleted_at = func.now()
 
@@ -108,22 +110,26 @@ class DeleteGroup:
 
         direct_members_to_remove_ids = [
             m.user_id
-            for m in db.session.scalars(
-                group_memberships_query.where(OktaUserGroupMember.is_owner.is_(False)).where(
-                    OktaUserGroupMember.role_group_map_id.is_(None)
+            for m in (
+                await db.session.scalars(
+                    group_memberships_query.where(OktaUserGroupMember.is_owner.is_(False)).where(
+                        OktaUserGroupMember.role_group_map_id.is_(None)
+                    )
                 )
             ).all()
         ]
         direct_owners_to_remove_ids = [
             m.user_id
-            for m in db.session.scalars(
-                group_memberships_query.where(OktaUserGroupMember.is_owner.is_(True)).where(
-                    OktaUserGroupMember.role_group_map_id.is_(None)
+            for m in (
+                await db.session.scalars(
+                    group_memberships_query.where(OktaUserGroupMember.is_owner.is_(True)).where(
+                        OktaUserGroupMember.role_group_map_id.is_(None)
+                    )
                 )
             ).all()
         ]
 
-        db.session.execute(
+        await db.session.execute(
             update(OktaUserGroupMember)
             .where(
                 or_(
@@ -137,7 +143,7 @@ class DeleteGroup:
         )
 
         # End all roles associations where this group was a member
-        db.session.execute(
+        await db.session.execute(
             update(RoleGroupMap)
             .where(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
             .where(RoleGroupMap.group_id == self.group.id)
@@ -147,7 +153,7 @@ class DeleteGroup:
 
         if type(self.group) is RoleGroup:
             # End all group memberships via the role grant
-            db.session.execute(
+            await db.session.execute(
                 update(OktaUserGroupMember)
                 .where(
                     or_(
@@ -181,26 +187,32 @@ class DeleteGroup:
             )
 
             if self.sync_to_okta:
-                role_associated_groups_mappings = db.session.scalars(role_associated_groups_mappings_query).all()
+                role_associated_groups_mappings = (
+                    await db.session.scalars(role_associated_groups_mappings_query)
+                ).all()
 
-                removed_role_group_users_with_other_access = db.session.execute(
-                    select(
-                        OktaUserGroupMember.user_id,
-                        OktaUserGroupMember.group_id,
-                        OktaUserGroupMember.is_owner,
-                    )
-                    .where(
-                        or_(
-                            OktaUserGroupMember.ended_at.is_(None),
-                            OktaUserGroupMember.ended_at > func.now(),
+                removed_role_group_users_with_other_access = (
+                    await db.session.execute(
+                        select(
+                            OktaUserGroupMember.user_id,
+                            OktaUserGroupMember.group_id,
+                            OktaUserGroupMember.is_owner,
                         )
-                    )
-                    .where(OktaUserGroupMember.user_id.in_(direct_members_to_remove_ids + direct_owners_to_remove_ids))
-                    .where(OktaUserGroupMember.group_id.in_([r.group_id for r in role_associated_groups_mappings]))
-                    .group_by(
-                        OktaUserGroupMember.user_id,
-                        OktaUserGroupMember.group_id,
-                        OktaUserGroupMember.is_owner,
+                        .where(
+                            or_(
+                                OktaUserGroupMember.ended_at.is_(None),
+                                OktaUserGroupMember.ended_at > func.now(),
+                            )
+                        )
+                        .where(
+                            OktaUserGroupMember.user_id.in_(direct_members_to_remove_ids + direct_owners_to_remove_ids)
+                        )
+                        .where(OktaUserGroupMember.group_id.in_([r.group_id for r in role_associated_groups_mappings]))
+                        .group_by(
+                            OktaUserGroupMember.user_id,
+                            OktaUserGroupMember.group_id,
+                            OktaUserGroupMember.is_owner,
+                        )
                     )
                 ).all()
 
@@ -217,7 +229,7 @@ class DeleteGroup:
                         for member_id in okta_members_to_remove_ids:
                             okta_tasks.append(
                                 asyncio.create_task(
-                                    okta.async_remove_user_from_group(role_associated_group_map.group_id, member_id)
+                                    okta.remove_user_from_group(role_associated_group_map.group_id, member_id)
                                 )
                             )
                     else:
@@ -234,12 +246,12 @@ class DeleteGroup:
                             # https://help.okta.com/en-us/Content/Topics/identity-governance/group-owner.htm
                             okta_tasks.append(
                                 asyncio.create_task(
-                                    okta.async_remove_owner_from_group(role_associated_group_map.group_id, owner_id)
+                                    okta.remove_owner_from_group(role_associated_group_map.group_id, owner_id)
                                 )
                             )
 
             # End all group attachments to this role
-            db.session.execute(
+            await db.session.execute(
                 update(RoleGroupMap)
                 .where(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
                 .where(RoleGroupMap.role_group_id == self.group.id)
@@ -247,17 +259,19 @@ class DeleteGroup:
                 .execution_options(synchronize_session="fetch")
             )
 
-        db.session.commit()
+        await db.session.commit()
 
         # Reject all pending access requests for this group
-        obsolete_access_requests = db.session.scalars(
-            select(AccessRequest)
-            .where(AccessRequest.requested_group_id == self.group.id)
-            .where(AccessRequest.status == AccessRequestStatus.PENDING)
-            .where(AccessRequest.resolved_at.is_(None))
+        obsolete_access_requests = (
+            await db.session.scalars(
+                select(AccessRequest)
+                .where(AccessRequest.requested_group_id == self.group.id)
+                .where(AccessRequest.status == AccessRequestStatus.PENDING)
+                .where(AccessRequest.resolved_at.is_(None))
+            )
         ).all()
         for obsolete_access_request in obsolete_access_requests:
-            RejectAccessRequest(
+            await RejectAccessRequest(
                 access_request=obsolete_access_request,
                 rejection_reason="Closed because the requested group was deleted",
                 current_user_id=self.current_user_id,
@@ -265,26 +279,28 @@ class DeleteGroup:
 
         # Reject all pending role requests touching this group, either as the
         # requested target or as the requester role.
-        obsolete_role_requests = db.session.scalars(
-            select(RoleRequest)
-            .where(
-                or_(
-                    RoleRequest.requested_group_id == self.group.id,
-                    RoleRequest.requester_role_id == self.group.id,
+        obsolete_role_requests = (
+            await db.session.scalars(
+                select(RoleRequest)
+                .where(
+                    or_(
+                        RoleRequest.requested_group_id == self.group.id,
+                        RoleRequest.requester_role_id == self.group.id,
+                    )
                 )
+                .where(RoleRequest.status == AccessRequestStatus.PENDING)
+                .where(RoleRequest.resolved_at.is_(None))
             )
-            .where(RoleRequest.status == AccessRequestStatus.PENDING)
-            .where(RoleRequest.resolved_at.is_(None))
         ).all()
         for obsolete_role_request in obsolete_role_requests:
-            RejectRoleRequest(
+            await RejectRoleRequest(
                 role_request=obsolete_role_request,
                 rejection_reason="Closed because a group in this role request was deleted",
                 current_user_id=self.current_user_id,
             ).execute()
 
         # End all tag mappings for this group
-        db.session.execute(
+        await db.session.execute(
             update(OktaGroupTagMap)
             .where(
                 or_(
@@ -298,7 +314,7 @@ class DeleteGroup:
             .values({OktaGroupTagMap.ended_at: func.now()})
             .execution_options(synchronize_session="fetch")
         )
-        db.session.commit()
+        await db.session.commit()
 
         # Invoke app group lifecycle plugin hook, if configured
         plugin_id = get_app_group_lifecycle_plugin_to_invoke(self.group)
@@ -306,12 +322,12 @@ class DeleteGroup:
             try:
                 hook = get_app_group_lifecycle_hook()
                 hook.group_deleted(session=db.session, group=self.group, plugin_id=plugin_id)
-                db.session.commit()
+                await db.session.commit()
             except Exception:
                 logging.getLogger("api").exception(
                     f"Failed to invoke group_deleted hook for group {self.group.id} with plugin '{plugin_id}'"
                 )
-                db.session.rollback()
+                await db.session.rollback()
 
         if len(okta_tasks) > 0:
             await asyncio.wait(okta_tasks)

--- a/api/operations/delete_tag.py
+++ b/api/operations/delete_tag.py
@@ -12,16 +12,22 @@ from api.schemas import AuditLogSchema, EventType
 
 class DeleteTag:
     def __init__(self, *, tag: Tag | str, current_user_id: Optional[str] = None):
+        self._tag_arg = tag
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
+        tag = self._tag_arg
         self.tag = db.session.scalars(select(Tag).where(Tag.id == (tag if isinstance(tag, str) else tag.id))).first()
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self) -> None:
+        self._resolve()
         # Audit logging
         email = None
         if self.current_user_id is not None:

--- a/api/operations/delete_tag.py
+++ b/api/operations/delete_tag.py
@@ -15,23 +15,28 @@ class DeleteTag:
         self._tag_arg = tag
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         tag = self._tag_arg
-        self.tag = db.session.scalars(select(Tag).where(Tag.id == (tag if isinstance(tag, str) else tag.id))).first()
+        tag_result = await db.session.scalars(select(Tag).where(Tag.id == (tag if isinstance(tag, str) else tag.id)))
+        self.tag = tag_result.first()
         self.current_user_id = getattr(
-            db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+            (
+                await db.session.scalars(
+                    select(OktaUser)
+                    .where(OktaUser.deleted_at.is_(None))
+                    .where(OktaUser.id == self._current_user_id_arg)
+                )
             ).first(),
             "id",
             None,
         )
 
-    def execute(self) -> None:
-        self._resolve()
+    async def execute(self) -> None:
+        await self._resolve()
         # Audit logging
         email = None
         if self.current_user_id is not None:
-            email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
+            email = getattr(await db.session.get(OktaUser, self.current_user_id), "email", None)
 
         _ctx = get_request_context()
 
@@ -53,7 +58,7 @@ class DeleteTag:
         self.tag.deleted_at = func.now()
 
         # End all active group tag mappings for tag
-        db.session.execute(
+        await db.session.execute(
             update(OktaGroupTagMap)
             .where(
                 or_(
@@ -67,7 +72,7 @@ class DeleteTag:
         )
 
         # End all active app tag mappings for tag
-        db.session.execute(
+        await db.session.execute(
             update(AppTagMap)
             .where(
                 or_(
@@ -80,4 +85,4 @@ class DeleteTag:
             .execution_options(synchronize_session="fetch")
         )
 
-        db.session.commit()
+        await db.session.commit()

--- a/api/operations/delete_user.py
+++ b/api/operations/delete_user.py
@@ -14,22 +14,29 @@ from api.services import okta
 
 class DeleteUser:
     def __init__(self, *, user: OktaUser | str, sync_to_okta: bool = True, current_user_id: Optional[str] = None):
+        self._user_arg = user
+
+        self.sync_to_okta = sync_to_okta
+
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
+        user = self._user_arg
         if isinstance(user, str):
             self.user = db.session.scalars(select(OktaUser).where(OktaUser.id == user)).first()
         else:
             self.user = user
 
-        self.sync_to_okta = sync_to_okta
-
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self) -> None:
+        self._resolve()
         # Run asychronously to parallelize Okta API requests
         return asyncio.run(self._execute())
 

--- a/api/operations/delete_user.py
+++ b/api/operations/delete_user.py
@@ -20,27 +20,27 @@ class DeleteUser:
 
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         user = self._user_arg
         if isinstance(user, str):
-            self.user = db.session.scalars(select(OktaUser).where(OktaUser.id == user)).first()
+            self.user = (await db.session.scalars(select(OktaUser).where(OktaUser.id == user))).first()
         else:
             self.user = user
 
         self.current_user_id = getattr(
-            db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+            (
+                await db.session.scalars(
+                    select(OktaUser)
+                    .where(OktaUser.deleted_at.is_(None))
+                    .where(OktaUser.id == self._current_user_id_arg)
+                )
             ).first(),
             "id",
             None,
         )
 
-    def execute(self) -> None:
-        self._resolve()
-        # Run asychronously to parallelize Okta API requests
-        return asyncio.run(self._execute())
-
-    async def _execute(self) -> None:
+    async def execute(self) -> None:
+        await self._resolve()
         # Create a list of okta asyncio tasks to wait to completion on at the end of this function
         okta_tasks = []
 
@@ -69,26 +69,26 @@ class DeleteUser:
             # Remove user from group membership in Okta
             group_memberships_to_remove_ids = [
                 m.group_id
-                for m in db.session.scalars(
-                    managed_group_access_query.where(OktaUserGroupMember.is_owner.is_(False))
+                for m in (
+                    await db.session.scalars(managed_group_access_query.where(OktaUserGroupMember.is_owner.is_(False)))
                 ).all()
             ]
 
             for group_id in group_memberships_to_remove_ids:
-                okta_tasks.append(asyncio.create_task(okta.async_remove_user_from_group(group_id, self.user.id)))
+                okta_tasks.append(asyncio.create_task(okta.remove_user_from_group(group_id, self.user.id)))
 
             # Remove user from group ownerships in Okta
             group_ownerships_to_remove_ids = [
                 m.group_id
-                for m in db.session.scalars(
-                    managed_group_access_query.where(OktaUserGroupMember.is_owner.is_(True))
+                for m in (
+                    await db.session.scalars(managed_group_access_query.where(OktaUserGroupMember.is_owner.is_(True)))
                 ).all()
             ]
 
             for group_id in group_ownerships_to_remove_ids:
-                okta_tasks.append(asyncio.create_task(okta.async_remove_owner_from_group(group_id, self.user.id)))
+                okta_tasks.append(asyncio.create_task(okta.remove_owner_from_group(group_id, self.user.id)))
 
-        db.session.execute(
+        await db.session.execute(
             update(OktaUserGroupMember)
             .where(
                 or_(
@@ -101,16 +101,18 @@ class DeleteUser:
             .execution_options(synchronize_session="fetch")
         )
 
-        db.session.commit()
+        await db.session.commit()
 
-        obsolete_access_requests = db.session.scalars(
-            select(AccessRequest)
-            .where(AccessRequest.requester_user_id == self.user.id)
-            .where(AccessRequest.status == AccessRequestStatus.PENDING)
-            .where(AccessRequest.resolved_at.is_(None))
+        obsolete_access_requests = (
+            await db.session.scalars(
+                select(AccessRequest)
+                .where(AccessRequest.requester_user_id == self.user.id)
+                .where(AccessRequest.status == AccessRequestStatus.PENDING)
+                .where(AccessRequest.resolved_at.is_(None))
+            )
         ).all()
         for obsolete_access_request in obsolete_access_requests:
-            RejectAccessRequest(
+            await RejectAccessRequest(
                 access_request=obsolete_access_request,
                 rejection_reason="Closed because the requestor was deleted",
                 current_user_id=self.current_user_id,

--- a/api/operations/delete_user.py
+++ b/api/operations/delete_user.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import (
 
 from sqlalchemy import func, or_, select, update
 from api.extensions import db
+from api.operations._fan_out import drain_fan_out_tasks
 from api.models import AccessRequest, AccessRequestStatus, OktaGroup, OktaUser, OktaUserGroupMember
 from api.operations import RejectAccessRequest
 from api.services import okta
@@ -118,5 +119,4 @@ class DeleteUser:
                 current_user_id=self.current_user_id,
             ).execute()
 
-        if len(okta_tasks) > 0:
-            await asyncio.wait(okta_tasks)
+        await drain_fan_out_tasks(okta_tasks, f"DeleteUser for user {self.user.id}")

--- a/api/operations/modify_app_tags.py
+++ b/api/operations/modify_app_tags.py
@@ -20,27 +20,35 @@ class ModifyAppTags:
         tags_to_remove: list[str] = [],
         current_user_id: Optional[str],
     ):
+        self._app_arg = app
+        self._tags_to_add_arg = tags_to_add
+        self._tags_to_remove_arg = tags_to_remove
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
+        app = self._app_arg
         self.app = db.session.scalars(
             select(App).where(App.deleted_at.is_(None)).where(App.id == (app if isinstance(app, str) else app.id))
         ).first()
 
         self.tags_to_add = db.session.scalars(
-            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(tags_to_add))
+            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_add_arg))
         ).all()
 
         self.tags_to_remove = db.session.scalars(
-            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(tags_to_remove))
+            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_remove_arg))
         ).all()
 
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self) -> App:
+        self._resolve()
         if len(self.tags_to_add) > 0:
             # Only add tags that are not already associated with this app
             tag_ids_to_add = [t.id for t in self.tags_to_add]

--- a/api/operations/modify_app_tags.py
+++ b/api/operations/modify_app_tags.py
@@ -25,46 +25,57 @@ class ModifyAppTags:
         self._tags_to_remove_arg = tags_to_remove
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         app = self._app_arg
-        self.app = db.session.scalars(
+        app_result = await db.session.scalars(
             select(App).where(App.deleted_at.is_(None)).where(App.id == (app if isinstance(app, str) else app.id))
-        ).first()
+        )
+        self.app = app_result.first()
 
-        self.tags_to_add = db.session.scalars(
-            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_add_arg))
+        self.tags_to_add = (
+            await db.session.scalars(
+                select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_add_arg))
+            )
         ).all()
 
-        self.tags_to_remove = db.session.scalars(
-            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_remove_arg))
+        self.tags_to_remove = (
+            await db.session.scalars(
+                select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_remove_arg))
+            )
         ).all()
 
         self.current_user_id = getattr(
-            db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+            (
+                await db.session.scalars(
+                    select(OktaUser)
+                    .where(OktaUser.deleted_at.is_(None))
+                    .where(OktaUser.id == self._current_user_id_arg)
+                )
             ).first(),
             "id",
             None,
         )
 
-    def execute(self) -> App:
-        self._resolve()
+    async def execute(self) -> App:
+        await self._resolve()
         if len(self.tags_to_add) > 0:
             # Only add tags that are not already associated with this app
             tag_ids_to_add = [t.id for t in self.tags_to_add]
-            existing_tag_maps = db.session.scalars(
-                select(AppTagMap)
-                .where(
-                    or_(
-                        AppTagMap.ended_at.is_(None),
-                        AppTagMap.ended_at > func.now(),
+            existing_tag_maps = (
+                await db.session.scalars(
+                    select(AppTagMap)
+                    .where(
+                        or_(
+                            AppTagMap.ended_at.is_(None),
+                            AppTagMap.ended_at > func.now(),
+                        )
                     )
-                )
-                .where(
-                    AppTagMap.app_id == self.app.id,
-                )
-                .where(
-                    AppTagMap.tag_id.in_(tag_ids_to_add),
+                    .where(
+                        AppTagMap.app_id == self.app.id,
+                    )
+                    .where(
+                        AppTagMap.tag_id.in_(tag_ids_to_add),
+                    )
                 )
             ).all()
 
@@ -77,22 +88,26 @@ class ModifyAppTags:
                         app_id=self.app.id,
                     )
                 )
-            db.session.commit()
+            await db.session.commit()
 
-            new_app_tag_maps = db.session.scalars(
-                select(AppTagMap)
-                .where(AppTagMap.tag_id.in_(new_tag_ids_to_add))
-                .where(AppTagMap.app_id == self.app.id)
-                .where(
-                    or_(
-                        AppTagMap.ended_at.is_(None),
-                        AppTagMap.ended_at > func.now(),
+            new_app_tag_maps = (
+                await db.session.scalars(
+                    select(AppTagMap)
+                    .where(AppTagMap.tag_id.in_(new_tag_ids_to_add))
+                    .where(AppTagMap.app_id == self.app.id)
+                    .where(
+                        or_(
+                            AppTagMap.ended_at.is_(None),
+                            AppTagMap.ended_at > func.now(),
+                        )
                     )
                 )
             ).all()
 
-            all_app_groups = db.session.scalars(
-                select(AppGroup).where(AppGroup.app_id == self.app.id).where(AppGroup.deleted_at.is_(None))
+            all_app_groups = (
+                await db.session.scalars(
+                    select(AppGroup).where(AppGroup.app_id == self.app.id).where(AppGroup.deleted_at.is_(None))
+                )
             ).all()
             for app_tag_map in new_app_tag_maps:
                 for app_group in all_app_groups:
@@ -106,9 +121,9 @@ class ModifyAppTags:
 
             # Handle group time limit constraints when adding tags
             # with time limit contraints to an app
-            ModifyGroupsTimeLimit(groups=[g.id for g in all_app_groups], tags=new_tag_ids_to_add).execute()
+            await ModifyGroupsTimeLimit(groups=[g.id for g in all_app_groups], tags=new_tag_ids_to_add).execute()
 
-            db.session.commit()
+            await db.session.commit()
 
         if len(self.tags_to_remove) > 0:
             tag_ids_to_remove = [t.id for t in self.tags_to_remove]
@@ -124,8 +139,8 @@ class ModifyAppTags:
                 )
             )
 
-            existing_tag_maps = db.session.scalars(existing_tag_maps_query).all()
-            db.session.execute(
+            existing_tag_maps = (await db.session.scalars(existing_tag_maps_query)).all()
+            await db.session.execute(
                 update(OktaGroupTagMap)
                 .where(
                     or_(
@@ -140,7 +155,7 @@ class ModifyAppTags:
                 .execution_options(synchronize_session="fetch")
             )
 
-            db.session.execute(
+            await db.session.execute(
                 update(AppTagMap)
                 .where(AppTagMap.tag_id.in_(tag_ids_to_remove))
                 .where(AppTagMap.app_id == self.app.id)
@@ -153,13 +168,13 @@ class ModifyAppTags:
                 .values({AppTagMap.ended_at: func.now()})
                 .execution_options(synchronize_session="fetch")
             )
-            db.session.commit()
+            await db.session.commit()
 
         # Audit log if tags changed
         if len(self.tags_to_add) > 0 or len(self.tags_to_remove) > 0:
             email = None
             if self.current_user_id is not None:
-                email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
+                email = getattr(await db.session.get(OktaUser, self.current_user_id), "email", None)
 
             _ctx = get_request_context()
             logging.getLogger("access.audit").info(

--- a/api/operations/modify_group_details.py
+++ b/api/operations/modify_group_details.py
@@ -27,16 +27,18 @@ class ModifyGroupDetails:
         self.description = description
         self.current_user_id = current_user_id
 
-    def execute(self) -> OktaGroup:
+    async def execute(self) -> OktaGroup:
         old_name = self.group.name
         old_description = self.group.description or ""
 
         # Do not allow non-deleted groups with the same name (case-insensitive)
         if self.name is not None and old_name.lower() != self.name.lower():
-            existing_group = db.session.scalars(
-                select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-                .where(func.lower(OktaGroup.name) == func.lower(self.name))
-                .where(OktaGroup.deleted_at.is_(None))
+            existing_group = (
+                await db.session.scalars(
+                    select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+                    .where(func.lower(OktaGroup.name) == func.lower(self.name))
+                    .where(OktaGroup.deleted_at.is_(None))
+                )
             ).first()
             if existing_group is not None:
                 raise ValueError("Group already exists with the same name")
@@ -47,8 +49,8 @@ class ModifyGroupDetails:
             self.group.description = self.description or ""
 
         if self.group.deleted_at is None:
-            okta.update_group(self.group.id, self.group.name, self.group.description)
-        db.session.commit()
+            await okta.update_group(self.group.id, self.group.name, self.group.description)
+        await db.session.commit()
 
         # Fire group_updated hook if name or description changed
         if old_name != self.group.name or old_description != self.group.description:
@@ -56,25 +58,28 @@ class ModifyGroupDetails:
             if plugin_id is not None:
                 try:
                     hook = get_app_group_lifecycle_hook()
-                    hook.group_updated(
-                        session=db.session,
-                        group=self.group,
-                        old_name=old_name,
-                        old_description=old_description,
-                        plugin_id=plugin_id,
+                    # sync plugin hook: session-bound, runs on the greenlet bridge
+                    await db.session.run_sync(
+                        lambda s: hook.group_updated(
+                            session=s,
+                            group=self.group,
+                            old_name=old_name,
+                            old_description=old_description,
+                            plugin_id=plugin_id,
+                        )
                     )
-                    db.session.commit()
+                    await db.session.commit()
                 except Exception:
                     logging.getLogger("api").exception(
                         f"Failed to invoke group_updated hook for group {self.group.id} with plugin '{plugin_id}'"
                     )
-                    db.session.rollback()
+                    await db.session.rollback()
 
         # Audit logging, only if group name changed
         if old_name.lower() != self.group.name.lower():
             _ctx = get_request_context()
             email = (
-                getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
+                getattr(await db.session.get(OktaUser, self.current_user_id), "email", None)
                 if self.current_user_id is not None
                 else None
             )

--- a/api/operations/modify_group_tags.py
+++ b/api/operations/modify_group_tags.py
@@ -26,52 +26,64 @@ class ModifyGroupTags:
         self._tags_to_remove_arg = tags_to_remove
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         group = self._group_arg
-        self.group = db.session.scalars(
-            select(OktaGroup)
-            .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
-            .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+        self.group = (
+            await db.session.scalars(
+                select(OktaGroup)
+                .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
+                .where(OktaGroup.deleted_at.is_(None))
+                .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+            )
         ).first()
 
-        self.tags_to_add = db.session.scalars(
-            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_add_arg))
+        self.tags_to_add = (
+            await db.session.scalars(
+                select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_add_arg))
+            )
         ).all()
 
-        self.tags_to_remove = db.session.scalars(
-            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_remove_arg))
+        self.tags_to_remove = (
+            await db.session.scalars(
+                select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_remove_arg))
+            )
         ).all()
 
         self.current_user_id = getattr(
-            db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+            (
+                await db.session.scalars(
+                    select(OktaUser)
+                    .where(OktaUser.deleted_at.is_(None))
+                    .where(OktaUser.id == self._current_user_id_arg)
+                )
             ).first(),
             "id",
             None,
         )
 
-    def execute(self) -> OktaGroup:
-        self._resolve()
+    async def execute(self) -> OktaGroup:
+        await self._resolve()
         if len(self.tags_to_add) > 0:
             # Only add tags that are not already associated with the group
             tag_ids_to_add = [t.id for t in self.tags_to_add]
-            existing_tag_maps = db.session.scalars(
-                select(OktaGroupTagMap)
-                .where(
-                    or_(
-                        OktaGroupTagMap.ended_at.is_(None),
-                        OktaGroupTagMap.ended_at > func.now(),
+            existing_tag_maps = (
+                await db.session.scalars(
+                    select(OktaGroupTagMap)
+                    .where(
+                        or_(
+                            OktaGroupTagMap.ended_at.is_(None),
+                            OktaGroupTagMap.ended_at > func.now(),
+                        )
                     )
-                )
-                .where(
-                    OktaGroupTagMap.group_id == self.group.id,
-                )
-                .where(
-                    OktaGroupTagMap.tag_id.in_(tag_ids_to_add),
-                )
-                .where(
-                    OktaGroupTagMap.app_tag_map_id.is_(None),
+                    .where(
+                        OktaGroupTagMap.group_id == self.group.id,
+                    )
+                    .where(
+                        OktaGroupTagMap.tag_id.in_(tag_ids_to_add),
+                    )
+                    .where(
+                        OktaGroupTagMap.app_tag_map_id.is_(None),
+                    )
                 )
             ).all()
 
@@ -87,12 +99,12 @@ class ModifyGroupTags:
 
             # Handle group time limit constraints when adding tags
             # with time limit contraints to a group
-            ModifyGroupsTimeLimit(groups=[self.group.id], tags=new_tag_ids_to_add).execute()
+            await ModifyGroupsTimeLimit(groups=[self.group.id], tags=new_tag_ids_to_add).execute()
 
-            db.session.commit()
+            await db.session.commit()
 
         if len(self.tags_to_remove) > 0:
-            db.session.execute(
+            await db.session.execute(
                 update(OktaGroupTagMap)
                 .where(
                     or_(
@@ -112,18 +124,20 @@ class ModifyGroupTags:
                 .values({OktaGroupTagMap.ended_at: func.now()})
                 .execution_options(synchronize_session="fetch")
             )
-            db.session.commit()
+            await db.session.commit()
 
         # Audit log if tags changed
         if len(self.tags_to_add) > 0 or len(self.tags_to_remove) > 0:
             email = None
             if self.current_user_id is not None:
-                email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
-                group = db.session.scalars(
-                    select(OktaGroup)
-                    .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
-                    .where(OktaGroup.deleted_at.is_(None))
-                    .where(OktaGroup.id == self.group.id)
+                email = getattr(await db.session.get(OktaUser, self.current_user_id), "email", None)
+                group = (
+                    await db.session.scalars(
+                        select(OktaGroup)
+                        .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
+                        .where(OktaGroup.deleted_at.is_(None))
+                        .where(OktaGroup.id == self.group.id)
+                    )
                 ).first()
 
             _ctx = get_request_context()

--- a/api/operations/modify_group_tags.py
+++ b/api/operations/modify_group_tags.py
@@ -21,6 +21,13 @@ class ModifyGroupTags:
         tags_to_remove: list[str] = [],
         current_user_id: Optional[str],
     ):
+        self._group_arg = group
+        self._tags_to_add_arg = tags_to_add
+        self._tags_to_remove_arg = tags_to_remove
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
+        group = self._group_arg
         self.group = db.session.scalars(
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
@@ -29,22 +36,23 @@ class ModifyGroupTags:
         ).first()
 
         self.tags_to_add = db.session.scalars(
-            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(tags_to_add))
+            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_add_arg))
         ).all()
 
         self.tags_to_remove = db.session.scalars(
-            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(tags_to_remove))
+            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(self._tags_to_remove_arg))
         ).all()
 
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self) -> OktaGroup:
+        self._resolve()
         if len(self.tags_to_add) > 0:
             # Only add tags that are not already associated with the group
             tag_ids_to_add = [t.id for t in self.tags_to_add]

--- a/api/operations/modify_group_type.py
+++ b/api/operations/modify_group_type.py
@@ -31,25 +31,31 @@ class ModifyGroupType:
         self.group_changes = group_changes
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         group = self._group_arg
-        self.group = db.session.scalars(
-            select(OktaGroup)
-            .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
-            .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+        self.group = (
+            await db.session.scalars(
+                select(OktaGroup)
+                .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
+                .where(OktaGroup.deleted_at.is_(None))
+                .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+            )
         ).first()
 
         self.current_user_id = getattr(
-            db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+            (
+                await db.session.scalars(
+                    select(OktaUser)
+                    .where(OktaUser.deleted_at.is_(None))
+                    .where(OktaUser.id == self._current_user_id_arg)
+                )
             ).first(),
             "id",
             None,
         )
 
-    def execute(self) -> OktaGroup:
-        self._resolve()
+    async def execute(self) -> OktaGroup:
+        await self._resolve()
         # Update group type if it's being modified
         if type(self.group) is not type(self.group_changes):
             group_id = self.group.id
@@ -67,25 +73,27 @@ class ModifyGroupType:
                     )
 
                 # End all group attachments to this role and all group memberships via the role grant
-                active_role_associated_groups = db.session.scalars(
-                    select(RoleGroupMap)
-                    .where(
-                        or_(
-                            RoleGroupMap.ended_at.is_(None),
-                            RoleGroupMap.ended_at > func.now(),
+                active_role_associated_groups = (
+                    await db.session.scalars(
+                        select(RoleGroupMap)
+                        .where(
+                            or_(
+                                RoleGroupMap.ended_at.is_(None),
+                                RoleGroupMap.ended_at > func.now(),
+                            )
                         )
+                        .where(RoleGroupMap.role_group_id == self.group.id)
                     )
-                    .where(RoleGroupMap.role_group_id == self.group.id)
                 ).all()
-                ModifyRoleGroups(
+                await ModifyRoleGroups(
                     role_group=self.group,
                     current_user_id=self.current_user_id,
                     groups_to_remove=[g.group_id for g in active_role_associated_groups if not g.is_owner],
                     owner_groups_to_remove=[g.group_id for g in active_role_associated_groups if g.is_owner],
                 ).execute()
-                db.session.commit()
+                await db.session.commit()
 
-                db.session.execute(delete(RoleGroup.__table__).where(RoleGroup.__table__.c.id == group_id))
+                await db.session.execute(delete(RoleGroup.__table__).where(RoleGroup.__table__.c.id == group_id))
             elif type(self.group) is AppGroup:
                 # Bail if this is the owner group for the app
                 # which cannot have its type changed
@@ -109,15 +117,15 @@ class ModifyGroupType:
                     try:
                         hook = get_app_group_lifecycle_hook()
                         hook.group_deleted(session=db.session, group=self.group, plugin_id=plugin_id)
-                        db.session.commit()
+                        await db.session.commit()
                     except Exception:
                         logging.getLogger("api").exception(
                             f"Failed to invoke group_deleted hook for group {self.group.id} with plugin '{plugin_id}'"
                         )
-                        db.session.rollback()
+                        await db.session.rollback()
 
                 # Remove app tag map for this group that is no longer attached to an app
-                db.session.execute(
+                await db.session.execute(
                     update(OktaGroupTagMap)
                     .where(
                         or_(
@@ -130,9 +138,9 @@ class ModifyGroupType:
                     .values({OktaGroupTagMap.app_tag_map_id: None})
                     .execution_options(synchronize_session="fetch")
                 )
-                db.session.commit()
+                await db.session.commit()
 
-                db.session.execute(delete(AppGroup.__table__).where(AppGroup.__table__.c.id == group_id))
+                await db.session.execute(delete(AppGroup.__table__).where(AppGroup.__table__.c.id == group_id))
             # Expunge the session so the changed object is flushed from the ORM
             # See https://stackoverflow.com/a/21792969
             db.session.expunge_all()
@@ -140,38 +148,42 @@ class ModifyGroupType:
             # We've deleted the group child class row group,
             # update the type to the base class type "okta_group"
             self.group.type = OktaGroup.__mapper_args__["polymorphic_identity"]
-            db.session.commit()
+            await db.session.commit()
 
-            self.group = db.session.scalars(
-                select(OktaGroup).where(OktaGroup.deleted_at.is_(None)).where(OktaGroup.id == group_id)
+            self.group = (
+                await db.session.scalars(
+                    select(OktaGroup).where(OktaGroup.deleted_at.is_(None)).where(OktaGroup.id == group_id)
+                )
             ).first()
 
             # Create new child table row
             if type(self.group_changes) is RoleGroup:
                 # Convert any group memberships and ownerships via a role to direct group memberships and ownerships
-                active_group_users_from_role = db.session.scalars(
-                    select(OktaUserGroupMember)
-                    .where(
-                        or_(
-                            OktaUserGroupMember.ended_at.is_(None),
-                            OktaUserGroupMember.ended_at > func.now(),
+                active_group_users_from_role = (
+                    await db.session.scalars(
+                        select(OktaUserGroupMember)
+                        .where(
+                            or_(
+                                OktaUserGroupMember.ended_at.is_(None),
+                                OktaUserGroupMember.ended_at > func.now(),
+                            )
                         )
+                        .where(OktaUserGroupMember.role_group_map_id.is_not(None))
+                        .where(OktaUserGroupMember.group_id == group_id)
                     )
-                    .where(OktaUserGroupMember.role_group_map_id.is_not(None))
-                    .where(OktaUserGroupMember.group_id == group_id)
                 ).all()
                 # Add all group memberships and ownerships via a role grant as direct memberships and ownerships
                 # Do this in a loop so we can preserve the ended_at value
                 for group_user in active_group_users_from_role:
                     if group_user.is_owner:
-                        ModifyGroupUsers(
+                        await ModifyGroupUsers(
                             group=group_id,
                             current_user_id=self.current_user_id,
                             owners_to_add=[group_user.user_id],
                             users_added_ended_at=group_user.ended_at,
                         ).execute()
                     else:
-                        ModifyGroupUsers(
+                        await ModifyGroupUsers(
                             group=group_id,
                             current_user_id=self.current_user_id,
                             members_to_add=[group_user.user_id],
@@ -179,33 +191,35 @@ class ModifyGroupType:
                         ).execute()
 
                 # Remove all group memberships and ownerships via a role grant
-                active_role_associated_groups = db.session.scalars(
-                    select(RoleGroupMap)
-                    .where(
-                        or_(
-                            RoleGroupMap.ended_at.is_(None),
-                            RoleGroupMap.ended_at > func.now(),
+                active_role_associated_groups = (
+                    await db.session.scalars(
+                        select(RoleGroupMap)
+                        .where(
+                            or_(
+                                RoleGroupMap.ended_at.is_(None),
+                                RoleGroupMap.ended_at > func.now(),
+                            )
                         )
+                        .where(RoleGroupMap.group_id == group_id)
                     )
-                    .where(RoleGroupMap.group_id == group_id)
                 ).all()
                 for role_group_map in active_role_associated_groups:
                     if role_group_map.is_owner:
-                        ModifyRoleGroups(
+                        await ModifyRoleGroups(
                             role_group=role_group_map.role_group_id,
                             current_user_id=self.current_user_id,
                             owner_groups_to_remove=[role_group_map.group_id],
                         ).execute()
                     else:
-                        ModifyRoleGroups(
+                        await ModifyRoleGroups(
                             role_group=role_group_map.role_group_id,
                             current_user_id=self.current_user_id,
                             groups_to_remove=[role_group_map.group_id],
                         ).execute()
 
-                db.session.execute(insert(RoleGroup.__table__).values(id=group_id))
+                await db.session.execute(insert(RoleGroup.__table__).values(id=group_id))
             elif type(self.group_changes) is AppGroup:
-                db.session.execute(
+                await db.session.execute(
                     insert(AppGroup.__table__).values(
                         id=group_id,
                         app_id=self.group_changes.app_id,
@@ -214,7 +228,7 @@ class ModifyGroupType:
 
             # Update the group type
             self.group.type = self.group_changes.type
-            db.session.commit()
+            await db.session.commit()
 
             # Expunge the session so the changed object is flushed from the ORM
             # See https://stackoverflow.com/a/21792969
@@ -222,17 +236,19 @@ class ModifyGroupType:
 
             # Add all app tags to this new app group, after we've updated the group type
             if type(self.group_changes) is AppGroup:
-                app_tag_maps = db.session.scalars(
-                    select(AppTagMap)
-                    .options(joinedload(AppTagMap.active_tag))
-                    .where(
-                        or_(
-                            AppTagMap.ended_at.is_(None),
-                            AppTagMap.ended_at > func.now(),
+                app_tag_maps = (
+                    await db.session.scalars(
+                        select(AppTagMap)
+                        .options(joinedload(AppTagMap.active_tag))
+                        .where(
+                            or_(
+                                AppTagMap.ended_at.is_(None),
+                                AppTagMap.ended_at > func.now(),
+                            )
                         )
-                    )
-                    .where(
-                        AppTagMap.app_id == self.group_changes.app_id,
+                        .where(
+                            AppTagMap.app_id == self.group_changes.app_id,
+                        )
                     )
                 ).all()
                 for app_tag_map in app_tag_maps:
@@ -245,16 +261,18 @@ class ModifyGroupType:
                     )
 
                 # Handle group time limit constraints when adding tags with time limit contraints to a group
-                ModifyGroupsTimeLimit(
+                await ModifyGroupsTimeLimit(
                     groups=[group_id], tags=[tag_map.active_tag.id for tag_map in app_tag_maps]
                 ).execute()
 
             # Return a new lookup for the group
-            self.group = db.session.scalars(
-                select(OktaGroup)
-                .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
-                .where(OktaGroup.deleted_at.is_(None))
-                .where(OktaGroup.id == group_id)
+            self.group = (
+                await db.session.scalars(
+                    select(OktaGroup)
+                    .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
+                    .where(OktaGroup.deleted_at.is_(None))
+                    .where(OktaGroup.id == group_id)
+                )
             ).first()
 
             # Invoke group_created hook after converting to an AppGroup (symmetric
@@ -265,19 +283,19 @@ class ModifyGroupType:
                     try:
                         hook = get_app_group_lifecycle_hook()
                         hook.group_created(session=db.session, group=self.group, plugin_id=plugin_id)
-                        db.session.commit()
+                        await db.session.commit()
                     except Exception:
                         logging.getLogger("api").exception(
                             f"Failed to invoke group_created hook for group {self.group.id}"
                             f" with plugin '{plugin_id}'"
                         )
-                        db.session.rollback()
+                        await db.session.rollback()
 
         # Audit logging if type changed
         if self.group.type != old_group_type:
             email = None
             if self.current_user_id is not None:
-                email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
+                email = getattr(await db.session.get(OktaUser, self.current_user_id), "email", None)
 
             _ctx = get_request_context()
             logging.getLogger("access.audit").info(

--- a/api/operations/modify_group_type.py
+++ b/api/operations/modify_group_type.py
@@ -26,6 +26,13 @@ from api.schemas import AuditLogSchema, EventType
 
 class ModifyGroupType:
     def __init__(self, *, group: OktaGroup | str, group_changes: OktaGroup, current_user_id: Optional[str]):
+        self._group_arg = group
+
+        self.group_changes = group_changes
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
+        group = self._group_arg
         self.group = db.session.scalars(
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
@@ -33,16 +40,16 @@ class ModifyGroupType:
             .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
         ).first()
 
-        self.group_changes = group_changes
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self) -> OktaGroup:
+        self._resolve()
         # Update group type if it's being modified
         if type(self.group) is not type(self.group_changes):
             group_id = self.group.id

--- a/api/operations/modify_group_users.py
+++ b/api/operations/modify_group_users.py
@@ -65,7 +65,7 @@ class ModifyGroupUsers:
 
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         group = self._group_arg
         users_added_ended_at = self._users_added_ended_at_arg
         members_to_add = self._members_to_add_arg
@@ -75,15 +75,17 @@ class ModifyGroupUsers:
         members_to_remove = self._members_to_remove_arg
         owners_to_remove = self._owners_to_remove_arg
 
-        self.group = db.session.scalars(
-            select(OktaGroup)
-            .options(
-                selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
-                joinedload(AppGroup.app),
-                selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
+        self.group = (
+            await db.session.scalars(
+                select(OktaGroup)
+                .options(
+                    selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
+                    joinedload(AppGroup.app),
+                    selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
+                )
+                .where(OktaGroup.deleted_at.is_(None))
+                .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
             )
-            .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
         ).first()
 
         # Determine the minimum time allowed for group membership and ownership by current group tags
@@ -103,62 +105,74 @@ class ModifyGroupUsers:
 
         self.members_to_add = []
         if len(members_to_add) > 0:
-            self.members_to_add = db.session.scalars(
-                select(OktaUser).where(OktaUser.id.in_(members_to_add)).where(OktaUser.deleted_at.is_(None))
+            self.members_to_add = (
+                await db.session.scalars(
+                    select(OktaUser).where(OktaUser.id.in_(members_to_add)).where(OktaUser.deleted_at.is_(None))
+                )
             ).all()
 
         self.owners_to_add = []
         if len(owners_to_add) > 0:
-            self.owners_to_add = db.session.scalars(
-                select(OktaUser).where(OktaUser.id.in_(owners_to_add)).where(OktaUser.deleted_at.is_(None))
+            self.owners_to_add = (
+                await db.session.scalars(
+                    select(OktaUser).where(OktaUser.id.in_(owners_to_add)).where(OktaUser.deleted_at.is_(None))
+                )
             ).all()
 
         self.members_should_expire = []
         if len(members_should_expire) > 0:
-            self.members_should_expire = db.session.scalars(
-                select(OktaUserGroupMember)
-                .where(OktaUserGroupMember.id.in_(members_should_expire))
-                .where(OktaUserGroupMember.group_id == self.group.id)
-                .where(OktaUserGroupMember.ended_at > func.now())
-                .where(OktaUserGroupMember.is_owner.is_(False))
+            self.members_should_expire = (
+                await db.session.scalars(
+                    select(OktaUserGroupMember)
+                    .where(OktaUserGroupMember.id.in_(members_should_expire))
+                    .where(OktaUserGroupMember.group_id == self.group.id)
+                    .where(OktaUserGroupMember.ended_at > func.now())
+                    .where(OktaUserGroupMember.is_owner.is_(False))
+                )
             ).all()
 
         self.owners_should_expire = []
         if len(owners_should_expire) > 0:
-            self.owners_should_expire = db.session.scalars(
-                select(OktaUserGroupMember)
-                .where(OktaUserGroupMember.id.in_(owners_should_expire))
-                .where(OktaUserGroupMember.group_id == self.group.id)
-                .where(OktaUserGroupMember.ended_at > func.now())
-                .where(OktaUserGroupMember.is_owner.is_(True))
+            self.owners_should_expire = (
+                await db.session.scalars(
+                    select(OktaUserGroupMember)
+                    .where(OktaUserGroupMember.id.in_(owners_should_expire))
+                    .where(OktaUserGroupMember.group_id == self.group.id)
+                    .where(OktaUserGroupMember.ended_at > func.now())
+                    .where(OktaUserGroupMember.is_owner.is_(True))
+                )
             ).all()
 
         self.members_to_remove = []
         if len(members_to_remove) > 0:
-            self.members_to_remove = db.session.scalars(
-                select(OktaUser).where(OktaUser.id.in_(members_to_remove)).where(OktaUser.deleted_at.is_(None))
+            self.members_to_remove = (
+                await db.session.scalars(
+                    select(OktaUser).where(OktaUser.id.in_(members_to_remove)).where(OktaUser.deleted_at.is_(None))
+                )
             ).all()
 
         self.owners_to_remove = []
         if len(owners_to_remove) > 0:
-            self.owners_to_remove = db.session.scalars(
-                select(OktaUser).where(OktaUser.id.in_(owners_to_remove)).where(OktaUser.deleted_at.is_(None))
+            self.owners_to_remove = (
+                await db.session.scalars(
+                    select(OktaUser).where(OktaUser.id.in_(owners_to_remove)).where(OktaUser.deleted_at.is_(None))
+                )
             ).all()
 
         self.current_user_id = getattr(
-            db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+            (
+                await db.session.scalars(
+                    select(OktaUser)
+                    .where(OktaUser.deleted_at.is_(None))
+                    .where(OktaUser.id == self._current_user_id_arg)
+                )
             ).first(),
             "id",
             None,
         )
 
-    def execute(self) -> OktaGroup:
-        self._resolve()
-        # Run asychronously to parallelize Okta API requests
-        return asyncio.run(self._execute())
-
-    async def _execute(self) -> OktaGroup:
+    async def execute(self) -> OktaGroup:
+        await self._resolve()
         # Fast return if no changes are being made
         if (
             len(self.members_to_add)
@@ -172,7 +186,7 @@ class ModifyGroupUsers:
             return self.group
 
         # Check groups tags to see if self-add is allowed
-        valid, _ = CheckForSelfAdd(
+        valid, _ = await CheckForSelfAdd(
             group=self.group,
             current_user=self.current_user_id,
             members_to_add=self.members_to_add,
@@ -182,7 +196,7 @@ class ModifyGroupUsers:
             return self.group
 
         # Check group tags to see if a reason is required for adding members or owners
-        valid, _ = CheckForReason(
+        valid, _ = await CheckForReason(
             group=self.group,
             reason=self.created_reason,
             members_to_add=self.members_to_add,
@@ -194,7 +208,7 @@ class ModifyGroupUsers:
         # Audit logging
         email = None
         if self.current_user_id is not None:
-            email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
+            email = getattr(await db.session.get(OktaUser, self.current_user_id), "email", None)
 
         _ctx = get_request_context()
 
@@ -235,7 +249,7 @@ class ModifyGroupUsers:
 
         # End group memberships and ownerships
         if len(remove_changed_members) > 0 or len(remove_changed_owners) > 0:
-            db.session.execute(
+            await db.session.execute(
                 update(OktaUserGroupMember)
                 .where(
                     or_(
@@ -253,7 +267,7 @@ class ModifyGroupUsers:
                 .execution_options(synchronize_session="fetch")
             )
 
-            db.session.execute(
+            await db.session.execute(
                 update(OktaUserGroupMember)
                 .where(
                     or_(
@@ -273,15 +287,17 @@ class ModifyGroupUsers:
 
             # For role groups, members to be removed should also be removed from all role associated groups
             if type(self.group) is RoleGroup:
-                role_associated_groups_mappings = db.session.scalars(
-                    select(RoleGroupMap)
-                    .where(
-                        or_(
-                            RoleGroupMap.ended_at.is_(None),
-                            RoleGroupMap.ended_at > func.now(),
+                role_associated_groups_mappings = (
+                    await db.session.scalars(
+                        select(RoleGroupMap)
+                        .where(
+                            or_(
+                                RoleGroupMap.ended_at.is_(None),
+                                RoleGroupMap.ended_at > func.now(),
+                            )
                         )
+                        .where(RoleGroupMap.role_group_id == self.group.id)
                     )
-                    .where(RoleGroupMap.role_group_id == self.group.id)
                 ).all()
                 role_associated_group_memberships = (
                     update(OktaUserGroupMember)
@@ -295,7 +311,7 @@ class ModifyGroupUsers:
                     .where(OktaUserGroupMember.role_group_map_id.in_([m.id for m in role_associated_groups_mappings]))
                 )
 
-                db.session.execute(
+                await db.session.execute(
                     role_associated_group_memberships.values(
                         {
                             OktaUserGroupMember.ended_at: func.now(),
@@ -311,17 +327,19 @@ class ModifyGroupUsers:
             # which allow group access for this user
             members_to_remove_ids = [m.id for m in self.members_to_remove]
             owners_to_remove_ids = [m.id for m in self.owners_to_remove]
-            removed_users_with_other_access = db.session.execute(
-                select(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
-                .where(
-                    or_(
-                        OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > func.now(),
+            removed_users_with_other_access = (
+                await db.session.execute(
+                    select(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
+                    .where(
+                        or_(
+                            OktaUserGroupMember.ended_at.is_(None),
+                            OktaUserGroupMember.ended_at > func.now(),
+                        )
                     )
+                    .where(OktaUserGroupMember.group_id == self.group.id)
+                    .where(OktaUserGroupMember.user_id.in_(members_to_remove_ids + owners_to_remove_ids))
+                    .group_by(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
                 )
-                .where(OktaUserGroupMember.group_id == self.group.id)
-                .where(OktaUserGroupMember.user_id.in_(members_to_remove_ids + owners_to_remove_ids))
-                .group_by(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
             ).all()
             removed_members_with_other_access_ids = [
                 m.user_id for m in removed_users_with_other_access if not m.is_owner
@@ -336,7 +354,7 @@ class ModifyGroupUsers:
             if self.sync_to_okta and self.group.is_managed:
                 for member_id in okta_members_to_remove_ids:
                     # Remove user from okta group membership if the group is managed by Access
-                    async_tasks.append(asyncio.create_task(okta.async_remove_user_from_group(self.group.id, member_id)))
+                    async_tasks.append(asyncio.create_task(okta.remove_user_from_group(self.group.id, member_id)))
 
             removed_owners_with_other_access_ids = [m.user_id for m in removed_users_with_other_access if m.is_owner]
             okta_owners_to_remove_ids = set(owners_to_remove_ids) - set(removed_owners_with_other_access_ids)
@@ -344,44 +362,48 @@ class ModifyGroupUsers:
                 for owner_id in okta_owners_to_remove_ids:
                     # Remove user from okta group owners if the group is managed by Access
                     # https://help.okta.com/en-us/Content/Topics/identity-governance/group-owner.htm
-                    async_tasks.append(asyncio.create_task(okta.async_remove_owner_from_group(self.group.id, owner_id)))
+                    async_tasks.append(asyncio.create_task(okta.remove_owner_from_group(self.group.id, owner_id)))
 
             # For role groups, members to be removed should also be removed from all role associated groups
             if type(self.group) is RoleGroup:
-                role_associated_groups_mappings = db.session.scalars(
-                    select(RoleGroupMap)
-                    .options(joinedload(RoleGroupMap.active_group))
-                    .join(RoleGroupMap.active_group)
-                    .where(OktaGroup.is_managed.is_(True))
-                    .where(
-                        or_(
-                            RoleGroupMap.ended_at.is_(None),
-                            RoleGroupMap.ended_at > func.now(),
+                role_associated_groups_mappings = (
+                    await db.session.scalars(
+                        select(RoleGroupMap)
+                        .options(joinedload(RoleGroupMap.active_group))
+                        .join(RoleGroupMap.active_group)
+                        .where(OktaGroup.is_managed.is_(True))
+                        .where(
+                            or_(
+                                RoleGroupMap.ended_at.is_(None),
+                                RoleGroupMap.ended_at > func.now(),
+                            )
                         )
+                        .where(RoleGroupMap.role_group_id == self.group.id)
                     )
-                    .where(RoleGroupMap.role_group_id == self.group.id)
                 ).all()
                 # Check if there are other OktaUserGroupMembers for this user/group
                 # combination before removing group membership, there can be multiple role groups
                 # which allow group access for this user
-                removed_role_group_users_with_other_access = db.session.execute(
-                    select(
-                        OktaUserGroupMember.user_id,
-                        OktaUserGroupMember.group_id,
-                        OktaUserGroupMember.is_owner,
-                    )
-                    .where(
-                        or_(
-                            OktaUserGroupMember.ended_at.is_(None),
-                            OktaUserGroupMember.ended_at > func.now(),
+                removed_role_group_users_with_other_access = (
+                    await db.session.execute(
+                        select(
+                            OktaUserGroupMember.user_id,
+                            OktaUserGroupMember.group_id,
+                            OktaUserGroupMember.is_owner,
                         )
-                    )
-                    .where(OktaUserGroupMember.user_id.in_(members_to_remove_ids + owners_to_remove_ids))
-                    .where(OktaUserGroupMember.group_id.in_([r.group_id for r in role_associated_groups_mappings]))
-                    .group_by(
-                        OktaUserGroupMember.user_id,
-                        OktaUserGroupMember.group_id,
-                        OktaUserGroupMember.is_owner,
+                        .where(
+                            or_(
+                                OktaUserGroupMember.ended_at.is_(None),
+                                OktaUserGroupMember.ended_at > func.now(),
+                            )
+                        )
+                        .where(OktaUserGroupMember.user_id.in_(members_to_remove_ids + owners_to_remove_ids))
+                        .where(OktaUserGroupMember.group_id.in_([r.group_id for r in role_associated_groups_mappings]))
+                        .group_by(
+                            OktaUserGroupMember.user_id,
+                            OktaUserGroupMember.group_id,
+                            OktaUserGroupMember.is_owner,
+                        )
                     )
                 ).all()
                 for role_associated_group_map in role_associated_groups_mappings:
@@ -409,7 +431,7 @@ class ModifyGroupUsers:
                                 # Remove user from okta group members
                                 async_tasks.append(
                                     asyncio.create_task(
-                                        okta.async_remove_user_from_group(role_associated_group_map.group_id, member_id)
+                                        okta.remove_user_from_group(role_associated_group_map.group_id, member_id)
                                     )
                                 )
                     else:
@@ -428,11 +450,11 @@ class ModifyGroupUsers:
                                 # https://help.okta.com/en-us/Content/Topics/identity-governance/group-owner.htm
                                 async_tasks.append(
                                     asyncio.create_task(
-                                        okta.async_remove_owner_from_group(role_associated_group_map.group_id, owner_id)
+                                        okta.remove_owner_from_group(role_associated_group_map.group_id, owner_id)
                                     )
                                 )
 
-            db.session.commit()
+            await db.session.commit()
 
             # Invoke app group lifecycle plugin hooks for removed members
             for group, members in members_lost_by_group.items():
@@ -443,21 +465,21 @@ class ModifyGroupUsers:
                         hook.group_members_removed(
                             session=db.session, group=group, members=members, plugin_id=plugin_id
                         )
-                        db.session.commit()
+                        await db.session.commit()
                     except Exception:
                         logging.getLogger("api").exception(
                             f"Failed to invoke group_members_removed hook for group {group.id if group else None} with plugin '{plugin_id}'"
                         )
-                        db.session.rollback()
+                        await db.session.rollback()
 
         # Commit all changes so far
-        db.session.commit()
+        await db.session.commit()
 
         # Mark relevant OktaUserGroupMembers as 'Should expire'
         # Only relevant for the expiring groups page so not adding checks for this field anywhere else since OK if marked to expire
         # then manually renewed from group page or with an access request
         if len(self.members_should_expire) > 0:
-            db.session.execute(
+            await db.session.execute(
                 update(OktaUserGroupMember)
                 .where(OktaUserGroupMember.id.in_(m.id for m in self.members_should_expire))
                 .values({OktaUserGroupMember.should_expire: True})
@@ -465,7 +487,7 @@ class ModifyGroupUsers:
             )
 
         if len(self.owners_should_expire) > 0:
-            db.session.execute(
+            await db.session.execute(
                 update(OktaUserGroupMember)
                 .where(OktaUserGroupMember.id.in_(m.id for m in self.owners_should_expire))
                 .values({OktaUserGroupMember.should_expire: True})
@@ -473,24 +495,26 @@ class ModifyGroupUsers:
             )
 
         # Commit all changes so far
-        db.session.commit()
+        await db.session.commit()
 
         # Add new group members and group owners and add them to Okta
         if len(self.members_to_add) > 0 or len(self.owners_to_add) > 0:
             # Check which members being added currently have NO active memberships (to track first-time access)
             members_to_add_ids = [m.id for m in self.members_to_add]
-            existing_members_with_access = db.session.scalars(
-                select(OktaUserGroupMember.user_id)
-                .where(
-                    or_(
-                        OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > func.now(),
+            existing_members_with_access = (
+                await db.session.scalars(
+                    select(OktaUserGroupMember.user_id)
+                    .where(
+                        or_(
+                            OktaUserGroupMember.ended_at.is_(None),
+                            OktaUserGroupMember.ended_at > func.now(),
+                        )
                     )
+                    .where(OktaUserGroupMember.group_id == self.group.id)
+                    .where(OktaUserGroupMember.user_id.in_(members_to_add_ids))
+                    .where(OktaUserGroupMember.is_owner.is_(False))
+                    .group_by(OktaUserGroupMember.user_id)
                 )
-                .where(OktaUserGroupMember.group_id == self.group.id)
-                .where(OktaUserGroupMember.user_id.in_(members_to_add_ids))
-                .where(OktaUserGroupMember.is_owner.is_(False))
-                .group_by(OktaUserGroupMember.user_id)
             ).all()
             existing_members_with_access_ids = set(existing_members_with_access)
             members_gaining_first_access_ids = set(members_to_add_ids) - existing_members_with_access_ids
@@ -505,7 +529,7 @@ class ModifyGroupUsers:
             for member in self.members_to_add:
                 if self.sync_to_okta and self.group.is_managed:
                     # Add user to Access-managed okta group members
-                    async_tasks.append(asyncio.create_task(okta.async_add_user_to_group(self.group.id, member.id)))
+                    async_tasks.append(asyncio.create_task(okta.add_user_to_group(self.group.id, member.id)))
                 membership_to_add = OktaUserGroupMember(
                     user_id=member.id,
                     group_id=self.group.id,
@@ -523,7 +547,7 @@ class ModifyGroupUsers:
                 if self.sync_to_okta and self.group.is_managed:
                     # Add user to Access-managed okta group owners
                     # https://help.okta.com/en-us/Content/Topics/identity-governance/group-owner.htm
-                    async_tasks.append(asyncio.create_task(okta.async_add_owner_to_group(self.group.id, owner.id)))
+                    async_tasks.append(asyncio.create_task(okta.add_owner_to_group(self.group.id, owner.id)))
                 ownership_to_add = OktaUserGroupMember(
                     user_id=owner.id,
                     group_id=self.group.id,
@@ -538,18 +562,20 @@ class ModifyGroupUsers:
 
             # For role groups, new members should also be added to all Access-managed role associated groups
             if type(self.group) is RoleGroup:
-                role_associated_groups_mappings = db.session.scalars(
-                    select(RoleGroupMap)
-                    .options(joinedload(RoleGroupMap.active_group))
-                    .join(RoleGroupMap.active_group)
-                    .where(OktaGroup.is_managed.is_(True))
-                    .where(
-                        or_(
-                            RoleGroupMap.ended_at.is_(None),
-                            RoleGroupMap.ended_at > func.now(),
+                role_associated_groups_mappings = (
+                    await db.session.scalars(
+                        select(RoleGroupMap)
+                        .options(joinedload(RoleGroupMap.active_group))
+                        .join(RoleGroupMap.active_group)
+                        .where(OktaGroup.is_managed.is_(True))
+                        .where(
+                            or_(
+                                RoleGroupMap.ended_at.is_(None),
+                                RoleGroupMap.ended_at > func.now(),
+                            )
                         )
+                        .where(RoleGroupMap.role_group_id == self.group.id)
                     )
-                    .where(RoleGroupMap.role_group_id == self.group.id)
                 ).all()
 
                 # Check which members being added currently have NO active memberships in role-associated groups
@@ -560,20 +586,22 @@ class ModifyGroupUsers:
                     for group_id in role_associated_group_ids:
                         existing_access_by_group[group_id] = set()
 
-                    existing_role_members_with_access = db.session.execute(
-                        select(
-                            OktaUserGroupMember.user_id,
-                            OktaUserGroupMember.group_id,
-                        )
-                        .where(
-                            or_(
-                                OktaUserGroupMember.ended_at.is_(None),
-                                OktaUserGroupMember.ended_at > func.now(),
+                    existing_role_members_with_access = (
+                        await db.session.execute(
+                            select(
+                                OktaUserGroupMember.user_id,
+                                OktaUserGroupMember.group_id,
                             )
+                            .where(
+                                or_(
+                                    OktaUserGroupMember.ended_at.is_(None),
+                                    OktaUserGroupMember.ended_at > func.now(),
+                                )
+                            )
+                            .where(OktaUserGroupMember.user_id.in_(members_to_add_ids))
+                            .where(OktaUserGroupMember.group_id.in_(role_associated_group_ids))
+                            .group_by(OktaUserGroupMember.user_id, OktaUserGroupMember.group_id)
                         )
-                        .where(OktaUserGroupMember.user_id.in_(members_to_add_ids))
-                        .where(OktaUserGroupMember.group_id.in_(role_associated_group_ids))
-                        .group_by(OktaUserGroupMember.user_id, OktaUserGroupMember.group_id)
                     ).all()
                     for row in existing_role_members_with_access:
                         existing_access_by_group[row.group_id].add(row.user_id)
@@ -591,7 +619,7 @@ class ModifyGroupUsers:
                                 # Add user to okta group members
                                 async_tasks.append(
                                     asyncio.create_task(
-                                        okta.async_add_user_to_group(
+                                        okta.add_user_to_group(
                                             role_associated_group_map.group_id,
                                             member.id,
                                         )
@@ -602,7 +630,7 @@ class ModifyGroupUsers:
                                 # https://help.okta.com/en-us/Content/Topics/identity-governance/group-owner.htm
                                 async_tasks.append(
                                     asyncio.create_task(
-                                        okta.async_add_owner_to_group(
+                                        okta.add_owner_to_group(
                                             role_associated_group_map.group_id,
                                             member.id,
                                         )
@@ -645,7 +673,7 @@ class ModifyGroupUsers:
                             ]
 
             # Commit changes so far, so we can reference OktaUserGroupMember in approved AccessRequests
-            db.session.commit()
+            await db.session.commit()
 
             # Invoke app group lifecycle plugin hooks for added members
             for group, members in members_gained_by_group.items():
@@ -654,12 +682,12 @@ class ModifyGroupUsers:
                     try:
                         hook = get_app_group_lifecycle_hook()
                         hook.group_members_added(session=db.session, group=group, members=members, plugin_id=plugin_id)
-                        db.session.commit()
+                        await db.session.commit()
                     except Exception:
                         logging.getLogger("api").exception(
                             f"Failed to invoke group_members_added hook for group {group.id if group else None} with plugin '{plugin_id}'"
                         )
-                        db.session.rollback()
+                        await db.session.rollback()
 
             # Approve any pending access requests for access granted by this operation
             pending_requests_query = (
@@ -671,10 +699,12 @@ class ModifyGroupUsers:
 
             # Find all pending membership access requests to approve for this group
             # and groups associated if this a role group
-            pending_member_requests = db.session.scalars(
-                pending_requests_query.where(AccessRequest.requested_group_id.in_(group_memberships_added.keys()))
-                .where(AccessRequest.requester_user_id.in_([m.id for m in self.members_to_add]))
-                .where(AccessRequest.request_ownership.is_(False))
+            pending_member_requests = (
+                await db.session.scalars(
+                    pending_requests_query.where(AccessRequest.requested_group_id.in_(group_memberships_added.keys()))
+                    .where(AccessRequest.requester_user_id.in_([m.id for m in self.members_to_add]))
+                    .where(AccessRequest.request_ownership.is_(False))
+                )
             ).all()
             for access_request in pending_member_requests:
                 approved_access_requests.append(
@@ -685,10 +715,12 @@ class ModifyGroupUsers:
                 )
 
             # Find all pending ownership requests to approve for this group
-            pending_owner_requests = db.session.scalars(
-                pending_requests_query.where(AccessRequest.requested_group_id == self.group.id)
-                .where(AccessRequest.requester_user_id.in_([m.id for m in self.owners_to_add]))
-                .where(AccessRequest.request_ownership.is_(True))
+            pending_owner_requests = (
+                await db.session.scalars(
+                    pending_requests_query.where(AccessRequest.requested_group_id == self.group.id)
+                    .where(AccessRequest.requester_user_id.in_([m.id for m in self.owners_to_add]))
+                    .where(AccessRequest.request_ownership.is_(True))
+                )
             ).all()
             for access_request in pending_owner_requests:
                 approved_access_requests.append(
@@ -699,12 +731,14 @@ class ModifyGroupUsers:
                 )
 
             # Find all pending ownership requests to approve for groups associated if this a role group
-            pending_role_associated_owner_requests = db.session.scalars(
-                pending_requests_query.where(
-                    AccessRequest.requested_group_id.in_(set(group_ownerships_added.keys()) - set([self.group.id]))
+            pending_role_associated_owner_requests = (
+                await db.session.scalars(
+                    pending_requests_query.where(
+                        AccessRequest.requested_group_id.in_(set(group_ownerships_added.keys()) - set([self.group.id]))
+                    )
+                    .where(AccessRequest.requester_user_id.in_([m.id for m in self.members_to_add]))
+                    .where(AccessRequest.request_ownership.is_(True))
                 )
-                .where(AccessRequest.requester_user_id.in_([m.id for m in self.members_to_add]))
-                .where(AccessRequest.request_ownership.is_(True))
             ).all()
             for access_request in pending_role_associated_owner_requests:
                 approved_access_requests.append(
@@ -714,7 +748,7 @@ class ModifyGroupUsers:
                     )
                 )
 
-            db.session.commit()
+            await db.session.commit()
 
         # Resolve everything the notification hooks need on the main coroutine
         # before spawning tasks: spawned tasks must only perform network I/O,
@@ -725,9 +759,9 @@ class ModifyGroupUsers:
                 group = access_request.requested_group
                 # `resolved_at` was assigned func.now() and expired at flush;
                 # reload it explicitly so the hook sees a concrete value.
-                db.session.refresh(access_request, attribute_names=["resolved_at"])
-                requester = db.session.get(OktaUser, access_request.requester_user_id)
-                approvers = get_all_possible_request_approvers(access_request)
+                await db.session.refresh(access_request, attribute_names=["resolved_at"])
+                requester = await db.session.get(OktaUser, access_request.requester_user_id)
+                approvers = await get_all_possible_request_approvers(access_request)
                 async_tasks.append(
                     asyncio.create_task(self._notify_access_request(access_request, group, requester, approvers))
                 )

--- a/api/operations/modify_group_users.py
+++ b/api/operations/modify_group_users.py
@@ -1,6 +1,6 @@
 import asyncio
 from datetime import UTC, datetime
-from typing import Dict, Optional
+from typing import Dict, Optional, Set
 
 import logging
 
@@ -219,6 +219,9 @@ class ModifyGroupUsers:
 
         # Create a list of okta asyncio tasks to wait to completion on at the end of this function
         async_tasks = []
+        # Access requests approved by this operation; their notifications are
+        # prepared after the final commit and dispatched alongside async_tasks.
+        approved_access_requests: list[AccessRequest] = []
 
         # First remove all users from the group including those that we wish to add.
         # That way we can easily extend time-bounded group memberships and audit when
@@ -674,7 +677,7 @@ class ModifyGroupUsers:
                 .where(AccessRequest.request_ownership.is_(False))
             ).all()
             for access_request in pending_member_requests:
-                async_tasks.append(
+                approved_access_requests.append(
                     self._approve_access_request(
                         access_request,
                         group_memberships_added[access_request.requested_group_id][access_request.requester_user_id],
@@ -688,7 +691,7 @@ class ModifyGroupUsers:
                 .where(AccessRequest.request_ownership.is_(True))
             ).all()
             for access_request in pending_owner_requests:
-                async_tasks.append(
+                approved_access_requests.append(
                     self._approve_access_request(
                         access_request,
                         group_ownerships_added[access_request.requested_group_id][access_request.requester_user_id],
@@ -704,7 +707,7 @@ class ModifyGroupUsers:
                 .where(AccessRequest.request_ownership.is_(True))
             ).all()
             for access_request in pending_role_associated_owner_requests:
-                async_tasks.append(
+                approved_access_requests.append(
                     self._approve_access_request(
                         access_request,
                         group_ownerships_added[access_request.requested_group_id][access_request.requester_user_id],
@@ -713,6 +716,22 @@ class ModifyGroupUsers:
 
             db.session.commit()
 
+        # Resolve everything the notification hooks need on the main coroutine
+        # before spawning tasks: spawned tasks must only perform network I/O,
+        # never db.session access (a session cannot be used concurrently, and
+        # under async SQLAlchemy that raises rather than interleaving).
+        if self.notify:
+            for access_request in approved_access_requests:
+                group = access_request.requested_group
+                # `resolved_at` was assigned func.now() and expired at flush;
+                # reload it explicitly so the hook sees a concrete value.
+                db.session.refresh(access_request, attribute_names=["resolved_at"])
+                requester = db.session.get(OktaUser, access_request.requester_user_id)
+                approvers = get_all_possible_request_approvers(access_request)
+                async_tasks.append(
+                    asyncio.create_task(self._notify_access_request(access_request, group, requester, approvers))
+                )
+
         if len(async_tasks) > 0:
             await asyncio.wait(async_tasks)
 
@@ -720,7 +739,7 @@ class ModifyGroupUsers:
 
     def _approve_access_request(
         self, access_request: AccessRequest, added_okta_user_group_member: OktaUserGroupMember
-    ) -> asyncio.Task[None]:
+    ) -> AccessRequest:
         access_request.status = AccessRequestStatus.APPROVED
         access_request.resolved_at = func.now()
         access_request.resolver_user_id = self.current_user_id
@@ -728,19 +747,18 @@ class ModifyGroupUsers:
         access_request.approval_ending_at = added_okta_user_group_member.ended_at
         access_request.approved_membership_id = added_okta_user_group_member.id
 
-        return asyncio.create_task(self._notify_access_request(access_request))
+        return access_request
 
-    async def _notify_access_request(self, access_request: AccessRequest) -> None:
-        if not self.notify:
-            return
-
-        requester = db.session.get(OktaUser, access_request.requester_user_id)
-
-        approvers = get_all_possible_request_approvers(access_request)
-
+    async def _notify_access_request(
+        self,
+        access_request: AccessRequest,
+        group: OktaGroup,
+        requester: Optional[OktaUser],
+        approvers: Set[OktaUser],
+    ) -> None:
         self.notification_hook.access_request_completed(
             access_request=access_request,
-            group=access_request.requested_group,
+            group=group,
             requester=requester,
             approvers=approvers,
             notify_requester=True,

--- a/api/operations/modify_group_users.py
+++ b/api/operations/modify_group_users.py
@@ -47,6 +47,34 @@ class ModifyGroupUsers:
         created_reason: str = "",
         notify: bool = True,
     ):
+        self._group_arg = group
+        self._users_added_ended_at_arg = users_added_ended_at
+        self._members_to_add_arg = members_to_add
+        self._owners_to_add_arg = owners_to_add
+        self._members_should_expire_arg = members_should_expire
+        self._owners_should_expire_arg = owners_should_expire
+        self._members_to_remove_arg = members_to_remove
+        self._owners_to_remove_arg = owners_to_remove
+
+        self.sync_to_okta = sync_to_okta
+
+        self._current_user_id_arg = current_user_id
+
+        self.created_reason = created_reason
+        self.notify = notify
+
+        self.notification_hook = get_notification_hook()
+
+    def _resolve(self) -> None:
+        group = self._group_arg
+        users_added_ended_at = self._users_added_ended_at_arg
+        members_to_add = self._members_to_add_arg
+        owners_to_add = self._owners_to_add_arg
+        members_should_expire = self._members_should_expire_arg
+        owners_should_expire = self._owners_should_expire_arg
+        members_to_remove = self._members_to_remove_arg
+        owners_to_remove = self._owners_to_remove_arg
+
         self.group = db.session.scalars(
             select(OktaGroup)
             .options(
@@ -117,22 +145,16 @@ class ModifyGroupUsers:
                 select(OktaUser).where(OktaUser.id.in_(owners_to_remove)).where(OktaUser.deleted_at.is_(None))
             ).all()
 
-        self.sync_to_okta = sync_to_okta
-
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
-        self.created_reason = created_reason
-        self.notify = notify
-
-        self.notification_hook = get_notification_hook()
-
     def execute(self) -> OktaGroup:
+        self._resolve()
         # Run asychronously to parallelize Okta API requests
         return asyncio.run(self._execute())
 

--- a/api/operations/modify_group_users.py
+++ b/api/operations/modify_group_users.py
@@ -9,6 +9,7 @@ from api.context import get_request_context
 from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload
 
 from api.extensions import db
+from api.operations._fan_out import drain_fan_out_tasks
 from api.models import (
     AccessRequest,
     AccessRequestStatus,
@@ -766,8 +767,7 @@ class ModifyGroupUsers:
                     asyncio.create_task(self._notify_access_request(access_request, group, requester, approvers))
                 )
 
-        if len(async_tasks) > 0:
-            await asyncio.wait(async_tasks)
+        await drain_fan_out_tasks(async_tasks, f"ModifyGroupUsers for group {self.group.id}")
 
         return self.group
 

--- a/api/operations/modify_groups_time_limit.py
+++ b/api/operations/modify_groups_time_limit.py
@@ -11,28 +11,32 @@ class ModifyGroupsTimeLimit:
         self._groups_arg = groups
         self._tags_arg = tags
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         groups = self._groups_arg
         # Only include groups that are managed
-        self.groups = db.session.scalars(
-            select(OktaGroup)
-            .where(OktaGroup.id.in_(groups))
-            .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.is_managed.is_(True))
+        self.groups = (
+            await db.session.scalars(
+                select(OktaGroup)
+                .where(OktaGroup.id.in_(groups))
+                .where(OktaGroup.deleted_at.is_(None))
+                .where(OktaGroup.is_managed.is_(True))
+            )
         ).all()
-        self.role_groups = db.session.scalars(
-            select(RoleGroup)
-            .where(RoleGroup.id.in_(groups))
-            .where(RoleGroup.deleted_at.is_(None))
-            .where(RoleGroup.is_managed.is_(True))
+        self.role_groups = (
+            await db.session.scalars(
+                select(RoleGroup)
+                .where(RoleGroup.id.in_(groups))
+                .where(RoleGroup.deleted_at.is_(None))
+                .where(RoleGroup.is_managed.is_(True))
+            )
         ).all()
 
-        self.tags = db.session.scalars(
-            select(Tag).where(Tag.id.in_(self._tags_arg)).where(Tag.deleted_at.is_(None))
+        self.tags = (
+            await db.session.scalars(select(Tag).where(Tag.id.in_(self._tags_arg)).where(Tag.deleted_at.is_(None)))
         ).all()
 
-    def execute(self) -> None:
-        self._resolve()
+    async def execute(self) -> None:
+        await self._resolve()
         if len(self.groups) == 0:
             return
 
@@ -43,7 +47,7 @@ class ModifyGroupsTimeLimit:
         if membership_seconds_limit is not None:
             membership_time_limit_from_now = datetime.now(UTC) + timedelta(seconds=membership_seconds_limit)
             # Reduce all user memberships for the given groups to minimum allowed time limit
-            db.session.execute(
+            await db.session.execute(
                 update(OktaUserGroupMember)
                 .where(OktaUserGroupMember.group_id.in_([g.id for g in self.groups]))
                 .where(OktaUserGroupMember.is_owner.is_(False))
@@ -57,7 +61,7 @@ class ModifyGroupsTimeLimit:
                 .execution_options(synchronize_session="fetch")
             )
             # Reduce all role memberships for the given groups to the minimum allowed time limit
-            db.session.execute(
+            await db.session.execute(
                 update(RoleGroupMap)
                 .where(RoleGroupMap.group_id.in_([g.id for g in self.groups]))
                 .where(RoleGroupMap.is_owner.is_(False))
@@ -72,18 +76,20 @@ class ModifyGroupsTimeLimit:
             )
             # Reduce all user memberships for groups associated with any given role groups
             # to the minimum allowed time limit
-            role_group_map_associations = db.session.scalars(
-                select(RoleGroupMap)
-                .where(RoleGroupMap.role_group_id.in_([g.id for g in self.role_groups]))
-                .where(RoleGroupMap.is_owner.is_(False))
-                .where(
-                    or_(
-                        RoleGroupMap.ended_at.is_(None),
-                        RoleGroupMap.ended_at > func.now(),
+            role_group_map_associations = (
+                await db.session.scalars(
+                    select(RoleGroupMap)
+                    .where(RoleGroupMap.role_group_id.in_([g.id for g in self.role_groups]))
+                    .where(RoleGroupMap.is_owner.is_(False))
+                    .where(
+                        or_(
+                            RoleGroupMap.ended_at.is_(None),
+                            RoleGroupMap.ended_at > func.now(),
+                        )
                     )
                 )
             ).all()
-            db.session.execute(
+            await db.session.execute(
                 update(OktaUserGroupMember)
                 .where(OktaUserGroupMember.role_group_map_id.in_([m.id for m in role_group_map_associations]))
                 .where(OktaUserGroupMember.is_owner.is_(False))
@@ -96,11 +102,11 @@ class ModifyGroupsTimeLimit:
                 .values({OktaUserGroupMember.ended_at: membership_time_limit_from_now})
                 .execution_options(synchronize_session="fetch")
             )
-            db.session.commit()
+            await db.session.commit()
         if ownership_seconds_limit is not None:
             ownership_time_limit_from_now = datetime.now(UTC) + timedelta(seconds=ownership_seconds_limit)
             # Reduce all user ownerships for the given groups to minimum allowed time limit
-            db.session.execute(
+            await db.session.execute(
                 update(OktaUserGroupMember)
                 .where(OktaUserGroupMember.group_id.in_([g.id for g in self.groups]))
                 .where(OktaUserGroupMember.is_owner.is_(True))
@@ -114,7 +120,7 @@ class ModifyGroupsTimeLimit:
                 .execution_options(synchronize_session="fetch")
             )
             # Reduce all role ownerships for the given groups to the minimum allowed time limit
-            db.session.execute(
+            await db.session.execute(
                 update(RoleGroupMap)
                 .where(RoleGroupMap.group_id.in_([g.id for g in self.groups]))
                 .where(RoleGroupMap.is_owner.is_(True))
@@ -129,18 +135,20 @@ class ModifyGroupsTimeLimit:
             )
             # Reduce all user ownerships for groups associated with any given role groups
             # to the minimum allowed time limit
-            role_group_map_associations = db.session.scalars(
-                select(RoleGroupMap)
-                .where(RoleGroupMap.role_group_id.in_([g.id for g in self.role_groups]))
-                .where(RoleGroupMap.is_owner.is_(True))
-                .where(
-                    or_(
-                        RoleGroupMap.ended_at.is_(None),
-                        RoleGroupMap.ended_at > func.now(),
+            role_group_map_associations = (
+                await db.session.scalars(
+                    select(RoleGroupMap)
+                    .where(RoleGroupMap.role_group_id.in_([g.id for g in self.role_groups]))
+                    .where(RoleGroupMap.is_owner.is_(True))
+                    .where(
+                        or_(
+                            RoleGroupMap.ended_at.is_(None),
+                            RoleGroupMap.ended_at > func.now(),
+                        )
                     )
                 )
             ).all()
-            db.session.execute(
+            await db.session.execute(
                 update(OktaUserGroupMember)
                 .where(OktaUserGroupMember.role_group_map_id.in_([m.id for m in role_group_map_associations]))
                 .where(OktaUserGroupMember.is_owner.is_(True))
@@ -153,4 +161,4 @@ class ModifyGroupsTimeLimit:
                 .values({OktaUserGroupMember.ended_at: membership_time_limit_from_now})
                 .execution_options(synchronize_session="fetch")
             )
-            db.session.commit()
+            await db.session.commit()

--- a/api/operations/modify_groups_time_limit.py
+++ b/api/operations/modify_groups_time_limit.py
@@ -8,6 +8,11 @@ from api.models.tag import coalesce_constraints
 
 class ModifyGroupsTimeLimit:
     def __init__(self, groups: list[str] | set[str], tags: list[str] | set[str]):
+        self._groups_arg = groups
+        self._tags_arg = tags
+
+    def _resolve(self) -> None:
+        groups = self._groups_arg
         # Only include groups that are managed
         self.groups = db.session.scalars(
             select(OktaGroup)
@@ -22,9 +27,12 @@ class ModifyGroupsTimeLimit:
             .where(RoleGroup.is_managed.is_(True))
         ).all()
 
-        self.tags = db.session.scalars(select(Tag).where(Tag.id.in_(tags)).where(Tag.deleted_at.is_(None))).all()
+        self.tags = db.session.scalars(
+            select(Tag).where(Tag.id.in_(self._tags_arg)).where(Tag.deleted_at.is_(None))
+        ).all()
 
     def execute(self) -> None:
+        self._resolve()
         if len(self.groups) == 0:
             return
 

--- a/api/operations/modify_role_groups.py
+++ b/api/operations/modify_role_groups.py
@@ -1,6 +1,6 @@
 import asyncio
 from datetime import UTC, datetime
-from typing import Dict, Optional
+from typing import Dict, Optional, Set
 
 import logging
 
@@ -218,6 +218,10 @@ class ModifyRoleGroups:
 
         # Create a list of okta asyncio tasks to wait to completion on at the end of this function
         async_tasks = []
+        # Requests approved by this operation; their notifications are
+        # prepared after the final commit and dispatched alongside async_tasks.
+        approved_access_requests: list[AccessRequest] = []
+        approved_role_requests: list[RoleRequest] = []
 
         # First remove all groups from the role including those that we wish to add.
         # That way we can easily extend time-bounded group memberships and audit when
@@ -520,6 +524,7 @@ class ModifyRoleGroups:
             # Approve any pending access requests for access granted by this operation
             pending_requests_query = (
                 select(AccessRequest)
+                .options(joinedload(AccessRequest.requested_group))
                 .where(AccessRequest.status == AccessRequestStatus.PENDING)
                 .where(AccessRequest.resolved_at.is_(None))
             )
@@ -532,7 +537,7 @@ class ModifyRoleGroups:
                 .where(AccessRequest.request_ownership.is_(False))
             ).all()
             for access_request in pending_member_requests:
-                async_tasks.append(
+                approved_access_requests.append(
                     self._approve_access_request(
                         access_request,
                         group_memberships_added[access_request.requested_group_id][access_request.requester_user_id],
@@ -546,7 +551,7 @@ class ModifyRoleGroups:
                 .where(AccessRequest.request_ownership.is_(True))
             ).all()
             for access_request in pending_role_associated_owner_requests:
-                async_tasks.append(
+                approved_access_requests.append(
                     self._approve_access_request(
                         access_request,
                         group_ownerships_added[access_request.requested_group_id][access_request.requester_user_id],
@@ -556,6 +561,7 @@ class ModifyRoleGroups:
             # Approve any pending role requests for memberships granted by this operation
             pending_role_requests_query = (
                 select(RoleRequest)
+                .options(joinedload(RoleRequest.requested_group), joinedload(RoleRequest.requester_role))
                 .where(RoleRequest.status == AccessRequestStatus.PENDING)
                 .where(RoleRequest.resolved_at.is_(None))
                 .where(RoleRequest.requester_role == self.role)
@@ -568,7 +574,7 @@ class ModifyRoleGroups:
                 )
             ).all()
             for role_request in pending_role_memberships:
-                async_tasks.append(
+                approved_role_requests.append(
                     self._approve_role_request(role_request, role_memberships_added[role_request.requested_group_id])
                 )
 
@@ -580,7 +586,7 @@ class ModifyRoleGroups:
                 )
             ).all()
             for role_request in pending_role_ownerships:
-                async_tasks.append(
+                approved_role_requests.append(
                     self._approve_role_request(role_request, role_ownerships_added[role_request.requested_group_id])
                 )
 
@@ -588,6 +594,32 @@ class ModifyRoleGroups:
 
         # Commit all changes
         db.session.commit()
+
+        # Resolve everything the notification hooks need on the main coroutine
+        # before spawning tasks: spawned tasks must only perform network I/O,
+        # never db.session access (a session cannot be used concurrently, and
+        # under async SQLAlchemy that raises rather than interleaving).
+        for access_request in approved_access_requests:
+            group = access_request.requested_group
+            # `resolved_at` was assigned func.now() and expired at flush;
+            # reload it explicitly so the hook sees a concrete value.
+            db.session.refresh(access_request, attribute_names=["resolved_at"])
+            requester = db.session.get(OktaUser, access_request.requester_user_id)
+            approvers = get_all_possible_request_approvers(access_request)
+            async_tasks.append(
+                asyncio.create_task(self._notify_access_request(access_request, group, requester, approvers))
+            )
+
+        if self.notify:
+            for role_request in approved_role_requests:
+                role = role_request.requester_role
+                group = role_request.requested_group
+                db.session.refresh(role_request, attribute_names=["resolved_at"])
+                requester = db.session.get(OktaUser, role_request.requester_user_id)
+                approvers = get_all_possible_request_approvers(role_request)
+                async_tasks.append(
+                    asyncio.create_task(self._notify_role_request(role_request, role, group, requester, approvers))
+                )
 
         if len(async_tasks) > 0:
             await asyncio.wait(async_tasks)
@@ -641,7 +673,7 @@ class ModifyRoleGroups:
 
     def _approve_access_request(
         self, access_request: AccessRequest, added_okta_user_group_member: OktaUserGroupMember
-    ) -> asyncio.Task[None]:
+    ) -> AccessRequest:
         access_request.status = AccessRequestStatus.APPROVED
         access_request.resolved_at = func.now()
         access_request.resolver_user_id = self.current_user_id
@@ -649,24 +681,24 @@ class ModifyRoleGroups:
         access_request.approval_ending_at = added_okta_user_group_member.ended_at
         access_request.approved_membership_id = added_okta_user_group_member.id
 
-        return asyncio.create_task(self._notify_access_request(access_request))
+        return access_request
 
-    async def _notify_access_request(self, access_request: AccessRequest) -> None:
-        requester = db.session.get(OktaUser, access_request.requester_user_id)
-
-        approvers = get_all_possible_request_approvers(access_request)
-
+    async def _notify_access_request(
+        self,
+        access_request: AccessRequest,
+        group: OktaGroup,
+        requester: Optional[OktaUser],
+        approvers: Set[OktaUser],
+    ) -> None:
         self.notification_hook.access_request_completed(
             access_request=access_request,
-            group=access_request.requested_group,
+            group=group,
             requester=requester,
             approvers=approvers,
             notify_requester=True,
         )
 
-    def _approve_role_request(
-        self, role_request: RoleRequest, added_role_group_map: RoleGroupMap
-    ) -> asyncio.Task[None]:
+    def _approve_role_request(self, role_request: RoleRequest, added_role_group_map: RoleGroupMap) -> RoleRequest:
         role_request.status = AccessRequestStatus.APPROVED
         role_request.resolved_at = func.now()
         role_request.resolver_user_id = self.current_user_id
@@ -674,20 +706,20 @@ class ModifyRoleGroups:
         role_request.approval_ending_at = added_role_group_map.ended_at
         role_request.approved_membership_id = added_role_group_map.id
 
-        return asyncio.create_task(self._notify_role_request(role_request))
+        return role_request
 
-    async def _notify_role_request(self, role_request: RoleRequest) -> None:
-        if not self.notify:
-            return
-
-        requester = db.session.get(OktaUser, role_request.requester_user_id)
-
-        approvers = get_all_possible_request_approvers(role_request)
-
+    async def _notify_role_request(
+        self,
+        role_request: RoleRequest,
+        role: OktaGroup,
+        group: OktaGroup,
+        requester: Optional[OktaUser],
+        approvers: Set[OktaUser],
+    ) -> None:
         self.notification_hook.access_role_request_completed(
             role_request=role_request,
-            role=role_request.requester_role,
-            group=role_request.requested_group,
+            role=role,
+            group=group,
             requester=requester,
             approvers=approvers,
             notify_requester=True,

--- a/api/operations/modify_role_groups.py
+++ b/api/operations/modify_role_groups.py
@@ -68,7 +68,7 @@ class ModifyRoleGroups:
 
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         role_group = self._role_group_arg
         groups_to_add = self._groups_to_add_arg
         owner_groups_to_add = self._owner_groups_to_add_arg
@@ -78,85 +78,101 @@ class ModifyRoleGroups:
         owner_groups_to_remove = self._owner_groups_to_remove_arg
 
         if isinstance(role_group, str):
-            self.role = db.session.scalars(
-                select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == role_group)
+            self.role = (
+                await db.session.scalars(
+                    select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == role_group)
+                )
             ).first()
         else:
             self.role = role_group
 
         self.groups_to_add = []
         if len(groups_to_add) > 0:
-            self.groups_to_add = db.session.scalars(
-                select(OktaGroup)
-                .options(
-                    selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
-                    selectin_polymorphic(OktaGroup, [AppGroup]),
-                    joinedload(AppGroup.app),
+            self.groups_to_add = (
+                await db.session.scalars(
+                    select(OktaGroup)
+                    .options(
+                        selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
+                        selectin_polymorphic(OktaGroup, [AppGroup]),
+                        joinedload(AppGroup.app),
+                    )
+                    .where(OktaGroup.id.in_(groups_to_add))
+                    .where(OktaGroup.is_managed.is_(True))
+                    .where(OktaGroup.deleted_at.is_(None))
+                    # Don't allow Roles to be added as Groups to Roles
+                    .where(OktaGroup.type != RoleGroup.__mapper_args__["polymorphic_identity"])
                 )
-                .where(OktaGroup.id.in_(groups_to_add))
-                .where(OktaGroup.is_managed.is_(True))
-                .where(OktaGroup.deleted_at.is_(None))
-                # Don't allow Roles to be added as Groups to Roles
-                .where(OktaGroup.type != RoleGroup.__mapper_args__["polymorphic_identity"])
             ).all()
         self.owner_groups_to_add = []
         if len(owner_groups_to_add) > 0:
-            self.owner_groups_to_add = db.session.scalars(
-                select(OktaGroup)
-                .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
-                .where(OktaGroup.id.in_(owner_groups_to_add))
-                .where(OktaGroup.is_managed.is_(True))
-                .where(OktaGroup.deleted_at.is_(None))
-                # Don't allow Roles to be added as Groups to Roles
-                .where(OktaGroup.type != RoleGroup.__mapper_args__["polymorphic_identity"])
+            self.owner_groups_to_add = (
+                await db.session.scalars(
+                    select(OktaGroup)
+                    .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
+                    .where(OktaGroup.id.in_(owner_groups_to_add))
+                    .where(OktaGroup.is_managed.is_(True))
+                    .where(OktaGroup.deleted_at.is_(None))
+                    # Don't allow Roles to be added as Groups to Roles
+                    .where(OktaGroup.type != RoleGroup.__mapper_args__["polymorphic_identity"])
+                )
             ).all()
 
         self.groups_should_expire = []
         if len(groups_should_expire) > 0:
-            self.groups_should_expire = db.session.scalars(
-                select(RoleGroupMap)
-                .where(RoleGroupMap.id.in_(groups_should_expire))
-                .where(RoleGroupMap.role_group_id == self.role.id)
-                .where(RoleGroupMap.ended_at > func.now())
-                .where(RoleGroupMap.is_owner.is_(False))
+            self.groups_should_expire = (
+                await db.session.scalars(
+                    select(RoleGroupMap)
+                    .where(RoleGroupMap.id.in_(groups_should_expire))
+                    .where(RoleGroupMap.role_group_id == self.role.id)
+                    .where(RoleGroupMap.ended_at > func.now())
+                    .where(RoleGroupMap.is_owner.is_(False))
+                )
             ).all()
 
         self.owner_groups_should_expire = []
         if len(owner_groups_should_expire) > 0:
-            self.owner_groups_should_expire = db.session.scalars(
-                select(RoleGroupMap)
-                .where(RoleGroupMap.id.in_(owner_groups_should_expire))
-                .where(RoleGroupMap.role_group_id == self.role.id)
-                .where(RoleGroupMap.ended_at > func.now())
-                .where(RoleGroupMap.is_owner.is_(True))
+            self.owner_groups_should_expire = (
+                await db.session.scalars(
+                    select(RoleGroupMap)
+                    .where(RoleGroupMap.id.in_(owner_groups_should_expire))
+                    .where(RoleGroupMap.role_group_id == self.role.id)
+                    .where(RoleGroupMap.ended_at > func.now())
+                    .where(RoleGroupMap.is_owner.is_(True))
+                )
             ).all()
 
         self.groups_to_remove = []
         if len(groups_to_remove) > 0:
-            self.groups_to_remove = db.session.scalars(
-                select(OktaGroup).where(OktaGroup.id.in_(groups_to_remove)).where(OktaGroup.deleted_at.is_(None))
+            self.groups_to_remove = (
+                await db.session.scalars(
+                    select(OktaGroup).where(OktaGroup.id.in_(groups_to_remove)).where(OktaGroup.deleted_at.is_(None))
+                )
             ).all()
 
         self.owner_groups_to_remove = []
         if len(owner_groups_to_remove) > 0:
-            self.owner_groups_to_remove = db.session.scalars(
-                select(OktaGroup).where(OktaGroup.id.in_(owner_groups_to_remove)).where(OktaGroup.deleted_at.is_(None))
+            self.owner_groups_to_remove = (
+                await db.session.scalars(
+                    select(OktaGroup)
+                    .where(OktaGroup.id.in_(owner_groups_to_remove))
+                    .where(OktaGroup.deleted_at.is_(None))
+                )
             ).all()
 
         self.current_user_id = getattr(
-            db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+            (
+                await db.session.scalars(
+                    select(OktaUser)
+                    .where(OktaUser.deleted_at.is_(None))
+                    .where(OktaUser.id == self._current_user_id_arg)
+                )
             ).first(),
             "id",
             None,
         )
 
-    def execute(self) -> RoleGroup:
-        self._resolve()
-        # Run asychronously to parallelize Okta API requests
-        return asyncio.run(self._execute())
-
-    async def _execute(self) -> RoleGroup:
+    async def execute(self) -> RoleGroup:
+        await self._resolve()
         # Fast return if no changes are being made
         if (
             len(self.groups_to_add)
@@ -170,7 +186,7 @@ class ModifyRoleGroups:
             return self.role
 
         # Check group tags on groups being added to see if current user isn't adding themselves as member or owner
-        valid, _ = CheckForSelfAdd(
+        valid, _ = await CheckForSelfAdd(
             group=self.role,
             current_user=self.current_user_id,
             members_to_add=[g.id for g in self.groups_to_add],
@@ -180,7 +196,7 @@ class ModifyRoleGroups:
             return self.role
 
         # Check group tags on groups being added to see if a reason is required
-        valid, _ = CheckForReason(
+        valid, _ = await CheckForReason(
             group=self.role,
             reason=self.created_reason,
             members_to_add=[g.id for g in self.groups_to_add],
@@ -192,7 +208,7 @@ class ModifyRoleGroups:
         # Audit logging
         email = None
         if self.current_user_id is not None:
-            email = getattr(db.session.get(OktaUser, self.current_user_id), "email", None)
+            email = getattr(await db.session.get(OktaUser, self.current_user_id), "email", None)
 
         _ctx = get_request_context()
 
@@ -228,9 +244,9 @@ class ModifyRoleGroups:
         # those extensions occured
 
         # Remove groups from role
-        self.__remove_groups_from_role(self.groups_to_remove + self.groups_to_add, False)
+        await self.__remove_groups_from_role(self.groups_to_remove + self.groups_to_add, False)
         # Remove owner groups from role
-        self.__remove_groups_from_role(self.owner_groups_to_remove + self.owner_groups_to_add, True)
+        await self.__remove_groups_from_role(self.owner_groups_to_remove + self.owner_groups_to_add, True)
 
         # Remove role members and owners from Okta groups associated with the role
         if len(self.groups_to_remove) > 0 or len(self.owner_groups_to_remove) > 0:
@@ -238,39 +254,43 @@ class ModifyRoleGroups:
             # combination before removing role, there can be multiple role groups
             # which allow group access for this user
 
-            active_role_members = db.session.scalars(
-                select(OktaUserGroupMember)
-                .where(
-                    or_(
-                        OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > func.now(),
+            active_role_members = (
+                await db.session.scalars(
+                    select(OktaUserGroupMember)
+                    .where(
+                        or_(
+                            OktaUserGroupMember.ended_at.is_(None),
+                            OktaUserGroupMember.ended_at > func.now(),
+                        )
                     )
+                    .where(OktaUserGroupMember.group_id == self.role.id)
+                    .where(OktaUserGroupMember.is_owner.is_(False))
                 )
-                .where(OktaUserGroupMember.group_id == self.role.id)
-                .where(OktaUserGroupMember.is_owner.is_(False))
             ).all()
 
             role_members_to_remove_ids = [m.user_id for m in active_role_members]
             groups_to_remove_ids = [m.id for m in self.groups_to_remove]
             owner_groups_to_remove_ids = [m.id for m in self.owner_groups_to_remove]
-            removed_role_group_users_with_other_access = db.session.execute(
-                select(
-                    OktaUserGroupMember.user_id,
-                    OktaUserGroupMember.group_id,
-                    OktaUserGroupMember.is_owner,
-                )
-                .where(
-                    or_(
-                        OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > func.now(),
+            removed_role_group_users_with_other_access = (
+                await db.session.execute(
+                    select(
+                        OktaUserGroupMember.user_id,
+                        OktaUserGroupMember.group_id,
+                        OktaUserGroupMember.is_owner,
                     )
-                )
-                .where(OktaUserGroupMember.user_id.in_(role_members_to_remove_ids))
-                .where(OktaUserGroupMember.group_id.in_(groups_to_remove_ids + owner_groups_to_remove_ids))
-                .group_by(
-                    OktaUserGroupMember.user_id,
-                    OktaUserGroupMember.group_id,
-                    OktaUserGroupMember.is_owner,
+                    .where(
+                        or_(
+                            OktaUserGroupMember.ended_at.is_(None),
+                            OktaUserGroupMember.ended_at > func.now(),
+                        )
+                    )
+                    .where(OktaUserGroupMember.user_id.in_(role_members_to_remove_ids))
+                    .where(OktaUserGroupMember.group_id.in_(groups_to_remove_ids + owner_groups_to_remove_ids))
+                    .group_by(
+                        OktaUserGroupMember.user_id,
+                        OktaUserGroupMember.group_id,
+                        OktaUserGroupMember.is_owner,
+                    )
                 )
             ).all()
 
@@ -286,30 +306,32 @@ class ModifyRoleGroups:
 
                 # Invoke app group lifecycle plugin hooks for removed members
                 if len(okta_members_to_remove_ids) > 0:
-                    group = db.session.get(OktaGroup, group_id)
+                    group = await db.session.get(OktaGroup, group_id)
                     plugin_id = get_app_group_lifecycle_plugin_to_invoke(group)
                     if plugin_id is not None:
-                        members_losing_access = db.session.scalars(
-                            select(OktaUser)
-                            .where(OktaUser.id.in_(okta_members_to_remove_ids))
-                            .where(OktaUser.deleted_at.is_(None))
+                        members_losing_access = (
+                            await db.session.scalars(
+                                select(OktaUser)
+                                .where(OktaUser.id.in_(okta_members_to_remove_ids))
+                                .where(OktaUser.deleted_at.is_(None))
+                            )
                         ).all()
                         try:
                             hook = get_app_group_lifecycle_hook()
                             hook.group_members_removed(
                                 session=db.session, group=group, members=members_losing_access, plugin_id=plugin_id
                             )
-                            db.session.commit()
+                            await db.session.commit()
                         except Exception:
                             logging.getLogger("api").exception(
                                 f"Failed to invoke group_members_removed hook for group {group.id} with plugin '{plugin_id}'"
                             )
-                            db.session.rollback()
+                            await db.session.rollback()
 
                 if self.sync_to_okta:
                     for member_id in okta_members_to_remove_ids:
                         # Remove user from okta group members
-                        async_tasks.append(asyncio.create_task(okta.async_remove_user_from_group(group_id, member_id)))
+                        async_tasks.append(asyncio.create_task(okta.remove_user_from_group(group_id, member_id)))
 
             if self.sync_to_okta:
                 for group_id in owner_groups_to_remove_ids:
@@ -324,13 +346,13 @@ class ModifyRoleGroups:
                     for owner_id in okta_owners_to_remove_ids:
                         # Remove user from okta group owners
                         # https://help.okta.com/en-us/Content/Topics/identity-governance/group-owner.htm
-                        async_tasks.append(asyncio.create_task(okta.async_remove_owner_from_group(group_id, owner_id)))
+                        async_tasks.append(asyncio.create_task(okta.remove_owner_from_group(group_id, owner_id)))
 
         # Mark relevant role memberships and ownerships as 'Should expire'
         # Only relevant for the expiring roles page so not adding checks for this field anywhere else since OK if marked to expire
         # then manually renewed from group/role page or with an access request
         if len(self.groups_should_expire) > 0:
-            db.session.execute(
+            await db.session.execute(
                 update(RoleGroupMap)
                 .where(RoleGroupMap.id.in_(m.id for m in self.groups_should_expire))
                 .values({RoleGroupMap.should_expire: True})
@@ -338,7 +360,7 @@ class ModifyRoleGroups:
             )
 
         if len(self.owner_groups_should_expire) > 0:
-            db.session.execute(
+            await db.session.execute(
                 update(RoleGroupMap)
                 .where(RoleGroupMap.id.in_(m.id for m in self.owner_groups_should_expire))
                 .values({RoleGroupMap.should_expire: True})
@@ -346,7 +368,7 @@ class ModifyRoleGroups:
             )
 
         # Commit all changes so far
-        db.session.commit()
+        await db.session.commit()
 
         # Add new groups to role and owner groups to role
         if len(self.groups_to_add) > 0 or len(self.owner_groups_to_add) > 0:
@@ -395,20 +417,22 @@ class ModifyRoleGroups:
                 db.session.add(ownership_to_add)
 
             # Commit changes so far so we can reference the ids of the new role group maps in the OktaUserGroupMembers
-            db.session.commit()
+            await db.session.commit()
 
             # Group members of a role should be added as members to all newly added groups
             # and owner groups associated with that role
-            active_role_memberships = db.session.scalars(
-                select(OktaUserGroupMember)
-                .where(
-                    or_(
-                        OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > func.now(),
+            active_role_memberships = (
+                await db.session.scalars(
+                    select(OktaUserGroupMember)
+                    .where(
+                        or_(
+                            OktaUserGroupMember.ended_at.is_(None),
+                            OktaUserGroupMember.ended_at > func.now(),
+                        )
                     )
+                    .where(OktaUserGroupMember.group_id == self.role.id)
+                    .where(OktaUserGroupMember.is_owner.is_(False))
                 )
-                .where(OktaUserGroupMember.group_id == self.role.id)
-                .where(OktaUserGroupMember.is_owner.is_(False))
             ).all()
             groups_added_by_id = {group.id: group for group in self.groups_to_add}
             group_memberships_added: Dict[str, Dict[str, OktaUserGroupMember]] = {}
@@ -417,13 +441,15 @@ class ModifyRoleGroups:
 
                 # Check which members being added currently have NO active memberships (to track first-time access)
                 members_to_add_ids = [m.user_id for m in active_role_memberships]
-                existing_members_with_access = db.session.scalars(
-                    select(OktaUserGroupMember.user_id)
-                    .where(or_(OktaUserGroupMember.ended_at.is_(None), OktaUserGroupMember.ended_at > func.now()))
-                    .where(OktaUserGroupMember.group_id == role_associated_group_map.group_id)
-                    .where(OktaUserGroupMember.user_id.in_(members_to_add_ids))
-                    .where(OktaUserGroupMember.is_owner.is_(False))
-                    .group_by(OktaUserGroupMember.user_id)
+                existing_members_with_access = (
+                    await db.session.scalars(
+                        select(OktaUserGroupMember.user_id)
+                        .where(or_(OktaUserGroupMember.ended_at.is_(None), OktaUserGroupMember.ended_at > func.now()))
+                        .where(OktaUserGroupMember.group_id == role_associated_group_map.group_id)
+                        .where(OktaUserGroupMember.user_id.in_(members_to_add_ids))
+                        .where(OktaUserGroupMember.is_owner.is_(False))
+                        .group_by(OktaUserGroupMember.user_id)
+                    )
                 ).all()
                 existing_member_ids = set(existing_members_with_access)
                 members_gaining_access_ids = set(members_to_add_ids) - existing_member_ids
@@ -433,29 +459,31 @@ class ModifyRoleGroups:
                     group = groups_added_by_id[role_associated_group_map.group_id]
                     plugin_id = get_app_group_lifecycle_plugin_to_invoke(group)
                     if plugin_id is not None:
-                        members_gaining_access = db.session.scalars(
-                            select(OktaUser)
-                            .where(OktaUser.id.in_(members_gaining_access_ids))
-                            .where(OktaUser.deleted_at.is_(None))
+                        members_gaining_access = (
+                            await db.session.scalars(
+                                select(OktaUser)
+                                .where(OktaUser.id.in_(members_gaining_access_ids))
+                                .where(OktaUser.deleted_at.is_(None))
+                            )
                         ).all()
                         try:
                             hook = get_app_group_lifecycle_hook()
                             hook.group_members_added(
                                 session=db.session, group=group, members=members_gaining_access, plugin_id=plugin_id
                             )
-                            db.session.commit()
+                            await db.session.commit()
                         except Exception:
                             logging.getLogger("api").exception(
                                 f"Failed to invoke group_members_added hook for group {group.id} with plugin '{plugin_id}'"
                             )
-                            db.session.rollback()
+                            await db.session.rollback()
 
                 for member in active_role_memberships:
                     # Add user to okta group members
                     if self.sync_to_okta:
                         async_tasks.append(
                             asyncio.create_task(
-                                okta.async_add_user_to_group(role_associated_group_map.group_id, member.user_id)
+                                okta.add_user_to_group(role_associated_group_map.group_id, member.user_id)
                             )
                         )
 
@@ -492,7 +520,7 @@ class ModifyRoleGroups:
                     if self.sync_to_okta:
                         async_tasks.append(
                             asyncio.create_task(
-                                okta.async_add_owner_to_group(role_associated_group_map.group_id, member.user_id)
+                                okta.add_owner_to_group(role_associated_group_map.group_id, member.user_id)
                             )
                         )
                     # If the both the role membership and role group map are time bounded,
@@ -519,7 +547,7 @@ class ModifyRoleGroups:
                     db.session.add(ownership_to_add)
 
             # Commit changes so far, so we can reference OktaUserGroupMember in approved AccessRequests
-            db.session.commit()
+            await db.session.commit()
 
             # Approve any pending access requests for access granted by this operation
             pending_requests_query = (
@@ -531,10 +559,12 @@ class ModifyRoleGroups:
             active_role_membership_ids = [m.user_id for m in active_role_memberships]
 
             # Find all pending membership requests to approve for groups added as members via this role
-            pending_member_requests = db.session.scalars(
-                pending_requests_query.where(AccessRequest.requested_group_id.in_(group_memberships_added.keys()))
-                .where(AccessRequest.requester_user_id.in_(active_role_membership_ids))
-                .where(AccessRequest.request_ownership.is_(False))
+            pending_member_requests = (
+                await db.session.scalars(
+                    pending_requests_query.where(AccessRequest.requested_group_id.in_(group_memberships_added.keys()))
+                    .where(AccessRequest.requester_user_id.in_(active_role_membership_ids))
+                    .where(AccessRequest.request_ownership.is_(False))
+                )
             ).all()
             for access_request in pending_member_requests:
                 approved_access_requests.append(
@@ -545,10 +575,12 @@ class ModifyRoleGroups:
                 )
 
             # Find all pending ownership requests to approve for groups added as owners via this role
-            pending_role_associated_owner_requests = db.session.scalars(
-                pending_requests_query.where(AccessRequest.requested_group_id.in_(group_ownerships_added.keys()))
-                .where(AccessRequest.requester_user_id.in_(active_role_membership_ids))
-                .where(AccessRequest.request_ownership.is_(True))
+            pending_role_associated_owner_requests = (
+                await db.session.scalars(
+                    pending_requests_query.where(AccessRequest.requested_group_id.in_(group_ownerships_added.keys()))
+                    .where(AccessRequest.requester_user_id.in_(active_role_membership_ids))
+                    .where(AccessRequest.request_ownership.is_(True))
+                )
             ).all()
             for access_request in pending_role_associated_owner_requests:
                 approved_access_requests.append(
@@ -568,9 +600,11 @@ class ModifyRoleGroups:
             )
 
             added_group_ids = [group.id for group in self.groups_to_add]
-            pending_role_memberships = db.session.scalars(
-                pending_role_requests_query.where(RoleRequest.request_ownership.is_(False)).where(
-                    RoleRequest.requested_group_id.in_(added_group_ids)
+            pending_role_memberships = (
+                await db.session.scalars(
+                    pending_role_requests_query.where(RoleRequest.request_ownership.is_(False)).where(
+                        RoleRequest.requested_group_id.in_(added_group_ids)
+                    )
                 )
             ).all()
             for role_request in pending_role_memberships:
@@ -580,9 +614,11 @@ class ModifyRoleGroups:
 
             # Approve any pending role requests for ownerships granted by this operation
             added_owner_group_ids = [group.id for group in self.owner_groups_to_add]
-            pending_role_ownerships = db.session.scalars(
-                pending_role_requests_query.where(RoleRequest.request_ownership.is_(True)).where(
-                    RoleRequest.requested_group_id.in_(added_owner_group_ids)
+            pending_role_ownerships = (
+                await db.session.scalars(
+                    pending_role_requests_query.where(RoleRequest.request_ownership.is_(True)).where(
+                        RoleRequest.requested_group_id.in_(added_owner_group_ids)
+                    )
                 )
             ).all()
             for role_request in pending_role_ownerships:
@@ -590,10 +626,10 @@ class ModifyRoleGroups:
                     self._approve_role_request(role_request, role_ownerships_added[role_request.requested_group_id])
                 )
 
-            db.session.commit()
+            await db.session.commit()
 
         # Commit all changes
-        db.session.commit()
+        await db.session.commit()
 
         # Resolve everything the notification hooks need on the main coroutine
         # before spawning tasks: spawned tasks must only perform network I/O,
@@ -603,9 +639,9 @@ class ModifyRoleGroups:
             group = access_request.requested_group
             # `resolved_at` was assigned func.now() and expired at flush;
             # reload it explicitly so the hook sees a concrete value.
-            db.session.refresh(access_request, attribute_names=["resolved_at"])
-            requester = db.session.get(OktaUser, access_request.requester_user_id)
-            approvers = get_all_possible_request_approvers(access_request)
+            await db.session.refresh(access_request, attribute_names=["resolved_at"])
+            requester = await db.session.get(OktaUser, access_request.requester_user_id)
+            approvers = await get_all_possible_request_approvers(access_request)
             async_tasks.append(
                 asyncio.create_task(self._notify_access_request(access_request, group, requester, approvers))
             )
@@ -614,9 +650,9 @@ class ModifyRoleGroups:
             for role_request in approved_role_requests:
                 role = role_request.requester_role
                 group = role_request.requested_group
-                db.session.refresh(role_request, attribute_names=["resolved_at"])
-                requester = db.session.get(OktaUser, role_request.requester_user_id)
-                approvers = get_all_possible_request_approvers(role_request)
+                await db.session.refresh(role_request, attribute_names=["resolved_at"])
+                requester = await db.session.get(OktaUser, role_request.requester_user_id)
+                approvers = await get_all_possible_request_approvers(role_request)
                 async_tasks.append(
                     asyncio.create_task(self._notify_role_request(role_request, role, group, requester, approvers))
                 )
@@ -626,26 +662,30 @@ class ModifyRoleGroups:
 
         return self.role
 
-    def __remove_groups_from_role(self, groups_to_remove: list[OktaGroup] = [], owner_groups: bool = False) -> None:
+    async def __remove_groups_from_role(
+        self, groups_to_remove: list[OktaGroup] = [], owner_groups: bool = False
+    ) -> None:
         if len(groups_to_remove) == 0:
             return
 
         # Role user members should be removed from any groups associated with that role being removed
-        old_role_associated_groups_mappings = db.session.scalars(
-            select(RoleGroupMap)
-            .where(
-                or_(
-                    RoleGroupMap.ended_at.is_(None),
-                    RoleGroupMap.ended_at > func.now(),
+        old_role_associated_groups_mappings = (
+            await db.session.scalars(
+                select(RoleGroupMap)
+                .where(
+                    or_(
+                        RoleGroupMap.ended_at.is_(None),
+                        RoleGroupMap.ended_at > func.now(),
+                    )
                 )
+                .where(RoleGroupMap.role_group_id == self.role.id)
+                .where(RoleGroupMap.group_id.in_([g.id for g in groups_to_remove]))
+                .where(RoleGroupMap.is_owner == owner_groups)
             )
-            .where(RoleGroupMap.role_group_id == self.role.id)
-            .where(RoleGroupMap.group_id.in_([g.id for g in groups_to_remove]))
-            .where(RoleGroupMap.is_owner == owner_groups)
         ).all()
 
         # End group memberships via role
-        db.session.execute(
+        await db.session.execute(
             update(OktaUserGroupMember)
             .where(
                 or_(
@@ -661,7 +701,7 @@ class ModifyRoleGroups:
         )
 
         # End mappings of role associated group to role
-        db.session.execute(
+        await db.session.execute(
             update(RoleGroupMap)
             .where(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
             .where(RoleGroupMap.role_group_id == self.role.id)

--- a/api/operations/modify_role_groups.py
+++ b/api/operations/modify_role_groups.py
@@ -47,14 +47,42 @@ class ModifyRoleGroups:
         created_reason: str = "",
         notify: bool = True,
     ):
+        self._role_group_arg = role_group
+
+        self.groups_added_ended_at = groups_added_ended_at
+
+        self._groups_to_add_arg = groups_to_add
+        self._owner_groups_to_add_arg = owner_groups_to_add
+        self._groups_should_expire_arg = groups_should_expire
+        self._owner_groups_should_expire_arg = owner_groups_should_expire
+        self._groups_to_remove_arg = groups_to_remove
+        self._owner_groups_to_remove_arg = owner_groups_to_remove
+
+        self.sync_to_okta = sync_to_okta
+
+        self._current_user_id_arg = current_user_id
+
+        self.created_reason = created_reason
+
+        self.notify = notify
+
+        self.notification_hook = get_notification_hook()
+
+    def _resolve(self) -> None:
+        role_group = self._role_group_arg
+        groups_to_add = self._groups_to_add_arg
+        owner_groups_to_add = self._owner_groups_to_add_arg
+        groups_should_expire = self._groups_should_expire_arg
+        owner_groups_should_expire = self._owner_groups_should_expire_arg
+        groups_to_remove = self._groups_to_remove_arg
+        owner_groups_to_remove = self._owner_groups_to_remove_arg
+
         if isinstance(role_group, str):
             self.role = db.session.scalars(
                 select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == role_group)
             ).first()
         else:
             self.role = role_group
-
-        self.groups_added_ended_at = groups_added_ended_at
 
         self.groups_to_add = []
         if len(groups_to_add) > 0:
@@ -115,23 +143,16 @@ class ModifyRoleGroups:
                 select(OktaGroup).where(OktaGroup.id.in_(owner_groups_to_remove)).where(OktaGroup.deleted_at.is_(None))
             ).all()
 
-        self.sync_to_okta = sync_to_okta
-
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
-        self.created_reason = created_reason
-
-        self.notify = notify
-
-        self.notification_hook = get_notification_hook()
-
     def execute(self) -> RoleGroup:
+        self._resolve()
         # Run asychronously to parallelize Okta API requests
         return asyncio.run(self._execute())
 

--- a/api/operations/modify_role_groups.py
+++ b/api/operations/modify_role_groups.py
@@ -9,6 +9,7 @@ from api.context import get_request_context
 from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload
 
 from api.extensions import db
+from api.operations._fan_out import drain_fan_out_tasks
 from api.models import (
     AccessRequest,
     AccessRequestStatus,
@@ -657,8 +658,7 @@ class ModifyRoleGroups:
                     asyncio.create_task(self._notify_role_request(role_request, role, group, requester, approvers))
                 )
 
-        if len(async_tasks) > 0:
-            await asyncio.wait(async_tasks)
+        await drain_fan_out_tasks(async_tasks, f"ModifyRoleGroups for role {self.role.id}")
 
         return self.role
 

--- a/api/operations/reject_access_request.py
+++ b/api/operations/reject_access_request.py
@@ -1,6 +1,9 @@
+import functools
 from typing import Optional
 
 import logging
+
+import anyio.to_thread
 
 from api.context import get_request_context
 from sqlalchemy import func, nullsfirst, select
@@ -33,7 +36,7 @@ class RejectAccessRequest:
 
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         access_request = self._access_request_arg
         current_user_id = self._current_user_id_arg
 
@@ -41,16 +44,19 @@ class RejectAccessRequest:
         # reject; both serialize on this row and the loser hits the resolved
         # guard. No-op on SQLite.
         request_id = access_request if isinstance(access_request, str) else access_request.id
-        self.access_request = db.session.scalars(
+        request_result = await db.session.scalars(
             select(AccessRequest).where(AccessRequest.id == request_id).with_for_update()
-        ).first()
+        )
+        self.access_request = request_result.first()
 
         if current_user_id is None:
             self.rejecter_id = None
         elif isinstance(current_user_id, str):
             self.rejecter_id = getattr(
-                db.session.scalars(
-                    select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                (
+                    await db.session.scalars(
+                        select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                    )
                 ).first(),
                 "id",
                 None,
@@ -58,8 +64,8 @@ class RejectAccessRequest:
         else:
             self.rejecter_id = current_user_id.id
 
-    def execute(self) -> AccessRequest:
-        self._resolve()
+    async def execute(self) -> AccessRequest:
+        await self._resolve()
         # Don't allow rejecting a request that is already resolved. Raise
         # rather than silently no-op so a stale/concurrent rejection surfaces
         # as a conflict instead of looking like a success.
@@ -71,18 +77,20 @@ class RejectAccessRequest:
         self.access_request.resolver_user_id = self.rejecter_id
         self.access_request.resolution_reason = self.rejection_reason
 
-        db.session.commit()
+        await db.session.commit()
 
         # Audit logging
         email = None
         if self.rejecter_id is not None:
-            email = getattr(db.session.get(OktaUser, self.rejecter_id), "email", None)
+            email = getattr(await db.session.get(OktaUser, self.rejecter_id), "email", None)
 
-        group = db.session.scalars(
-            select(OktaGroup)
-            .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
-            .where(OktaGroup.id == self.access_request.requested_group_id)
-            .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
+        group = (
+            await db.session.scalars(
+                select(OktaGroup)
+                .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]), joinedload(AppGroup.app))
+                .where(OktaGroup.id == self.access_request.requested_group_id)
+                .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
+            )
         ).first()
 
         _ctx = get_request_context()
@@ -97,22 +105,27 @@ class RejectAccessRequest:
                     "current_user_email": email,
                     "group": group,
                     "request": self.access_request,
-                    "requester": db.session.get(OktaUser, self.access_request.requester_user_id),
+                    "requester": await db.session.get(OktaUser, self.access_request.requester_user_id),
                 }
             )
         )
 
         if self.notify:
-            requester = db.session.get(OktaUser, self.access_request.requester_user_id)
+            requester = await db.session.get(OktaUser, self.access_request.requester_user_id)
 
-            approvers = get_all_possible_request_approvers(self.access_request)
+            approvers = await get_all_possible_request_approvers(self.access_request)
 
-            self.notification_hook.access_request_completed(
-                access_request=self.access_request,
-                group=group,
-                requester=requester,
-                approvers=approvers,
-                notify_requester=self.notify_requester,
+            # Sync notification hook may do network I/O; run it on a worker
+            # thread so it doesn't block the event loop.
+            await anyio.to_thread.run_sync(
+                functools.partial(
+                    self.notification_hook.access_request_completed,
+                    access_request=self.access_request,
+                    group=group,
+                    requester=requester,
+                    approvers=approvers,
+                    notify_requester=self.notify_requester,
+                )
             )
 
         return self.access_request

--- a/api/operations/reject_access_request.py
+++ b/api/operations/reject_access_request.py
@@ -24,6 +24,19 @@ class RejectAccessRequest:
         notify_requester: bool = True,
         current_user_id: Optional[str | OktaUser] = None,
     ):
+        self._access_request_arg = access_request
+        self._current_user_id_arg = current_user_id
+
+        self.rejection_reason = rejection_reason
+        self.notify = notify
+        self.notify_requester = notify_requester
+
+        self.notification_hook = get_notification_hook()
+
+    def _resolve(self) -> None:
+        access_request = self._access_request_arg
+        current_user_id = self._current_user_id_arg
+
         # Lock the request row so a reject can't race a concurrent approve/
         # reject; both serialize on this row and the loser hits the resolved
         # guard. No-op on SQLite.
@@ -45,13 +58,8 @@ class RejectAccessRequest:
         else:
             self.rejecter_id = current_user_id.id
 
-        self.rejection_reason = rejection_reason
-        self.notify = notify
-        self.notify_requester = notify_requester
-
-        self.notification_hook = get_notification_hook()
-
     def execute(self) -> AccessRequest:
+        self._resolve()
         # Don't allow rejecting a request that is already resolved. Raise
         # rather than silently no-op so a stale/concurrent rejection surfaces
         # as a conflict instead of looking like a success.

--- a/api/operations/reject_group_request.py
+++ b/api/operations/reject_group_request.py
@@ -1,7 +1,9 @@
+import functools
 from typing import Optional
 
 import logging
 
+import anyio.to_thread
 from sqlalchemy import func, select
 from api.context import get_request_context
 
@@ -33,7 +35,7 @@ class RejectGroupRequest:
 
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         group_request = self._group_request_arg
         current_user_id = self._current_user_id_arg
 
@@ -41,22 +43,25 @@ class RejectGroupRequest:
         # reject; both serialize on this row and the loser hits the resolved
         # guard. No-op on SQLite.
         request_id = group_request if isinstance(group_request, str) else group_request.id
-        self.group_request = db.session.scalars(
+        request_result = await db.session.scalars(
             select(GroupRequest).where(GroupRequest.id == request_id).with_for_update()
-        ).first()
+        )
+        self.group_request = request_result.first()
 
         if current_user_id is None:
             self.rejecter_id = None
         elif isinstance(current_user_id, str):
-            user = db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+            user = (
+                await db.session.scalars(
+                    select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                )
             ).first()
             self.rejecter_id = user.id if user else None
         else:
             self.rejecter_id = current_user_id.id
 
-    def execute(self) -> GroupRequest:
-        self._resolve()
+    async def execute(self) -> GroupRequest:
+        await self._resolve()
         # Already resolved — raise rather than silently no-op so a stale/
         # concurrent rejection surfaces as a conflict instead of a success.
         if self.group_request.status != AccessRequestStatus.PENDING or self.group_request.resolved_at is not None:
@@ -72,22 +77,24 @@ class RejectGroupRequest:
             is_self_rejection = self.group_request.requester_user_id == self.rejecter_id
 
             if not is_self_rejection:
-                access_owner_ids = {u.id for u in get_access_owners()}
+                access_owner_ids = {u.id for u in await get_access_owners()}
                 is_global_admin = self.rejecter_id in access_owner_ids
 
                 if not is_global_admin:
                     # Check app ownership if this is an app group request
                     if resolved_app_id is not None:
-                        is_app_owner = db.session.scalars(
-                            select(OktaUserGroupMember)
-                            .join(AppGroup, OktaUserGroupMember.group_id == AppGroup.id)
-                            .where(
-                                AppGroup.app_id == resolved_app_id,
-                                AppGroup.is_owner.is_(True),
-                                AppGroup.deleted_at.is_(None),
-                                OktaUserGroupMember.user_id == self.rejecter_id,
-                                OktaUserGroupMember.is_owner.is_(True),
-                                OktaUserGroupMember.ended_at.is_(None),
+                        is_app_owner = (
+                            await db.session.scalars(
+                                select(OktaUserGroupMember)
+                                .join(AppGroup, OktaUserGroupMember.group_id == AppGroup.id)
+                                .where(
+                                    AppGroup.app_id == resolved_app_id,
+                                    AppGroup.is_owner.is_(True),
+                                    AppGroup.deleted_at.is_(None),
+                                    OktaUserGroupMember.user_id == self.rejecter_id,
+                                    OktaUserGroupMember.is_owner.is_(True),
+                                    OktaUserGroupMember.ended_at.is_(None),
+                                )
                             )
                         ).first()
 
@@ -98,7 +105,7 @@ class RejectGroupRequest:
                         return self.group_request
 
         # Audit logging
-        email = getattr(db.session.get(OktaUser, self.rejecter_id), "email", None) if self.rejecter_id else None
+        email = getattr(await db.session.get(OktaUser, self.rejecter_id), "email", None) if self.rejecter_id else None
         _ctx = get_request_context()
         logging.getLogger("access.audit").info(
             AuditLogSchema().dumps(
@@ -109,7 +116,7 @@ class RejectGroupRequest:
                     "current_user_id": self.rejecter_id,
                     "current_user_email": email,
                     "group_request": self.group_request,
-                    "requester": db.session.get(OktaUser, self.group_request.requester_user_id),
+                    "requester": await db.session.get(OktaUser, self.group_request.requester_user_id),
                 }
             )
         )
@@ -119,19 +126,24 @@ class RejectGroupRequest:
         self.group_request.resolver_user_id = self.rejecter_id
         self.group_request.resolution_reason = self.rejection_reason
 
-        db.session.commit()
+        await db.session.commit()
 
         if self.notify:
-            requester = db.session.get(OktaUser, self.group_request.requester_user_id)
+            requester = await db.session.get(OktaUser, self.group_request.requester_user_id)
 
-            approvers = get_all_possible_request_approvers(self.group_request)
+            approvers = await get_all_possible_request_approvers(self.group_request)
 
-            self.notification_hook.access_group_request_completed(
-                group_request=self.group_request,
-                group=None,
-                requester=requester,
-                approvers=approvers,
-                notify_requester=self.notify_requester,
+            # Sync notification hook may do network I/O; run it on a worker
+            # thread so it doesn't block the event loop.
+            await anyio.to_thread.run_sync(
+                functools.partial(
+                    self.notification_hook.access_group_request_completed,
+                    group_request=self.group_request,
+                    group=None,
+                    requester=requester,
+                    approvers=approvers,
+                    notify_requester=self.notify_requester,
+                )
             )
 
         return self.group_request

--- a/api/operations/reject_group_request.py
+++ b/api/operations/reject_group_request.py
@@ -24,6 +24,19 @@ class RejectGroupRequest:
         notify_requester: bool = True,
         current_user_id: Optional[str | OktaUser] = None,
     ):
+        self._group_request_arg = group_request
+        self._current_user_id_arg = current_user_id
+
+        self.rejection_reason = rejection_reason
+        self.notify = notify
+        self.notify_requester = notify_requester
+
+        self.notification_hook = get_notification_hook()
+
+    def _resolve(self) -> None:
+        group_request = self._group_request_arg
+        current_user_id = self._current_user_id_arg
+
         # Lock the request row so a reject can't race a concurrent approve/
         # reject; both serialize on this row and the loser hits the resolved
         # guard. No-op on SQLite.
@@ -42,13 +55,8 @@ class RejectGroupRequest:
         else:
             self.rejecter_id = current_user_id.id
 
-        self.rejection_reason = rejection_reason
-        self.notify = notify
-        self.notify_requester = notify_requester
-
-        self.notification_hook = get_notification_hook()
-
     def execute(self) -> GroupRequest:
+        self._resolve()
         # Already resolved — raise rather than silently no-op so a stale/
         # concurrent rejection surfaces as a conflict instead of a success.
         if self.group_request.status != AccessRequestStatus.PENDING or self.group_request.resolved_at is not None:

--- a/api/operations/reject_role_request.py
+++ b/api/operations/reject_role_request.py
@@ -24,6 +24,19 @@ class RejectRoleRequest:
         notify_requester: bool = True,
         current_user_id: Optional[str | OktaUser] = None,
     ):
+        self._role_request_arg = role_request
+        self._current_user_id_arg = current_user_id
+
+        self.rejection_reason = rejection_reason
+        self.notify = notify
+        self.notify_requester = notify_requester
+
+        self.notification_hook = get_notification_hook()
+
+    def _resolve(self) -> None:
+        role_request = self._role_request_arg
+        current_user_id = self._current_user_id_arg
+
         # Lock the request row so a reject can't race a concurrent approve/
         # reject; both serialize on this row and the loser hits the resolved
         # guard. No-op on SQLite.
@@ -45,13 +58,8 @@ class RejectRoleRequest:
         else:
             self.rejecter_id = current_user_id.id
 
-        self.rejection_reason = rejection_reason
-        self.notify = notify
-        self.notify_requester = notify_requester
-
-        self.notification_hook = get_notification_hook()
-
     def execute(self) -> RoleRequest:
+        self._resolve()
         # Don't allow rejecting a request that is already resolved. Raise
         # rather than silently no-op so a stale/concurrent rejection surfaces
         # as a conflict instead of looking like a success.

--- a/api/operations/reject_role_request.py
+++ b/api/operations/reject_role_request.py
@@ -1,6 +1,9 @@
+import functools
 from typing import Optional
 
 import logging
+
+import anyio.to_thread
 
 from api.context import get_request_context
 from sqlalchemy import func, nullsfirst, select
@@ -33,7 +36,7 @@ class RejectRoleRequest:
 
         self.notification_hook = get_notification_hook()
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         role_request = self._role_request_arg
         current_user_id = self._current_user_id_arg
 
@@ -41,16 +44,19 @@ class RejectRoleRequest:
         # reject; both serialize on this row and the loser hits the resolved
         # guard. No-op on SQLite.
         request_id = role_request if isinstance(role_request, str) else role_request.id
-        self.role_request = db.session.scalars(
+        request_result = await db.session.scalars(
             select(RoleRequest).where(RoleRequest.id == request_id).with_for_update()
-        ).first()
+        )
+        self.role_request = request_result.first()
 
         if current_user_id is None:
             self.rejecter_id = None
         elif isinstance(current_user_id, str):
             self.rejecter_id = getattr(
-                db.session.scalars(
-                    select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                (
+                    await db.session.scalars(
+                        select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                    )
                 ).first(),
                 "id",
                 None,
@@ -58,8 +64,8 @@ class RejectRoleRequest:
         else:
             self.rejecter_id = current_user_id.id
 
-    def execute(self) -> RoleRequest:
-        self._resolve()
+    async def execute(self) -> RoleRequest:
+        await self._resolve()
         # Don't allow rejecting a request that is already resolved. Raise
         # rather than silently no-op so a stale/concurrent rejection surfaces
         # as a conflict instead of looking like a success.
@@ -71,18 +77,20 @@ class RejectRoleRequest:
         self.role_request.resolver_user_id = self.rejecter_id
         self.role_request.resolution_reason = self.rejection_reason
 
-        db.session.commit()
+        await db.session.commit()
 
         # Audit logging
         email = None
         if self.rejecter_id is not None:
-            email = getattr(db.session.get(OktaUser, self.rejecter_id), "email", None)
+            email = getattr(await db.session.get(OktaUser, self.rejecter_id), "email", None)
 
-        group = db.session.scalars(
-            select(OktaGroup)
-            .options(selectin_polymorphic(OktaGroup, [AppGroup]), joinedload(AppGroup.app))
-            .where(OktaGroup.id == self.role_request.requested_group_id)
-            .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
+        group = (
+            await db.session.scalars(
+                select(OktaGroup)
+                .options(selectin_polymorphic(OktaGroup, [AppGroup]), joinedload(AppGroup.app))
+                .where(OktaGroup.id == self.role_request.requested_group_id)
+                .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
+            )
         ).first()
 
         _ctx = get_request_context()
@@ -97,24 +105,29 @@ class RejectRoleRequest:
                     "current_user_email": email,
                     "group": group,
                     "role_request": self.role_request,
-                    "requester": db.session.get(OktaUser, self.role_request.requester_user_id),
+                    "requester": await db.session.get(OktaUser, self.role_request.requester_user_id),
                 }
             )
         )
 
         if self.notify:
-            requester = db.session.get(OktaUser, self.role_request.requester_user_id)
-            requester_role = db.session.get(OktaGroup, self.role_request.requester_role_id)
+            requester = await db.session.get(OktaUser, self.role_request.requester_user_id)
+            requester_role = await db.session.get(OktaGroup, self.role_request.requester_role_id)
 
-            approvers = get_all_possible_request_approvers(self.role_request)
+            approvers = await get_all_possible_request_approvers(self.role_request)
 
-            self.notification_hook.access_role_request_completed(
-                role_request=self.role_request,
-                role=requester_role,
-                group=group,
-                requester=requester,
-                approvers=approvers,
-                notify_requester=self.notify_requester,
+            # Sync notification hook may do network I/O; run it on a worker
+            # thread so it doesn't block the event loop.
+            await anyio.to_thread.run_sync(
+                functools.partial(
+                    self.notification_hook.access_role_request_completed,
+                    role_request=self.role_request,
+                    role=requester_role,
+                    group=group,
+                    requester=requester,
+                    approvers=approvers,
+                    notify_requester=self.notify_requester,
+                )
             )
 
         return self.role_request

--- a/api/operations/unmanage_group.py
+++ b/api/operations/unmanage_group.py
@@ -25,6 +25,11 @@ logger = logging.getLogger(__name__)
 # Run this operation when a group becomes unmanaged by Access
 class UnmanageGroup:
     def __init__(self, *, group: OktaGroup | str, current_user_id: Optional[str] = None):
+        self._group_arg = group
+        self._current_user_id_arg = current_user_id
+
+    def _resolve(self) -> None:
+        group = self._group_arg
         self.group = db.session.scalars(
             select(OktaGroup)
             .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
@@ -33,13 +38,14 @@ class UnmanageGroup:
 
         self.current_user_id = getattr(
             db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
             ).first(),
             "id",
             None,
         )
 
     def execute(self, dry_run: bool = False) -> None:
+        self._resolve()
         if self.group.is_managed:
             return
 

--- a/api/operations/unmanage_group.py
+++ b/api/operations/unmanage_group.py
@@ -28,24 +28,30 @@ class UnmanageGroup:
         self._group_arg = group
         self._current_user_id_arg = current_user_id
 
-    def _resolve(self) -> None:
+    async def _resolve(self) -> None:
         group = self._group_arg
-        self.group = db.session.scalars(
-            select(OktaGroup)
-            .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-            .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+        self.group = (
+            await db.session.scalars(
+                select(OktaGroup)
+                .options(selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+                .where(OktaGroup.id == (group if isinstance(group, str) else group.id))
+            )
         ).first()
 
         self.current_user_id = getattr(
-            db.session.scalars(
-                select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == self._current_user_id_arg)
+            (
+                await db.session.scalars(
+                    select(OktaUser)
+                    .where(OktaUser.deleted_at.is_(None))
+                    .where(OktaUser.id == self._current_user_id_arg)
+                )
             ).first(),
             "id",
             None,
         )
 
-    def execute(self, dry_run: bool = False) -> None:
-        self._resolve()
+    async def execute(self, dry_run: bool = False) -> None:
+        await self._resolve()
         if self.group.is_managed:
             return
 
@@ -64,7 +70,7 @@ class UnmanageGroup:
             .where(OktaUserGroupMember.role_group_map_id.isnot(None))
         )
 
-        for active_access_via_role in db.session.scalars(active_access_via_roles_query).all():
+        for active_access_via_role in (await db.session.scalars(active_access_via_roles_query)).all():
             logger.info(
                 f"User {active_access_via_role.user_id} has invalid "
                 f"{'ownership' if active_access_via_role.is_owner else 'membership'} "
@@ -72,7 +78,7 @@ class UnmanageGroup:
             )
 
         if not dry_run:
-            db.session.execute(
+            await db.session.execute(
                 update(OktaUserGroupMember)
                 .where(
                     or_(
@@ -85,7 +91,7 @@ class UnmanageGroup:
                 .values({OktaUserGroupMember.ended_at: func.now()})
                 .execution_options(synchronize_session="fetch")
             )
-            db.session.commit()
+            await db.session.commit()
 
         # End all roles associations where this group was a member
         active_role_assignments_query = (
@@ -94,7 +100,7 @@ class UnmanageGroup:
             .where(RoleGroupMap.group_id == self.group.id)
         )
 
-        for active_role_assignment in db.session.scalars(active_role_assignments_query).all():
+        for active_role_assignment in (await db.session.scalars(active_role_assignments_query)).all():
             logger.info(
                 f"Role {active_role_assignment.role_group_id} has invalid "
                 f"{'ownership' if active_role_assignment.is_owner else 'membership'} "
@@ -102,24 +108,26 @@ class UnmanageGroup:
             )
 
         if not dry_run:
-            db.session.execute(
+            await db.session.execute(
                 update(RoleGroupMap)
                 .where(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
                 .where(RoleGroupMap.group_id == self.group.id)
                 .values({RoleGroupMap.ended_at: func.now()})
                 .execution_options(synchronize_session="fetch")
             )
-            db.session.commit()
+            await db.session.commit()
 
         # If this groups is a RoleGroup, do not remove the groups associated with the role
         # Unmanaged roles can still be associated with groups
 
         # Reject all pending access requests for this group
-        obsolete_access_requests = db.session.scalars(
-            select(AccessRequest)
-            .where(AccessRequest.requested_group_id == self.group.id)
-            .where(AccessRequest.status == AccessRequestStatus.PENDING)
-            .where(AccessRequest.resolved_at.is_(None))
+        obsolete_access_requests = (
+            await db.session.scalars(
+                select(AccessRequest)
+                .where(AccessRequest.requested_group_id == self.group.id)
+                .where(AccessRequest.status == AccessRequestStatus.PENDING)
+                .where(AccessRequest.resolved_at.is_(None))
+            )
         ).all()
         for obsolete_access_request in obsolete_access_requests:
             logger.info(
@@ -127,7 +135,7 @@ class UnmanageGroup:
                 f"for unmanaged group {self.group.id}"
             )
             if not dry_run:
-                RejectAccessRequest(
+                await RejectAccessRequest(
                     access_request=obsolete_access_request,
                     rejection_reason="Closed because the requested group is no longer managed by Access",
                     current_user_id=self.current_user_id,
@@ -135,23 +143,25 @@ class UnmanageGroup:
 
         # Reject all pending role requests touching this group, either as the
         # requested target or as the requester role.
-        obsolete_role_requests = db.session.scalars(
-            select(RoleRequest)
-            .where(
-                or_(
-                    RoleRequest.requested_group_id == self.group.id,
-                    RoleRequest.requester_role_id == self.group.id,
+        obsolete_role_requests = (
+            await db.session.scalars(
+                select(RoleRequest)
+                .where(
+                    or_(
+                        RoleRequest.requested_group_id == self.group.id,
+                        RoleRequest.requester_role_id == self.group.id,
+                    )
                 )
+                .where(RoleRequest.status == AccessRequestStatus.PENDING)
+                .where(RoleRequest.resolved_at.is_(None))
             )
-            .where(RoleRequest.status == AccessRequestStatus.PENDING)
-            .where(RoleRequest.resolved_at.is_(None))
         ).all()
         for obsolete_role_request in obsolete_role_requests:
             logger.info(
                 f"Rejecting obsolete role request {obsolete_role_request.id} for unmanaged group {self.group.id}"
             )
             if not dry_run:
-                RejectRoleRequest(
+                await RejectRoleRequest(
                     role_request=obsolete_role_request,
                     rejection_reason="Closed because a group in this role request is no longer managed by Access",
                     current_user_id=self.current_user_id,

--- a/api/routers/access_requests.py
+++ b/api/routers/access_requests.py
@@ -64,13 +64,19 @@ def _detail_load_options() -> tuple:
 def _summary_load_options() -> tuple:
     """Slim eager-loads for list / POST / PUT (`AccessRequestSummary`).
     Skips the per-type tag and role-association loaders the summary shape
-    doesn't expose."""
-    return (
+    doesn't expose. The polymorphic + AppGroup.app loaders must be nested
+    under each group relationship — applied at the top level of a
+    `select(AccessRequest)` they target the wrong entity and never run,
+    leaving AppGroup subclass attributes unloaded at serialization time."""
+    group_load_options = (
         selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
+        joinedload(AppGroup.app),
+    )
+    return (
         joinedload(AccessRequest.requester),
         joinedload(AccessRequest.active_requester),
-        selectinload(AccessRequest.requested_group),
-        selectinload(AccessRequest.active_requested_group),
+        selectinload(AccessRequest.requested_group).options(*group_load_options),
+        selectinload(AccessRequest.active_requested_group).options(*group_load_options),
         joinedload(AccessRequest.resolver),
         joinedload(AccessRequest.active_resolver),
     )
@@ -263,9 +269,10 @@ async def post_access_request(
         raise HTTPException(400, "Access request could not be created")
     # Drop cached ORM state so the response reflects what the operation
     # committed (expire_on_commit=False keeps pre-operation state otherwise).
+    ar_id = ar.id
     db.expire_all()
     refreshed = (
-        await db.scalars(select(AccessRequest).options(*_summary_load_options()).where(AccessRequest.id == ar.id))
+        await db.scalars(select(AccessRequest).options(*_summary_load_options()).where(AccessRequest.id == ar_id))
     ).first()
     return AccessRequestSummary.model_validate(refreshed, from_attributes=True)
 

--- a/api/routers/access_requests.py
+++ b/api/routers/access_requests.py
@@ -23,7 +23,7 @@ from api.models import (
     RoleGroup,
 )
 from api.operations import ApproveAccessRequest, CreateAccessRequest, RejectAccessRequest
-from fastapi_pagination.ext.sqlalchemy import paginate
+from fastapi_pagination.ext.sqlalchemy import apaginate
 
 from api.pagination import Page, validated
 from api.routers._eager import group_tag_map_options, role_group_map_options
@@ -77,7 +77,7 @@ def _summary_load_options() -> tuple:
 
 
 @router.get("", name="access_requests")
-def list_access_requests(
+async def list_access_requests(
     request: Request,
     db: DbSession,
     current_user_id: CurrentUserId,
@@ -114,8 +114,10 @@ def list_access_requests(
 
     if q_args.assignee_user_id:
         assignee_user_id = current_user_id if q_args.assignee_user_id == "@me" else q_args.assignee_user_id
-        assignee_user = db.scalars(
-            select(OktaUser).where(or_(OktaUser.id == assignee_user_id, OktaUser.email.ilike(assignee_user_id)))
+        assignee_user = (
+            await db.scalars(
+                select(OktaUser).where(or_(OktaUser.id == assignee_user_id, OktaUser.email.ilike(assignee_user_id)))
+            )
         ).first()
         if assignee_user is not None:
             groups_owned_subquery = (
@@ -191,13 +193,17 @@ def list_access_requests(
                 )
             )
         )
-    return paginate(db, stmt, transformer=validated(AccessRequestSummary))
+    return await apaginate(db, stmt, transformer=validated(AccessRequestSummary))
 
 
 @router.get("/{access_request_id}", name="access_request_by_id")
-def get_access_request(access_request_id: str, db: DbSession, current_user_id: CurrentUserId) -> AccessRequestDetail:
-    ar = db.scalars(
-        select(AccessRequest).options(*_detail_load_options()).where(AccessRequest.id == access_request_id)
+async def get_access_request(
+    access_request_id: str, db: DbSession, current_user_id: CurrentUserId
+) -> AccessRequestDetail:
+    ar = (
+        await db.scalars(
+            select(AccessRequest).options(*_detail_load_options()).where(AccessRequest.id == access_request_id)
+        )
     ).first()
     if ar is None:
         raise HTTPException(404, "Not Found")
@@ -205,18 +211,18 @@ def get_access_request(access_request_id: str, db: DbSession, current_user_id: C
 
 
 @router.post("", name="access_requests_create", status_code=201)
-def post_access_request(
+async def post_access_request(
     body: CreateAccessRequestBody,
     db: DbSession,
     current_user_id: CurrentUserId,
 ) -> AccessRequestSummary:
-    requester = db.scalars(
-        select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+    requester = (
+        await db.scalars(select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id))
     ).first()
     if requester is None:
         raise HTTPException(403, "Current user is not allowed to perform this action")
-    group = db.scalars(
-        select(OktaGroup).where(OktaGroup.id == body.group_id).where(OktaGroup.deleted_at.is_(None))
+    group = (
+        await db.scalars(select(OktaGroup).where(OktaGroup.id == body.group_id).where(OktaGroup.deleted_at.is_(None)))
     ).first()
     if group is None:
         raise HTTPException(404, "Group not found")
@@ -226,23 +232,25 @@ def post_access_request(
     # Auto-cancel any prior PENDING access request from the same user for the
     # same group + ownership mode. Without this, a user clicking "Request"
     # twice produces multiple PENDING rows that approvers see as duplicates.
-    existing_pending = db.scalars(
-        select(AccessRequest)
-        .where(AccessRequest.status == AccessRequestStatus.PENDING)
-        .where(AccessRequest.requester_user_id == requester.id)
-        .where(AccessRequest.requested_group_id == group.id)
-        .where(AccessRequest.request_ownership.is_(body.group_owner))
-        .where(AccessRequest.resolved_at.is_(None))
+    existing_pending = (
+        await db.scalars(
+            select(AccessRequest)
+            .where(AccessRequest.status == AccessRequestStatus.PENDING)
+            .where(AccessRequest.requester_user_id == requester.id)
+            .where(AccessRequest.requested_group_id == group.id)
+            .where(AccessRequest.request_ownership.is_(body.group_owner))
+            .where(AccessRequest.resolved_at.is_(None))
+        )
     ).all()
     for prior in existing_pending:
-        RejectAccessRequest(
+        await RejectAccessRequest(
             access_request=prior,
             current_user_id=current_user_id,
             rejection_reason="Superseded by a newer request from the same user",
             notify_requester=False,
         ).execute()
 
-    ar = CreateAccessRequest(
+    ar = await CreateAccessRequest(
         requester_user=requester,
         requested_group=group,
         request_ownership=body.group_owner,
@@ -256,14 +264,14 @@ def post_access_request(
     # Drop cached ORM state so the response reflects what the operation
     # committed (expire_on_commit=False keeps pre-operation state otherwise).
     db.expire_all()
-    refreshed = db.scalars(
-        select(AccessRequest).options(*_summary_load_options()).where(AccessRequest.id == ar.id)
+    refreshed = (
+        await db.scalars(select(AccessRequest).options(*_summary_load_options()).where(AccessRequest.id == ar.id))
     ).first()
     return AccessRequestSummary.model_validate(refreshed, from_attributes=True)
 
 
 @router.put("/{access_request_id}", name="access_request_by_id_put")
-def put_access_request(
+async def put_access_request(
     access_request_id: str,
     body: ResolveAccessRequestBody,
     db: DbSession,
@@ -272,10 +280,12 @@ def put_access_request(
     from api.auth.permissions import can_manage_group
     from api.operations.constraints import CheckForReason
 
-    ar = db.scalars(
-        select(AccessRequest)
-        .options(joinedload(AccessRequest.active_requested_group))
-        .where(AccessRequest.id == access_request_id)
+    ar = (
+        await db.scalars(
+            select(AccessRequest)
+            .options(joinedload(AccessRequest.active_requested_group))
+            .where(AccessRequest.id == access_request_id)
+        )
     ).first()
     if ar is None:
         raise HTTPException(404, "Not Found")
@@ -284,11 +294,11 @@ def put_access_request(
     if ar.requester_user_id == current_user_id:
         if body.approved:
             raise HTTPException(403, "Users cannot approve their own requests")
-    elif not can_manage_group(db, current_user_id, ar.active_requested_group):
+    elif not await can_manage_group(db, current_user_id, ar.active_requested_group):
         raise HTTPException(403, "Current user is not allowed to perform this action")
 
     if body.approved:
-        valid, err_message = CheckForReason(
+        valid, err_message = await CheckForReason(
             group=ar.active_requested_group,
             reason=body.reason,
             members_to_add=[ar.requester_user_id] if not ar.request_ownership else [],
@@ -303,14 +313,14 @@ def put_access_request(
     if body.approved:
         if not ar.requested_group.is_managed:
             raise HTTPException(400, "Groups not managed by Access cannot be modified")
-        ApproveAccessRequest(
+        await ApproveAccessRequest(
             access_request=ar,
             approver_user=current_user_id,
             approval_reason=body.reason or "",
             ending_at=body.ending_at,
         ).execute()
     else:
-        RejectAccessRequest(
+        await RejectAccessRequest(
             access_request=ar,
             rejection_reason=body.reason or "",
             notify_requester=ar.requester_user_id != current_user_id,
@@ -319,7 +329,9 @@ def put_access_request(
     # Drop cached ORM state so the response reflects what the operation
     # committed (expire_on_commit=False keeps pre-operation state otherwise).
     db.expire_all()
-    refreshed = db.scalars(
-        select(AccessRequest).options(*_summary_load_options()).where(AccessRequest.id == access_request_id)
+    refreshed = (
+        await db.scalars(
+            select(AccessRequest).options(*_summary_load_options()).where(AccessRequest.id == access_request_id)
+        )
     ).first()
     return AccessRequestSummary.model_validate(refreshed, from_attributes=True)

--- a/api/routers/apps.py
+++ b/api/routers/apps.py
@@ -22,7 +22,7 @@ from api.models import (
     AppTagMap,
     OktaGroup,
 )
-from fastapi_pagination.ext.sqlalchemy import paginate
+from fastapi_pagination.ext.sqlalchemy import apaginate
 
 from api.pagination import Page, validated
 from api.routers._eager import (
@@ -61,7 +61,7 @@ router = APIRouter(prefix="/api/apps", tags=["apps"])
 
 
 @router.get("", name="apps")
-def list_apps(
+async def list_apps(
     request: Request,
     db: DbSession,
     current_user_id: CurrentUserId,
@@ -71,16 +71,18 @@ def list_apps(
     if q_args.q:
         like = f"%{q_args.q}%"
         stmt = stmt.where(or_(App.name.ilike(like), App.description.ilike(like)))
-    return paginate(db, stmt, transformer=validated(AppSummary))
+    return await apaginate(db, stmt, transformer=validated(AppSummary))
 
 
 @router.get("/{app_id}", name="app_by_id")
-def get_app(app_id: str, db: DbSession, current_user_id: CurrentUserId) -> AppDetail:
-    app = db.scalars(
-        select(App)
-        .options(*APP_LOAD_OPTIONS)
-        .where(App.deleted_at.is_(None))
-        .where(or_(App.id == app_id, App.name == app_id))
+async def get_app(app_id: str, db: DbSession, current_user_id: CurrentUserId) -> AppDetail:
+    app = (
+        await db.scalars(
+            select(App)
+            .options(*APP_LOAD_OPTIONS)
+            .where(App.deleted_at.is_(None))
+            .where(or_(App.id == app_id, App.name == app_id))
+        )
     ).first()
     if app is None:
         raise HTTPException(404, "Not Found")
@@ -88,7 +90,7 @@ def get_app(app_id: str, db: DbSession, current_user_id: CurrentUserId) -> AppDe
 
 
 @router.post("", name="apps_create", status_code=201)
-def post_app(
+async def post_app(
     body: CreateAppBody,
     db: DbSession,
     current_user_id: str = Depends(require_access_admin_or_app_creator),
@@ -99,24 +101,28 @@ def post_app(
     description = body.description if body.description is not None else ""
 
     # Reject duplicates by name.
-    existing = db.scalars(
-        select(App).where(func.lower(App.name) == func.lower(body.name)).where(App.deleted_at.is_(None))
+    existing = (
+        await db.scalars(
+            select(App).where(func.lower(App.name) == func.lower(body.name)).where(App.deleted_at.is_(None))
+        )
     ).first()
     if existing is not None:
         raise HTTPException(400, "App already exists with the same name")
 
     # Default owner = current user; explicit initial_owner_id wins.
     owner_id: str | None = None
-    if db.get(OktaUser, current_user_id) is not None:
+    if await db.get(OktaUser, current_user_id) is not None:
         owner_id = current_user_id
     if body.initial_owner_id is not None:
-        owner = db.scalars(
-            select(OktaUser)
-            .where(OktaUser.deleted_at.is_(None))
-            .where(
-                or_(
-                    OktaUser.id == body.initial_owner_id,
-                    OktaUser.email.ilike(body.initial_owner_id),
+        owner = (
+            await db.scalars(
+                select(OktaUser)
+                .where(OktaUser.deleted_at.is_(None))
+                .where(
+                    or_(
+                        OktaUser.id == body.initial_owner_id,
+                        OktaUser.email.ilike(body.initial_owner_id),
+                    )
                 )
             )
         ).first()
@@ -129,8 +135,12 @@ def post_app(
 
     owner_role_ids: list[str] = []
     if body.initial_owner_role_ids is not None:
-        roles = db.scalars(
-            select(RoleGroup).where(RoleGroup.id.in_(body.initial_owner_role_ids)).where(RoleGroup.deleted_at.is_(None))
+        roles = (
+            await db.scalars(
+                select(RoleGroup)
+                .where(RoleGroup.id.in_(body.initial_owner_role_ids))
+                .where(RoleGroup.deleted_at.is_(None))
+            )
         ).all()
         owner_role_ids = [r.id for r in roles]
         if len(owner_role_ids) != len(body.initial_owner_role_ids):
@@ -148,11 +158,13 @@ def post_app(
     from sqlalchemy.orm import with_polymorphic
 
     poly_group = with_polymorphic(OktaGroup, [_AppGroup, RoleGroup])
-    existing_owner_group = db.scalars(
-        select(poly_group)
-        .options(selectinload(poly_group.active_user_ownerships))
-        .where(func.lower(OktaGroup.name) == func.lower(owner_group_name))
-        .where(OktaGroup.deleted_at.is_(None))
+    existing_owner_group = (
+        await db.scalars(
+            select(poly_group)
+            .options(selectinload(poly_group.active_user_ownerships))
+            .where(func.lower(OktaGroup.name) == func.lower(owner_group_name))
+            .where(OktaGroup.deleted_at.is_(None))
+        )
     ).first()
     if existing_owner_group is not None and len(existing_owner_group.active_user_ownerships) > 0:
         raise HTTPException(
@@ -167,7 +179,7 @@ def post_app(
     ]
 
     app_obj = App(name=name, description=description)
-    created = CreateApp(
+    created = await CreateApp(
         app=app_obj,
         owner_id=owner_id,
         owner_role_ids=owner_role_ids,
@@ -178,12 +190,12 @@ def post_app(
     # Drop cached ORM state so the response reflects what the operation
     # committed (expire_on_commit=False keeps pre-operation state otherwise).
     db.expire_all()
-    refreshed = db.scalars(select(App).options(*APP_LOAD_OPTIONS).where(App.id == created.id)).first()
+    refreshed = (await db.scalars(select(App).options(*APP_LOAD_OPTIONS).where(App.id == created.id))).first()
     return AppDetail.model_validate(refreshed, from_attributes=True)
 
 
 @router.put("/{app_id}", name="app_by_id_put")
-def put_app(
+async def put_app(
     app_id: str,
     body: UpdateAppBody,
     db: DbSession,
@@ -231,21 +243,23 @@ def put_app(
     if (
         new_plugin != app_obj.app_group_lifecycle_plugin
         or (new_plugin_data is not None and new_plugin_data != (app_obj.plugin_data or {}))
-    ) and not is_access_admin(db, current_user_id):
+    ) and not await is_access_admin(db, current_user_id):
         raise HTTPException(403, "Only Access owners are allowed to configure plugins at the app level")
 
     # Reject duplicate name on rename
     new_name = body.name
     if new_name and new_name.lower() != app_obj.name.lower():
-        existing = db.scalars(
-            select(App).where(func.lower(App.name) == func.lower(new_name)).where(App.deleted_at.is_(None))
+        existing = (
+            await db.scalars(
+                select(App).where(func.lower(App.name) == func.lower(new_name)).where(App.deleted_at.is_(None))
+            )
         ).first()
         if existing is not None:
             raise HTTPException(400, "App already exists with the same name")
 
     # tags_to_remove gated on admin
     if body.tags_to_remove and len(body.tags_to_remove) > 0:
-        if not is_access_admin(db, current_user_id):
+        if not await is_access_admin(db, current_user_id):
             raise HTTPException(403, "Current user is not an Access Admin and not allowed to remove tags from this app")
 
     tags_to_add = body.tags_to_add or []
@@ -254,7 +268,7 @@ def put_app(
     # Built-in Access app: only tags can be modified
     if app_obj.name == App.ACCESS_APP_RESERVED_NAME:
         if len(tags_to_add) > 0 or len(tags_to_remove) > 0:
-            ModifyAppTags(
+            await ModifyAppTags(
                 app=app_obj,
                 tags_to_add=tags_to_add,
                 tags_to_remove=tags_to_remove,
@@ -263,7 +277,7 @@ def put_app(
             # Drop cached ORM state so the response reflects what the operation
             # committed (expire_on_commit=False keeps pre-operation state otherwise).
             db.expire_all()
-            refreshed = db.scalars(select(App).options(*APP_LOAD_OPTIONS).where(App.id == app_obj.id)).first()
+            refreshed = (await db.scalars(select(App).options(*APP_LOAD_OPTIONS).where(App.id == app_obj.id))).first()
             return AppDetail.model_validate(refreshed, from_attributes=True)
         raise HTTPException(400, "Only tags can be modified for the Access application")
 
@@ -288,7 +302,7 @@ def put_app(
     if app_obj.name != old_app_name:
         old_prefix = f"{_AppGroup.APP_GROUP_NAME_PREFIX}{old_app_name}{_AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}"
         new_prefix = f"{_AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}{_AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}"
-        app_groups = db.scalars(select(_AppGroup).where(_AppGroup.app_id == app_obj.id)).all()
+        app_groups = (await db.scalars(select(_AppGroup).where(_AppGroup.app_id == app_obj.id))).all()
         for ag in app_groups:
             if ag.name.startswith(old_prefix):
                 suffix = ag.name[len(old_prefix) :]
@@ -296,11 +310,11 @@ def put_app(
             else:
                 new_group_name = f"{new_prefix}{ag.name}"
             new_description = app_owners_group_description(app_obj.name) if ag.is_owner else None
-            ModifyGroupDetails(group=ag, name=new_group_name, description=new_description).execute()
+            await ModifyGroupDetails(group=ag, name=new_group_name, description=new_description).execute()
 
-    db.commit()
+    await db.commit()
 
-    ModifyAppTags(
+    await ModifyAppTags(
         app=app_obj,
         tags_to_add=tags_to_add,
         tags_to_remove=tags_to_remove,
@@ -310,7 +324,7 @@ def put_app(
     # Drop cached ORM state so the response reflects what the operation
     # committed (expire_on_commit=False keeps pre-operation state otherwise).
     db.expire_all()
-    refreshed = db.scalars(select(App).options(*APP_LOAD_OPTIONS).where(App.id == app_obj.id)).first()
+    refreshed = (await db.scalars(select(App).options(*APP_LOAD_OPTIONS).where(App.id == app_obj.id))).first()
 
     # Audit logging — both name renames and plugin assignment/configuration
     # changes.
@@ -326,7 +340,7 @@ def put_app(
         import logging as _logging
 
         _ctx = get_request_context()
-        email = getattr(db.get(OktaUser, current_user_id), "email", None) if current_user_id is not None else None
+        email = getattr(await db.get(OktaUser, current_user_id), "email", None) if current_user_id is not None else None
         audit_logger = _logging.getLogger("access.audit")
 
         if name_changed:
@@ -363,7 +377,7 @@ def put_app(
 
 
 @router.delete("/{app_id}", name="app_by_id_delete")
-def delete_app(
+async def delete_app(
     app_id: str,
     db: DbSession,
     app_obj=Depends(require_app_owner_or_access_admin_for_app),
@@ -376,5 +390,5 @@ def delete_app(
     if app_obj.name == App.ACCESS_APP_RESERVED_NAME:
         raise HTTPException(400, "The Access Application cannot be deleted")
 
-    DeleteApp(app=app_obj, current_user_id=current_user_id).execute()
+    await DeleteApp(app=app_obj, current_user_id=current_user_id).execute()
     return DeleteMessage(deleted=True)

--- a/api/routers/apps.py
+++ b/api/routers/apps.py
@@ -189,8 +189,9 @@ async def post_app(
     ).execute()
     # Drop cached ORM state so the response reflects what the operation
     # committed (expire_on_commit=False keeps pre-operation state otherwise).
+    created_id = created.id
     db.expire_all()
-    refreshed = (await db.scalars(select(App).options(*APP_LOAD_OPTIONS).where(App.id == created.id))).first()
+    refreshed = (await db.scalars(select(App).options(*APP_LOAD_OPTIONS).where(App.id == created_id))).first()
     return AppDetail.model_validate(refreshed, from_attributes=True)
 
 
@@ -276,8 +277,9 @@ async def put_app(
             ).execute()
             # Drop cached ORM state so the response reflects what the operation
             # committed (expire_on_commit=False keeps pre-operation state otherwise).
+            app_id = app_obj.id
             db.expire_all()
-            refreshed = (await db.scalars(select(App).options(*APP_LOAD_OPTIONS).where(App.id == app_obj.id))).first()
+            refreshed = (await db.scalars(select(App).options(*APP_LOAD_OPTIONS).where(App.id == app_id))).first()
             return AppDetail.model_validate(refreshed, from_attributes=True)
         raise HTTPException(400, "Only tags can be modified for the Access application")
 
@@ -323,8 +325,11 @@ async def put_app(
 
     # Drop cached ORM state so the response reflects what the operation
     # committed (expire_on_commit=False keeps pre-operation state otherwise).
+    # Capture the pk first: reading it after expire_all() would lazy-load
+    # synchronously, which raises MissingGreenlet on an AsyncSession.
+    app_id = app_obj.id
     db.expire_all()
-    refreshed = (await db.scalars(select(App).options(*APP_LOAD_OPTIONS).where(App.id == app_obj.id))).first()
+    refreshed = (await db.scalars(select(App).options(*APP_LOAD_OPTIONS).where(App.id == app_id))).first()
 
     # Audit logging — both name renames and plugin assignment/configuration
     # changes.

--- a/api/routers/audit.py
+++ b/api/routers/audit.py
@@ -32,7 +32,7 @@ from api.models import (
     RoleGroup,
     RoleGroupMap,
 )
-from fastapi_pagination.ext.sqlalchemy import paginate
+from fastapi_pagination.ext.sqlalchemy import apaginate
 
 from api.pagination import Page
 from api.schemas import (
@@ -72,39 +72,45 @@ def _resolve_me(value: str | None, current_user_id: str) -> str | None:
     return current_user_id if value == "@me" else value
 
 
-def _resolve_user(db: DbSession, value: str | None) -> OktaUser | None:
+async def _resolve_user(db: DbSession, value: str | None) -> OktaUser | None:
     if value is None:
         return None
-    user = db.scalars(
-        select(OktaUser)
-        .where(or_(OktaUser.id == value, OktaUser.email.ilike(value)))
-        .order_by(nullsfirst(OktaUser.deleted_at.desc()))
+    user = (
+        await db.scalars(
+            select(OktaUser)
+            .where(or_(OktaUser.id == value, OktaUser.email.ilike(value)))
+            .order_by(nullsfirst(OktaUser.deleted_at.desc()))
+        )
     ).first()
     if user is None:
         raise HTTPException(404, "Not Found")
     return user
 
 
-def _resolve_group(db: DbSession, value: str | None) -> OktaGroup | None:
+async def _resolve_group(db: DbSession, value: str | None) -> OktaGroup | None:
     if value is None:
         return None
-    group = db.scalars(
-        select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-        .where(or_(OktaGroup.id == value, OktaGroup.name == value))
-        .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
+    group = (
+        await db.scalars(
+            select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+            .where(or_(OktaGroup.id == value, OktaGroup.name == value))
+            .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
+        )
     ).first()
     if group is None:
         raise HTTPException(404, "Not Found")
     return group
 
 
-def _resolve_role(db: DbSession, value: str | None) -> RoleGroup | None:
+async def _resolve_role(db: DbSession, value: str | None) -> RoleGroup | None:
     if value is None:
         return None
-    role = db.scalars(
-        select(RoleGroup)
-        .where(or_(RoleGroup.id == value, RoleGroup.name == value))
-        .order_by(nullsfirst(RoleGroup.deleted_at.desc()))
+    role = (
+        await db.scalars(
+            select(RoleGroup)
+            .where(or_(RoleGroup.id == value, RoleGroup.name == value))
+            .order_by(nullsfirst(RoleGroup.deleted_at.desc()))
+        )
     ).first()
     if role is None:
         raise HTTPException(404, "Not Found")
@@ -269,16 +275,16 @@ def _audit_group_role_row(rgm: RoleGroupMap) -> AuditGroupRoleRow:
 
 
 @router.get("/users", name="users_and_groups")
-def users_and_groups(
+async def users_and_groups(
     db: DbSession,
     current_user_id: CurrentUserId,
     q_args: Annotated[SearchUserGroupAuditQuery, Query()],
 ) -> Page[AuditUserGroupRow]:
     user_id = _resolve_me(q_args.user_id, current_user_id)
     owner_id = _resolve_me(q_args.owner_id, current_user_id)
-    user = _resolve_user(db, user_id)
-    group = _resolve_group(db, q_args.group_id)
-    owner = _resolve_user(db, owner_id)
+    user = await _resolve_user(db, user_id)
+    group = await _resolve_group(db, q_args.group_id)
+    owner = await _resolve_user(db, owner_id)
 
     group_alias = aliased(OktaGroup)
 
@@ -333,28 +339,36 @@ def users_and_groups(
     # Owner filter — only return memberships in groups owned by `owner`,
     # either directly or transitively via the owning app.
     if owner is not None:
-        owner_group_ids = db.scalars(
-            select(OktaUserGroupMember.group_id)
-            .where(OktaUserGroupMember.user_id == owner.id)
-            .where(OktaUserGroupMember.is_owner.is_(True))
-            .where(
-                or_(
-                    OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > func.now(),
+        owner_group_ids = (
+            await db.scalars(
+                select(OktaUserGroupMember.group_id)
+                .where(OktaUserGroupMember.user_id == owner.id)
+                .where(OktaUserGroupMember.is_owner.is_(True))
+                .where(
+                    or_(
+                        OktaUserGroupMember.ended_at.is_(None),
+                        OktaUserGroupMember.ended_at > func.now(),
+                    )
                 )
             )
         ).all()
         app_owner_group_ids = [
             ag.id
-            for ag in db.scalars(
-                select(AppGroup).where(AppGroup.id.in_(owner_group_ids)).where(AppGroup.is_owner.is_(True))
+            for ag in (
+                await db.scalars(
+                    select(AppGroup).where(AppGroup.id.in_(owner_group_ids)).where(AppGroup.is_owner.is_(True))
+                )
             ).all()
         ]
-        app_ids = [ag.app_id for ag in db.scalars(select(AppGroup).where(AppGroup.id.in_(app_owner_group_ids))).all()]
+        app_ids = [
+            ag.app_id for ag in (await db.scalars(select(AppGroup).where(AppGroup.id.in_(app_owner_group_ids)))).all()
+        ]
         app_groups_owned_ids = [
             ag.id
-            for ag in db.scalars(
-                select(AppGroup).where(AppGroup.app_id.in_(app_ids)).where(AppGroup.deleted_at.is_(None))
+            for ag in (
+                await db.scalars(
+                    select(AppGroup).where(AppGroup.app_id.in_(app_ids)).where(AppGroup.deleted_at.is_(None))
+                )
             ).all()
         ]
         if q_args.app_owner is True:
@@ -366,15 +380,17 @@ def users_and_groups(
             )
         else:
             # Exclude app groups that have at least one direct owner who isn't `owner`.
-            directly_owned_by_others_ids = db.scalars(
-                select(OktaUserGroupMember.group_id)
-                .where(OktaUserGroupMember.group_id.in_(app_groups_owned_ids))
-                .where(OktaUserGroupMember.user_id != owner.id)
-                .where(OktaUserGroupMember.is_owner.is_(True))
-                .where(
-                    or_(
-                        OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > func.now(),
+            directly_owned_by_others_ids = (
+                await db.scalars(
+                    select(OktaUserGroupMember.group_id)
+                    .where(OktaUserGroupMember.group_id.in_(app_groups_owned_ids))
+                    .where(OktaUserGroupMember.user_id != owner.id)
+                    .where(OktaUserGroupMember.is_owner.is_(True))
+                    .where(
+                        or_(
+                            OktaUserGroupMember.ended_at.is_(None),
+                            OktaUserGroupMember.ended_at > func.now(),
+                        )
                     )
                 )
             ).all()
@@ -486,7 +502,7 @@ def users_and_groups(
             primary_dir = col.desc() if q_args.order_desc else col.asc()
             stmt = stmt.order_by(nulls_order(primary_dir), func.lower(OktaUser.email).asc())
 
-    return paginate(
+    return await apaginate(
         db,
         stmt,
         transformer=lambda items: [_audit_user_group_row(m, include_role_associations) for m in items],
@@ -494,7 +510,7 @@ def users_and_groups(
 
 
 @router.get("/groups", name="groups_and_roles")
-def groups_and_roles(
+async def groups_and_roles(
     db: DbSession,
     current_user_id: CurrentUserId,
     q_args: Annotated[SearchGroupRoleAuditQuery, Query()],
@@ -504,10 +520,10 @@ def groups_and_roles(
     role_id = _resolve_me(q_args.role_id, current_user_id)
     owner_id = _resolve_me(q_args.owner_id, current_user_id)
     role_owner_id = _resolve_me(q_args.role_owner_id, current_user_id)
-    role = _resolve_role(db, role_id)
-    group = _resolve_group(db, q_args.group_id)
-    owner = _resolve_user(db, owner_id)
-    role_owner = _resolve_user(db, role_owner_id)
+    role = await _resolve_role(db, role_id)
+    group = await _resolve_group(db, q_args.group_id)
+    owner = await _resolve_user(db, owner_id)
+    role_owner = await _resolve_user(db, role_owner_id)
 
     group_alias = aliased(OktaGroup)
 
@@ -536,28 +552,36 @@ def groups_and_roles(
         stmt = stmt.where(RoleGroupMap.group_id == group.id)
 
     if owner is not None:
-        owner_group_ids = db.scalars(
-            select(OktaUserGroupMember.group_id)
-            .where(OktaUserGroupMember.user_id == owner.id)
-            .where(OktaUserGroupMember.is_owner.is_(True))
-            .where(
-                or_(
-                    OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > func.now(),
+        owner_group_ids = (
+            await db.scalars(
+                select(OktaUserGroupMember.group_id)
+                .where(OktaUserGroupMember.user_id == owner.id)
+                .where(OktaUserGroupMember.is_owner.is_(True))
+                .where(
+                    or_(
+                        OktaUserGroupMember.ended_at.is_(None),
+                        OktaUserGroupMember.ended_at > func.now(),
+                    )
                 )
             )
         ).all()
         app_owner_group_ids = [
             ag.id
-            for ag in db.scalars(
-                select(AppGroup).where(AppGroup.id.in_(owner_group_ids)).where(AppGroup.is_owner.is_(True))
+            for ag in (
+                await db.scalars(
+                    select(AppGroup).where(AppGroup.id.in_(owner_group_ids)).where(AppGroup.is_owner.is_(True))
+                )
             ).all()
         ]
-        app_ids = [ag.app_id for ag in db.scalars(select(AppGroup).where(AppGroup.id.in_(app_owner_group_ids))).all()]
+        app_ids = [
+            ag.app_id for ag in (await db.scalars(select(AppGroup).where(AppGroup.id.in_(app_owner_group_ids)))).all()
+        ]
         app_groups_owned_ids = [
             ag.id
-            for ag in db.scalars(
-                select(AppGroup).where(AppGroup.app_id.in_(app_ids)).where(AppGroup.deleted_at.is_(None))
+            for ag in (
+                await db.scalars(
+                    select(AppGroup).where(AppGroup.app_id.in_(app_ids)).where(AppGroup.deleted_at.is_(None))
+                )
             ).all()
         ]
         if q_args.app_owner is True:
@@ -568,15 +592,17 @@ def groups_and_roles(
                 )
             )
         else:
-            directly_owned_by_others_ids = db.scalars(
-                select(OktaUserGroupMember.group_id)
-                .where(OktaUserGroupMember.group_id.in_(app_groups_owned_ids))
-                .where(OktaUserGroupMember.user_id != owner.id)
-                .where(OktaUserGroupMember.is_owner.is_(True))
-                .where(
-                    or_(
-                        OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > func.now(),
+            directly_owned_by_others_ids = (
+                await db.scalars(
+                    select(OktaUserGroupMember.group_id)
+                    .where(OktaUserGroupMember.group_id.in_(app_groups_owned_ids))
+                    .where(OktaUserGroupMember.user_id != owner.id)
+                    .where(OktaUserGroupMember.is_owner.is_(True))
+                    .where(
+                        or_(
+                            OktaUserGroupMember.ended_at.is_(None),
+                            OktaUserGroupMember.ended_at > func.now(),
+                        )
                     )
                 )
             ).all()
@@ -589,21 +615,23 @@ def groups_and_roles(
             )
 
     if role_owner is not None:
-        role_owner_role_ids = db.scalars(
-            select(OktaUserGroupMember.group_id)
-            .where(OktaUserGroupMember.user_id == role_owner.id)
-            .where(OktaUserGroupMember.is_owner.is_(True))
-            .where(
-                or_(
-                    OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > func.now(),
+        role_owner_role_ids = (
+            await db.scalars(
+                select(OktaUserGroupMember.group_id)
+                .where(OktaUserGroupMember.user_id == role_owner.id)
+                .where(OktaUserGroupMember.is_owner.is_(True))
+                .where(
+                    or_(
+                        OktaUserGroupMember.ended_at.is_(None),
+                        OktaUserGroupMember.ended_at > func.now(),
+                    )
                 )
             )
         ).all()
         # Access admins additionally see roles that have NO active owner —
         # those are the roles only an admin can resolve expiring access for.
         unowned_admin_role_ids: list[str] = []
-        if is_access_admin(db, role_owner.id):
+        if await is_access_admin(db, role_owner.id):
             owners_subquery = (
                 select(OktaUserGroupMember.group_id)
                 .where(
@@ -619,8 +647,12 @@ def groups_and_roles(
             )
             unowned_admin_role_ids = [
                 rg.id
-                for rg in db.scalars(
-                    select(RoleGroup).where(and_(RoleGroup.deleted_at.is_(None), ~RoleGroup.id.in_(owners_subquery)))
+                for rg in (
+                    await db.scalars(
+                        select(RoleGroup).where(
+                            and_(RoleGroup.deleted_at.is_(None), ~RoleGroup.id.in_(owners_subquery))
+                        )
+                    )
                 ).all()
             ]
         stmt = stmt.where(
@@ -704,7 +736,7 @@ def groups_and_roles(
 
     stmt = stmt.order_by(*_groups_audit_ordering())
 
-    return paginate(
+    return await apaginate(
         db,
         stmt,
         transformer=lambda items: [_audit_group_role_row(rgm) for rgm in items],

--- a/api/routers/group_requests.py
+++ b/api/routers/group_requests.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query
-from fastapi_pagination.ext.sqlalchemy import paginate
+from fastapi_pagination.ext.sqlalchemy import apaginate
 from sqlalchemy import String, and_, cast, or_, select
 from sqlalchemy.orm import aliased, joinedload
 from starlette.requests import Request
@@ -37,7 +37,7 @@ def _load_options() -> tuple:
 
 
 @router.get("", name="group_requests")
-def list_group_requests(
+async def list_group_requests(
     request: Request,
     db: DbSession,
     current_user_id: CurrentUserId,
@@ -74,14 +74,16 @@ def list_group_requests(
         # owners see app-group requests for apps they own. In both cases the
         # assignee's own requests are stripped out.
         assignee_user_id = current_user_id if q_args.assignee_user_id == "@me" else q_args.assignee_user_id
-        assignee_user = db.scalars(
-            select(OktaUser).where(or_(OktaUser.id == assignee_user_id, OktaUser.email.ilike(assignee_user_id)))
+        assignee_user = (
+            await db.scalars(
+                select(OktaUser).where(or_(OktaUser.id == assignee_user_id, OktaUser.email.ilike(assignee_user_id)))
+            )
         ).first()
         if assignee_user is not None:
-            if not is_access_admin(db, assignee_user.id):
+            if not await is_access_admin(db, assignee_user.id):
                 owned_app_ids: list[str] = []
-                for app in db.scalars(select(App).where(App.deleted_at.is_(None))).all():
-                    manager_ids = [m.id for m in get_app_managers(app.id)]
+                for app in (await db.scalars(select(App).where(App.deleted_at.is_(None)))).all():
+                    manager_ids = [m.id for m in await get_app_managers(app.id)]
                     if assignee_user.id in manager_ids:
                         owned_app_ids.append(app.id)
                 if owned_app_ids:
@@ -142,27 +144,29 @@ def list_group_requests(
             )
         )
 
-    return paginate(db, stmt, transformer=validated(GroupRequestDetail))
+    return await apaginate(db, stmt, transformer=validated(GroupRequestDetail))
 
 
 @router.get("/{group_request_id}", name="group_request_by_id")
-def get_group_request(group_request_id: str, db: DbSession, current_user_id: CurrentUserId) -> GroupRequestDetail:
-    gr = db.scalars(select(GroupRequest).options(*_load_options()).where(GroupRequest.id == group_request_id)).first()
+async def get_group_request(group_request_id: str, db: DbSession, current_user_id: CurrentUserId) -> GroupRequestDetail:
+    gr = (
+        await db.scalars(select(GroupRequest).options(*_load_options()).where(GroupRequest.id == group_request_id))
+    ).first()
     if gr is None:
         raise HTTPException(404, "Not Found")
     return GroupRequestDetail.model_validate(gr, from_attributes=True)
 
 
 @router.post("", name="group_requests_create", status_code=201)
-def post_group_request(
+async def post_group_request(
     body: CreateGroupRequestBody,
     db: DbSession,
     current_user_id: CurrentUserId,
 ) -> GroupRequestDetail:
     # Soft-deleted requesters cannot create new requests; Flask returned 403
     # here, not 404.
-    requester = db.scalars(
-        select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+    requester = (
+        await db.scalars(select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id))
     ).first()
     if requester is None:
         raise HTTPException(403, "Current user is not allowed to perform this action")
@@ -173,14 +177,14 @@ def post_group_request(
     if body.requested_group_type == "app_group":
         if requested_app_id is None:
             raise HTTPException(400, "app_id is required for app group requests")
-        app = db.scalars(select(App).where(App.deleted_at.is_(None)).where(App.id == requested_app_id)).first()
+        app = (await db.scalars(select(App).where(App.deleted_at.is_(None)).where(App.id == requested_app_id))).first()
         if app is None:
             raise HTTPException(404, "App not found")
 
     # Every requested tag id must resolve to a non-deleted tag.
     if body.requested_group_tags:
-        tags = db.scalars(
-            select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(body.requested_group_tags))
+        tags = (
+            await db.scalars(select(Tag).where(Tag.deleted_at.is_(None)).where(Tag.id.in_(body.requested_group_tags)))
         ).all()
         if len(tags) != len(body.requested_group_tags):
             raise HTTPException(400, "One or more tags not found")
@@ -197,15 +201,15 @@ def post_group_request(
     )
     if body.requested_group_type == "app_group":
         existing_stmt = existing_stmt.where(GroupRequest.requested_app_id == requested_app_id)
-    for prior in db.scalars(existing_stmt).all():
-        RejectGroupRequest(
+    for prior in (await db.scalars(existing_stmt)).all():
+        await RejectGroupRequest(
             group_request=prior,
             rejection_reason="Closed due to duplicate group request creation",
             notify_requester=False,
             current_user_id=current_user_id,
         ).execute()
 
-    gr = CreateGroupRequest(
+    gr = await CreateGroupRequest(
         requester_user=requester,
         requested_group_name=body.requested_group_name,
         requested_group_description=body.requested_group_description or "",
@@ -220,12 +224,14 @@ def post_group_request(
     # Drop cached ORM state so the response reflects what the operation
     # committed (expire_on_commit=False keeps pre-operation state otherwise).
     db.expire_all()
-    refreshed = db.scalars(select(GroupRequest).options(*_load_options()).where(GroupRequest.id == gr.id)).first()
+    refreshed = (
+        await db.scalars(select(GroupRequest).options(*_load_options()).where(GroupRequest.id == gr.id))
+    ).first()
     return GroupRequestDetail.model_validate(refreshed, from_attributes=True)
 
 
 @router.put("/{group_request_id}", name="group_request_by_id_put")
-def put_group_request(
+async def put_group_request(
     group_request_id: str,
     body: ResolveGroupRequestBody,
     db: DbSession,
@@ -234,7 +240,9 @@ def put_group_request(
     from api.auth.permissions import is_access_admin
     from api.models.app_group import get_app_managers
 
-    gr = db.scalars(select(GroupRequest).options(*_load_options()).where(GroupRequest.id == group_request_id)).first()
+    gr = (
+        await db.scalars(select(GroupRequest).options(*_load_options()).where(GroupRequest.id == group_request_id))
+    ).first()
     if gr is None:
         raise HTTPException(404, "Not Found")
 
@@ -243,9 +251,9 @@ def put_group_request(
     if gr.requester_user_id == current_user_id:
         if body.approved:
             raise HTTPException(403, "Users cannot approve their own requests")
-    elif not is_access_admin(db, current_user_id):
+    elif not await is_access_admin(db, current_user_id):
         if gr.requested_app_id is not None:
-            approver_ids = [u.id for u in get_app_managers(gr.requested_app_id)]
+            approver_ids = [u.id for u in await get_app_managers(gr.requested_app_id)]
             if current_user_id not in approver_ids:
                 raise HTTPException(403, "Current user is not allowed to perform this action")
         else:
@@ -254,7 +262,7 @@ def put_group_request(
     if gr.status != AccessRequestStatus.PENDING or gr.resolved_at is not None:
         raise HTTPException(409, "Group request is not pending")
 
-    if body.approved and not is_access_admin(db, current_user_id):
+    if body.approved and not await is_access_admin(db, current_user_id):
         type_changed = body.resolved_group_type is not None and body.resolved_group_type != gr.requested_group_type
         app_changed = body.resolved_app_id is not None and body.resolved_app_id != gr.requested_app_id
         if type_changed or app_changed:
@@ -277,17 +285,17 @@ def put_group_request(
     if body.resolved_ownership_ending_at is not None:
         gr.resolved_ownership_ending_at = body.resolved_ownership_ending_at
 
-    db.commit()
+    await db.commit()
 
     resolution_reason = body.reason or ""
     if body.approved:
-        ApproveGroupRequest(
+        await ApproveGroupRequest(
             group_request=gr,
             approver_user=current_user_id,
             approval_reason=resolution_reason,
         ).execute()
     else:
-        RejectGroupRequest(
+        await RejectGroupRequest(
             group_request=gr,
             current_user_id=current_user_id,
             rejection_reason=resolution_reason,
@@ -296,7 +304,7 @@ def put_group_request(
     # Drop cached ORM state so the response reflects what the operation
     # committed (expire_on_commit=False keeps pre-operation state otherwise).
     db.expire_all()
-    refreshed = db.scalars(
-        select(GroupRequest).options(*_load_options()).where(GroupRequest.id == group_request_id)
+    refreshed = (
+        await db.scalars(select(GroupRequest).options(*_load_options()).where(GroupRequest.id == group_request_id))
     ).first()
     return GroupRequestDetail.model_validate(refreshed, from_attributes=True)

--- a/api/routers/group_requests.py
+++ b/api/routers/group_requests.py
@@ -223,9 +223,10 @@ async def post_group_request(
         raise HTTPException(400, "Failed to create group request")
     # Drop cached ORM state so the response reflects what the operation
     # committed (expire_on_commit=False keeps pre-operation state otherwise).
+    gr_id = gr.id
     db.expire_all()
     refreshed = (
-        await db.scalars(select(GroupRequest).options(*_load_options()).where(GroupRequest.id == gr.id))
+        await db.scalars(select(GroupRequest).options(*_load_options()).where(GroupRequest.id == gr_id))
     ).first()
     return GroupRequestDetail.model_validate(refreshed, from_attributes=True)
 

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -39,7 +39,7 @@ from api.operations import (
     ModifyGroupUsers,
 )
 from api.operations.constraints import CheckForReason, CheckForSelfAdd
-from fastapi_pagination.ext.sqlalchemy import paginate
+from fastapi_pagination.ext.sqlalchemy import apaginate
 
 from api.pagination import Page, validated
 from api.plugins.app_group_lifecycle import merge_app_lifecycle_plugin_data
@@ -89,21 +89,23 @@ DEFAULT_LOAD_OPTIONS = (
 _group_adapter: TypeAdapter[Any] = TypeAdapter(GroupDetail)
 
 
-def _load_group_with_options(db: DbSession, group_id: str) -> OktaGroup | None:
+async def _load_group_with_options(db: DbSession, group_id: str) -> OktaGroup | None:
     # Routes call this after operations mutate the group; with
     # expire_on_commit=False the identity map would otherwise serve
     # pre-operation relationship state, so drop cached ORM state first.
     db.expire_all()
-    return db.scalars(
-        select(OktaGroup)
-        .options(*DEFAULT_LOAD_OPTIONS)
-        .where(or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
-        .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
+    return (
+        await db.scalars(
+            select(OktaGroup)
+            .options(*DEFAULT_LOAD_OPTIONS)
+            .where(or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
+            .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
+        )
     ).first()
 
 
 @router.get("", name="groups")
-def list_groups(
+async def list_groups(
     request: Request,
     db: DbSession,
     current_user_id: CurrentUserId,
@@ -129,19 +131,19 @@ def list_groups(
     if q_args.managed is not None:
         stmt = stmt.where(OktaGroup.is_managed == q_args.managed)
 
-    return paginate(db, stmt, transformer=validated(GroupSummary))
+    return await apaginate(db, stmt, transformer=validated(GroupSummary))
 
 
 @router.get("/{group_id}", name="group_by_id")
-def get_group(group_id: str, db: DbSession, current_user_id: CurrentUserId) -> GroupDetail:
-    group = _load_group_with_options(db, group_id)
+async def get_group(group_id: str, db: DbSession, current_user_id: CurrentUserId) -> GroupDetail:
+    group = await _load_group_with_options(db, group_id)
     if group is None:
         raise HTTPException(status_code=404, detail="Not Found")
     return _group_adapter.validate_python(group, from_attributes=True)
 
 
 @router.post("", name="groups_create", status_code=201)
-def post_group(
+async def post_group(
     request: Request,
     body: CreateGroupBody,
     db: DbSession,
@@ -164,15 +166,17 @@ def post_group(
         group = OktaGroup(name=body.name, description=description)
 
     if not (
-        is_access_admin(db, current_user_id)
-        or is_app_owner_group_owner(db, current_user_id, app_group=group if isinstance(group, AppGroup) else None)
+        await is_access_admin(db, current_user_id)
+        or await is_app_owner_group_owner(db, current_user_id, app_group=group if isinstance(group, AppGroup) else None)
     ):
         raise HTTPException(403, "Current user is not allowed to perform this action")
 
-    existing = db.scalars(
-        select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-        .where(func.lower(OktaGroup.name) == func.lower(group.name))
-        .where(OktaGroup.deleted_at.is_(None))
+    existing = (
+        await db.scalars(
+            select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+            .where(func.lower(OktaGroup.name) == func.lower(group.name))
+            .where(OktaGroup.deleted_at.is_(None))
+        )
     ).first()
     if existing is not None:
         raise HTTPException(400, "Group already exists with the same name")
@@ -192,13 +196,13 @@ def post_group(
             400, "App owner groups cannot be created directly. They are created automatically when an app is created."
         )
 
-    created = CreateGroup(group=group, tags=body.tags_to_add or [], current_user_id=current_user_id).execute()
-    refreshed = _load_group_with_options(db, created.id)
+    created = await CreateGroup(group=group, tags=body.tags_to_add or [], current_user_id=current_user_id).execute()
+    refreshed = await _load_group_with_options(db, created.id)
     return _group_adapter.validate_python(refreshed, from_attributes=True)
 
 
 @router.put("/{group_id}", name="group_by_id_put")
-def put_group(
+async def put_group(
     group_id: str,
     request: Request,
     body: UpdateGroupBody,
@@ -211,7 +215,7 @@ def put_group(
     )
 
     fields_set = body.model_fields_set
-    group = _load_group_with_options(db, group_id)
+    group = await _load_group_with_options(db, group_id)
     if group is None:
         raise HTTPException(404, "Not Found")
     # Length + REQUIRE_DESCRIPTIONS-when-set are enforced by the schema; this
@@ -230,7 +234,7 @@ def put_group(
             if errors:
                 raise HTTPException(400, f"plugin_data: {errors}")
 
-    if not _perms.can_manage_group(db, current_user_id, group):
+    if not await _perms.can_manage_group(db, current_user_id, group):
         raise HTTPException(403, "Current user is not allowed to perform this action")
     if not group.is_managed:
         raise HTTPException(400, "Groups not managed by Access cannot be modified")
@@ -240,15 +244,15 @@ def put_group(
     )
     if new_plugin_data is not None and new_plugin_data != (group.plugin_data or {}):
         if not (
-            is_access_admin(db, current_user_id)
-            or (type(group) is AppGroup and is_app_owner_group_owner(db, current_user_id, app_group=group))
+            await is_access_admin(db, current_user_id)
+            or (type(group) is AppGroup and await is_app_owner_group_owner(db, current_user_id, app_group=group))
         ):
             raise HTTPException(
                 403, "Only Access owners and app owners are allowed to configure plugins at the group level"
             )
 
     if body.tags_to_remove and len(body.tags_to_remove) > 0:
-        if not is_access_admin(db, current_user_id):
+        if not await is_access_admin(db, current_user_id):
             raise HTTPException(
                 403, "Current user is not an Access Admin and not allowed to remove tags from this group"
             )
@@ -265,12 +269,14 @@ def put_group(
     ):
         from api.models import App
 
-        target_app = db.scalars(select(App).where(App.id == body.app_id).where(App.deleted_at.is_(None))).first()
+        target_app = (
+            await db.scalars(select(App).where(App.id == body.app_id).where(App.deleted_at.is_(None)))
+        ).first()
         if target_app is None:
             raise HTTPException(404, "Not Found")
         if not (
-            _perms.is_access_admin(db, current_user_id)
-            or _perms.is_app_owner_group_owner(db, current_user_id, app=target_app)
+            await _perms.is_access_admin(db, current_user_id)
+            or await _perms.is_app_owner_group_owner(db, current_user_id, app=target_app)
         ):
             raise HTTPException(
                 403, "Current user is not an app owner of the target app and not allowed to reassign this group"
@@ -284,13 +290,13 @@ def put_group(
     # App owner groups: only tag changes allowed
     if type(group) is AppGroup and group.is_owner:
         if len(tags_to_add) > 0 or len(tags_to_remove) > 0:
-            ModifyGroupTags(
+            await ModifyGroupTags(
                 group=group,
                 tags_to_add=tags_to_add,
                 tags_to_remove=tags_to_remove,
                 current_user_id=current_user_id,
             ).execute()
-            refreshed = _load_group_with_options(db, group.id)
+            refreshed = await _load_group_with_options(db, group.id)
             return _group_adapter.validate_python(refreshed, from_attributes=True)
         raise HTTPException(400, "Only tags can be modifed for application owner groups")
 
@@ -311,7 +317,7 @@ def put_group(
             )
 
     try:
-        ModifyGroupDetails(
+        await ModifyGroupDetails(
             group=group,
             name=body.name if "name" in fields_set else None,
             description=description,
@@ -321,7 +327,7 @@ def put_group(
 
     body_type = body.type
     if body_type != group.type:
-        if not is_access_admin(db, current_user_id):
+        if not await is_access_admin(db, current_user_id):
             raise HTTPException(403, "Current user is not an Access admin and not allowed to change group types")
         type_klass = {"okta_group": OktaGroup, "role_group": RoleGroup, "app_group": AppGroup}[body_type]
         new_group = type_klass()
@@ -331,7 +337,9 @@ def put_group(
             new_group.app_id = body.app_id if "app_id" in fields_set else getattr(group, "app_id", None)
             new_group.is_owner = False
         try:
-            group = ModifyGroupType(group=group, group_changes=new_group, current_user_id=current_user_id).execute()
+            group = await ModifyGroupType(
+                group=group, group_changes=new_group, current_user_id=current_user_id
+            ).execute()
         except ValueError as e:
             raise HTTPException(400, str(e)) from e
 
@@ -345,16 +353,16 @@ def put_group(
                     group.plugin_data[key] = old_plugin_data[key]
             if type(group) is AppGroup:
                 merge_app_lifecycle_plugin_data(group, old_plugin_data)
-    db.commit()
+    await db.commit()
 
-    ModifyGroupTags(
+    await ModifyGroupTags(
         group=group,
         tags_to_add=tags_to_add,
         tags_to_remove=tags_to_remove,
         current_user_id=current_user_id,
     ).execute()
 
-    refreshed = _load_group_with_options(db, group.id)
+    refreshed = await _load_group_with_options(db, group.id)
 
     # Audit log — plugin configuration changes at the group level
     if old_plugin_data_for_audit != (refreshed.plugin_data or {}):
@@ -364,7 +372,7 @@ def put_group(
         import logging as _logging
 
         _ctx = get_request_context()
-        email = getattr(db.get(OktaUser, current_user_id), "email", None) if current_user_id is not None else None
+        email = getattr(await db.get(OktaUser, current_user_id), "email", None) if current_user_id is not None else None
         _logging.getLogger("access.audit").info(
             AuditLogSchema().dumps(
                 {
@@ -383,22 +391,22 @@ def put_group(
 
 
 @router.delete("/{group_id}", name="group_by_id_delete")
-def delete_group(group_id: str, db: DbSession, current_user_id: CurrentUserId) -> DeleteMessage:
-    group = _load_group_with_options(db, group_id)
+async def delete_group(group_id: str, db: DbSession, current_user_id: CurrentUserId) -> DeleteMessage:
+    group = await _load_group_with_options(db, group_id)
     if group is None:
         raise HTTPException(404, "Not Found")
-    if not _perms.can_delete_group(db, current_user_id, group):
+    if not await _perms.can_delete_group(db, current_user_id, group):
         raise HTTPException(403, "Current user is not allowed to perform this action")
     if not group.is_managed:
         raise HTTPException(400, "Groups not managed by Access cannot be modified")
     if type(group) is AppGroup and group.is_owner:
         raise HTTPException(400, "Application owner groups cannot be deleted without first deleting the application")
-    DeleteGroup(group=group, current_user_id=current_user_id).execute()
+    await DeleteGroup(group=group, current_user_id=current_user_id).execute()
     return DeleteMessage(deleted=True)
 
 
 @router.get("/{group_id}/audit", name="group_audit_by_id")
-def get_group_audit(group_id: str, request: Request, current_user_id: CurrentUserId) -> RedirectResponse:
+async def get_group_audit(group_id: str, request: Request, current_user_id: CurrentUserId) -> RedirectResponse:
     from urllib.parse import urlencode
 
     qp = dict(request.query_params)
@@ -407,11 +415,13 @@ def get_group_audit(group_id: str, request: Request, current_user_id: CurrentUse
 
 
 @router.get("/{group_id}/members", name="group_members_by_id")
-def get_group_members(group_id: str, db: DbSession, current_user_id: CurrentUserId) -> GroupMembersSummary:
-    group = db.scalars(
-        select(OktaGroup)
-        .where(OktaGroup.deleted_at.is_(None))
-        .where(or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
+async def get_group_members(group_id: str, db: DbSession, current_user_id: CurrentUserId) -> GroupMembersSummary:
+    group = (
+        await db.scalars(
+            select(OktaGroup)
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
+        )
     ).first()
     if group is None:
         raise HTTPException(404, "Not Found")
@@ -427,7 +437,7 @@ def get_group_members(group_id: str, db: DbSession, current_user_id: CurrentUser
         .where(OktaUserGroupMember.group_id == group.id)
         .group_by(OktaUserGroupMember.user_id, OktaUserGroupMember.is_owner)
     )
-    rows = db.execute(base_stmt).all()
+    rows = (await db.execute(base_stmt)).all()
     return GroupMembersSummary(
         members=[r.user_id for r in rows if not r.is_owner],
         owners=[r.user_id for r in rows if r.is_owner],
@@ -435,16 +445,18 @@ def get_group_members(group_id: str, db: DbSession, current_user_id: CurrentUser
 
 
 @router.put("/{group_id}/members", name="group_members_by_id_put")
-def put_group_members(
+async def put_group_members(
     group_id: str,
     db: DbSession,
     current_user_id: CurrentUserId,
     body: GroupMember | None = None,
 ) -> GroupMembersSummary:
-    group = db.scalars(
-        select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-        .where(OktaGroup.deleted_at.is_(None))
-        .where(or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
+    group = (
+        await db.scalars(
+            select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
+        )
     ).first()
     if group is None:
         raise HTTPException(404, "Not Found")
@@ -456,7 +468,7 @@ def put_group_members(
     if not group.is_managed:
         raise HTTPException(400, "Groups not managed by Access cannot be modified")
 
-    if not _perms.can_manage_group(db, current_user_id, group):
+    if not await _perms.can_manage_group(db, current_user_id, group):
         if (
             len(body.members_to_add) > 0
             or len(body.owners_to_add) > 0
@@ -468,7 +480,7 @@ def put_group_members(
             if user_id != current_user_id:
                 raise HTTPException(403, "Current user is not allowed to perform this action")
 
-    valid, err_message = CheckForSelfAdd(
+    valid, err_message = await CheckForSelfAdd(
         group=group,
         current_user=current_user_id,
         members_to_add=body.members_to_add,
@@ -477,7 +489,7 @@ def put_group_members(
     if not valid:
         raise HTTPException(400, err_message)
 
-    valid, err_message = CheckForReason(
+    valid, err_message = await CheckForReason(
         group=group,
         reason=body.created_reason or "",
         members_to_add=body.members_to_add,
@@ -486,7 +498,7 @@ def put_group_members(
     if not valid:
         raise HTTPException(400, err_message)
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=group,
         current_user_id=current_user_id,
         users_added_ended_at=body.users_added_ending_at,
@@ -499,4 +511,4 @@ def put_group_members(
         created_reason=body.created_reason or "",
     ).execute()
 
-    return get_group_members(group_id, db, current_user_id)
+    return await get_group_members(group_id, db, current_user_id)

--- a/api/routers/health.py
+++ b/api/routers/health.py
@@ -22,9 +22,9 @@ router = APIRouter(prefix="/api/healthz", tags=["health"])
 # one here — adding it would be misleading. Refactoring to a single
 # `HealthResponse` would change the error-path wire shape.
 @router.get("", name="health_check")
-def health_check(db: DbSession) -> JSONResponse:
+async def health_check(db: DbSession) -> JSONResponse:
     try:
-        db.execute(text("SELECT 1"))
+        await db.execute(text("SELECT 1"))
     except Exception:
         # Log server-side only — the exception text carries driver/connection
         # detail (host, db name, user) and this endpoint is unauthenticated.

--- a/api/routers/plugins.py
+++ b/api/routers/plugins.py
@@ -37,7 +37,7 @@ def _ensure_plugin(plugin_id: str) -> None:
 
 
 @router.get("/app-group-lifecycle", name="app_group_lifecycle_plugins")
-def list_plugins(current_user_id: CurrentUserId) -> AppGroupLifecyclePlugins:
+async def list_plugins(current_user_id: CurrentUserId) -> AppGroupLifecyclePlugins:
     plugins = sorted(get_app_group_lifecycle_plugins(), key=lambda p: p.display_name.lower())
     return AppGroupLifecyclePlugins.model_validate([asdict(p) for p in plugins])
 
@@ -46,7 +46,7 @@ def list_plugins(current_user_id: CurrentUserId) -> AppGroupLifecyclePlugins:
     "/app-group-lifecycle/{plugin_id}/app-config-props",
     name="app_group_lifecycle_plugin_app_config_props",
 )
-def app_config_props(plugin_id: str, current_user_id: CurrentUserId) -> AppGroupLifecyclePluginAppConfig:
+async def app_config_props(plugin_id: str, current_user_id: CurrentUserId) -> AppGroupLifecyclePluginAppConfig:
     _ensure_plugin(plugin_id)
     return AppGroupLifecyclePluginAppConfig.model_validate(
         {
@@ -60,7 +60,7 @@ def app_config_props(plugin_id: str, current_user_id: CurrentUserId) -> AppGroup
     "/app-group-lifecycle/{plugin_id}/group-config-props",
     name="app_group_lifecycle_plugin_group_config_props",
 )
-def group_config_props(plugin_id: str, current_user_id: CurrentUserId) -> AppGroupLifecyclePluginGroupConfig:
+async def group_config_props(plugin_id: str, current_user_id: CurrentUserId) -> AppGroupLifecyclePluginGroupConfig:
     _ensure_plugin(plugin_id)
     return AppGroupLifecyclePluginGroupConfig.model_validate(
         {
@@ -74,7 +74,7 @@ def group_config_props(plugin_id: str, current_user_id: CurrentUserId) -> AppGro
     "/app-group-lifecycle/{plugin_id}/app-status-props",
     name="app_group_lifecycle_plugin_app_status_props",
 )
-def app_status_props(plugin_id: str, current_user_id: CurrentUserId) -> AppGroupLifecyclePluginAppStatus:
+async def app_status_props(plugin_id: str, current_user_id: CurrentUserId) -> AppGroupLifecyclePluginAppStatus:
     _ensure_plugin(plugin_id)
     return AppGroupLifecyclePluginAppStatus.model_validate(
         {
@@ -88,7 +88,7 @@ def app_status_props(plugin_id: str, current_user_id: CurrentUserId) -> AppGroup
     "/app-group-lifecycle/{plugin_id}/group-status-props",
     name="app_group_lifecycle_plugin_group_status_props",
 )
-def group_status_props(plugin_id: str, current_user_id: CurrentUserId) -> AppGroupLifecyclePluginGroupStatus:
+async def group_status_props(plugin_id: str, current_user_id: CurrentUserId) -> AppGroupLifecyclePluginGroupStatus:
     _ensure_plugin(plugin_id)
     return AppGroupLifecyclePluginGroupStatus.model_validate(
         {

--- a/api/routers/role_requests.py
+++ b/api/routers/role_requests.py
@@ -25,7 +25,7 @@ from api.models import (
 )
 from api.models.tag import coalesce_constraints
 from api.operations import ApproveRoleRequest, CreateRoleRequest, RejectRoleRequest
-from fastapi_pagination.ext.sqlalchemy import paginate
+from fastapi_pagination.ext.sqlalchemy import apaginate
 
 from api.pagination import Page, validated
 from api.routers._eager import (
@@ -84,7 +84,7 @@ def _summary_load_options() -> tuple:
 
 
 @router.get("", name="role_requests")
-def list_role_requests(
+async def list_role_requests(
     request: Request,
     db: DbSession,
     current_user_id: CurrentUserId,
@@ -133,8 +133,10 @@ def list_role_requests(
         # Non-admins are restricted to groups they own, and pre-filtered to
         # exclude requests they can't resolve due to those same tags.
         assignee_user_id = current_user_id if q_args.assignee_user_id == "@me" else q_args.assignee_user_id
-        assignee_user = db.scalars(
-            select(OktaUser).where(or_(OktaUser.id == assignee_user_id, OktaUser.email.ilike(assignee_user_id)))
+        assignee_user = (
+            await db.scalars(
+                select(OktaUser).where(or_(OktaUser.id == assignee_user_id, OktaUser.email.ilike(assignee_user_id)))
+            )
         ).first()
         if assignee_user is not None:
             groups_owned_subquery = (
@@ -161,25 +163,27 @@ def list_role_requests(
                 .subquery()
             )
 
-            if is_access_admin(db, assignee_user.id):
+            if await is_access_admin(db, assignee_user.id):
                 # Pending role requests for ownership / membership where the
                 # target group is tagged `disallow_self_add_*` and every
                 # existing owner is in the requester role's membership.
                 tagged_owner_requests = [
                     rr
-                    for rr in db.scalars(
-                        select(RoleRequest)
-                        .options(
-                            joinedload(RoleRequest.requester_role).options(
-                                selectinload(OktaGroup.active_user_memberships)
-                            ),
-                            joinedload(RoleRequest.requested_group).options(
-                                selectinload(OktaGroup.active_group_tags),
-                                selectinload(OktaGroup.active_user_ownerships),
-                            ),
+                    for rr in (
+                        await db.scalars(
+                            select(RoleRequest)
+                            .options(
+                                joinedload(RoleRequest.requester_role).options(
+                                    selectinload(OktaGroup.active_user_memberships)
+                                ),
+                                joinedload(RoleRequest.requested_group).options(
+                                    selectinload(OktaGroup.active_group_tags),
+                                    selectinload(OktaGroup.active_user_ownerships),
+                                ),
+                            )
+                            .where(RoleRequest.status == AccessRequestStatus.PENDING)
+                            .where(RoleRequest.request_ownership.is_(True))
                         )
-                        .where(RoleRequest.status == AccessRequestStatus.PENDING)
-                        .where(RoleRequest.request_ownership.is_(True))
                     ).all()
                     if coalesce_constraints(
                         constraint_key=Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY,
@@ -188,19 +192,21 @@ def list_role_requests(
                 ]
                 tagged_member_requests = [
                     rr
-                    for rr in db.scalars(
-                        select(RoleRequest)
-                        .options(
-                            joinedload(RoleRequest.requester_role).options(
-                                selectinload(OktaGroup.active_user_memberships)
-                            ),
-                            joinedload(RoleRequest.requested_group).options(
-                                selectinload(OktaGroup.active_group_tags),
-                                selectinload(OktaGroup.active_user_ownerships),
-                            ),
+                    for rr in (
+                        await db.scalars(
+                            select(RoleRequest)
+                            .options(
+                                joinedload(RoleRequest.requester_role).options(
+                                    selectinload(OktaGroup.active_user_memberships)
+                                ),
+                                joinedload(RoleRequest.requested_group).options(
+                                    selectinload(OktaGroup.active_group_tags),
+                                    selectinload(OktaGroup.active_user_ownerships),
+                                ),
+                            )
+                            .where(RoleRequest.status == AccessRequestStatus.PENDING)
+                            .where(RoleRequest.request_ownership.is_(False))
                         )
-                        .where(RoleRequest.status == AccessRequestStatus.PENDING)
-                        .where(RoleRequest.request_ownership.is_(False))
                     ).all()
                     if coalesce_constraints(
                         constraint_key=Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY,
@@ -230,13 +236,15 @@ def list_role_requests(
                 )
 
                 owned_groups = (
-                    db.scalars(
-                        select(OktaGroup)
-                        .options(joinedload(OktaGroup.active_group_tags))
-                        .where(
-                            or_(
-                                OktaGroup.id.in_(groups_owned_subquery),
-                                OktaGroup.id.in_(app_groups_owned_subquery),
+                    (
+                        await db.scalars(
+                            select(OktaGroup)
+                            .options(joinedload(OktaGroup.active_group_tags))
+                            .where(
+                                or_(
+                                    OktaGroup.id.in_(groups_owned_subquery),
+                                    OktaGroup.id.in_(app_groups_owned_subquery),
+                                )
                             )
                         )
                     )
@@ -261,7 +269,9 @@ def list_role_requests(
                 ]
                 role_membership_ids = [
                     rg.id
-                    for rg in db.scalars(select(RoleGroup).options(joinedload(RoleGroup.active_user_memberships)))
+                    for rg in (
+                        await db.scalars(select(RoleGroup).options(joinedload(RoleGroup.active_user_memberships)))
+                    )
                     .unique()
                     .all()
                     if assignee_user.id in [m.user_id for m in rg.active_user_memberships]
@@ -334,13 +344,13 @@ def list_role_requests(
             )
         )
 
-    return paginate(db, stmt, transformer=validated(RoleRequestSummary))
+    return await apaginate(db, stmt, transformer=validated(RoleRequestSummary))
 
 
 @router.get("/{role_request_id}", name="role_request_by_id")
-def get_role_request(role_request_id: str, db: DbSession, current_user_id: CurrentUserId) -> RoleRequestDetail:
-    rr = db.scalars(
-        select(RoleRequest).options(*_detail_load_options()).where(RoleRequest.id == role_request_id)
+async def get_role_request(role_request_id: str, db: DbSession, current_user_id: CurrentUserId) -> RoleRequestDetail:
+    rr = (
+        await db.scalars(select(RoleRequest).options(*_detail_load_options()).where(RoleRequest.id == role_request_id))
     ).first()
     if rr is None:
         raise HTTPException(404, "Not Found")
@@ -348,25 +358,25 @@ def get_role_request(role_request_id: str, db: DbSession, current_user_id: Curre
 
 
 @router.post("", name="role_requests_create", status_code=201)
-def post_role_request(
+async def post_role_request(
     body: CreateRoleRequestBody,
     db: DbSession,
     current_user_id: CurrentUserId,
 ) -> RoleRequestSummary:
     from api.auth import permissions as _perms
 
-    requester = db.scalars(
-        select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id)
+    requester = (
+        await db.scalars(select(OktaUser).where(OktaUser.deleted_at.is_(None)).where(OktaUser.id == current_user_id))
     ).first()
-    role = db.scalars(
-        select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == body.role_id)
+    role = (
+        await db.scalars(select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).where(RoleGroup.id == body.role_id))
     ).first()
     if role is None:
         raise HTTPException(404, "Not Found")
-    if requester is None or not _perms.can_manage_group(db, current_user_id, role):
+    if requester is None or not await _perms.can_manage_group(db, current_user_id, role):
         raise HTTPException(403, "Current user is not allowed to perform this action")
-    group = db.scalars(
-        select(OktaGroup).where(OktaGroup.deleted_at.is_(None)).where(OktaGroup.id == body.group_id)
+    group = (
+        await db.scalars(select(OktaGroup).where(OktaGroup.deleted_at.is_(None)).where(OktaGroup.id == body.group_id))
     ).first()
     if group is None:
         raise HTTPException(404, "Not Found")
@@ -376,23 +386,25 @@ def post_role_request(
         raise HTTPException(400, "Role requests may only be made for groups and app groups (not roles).")
 
     # Close any existing pending duplicate requests
-    existing = db.scalars(
-        select(RoleRequest)
-        .where(RoleRequest.requester_user_id == current_user_id)
-        .where(RoleRequest.requester_role_id == body.role_id)
-        .where(RoleRequest.requested_group_id == body.group_id)
-        .where(RoleRequest.request_ownership == body.group_owner)
-        .where(RoleRequest.status == AccessRequestStatus.PENDING)
-        .where(RoleRequest.resolved_at.is_(None))
+    existing = (
+        await db.scalars(
+            select(RoleRequest)
+            .where(RoleRequest.requester_user_id == current_user_id)
+            .where(RoleRequest.requester_role_id == body.role_id)
+            .where(RoleRequest.requested_group_id == body.group_id)
+            .where(RoleRequest.request_ownership == body.group_owner)
+            .where(RoleRequest.status == AccessRequestStatus.PENDING)
+            .where(RoleRequest.resolved_at.is_(None))
+        )
     ).all()
     for old in existing:
-        RejectRoleRequest(
+        await RejectRoleRequest(
             role_request=old,
             rejection_reason="Closed due to duplicate role request creation",
             notify_requester=False,
             current_user_id=current_user_id,
         ).execute()
-    rr = CreateRoleRequest(
+    rr = await CreateRoleRequest(
         requester_user=requester,
         requester_role=role,
         requested_group=group,
@@ -403,12 +415,14 @@ def post_role_request(
     # Drop cached ORM state so the response reflects what the operation
     # committed (expire_on_commit=False keeps pre-operation state otherwise).
     db.expire_all()
-    refreshed = db.scalars(select(RoleRequest).options(*_summary_load_options()).where(RoleRequest.id == rr.id)).first()
+    refreshed = (
+        await db.scalars(select(RoleRequest).options(*_summary_load_options()).where(RoleRequest.id == rr.id))
+    ).first()
     return RoleRequestSummary.model_validate(refreshed or rr, from_attributes=True)
 
 
 @router.put("/{role_request_id}", name="role_request_by_id_put")
-def put_role_request(
+async def put_role_request(
     role_request_id: str,
     body: ResolveRoleRequestBody,
     db: DbSession,
@@ -417,8 +431,8 @@ def put_role_request(
     from api.auth import permissions as _perms
     from api.operations.constraints import CheckForReason
 
-    rr = db.scalars(
-        select(RoleRequest).options(*_summary_load_options()).where(RoleRequest.id == role_request_id)
+    rr = (
+        await db.scalars(select(RoleRequest).options(*_summary_load_options()).where(RoleRequest.id == role_request_id))
     ).first()
     if rr is None:
         raise HTTPException(404, "Not Found")
@@ -427,7 +441,7 @@ def put_role_request(
     if rr.requester_user_id == current_user_id:
         if body.approved:
             raise HTTPException(403, "Users cannot approve their own requests")
-    elif not _perms.can_manage_group(db, current_user_id, rr.active_requested_group):
+    elif not await _perms.can_manage_group(db, current_user_id, rr.active_requested_group):
         raise HTTPException(403, "Current user is not allowed to perform this action")
 
     # Tags on the requester role can require a justification before approval.
@@ -435,7 +449,7 @@ def put_role_request(
     # the target group's), and the members/owners lists carry the target
     # group id (not user ids) — see Flask api/views/resources/role_request.py.
     if body.approved:
-        valid, err_message = CheckForReason(
+        valid, err_message = await CheckForReason(
             group=rr.requester_role_id,
             reason=body.reason,
             members_to_add=[rr.requested_group_id] if not rr.request_ownership else [],
@@ -449,14 +463,14 @@ def put_role_request(
     if body.approved:
         if not rr.requested_group.is_managed:
             raise HTTPException(400, "Groups not managed by Access cannot be modified")
-        ApproveRoleRequest(
+        await ApproveRoleRequest(
             role_request=rr,
             approver_user=current_user_id,
             approval_reason=body.reason or "",
             ending_at=body.ending_at,
         ).execute()
     else:
-        RejectRoleRequest(
+        await RejectRoleRequest(
             role_request=rr,
             current_user_id=current_user_id,
             rejection_reason=body.reason or "",
@@ -465,7 +479,7 @@ def put_role_request(
     # Drop cached ORM state so the response reflects what the operation
     # committed (expire_on_commit=False keeps pre-operation state otherwise).
     db.expire_all()
-    refreshed = db.scalars(
-        select(RoleRequest).options(*_summary_load_options()).where(RoleRequest.id == role_request_id)
+    refreshed = (
+        await db.scalars(select(RoleRequest).options(*_summary_load_options()).where(RoleRequest.id == role_request_id))
     ).first()
     return RoleRequestSummary.model_validate(refreshed, from_attributes=True)

--- a/api/routers/role_requests.py
+++ b/api/routers/role_requests.py
@@ -414,9 +414,10 @@ async def post_role_request(
     ).execute()
     # Drop cached ORM state so the response reflects what the operation
     # committed (expire_on_commit=False keeps pre-operation state otherwise).
+    rr_id = rr.id
     db.expire_all()
     refreshed = (
-        await db.scalars(select(RoleRequest).options(*_summary_load_options()).where(RoleRequest.id == rr.id))
+        await db.scalars(select(RoleRequest).options(*_summary_load_options()).where(RoleRequest.id == rr_id))
     ).first()
     return RoleRequestSummary.model_validate(refreshed or rr, from_attributes=True)
 

--- a/api/routers/roles.py
+++ b/api/routers/roles.py
@@ -19,7 +19,7 @@ from api.auth.dependencies import CurrentUserId
 from api.database import DbSession
 from api.models import OktaGroup, OktaUser, OktaUserGroupMember, RoleGroup, RoleGroupMap
 from api.operations import ModifyRoleGroups
-from fastapi_pagination.ext.sqlalchemy import paginate
+from fastapi_pagination.ext.sqlalchemy import apaginate
 
 from api.pagination import Page, validated
 from api.routers.groups import DEFAULT_LOAD_OPTIONS as _GROUP_LOAD_OPTIONS
@@ -38,7 +38,7 @@ _role_adapter: TypeAdapter[Any] = TypeAdapter(GroupDetail)
 
 
 @router.get("", name="roles")
-def list_roles(
+async def list_roles(
     request: Request,
     db: DbSession,
     current_user_id: CurrentUserId,
@@ -54,21 +54,25 @@ def list_roles(
     # Filter to roles owned by `owner_id` (id or email; supports `@me`).
     if q_args.owner_id:
         owner_id = current_user_id if q_args.owner_id == "@me" else q_args.owner_id
-        owner = db.scalars(
-            select(OktaUser)
-            .where(or_(OktaUser.id == owner_id, OktaUser.email.ilike(owner_id)))
-            .order_by(nullsfirst(OktaUser.deleted_at.desc()))
+        owner = (
+            await db.scalars(
+                select(OktaUser)
+                .where(or_(OktaUser.id == owner_id, OktaUser.email.ilike(owner_id)))
+                .order_by(nullsfirst(OktaUser.deleted_at.desc()))
+            )
         ).first()
         if owner is None:
             raise HTTPException(404, "Not Found")
-        owned_role_ids = db.scalars(
-            select(OktaUserGroupMember.group_id)
-            .where(OktaUserGroupMember.user_id == owner.id)
-            .where(OktaUserGroupMember.is_owner.is_(True))
-            .where(
-                or_(
-                    OktaUserGroupMember.ended_at.is_(None),
-                    OktaUserGroupMember.ended_at > func.now(),
+        owned_role_ids = (
+            await db.scalars(
+                select(OktaUserGroupMember.group_id)
+                .where(OktaUserGroupMember.user_id == owner.id)
+                .where(OktaUserGroupMember.is_owner.is_(True))
+                .where(
+                    or_(
+                        OktaUserGroupMember.ended_at.is_(None),
+                        OktaUserGroupMember.ended_at > func.now(),
+                    )
                 )
             )
         ).all()
@@ -77,16 +81,18 @@ def list_roles(
     if q_args.q:
         like = f"%{q_args.q}%"
         stmt = stmt.where(or_(RoleGroup.name.ilike(like), RoleGroup.description.ilike(like)))
-    return paginate(db, stmt, transformer=validated(RoleGroupListItem))
+    return await apaginate(db, stmt, transformer=validated(RoleGroupListItem))
 
 
 @router.get("/{role_id}", name="role_by_id")
-def get_role(role_id: str, db: DbSession, current_user_id: CurrentUserId) -> GroupDetail:
-    role = db.scalars(
-        select(RoleGroup)
-        .options(*_GROUP_LOAD_OPTIONS)
-        .where(or_(RoleGroup.id == role_id, RoleGroup.name == role_id))
-        .order_by(nullsfirst(RoleGroup.deleted_at.desc()))
+async def get_role(role_id: str, db: DbSession, current_user_id: CurrentUserId) -> GroupDetail:
+    role = (
+        await db.scalars(
+            select(RoleGroup)
+            .options(*_GROUP_LOAD_OPTIONS)
+            .where(or_(RoleGroup.id == role_id, RoleGroup.name == role_id))
+            .order_by(nullsfirst(RoleGroup.deleted_at.desc()))
+        )
     ).first()
     if role is None:
         raise HTTPException(404, "Not Found")
@@ -94,7 +100,7 @@ def get_role(role_id: str, db: DbSession, current_user_id: CurrentUserId) -> Gro
 
 
 @router.get("/{role_id}/audit", name="role_audit_by_id")
-def get_role_audit(role_id: str, request: Request, current_user_id: CurrentUserId) -> RedirectResponse:
+async def get_role_audit(role_id: str, request: Request, current_user_id: CurrentUserId) -> RedirectResponse:
     from urllib.parse import urlencode
 
     qp = dict(request.query_params)
@@ -103,18 +109,22 @@ def get_role_audit(role_id: str, request: Request, current_user_id: CurrentUserI
 
 
 @router.get("/{role_id}/members", name="role_members_by_id")
-def get_role_members(role_id: str, db: DbSession, current_user_id: CurrentUserId) -> RoleMembersSummary:
-    role = db.scalars(
-        select(RoleGroup)
-        .where(RoleGroup.deleted_at.is_(None))
-        .where(or_(RoleGroup.id == role_id, RoleGroup.name == role_id))
+async def get_role_members(role_id: str, db: DbSession, current_user_id: CurrentUserId) -> RoleMembersSummary:
+    role = (
+        await db.scalars(
+            select(RoleGroup)
+            .where(RoleGroup.deleted_at.is_(None))
+            .where(or_(RoleGroup.id == role_id, RoleGroup.name == role_id))
+        )
     ).first()
     if role is None:
         raise HTTPException(404, "Not Found")
-    mappings = db.scalars(
-        select(RoleGroupMap)
-        .where(RoleGroupMap.role_group_id == role.id)
-        .where(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
+    mappings = (
+        await db.scalars(
+            select(RoleGroupMap)
+            .where(RoleGroupMap.role_group_id == role.id)
+            .where(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
+        )
     ).all()
     return RoleMembersSummary(
         groups_in_role=[m.group_id for m in mappings if not m.is_owner],
@@ -123,7 +133,7 @@ def get_role_members(role_id: str, db: DbSession, current_user_id: CurrentUserId
 
 
 @router.put("/{role_id}/members", name="role_members_by_id_put")
-def put_role_members(
+async def put_role_members(
     role_id: str,
     db: DbSession,
     current_user_id: CurrentUserId,
@@ -134,10 +144,12 @@ def put_role_members(
     from api.models import AppGroup, RoleGroupMap
     from api.operations.constraints import CheckForReason, CheckForSelfAdd
 
-    role = db.scalars(
-        select(RoleGroup)
-        .where(RoleGroup.deleted_at.is_(None))
-        .where(or_(RoleGroup.id == role_id, RoleGroup.name == role_id))
+    role = (
+        await db.scalars(
+            select(RoleGroup)
+            .where(RoleGroup.deleted_at.is_(None))
+            .where(or_(RoleGroup.id == role_id, RoleGroup.name == role_id))
+        )
     ).first()
     if role is None:
         raise HTTPException(404, "Not Found")
@@ -150,43 +162,53 @@ def put_role_members(
     # Authorization: should_expire requires can_manage_group on each affected group.
     if body.groups_should_expire or body.owner_groups_should_expire:
         all_should_expire_ids = body.groups_should_expire + body.owner_groups_should_expire
-        maps = db.scalars(
-            select(RoleGroupMap)
-            .where(RoleGroupMap.id.in_(all_should_expire_ids))
-            .where(RoleGroupMap.role_group_id == role.id)
+        maps = (
+            await db.scalars(
+                select(RoleGroupMap)
+                .where(RoleGroupMap.id.in_(all_should_expire_ids))
+                .where(RoleGroupMap.role_group_id == role.id)
+            )
         ).all()
         affected_group_ids = [m.group_id for m in maps]
-        affected_groups = db.scalars(
-            select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-            .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id.in_(affected_group_ids))
+        affected_groups = (
+            await db.scalars(
+                select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+                .where(OktaGroup.deleted_at.is_(None))
+                .where(OktaGroup.id.in_(affected_group_ids))
+            )
         ).all()
         for g in affected_groups:
-            if not _perms.can_manage_group(db, current_user_id, g):
+            if not await _perms.can_manage_group(db, current_user_id, g):
                 raise HTTPException(403, "Current user is not allowed to perform this action")
 
-    if not _perms.is_access_admin(db, current_user_id):
+    if not await _perms.is_access_admin(db, current_user_id):
         # Each group being added: must be group owner or app owner.
-        added_groups = db.scalars(
-            select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-            .where(OktaGroup.deleted_at.is_(None))
-            .where(OktaGroup.id.in_(body.groups_to_add + body.owner_groups_to_add))
+        added_groups = (
+            await db.scalars(
+                select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+                .where(OktaGroup.deleted_at.is_(None))
+                .where(OktaGroup.id.in_(body.groups_to_add + body.owner_groups_to_add))
+            )
         ).all()
         for g in added_groups:
-            if not _perms.is_group_owner(db, current_user_id, g) and not _perms.is_app_owner_group_owner(
+            if not await _perms.is_group_owner(db, current_user_id, g) and not await _perms.is_app_owner_group_owner(
                 db, current_user_id, app_group=g if isinstance(g, AppGroup) else None
             ):
                 raise HTTPException(403, "Current user is not allowed to perform this action")
 
         # Each group being removed: role owners exempt; otherwise must own the group/app.
-        if not _perms.is_group_owner(db, current_user_id, role):
-            removed_groups = db.scalars(
-                select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-                .where(OktaGroup.deleted_at.is_(None))
-                .where(OktaGroup.id.in_(body.groups_to_remove + body.owner_groups_to_remove))
+        if not await _perms.is_group_owner(db, current_user_id, role):
+            removed_groups = (
+                await db.scalars(
+                    select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+                    .where(OktaGroup.deleted_at.is_(None))
+                    .where(OktaGroup.id.in_(body.groups_to_remove + body.owner_groups_to_remove))
+                )
             ).all()
             for g in removed_groups:
-                if not _perms.is_group_owner(db, current_user_id, g) and not _perms.is_app_owner_group_owner(
+                if not await _perms.is_group_owner(
+                    db, current_user_id, g
+                ) and not await _perms.is_app_owner_group_owner(
                     db, current_user_id, app_group=g if isinstance(g, AppGroup) else None
                 ):
                     raise HTTPException(403, "Current user is not allowed to perform this action")
@@ -194,7 +216,7 @@ def put_role_members(
     # Reject changes to unmanaged groups.
     affected_ids = body.groups_to_add + body.owner_groups_to_add + body.groups_to_remove + body.owner_groups_to_remove
     if affected_ids:
-        unmanaged_count = db.scalar(
+        unmanaged_count = await db.scalar(
             select(func.count(OktaGroup.id))
             .where(OktaGroup.id.in_(affected_ids))
             .where(OktaGroup.deleted_at.is_(None))
@@ -206,7 +228,7 @@ def put_role_members(
     # Reject role-in-role nesting. Roles can only contain non-role groups.
     add_ids = body.groups_to_add + body.owner_groups_to_add
     if add_ids:
-        role_in_add_count = db.scalar(
+        role_in_add_count = await db.scalar(
             select(func.count(OktaGroup.id))
             .where(OktaGroup.id.in_(add_ids))
             .where(OktaGroup.deleted_at.is_(None))
@@ -215,7 +237,7 @@ def put_role_members(
         if role_in_add_count and role_in_add_count > 0:
             raise HTTPException(400, "Roles cannot be added to other Roles")
 
-    valid, err_message = CheckForSelfAdd(
+    valid, err_message = await CheckForSelfAdd(
         group=role,
         current_user=current_user_id,
         members_to_add=body.groups_to_add,
@@ -224,7 +246,7 @@ def put_role_members(
     if not valid:
         raise HTTPException(400, err_message)
 
-    valid, err_message = CheckForReason(
+    valid, err_message = await CheckForReason(
         group=role,
         reason=body.created_reason or "",
         members_to_add=body.groups_to_add,
@@ -233,7 +255,7 @@ def put_role_members(
     if not valid:
         raise HTTPException(400, err_message)
 
-    ModifyRoleGroups(
+    await ModifyRoleGroups(
         role_group=role,
         groups_to_add=body.groups_to_add,
         groups_to_remove=body.groups_to_remove,
@@ -245,4 +267,4 @@ def put_role_members(
         current_user_id=current_user_id,
         created_reason=body.created_reason or "",
     ).execute()
-    return get_role_members(role_id, db, current_user_id)
+    return await get_role_members(role_id, db, current_user_id)

--- a/api/routers/tags.py
+++ b/api/routers/tags.py
@@ -17,7 +17,7 @@ from api.context import get_request_context
 from api.database import DbSession
 from api.models import AppTagMap, OktaUser, Tag
 from api.operations import CreateTag, DeleteTag
-from fastapi_pagination.ext.sqlalchemy import paginate
+from fastapi_pagination.ext.sqlalchemy import apaginate
 
 from api.pagination import Page, validated
 from api.routers._eager import group_tag_map_options
@@ -45,7 +45,7 @@ router = APIRouter(prefix="/api/tags", tags=["tags"])
 
 
 @router.get("", name="tags")
-def list_tags(
+async def list_tags(
     request: Request,
     db: DbSession,
     current_user_id: CurrentUserId,
@@ -55,19 +55,21 @@ def list_tags(
     if q_args.q:
         like = f"%{q_args.q}%"
         stmt = stmt.where(or_(Tag.name.ilike(like), Tag.description.ilike(like)))
-    return paginate(db, stmt, transformer=validated(TagListItem))
+    return await apaginate(db, stmt, transformer=validated(TagListItem))
 
 
 @router.get("/{tag_id}", name="tag_by_id")
-def get_tag(tag_id: str, db: DbSession, current_user_id: CurrentUserId) -> TagDetail:
+async def get_tag(tag_id: str, db: DbSession, current_user_id: CurrentUserId) -> TagDetail:
     # `nullsfirst(deleted_at.desc())` makes an active row beat a soft-deleted
     # row that shares the same name. Without the order, `.first()` may return
     # an old deleted tag and 404 on a name that still exists.
-    tag = db.scalars(
-        select(Tag)
-        .options(*_TAG_LOAD_OPTIONS)
-        .where(or_(Tag.id == tag_id, Tag.name == tag_id))
-        .order_by(nullsfirst(Tag.deleted_at.desc()))
+    tag = (
+        await db.scalars(
+            select(Tag)
+            .options(*_TAG_LOAD_OPTIONS)
+            .where(or_(Tag.id == tag_id, Tag.name == tag_id))
+            .order_by(nullsfirst(Tag.deleted_at.desc()))
+        )
     ).first()
     if tag is None:
         raise HTTPException(404, "Not Found")
@@ -75,7 +77,7 @@ def get_tag(tag_id: str, db: DbSession, current_user_id: CurrentUserId) -> TagDe
 
 
 @router.post("", name="tags_create", status_code=201)
-def post_tag(
+async def post_tag(
     body: CreateTagBody,
     db: DbSession,
     current_user_id: CurrentUserId,
@@ -84,8 +86,10 @@ def post_tag(
     # Reject duplicates by name. Without this, CreateTag.execute() silently
     # returns the existing tag and the endpoint replies 201 with the wrong
     # row, which clients don't expect.
-    existing = db.scalars(
-        select(Tag).where(func.lower(Tag.name) == func.lower(body.name)).where(Tag.deleted_at.is_(None))
+    existing = (
+        await db.scalars(
+            select(Tag).where(func.lower(Tag.name) == func.lower(body.name)).where(Tag.deleted_at.is_(None))
+        )
     ).first()
     if existing is not None:
         raise HTTPException(400, "Tag already exists with the same name")
@@ -96,16 +100,16 @@ def post_tag(
         constraints=body.constraints or {},
         enabled=body.enabled,
     )
-    created = CreateTag(tag=tag, current_user_id=current_user_id).execute()
+    created = await CreateTag(tag=tag, current_user_id=current_user_id).execute()
     # Drop cached ORM state so the response reflects what the operation
     # committed (expire_on_commit=False keeps pre-operation state otherwise).
     db.expire_all()
-    refreshed = db.scalars(select(Tag).options(*_TAG_LOAD_OPTIONS).where(Tag.id == created.id)).first()
+    refreshed = (await db.scalars(select(Tag).options(*_TAG_LOAD_OPTIONS).where(Tag.id == created.id))).first()
     return TagDetail.model_validate(refreshed or created, from_attributes=True)
 
 
 @router.put("/{tag_id}", name="tag_by_id_put")
-def put_tag(
+async def put_tag(
     tag_id: str,
     body: UpdateTagBody,
     db: DbSession,
@@ -116,8 +120,8 @@ def put_tag(
 
     from api.operations import ModifyGroupsTimeLimit
 
-    tag = db.scalars(
-        select(Tag).where(Tag.deleted_at.is_(None)).where(or_(Tag.id == tag_id, Tag.name == tag_id))
+    tag = (
+        await db.scalars(select(Tag).where(Tag.deleted_at.is_(None)).where(or_(Tag.id == tag_id, Tag.name == tag_id)))
     ).first()
     if tag is None:
         raise HTTPException(404, "Not Found")
@@ -136,11 +140,13 @@ def put_tag(
     # Reject renames that collide with another existing tag (case-insensitive).
     new_name = payload.get("name")
     if new_name and new_name.lower() != tag.name.lower():
-        collision = db.scalars(
-            select(Tag)
-            .where(Tag.id != tag.id)
-            .where(func.lower(Tag.name) == func.lower(new_name))
-            .where(Tag.deleted_at.is_(None))
+        collision = (
+            await db.scalars(
+                select(Tag)
+                .where(Tag.id != tag.id)
+                .where(func.lower(Tag.name) == func.lower(new_name))
+                .where(Tag.deleted_at.is_(None))
+            )
         ).first()
         if collision is not None:
             raise HTTPException(400, "Tag already exists with the same name")
@@ -152,14 +158,16 @@ def put_tag(
     for key in ("name", "description", "constraints", "enabled"):
         if key in payload:
             setattr(tag, key, payload[key])
-    db.commit()
+    await db.commit()
 
     # Re-evaluate time-limit constraints for groups associated with this tag.
     # `ModifyGroupsTimeLimit` commits, expiring objects, so we re-load
     # `refreshed` afterwards before serializing.
-    pre_refresh = db.scalars(select(Tag).options(selectinload(Tag.active_group_tags)).where(Tag.id == tag.id)).first()
+    pre_refresh = (
+        await db.scalars(select(Tag).options(selectinload(Tag.active_group_tags)).where(Tag.id == tag.id))
+    ).first()
     if pre_refresh is not None and pre_refresh.active_group_tags:
-        ModifyGroupsTimeLimit(
+        await ModifyGroupsTimeLimit(
             groups=[tm.group_id for tm in pre_refresh.active_group_tags],
             tags=[pre_refresh.id],
         ).execute()
@@ -167,9 +175,9 @@ def put_tag(
     # Drop cached ORM state so the response reflects what the operation
     # committed (expire_on_commit=False keeps pre-operation state otherwise).
     db.expire_all()
-    refreshed = db.scalars(select(Tag).options(*_TAG_LOAD_OPTIONS).where(Tag.id == tag.id)).first()
+    refreshed = (await db.scalars(select(Tag).options(*_TAG_LOAD_OPTIONS).where(Tag.id == tag.id))).first()
 
-    email = getattr(db.get(OktaUser, current_user_id), "email", None) if current_user_id else None
+    email = getattr(await db.get(OktaUser, current_user_id), "email", None) if current_user_id else None
     _ctx = get_request_context()
     logging.getLogger("access.audit").info(
         AuditLogSchema().dumps(
@@ -189,16 +197,16 @@ def put_tag(
 
 
 @router.delete("/{tag_id}", name="tag_by_id_delete")
-def delete_tag(
+async def delete_tag(
     tag_id: str,
     db: DbSession,
     _admin: str = Depends(require_access_admin),
     current_user_id: CurrentUserId = None,  # type: ignore[assignment]
 ) -> DeleteMessage:
-    tag = db.scalars(
-        select(Tag).where(Tag.deleted_at.is_(None)).where(or_(Tag.id == tag_id, Tag.name == tag_id))
+    tag = (
+        await db.scalars(select(Tag).where(Tag.deleted_at.is_(None)).where(or_(Tag.id == tag_id, Tag.name == tag_id)))
     ).first()
     if tag is None:
         raise HTTPException(404, "Not Found")
-    DeleteTag(tag=tag, current_user_id=current_user_id).execute()
+    await DeleteTag(tag=tag, current_user_id=current_user_id).execute()
     return DeleteMessage(deleted=True)

--- a/api/routers/tags.py
+++ b/api/routers/tags.py
@@ -103,8 +103,9 @@ async def post_tag(
     created = await CreateTag(tag=tag, current_user_id=current_user_id).execute()
     # Drop cached ORM state so the response reflects what the operation
     # committed (expire_on_commit=False keeps pre-operation state otherwise).
+    created_id = created.id
     db.expire_all()
-    refreshed = (await db.scalars(select(Tag).options(*_TAG_LOAD_OPTIONS).where(Tag.id == created.id))).first()
+    refreshed = (await db.scalars(select(Tag).options(*_TAG_LOAD_OPTIONS).where(Tag.id == created_id))).first()
     return TagDetail.model_validate(refreshed or created, from_attributes=True)
 
 
@@ -174,8 +175,9 @@ async def put_tag(
 
     # Drop cached ORM state so the response reflects what the operation
     # committed (expire_on_commit=False keeps pre-operation state otherwise).
+    tag_id_val = tag.id
     db.expire_all()
-    refreshed = (await db.scalars(select(Tag).options(*_TAG_LOAD_OPTIONS).where(Tag.id == tag.id))).first()
+    refreshed = (await db.scalars(select(Tag).options(*_TAG_LOAD_OPTIONS).where(Tag.id == tag_id_val))).first()
 
     email = getattr(await db.get(OktaUser, current_user_id), "email", None) if current_user_id else None
     _ctx = get_request_context()

--- a/api/routers/users.py
+++ b/api/routers/users.py
@@ -12,7 +12,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import RedirectResponse
-from fastapi_pagination.ext.sqlalchemy import paginate
+from fastapi_pagination.ext.sqlalchemy import apaginate
 from sqlalchemy import cast, func, nullsfirst, or_, select
 from sqlalchemy.orm import joinedload, selectinload, with_polymorphic
 from sqlalchemy.sql import sqltypes
@@ -41,7 +41,7 @@ ALL_GROUP_TYPES = with_polymorphic(OktaGroup, [AppGroup, RoleGroup])
 
 
 @router.get("", name="users")
-def list_users(
+async def list_users(
     db: DbSession,
     current_user_id: CurrentUserId,
     q_args: Annotated[SearchUserQuery, Query()],
@@ -95,23 +95,25 @@ def list_users(
                 )
             )
 
-    return paginate(db, stmt, transformer=validated(OktaUserSummary))
+    return await apaginate(db, stmt, transformer=validated(OktaUserSummary))
 
 
 @router.get("/{user_id}", name="user_by_id")
-def get_user(user_id: str, db: DbSession, current_user_id: CurrentUserId) -> OktaUserDetail:
+async def get_user(user_id: str, db: DbSession, current_user_id: CurrentUserId) -> OktaUserDetail:
     if user_id == "@me":
         user_id = current_user_id
 
-    user = db.scalars(
-        select(OktaUser)
-        .options(
-            selectinload(OktaUser.active_group_memberships).options(*user_group_member_options()),
-            selectinload(OktaUser.active_group_ownerships).options(*user_group_member_options()),
-            joinedload(OktaUser.manager),
+    user = (
+        await db.scalars(
+            select(OktaUser)
+            .options(
+                selectinload(OktaUser.active_group_memberships).options(*user_group_member_options()),
+                selectinload(OktaUser.active_group_ownerships).options(*user_group_member_options()),
+                joinedload(OktaUser.manager),
+            )
+            .where(or_(OktaUser.id == user_id, OktaUser.email.ilike(user_id)))
+            .order_by(nullsfirst(OktaUser.deleted_at.desc()))
         )
-        .where(or_(OktaUser.id == user_id, OktaUser.email.ilike(user_id)))
-        .order_by(nullsfirst(OktaUser.deleted_at.desc()))
     ).first()
     if user is None:
         raise HTTPException(status_code=404, detail="Not Found")
@@ -119,7 +121,7 @@ def get_user(user_id: str, db: DbSession, current_user_id: CurrentUserId) -> Okt
 
 
 @router.get("/{user_id}/audit", name="user_audit_by_id")
-def get_user_audit(user_id: str, request: Request, current_user_id: CurrentUserId) -> RedirectResponse:
+async def get_user_audit(user_id: str, request: Request, current_user_id: CurrentUserId) -> RedirectResponse:
     qp = dict(request.query_params)
     qp["user_id"] = user_id
     from urllib.parse import urlencode

--- a/api/services/okta_service.py
+++ b/api/services/okta_service.py
@@ -50,11 +50,13 @@ class OktaService:
     async def _okta_client(self) -> AsyncIterator[OktaClient]:
         """Yield a fresh Okta client whose pooled session is bound to the running loop.
 
-        Each public method runs its coroutine under its own ``asyncio.run`` event
-        loop. A new client per call keeps the aiohttp session, connector, and DNS
-        resolver from being shared across those loops, which otherwise races when
-        calls run concurrently (e.g. on the FastAPI/MCP threadpools) and raises
-        "Future attached to a different loop".
+        Callers run on different event loops: the FastAPI server loop, a
+        per-invocation loop in each CLI command (``asyncio.run`` in
+        ``manage.py``), and per-test loops under pytest. A new client per call
+        keeps the aiohttp session, connector, and DNS resolver from being
+        shared across loops, which otherwise raises "Future attached to a
+        different loop". A shared, lifespan-managed client (for connection
+        pooling on the server loop) is a possible follow-up.
         """
         client = OktaClient({"orgUrl": f"https://{self.okta_domain}", "token": self.okta_api_token})
         async with client:
@@ -103,123 +105,108 @@ class OktaService:
                 wait_time = RETRY_BACKOFF_FACTOR * (2**attempt)
             await asyncio.sleep(wait_time)
 
-    def get_user(self, userId: str) -> User:
-        async def _get_user(userId: str) -> User:
-            async with self._okta_client() as client:
-                user, _, error = await OktaService._retry(client.get_user, userId)
+    async def get_user(self, userId: str) -> User:
+        async with self._okta_client() as client:
+            user, _, error = await OktaService._retry(client.get_user, userId)
+
+        if error is not None:
+            raise Exception(error)
+
+        assert user is not None
+
+        return User(user)
+
+    async def get_user_schema(self, userTypeId: str) -> UserSchema:
+        async with self._okta_client() as client:
+            userType, _, error = await OktaService._retry(client.get_user_type, userTypeId)
 
             if error is not None:
                 raise Exception(error)
 
-            assert user is not None
+            assert userType is not None
 
-            return User(user)
+            schemaId = userType.links["schema"]["href"].rsplit("/", 1).pop()
 
-        return asyncio.run(_get_user(userId))
+            schema, _, error = await OktaService._retry(client.get_user_schema, schemaId)
 
-    def get_user_schema(self, userTypeId: str) -> UserSchema:
-        async def _get_user_schema(userTypeId: str) -> UserSchema:
-            async with self._okta_client() as client:
-                userType, _, error = await OktaService._retry(client.get_user_type, userTypeId)
+        if error is not None:
+            raise Exception(error)
 
-                if error is not None:
-                    raise Exception(error)
+        return UserSchema(schema)
 
-                assert userType is not None
-
-                schemaId = userType.links["schema"]["href"].rsplit("/", 1).pop()
-
-                schema, _, error = await OktaService._retry(client.get_user_schema, schemaId)
+    async def list_users(self) -> list[User]:
+        async with self._okta_client() as client:
+            users, resp, error = await OktaService._retry(client.list_users)
 
             if error is not None:
                 raise Exception(error)
 
-            return UserSchema(schema)
+            assert users is not None and resp is not None
 
-        return asyncio.run(_get_user_schema(userTypeId))
+            while resp.has_next():
+                more_users, _ = await OktaService._retry(resp.next)
+                users.extend(more_users)
 
-    def list_users(self) -> list[User]:
-        async def _list_users() -> list[User]:
-            async with self._okta_client() as client:
-                users, resp, error = await OktaService._retry(client.list_users)
+        return list(map(lambda user: User(user), users))
 
-                if error is not None:
-                    raise Exception(error)
+    async def create_group(self, name: str, description: str) -> Group:
+        async with self._okta_client() as client:
+            group, _, error = await OktaService._retry(
+                client.create_group,
+                OktaGroupType({"profile": {"name": name, "description": description}}),
+            )
 
-                assert users is not None and resp is not None
+        if error is not None:
+            raise Exception(error)
 
-                while resp.has_next():
-                    more_users, _ = await OktaService._retry(resp.next)
-                    users.extend(more_users)
+        assert group is not None
 
-            return list(map(lambda user: User(user), users))
+        return Group(group)
 
-        return asyncio.run(_list_users())
+    async def update_group(self, groupId: str, name: str, description: str) -> Group:
+        async with self._okta_client() as client:
+            # Fetch Existing Group Data
+            existing_group_data, _, get_error = await OktaService._retry(client.get_group, groupId)
+            if get_error is not None:
+                logger.error(f"Failed to fetch existing group {groupId} before update: {get_error}")
+                raise Exception(f"Failed to fetch existing group {groupId} before update: {get_error}")
+            if existing_group_data is None:
+                logger.error(f"Group {groupId} not found in Okta before update.")
+                raise Exception(f"Group {groupId} not found in Okta before update.")
 
-    def create_group(self, name: str, description: str) -> Group:
-        async def _create_group(name: str, description: str) -> Group:
-            async with self._okta_client() as client:
-                group, _, error = await OktaService._retry(
-                    client.create_group,
-                    OktaGroupType({"profile": {"name": name, "description": description}}),
-                )
+            # Extract Existing Profile
+            existing_profile = {}
+            if existing_group_data.profile:
+                # Using __dict__ can be fragile if Okta changes internal representation.
+                # If specific profile attributes are known, accessing them directly might be safer.
+                # Filter out None values if needed by Okta API or desired.
+                existing_profile = {k: v for k, v in existing_group_data.profile.__dict__.items() if v is not None}
 
-            if error is not None:
-                raise Exception(error)
+            # Merge Updated Profile Data
+            new_profile = {**existing_profile}  # Start with a copy of the existing profile
+            new_profile["name"] = name  # Update/set the name
+            new_profile["description"] = (
+                description if description is not None else ""
+            )  # Update/set the description (handle None)
 
-            assert group is not None
+            # Construct the New Payload
+            group_payload = OktaGroupType({"profile": new_profile})
 
-            return Group(group)
+            # Modify the Update Call to use the new payload
+            group, _, error = await OktaService._retry(
+                client.update_group,
+                groupId,
+                group_payload,
+            )
 
-        return asyncio.run(_create_group(name, description))
+        if error is not None:
+            raise Exception(error)
 
-    def update_group(self, groupId: str, name: str, description: str) -> Group:
-        async def _update_group(groupId: str, name: str, description: str) -> Group:
-            async with self._okta_client() as client:
-                # Fetch Existing Group Data
-                existing_group_data, _, get_error = await OktaService._retry(client.get_group, groupId)
-                if get_error is not None:
-                    logger.error(f"Failed to fetch existing group {groupId} before update: {get_error}")
-                    raise Exception(f"Failed to fetch existing group {groupId} before update: {get_error}")
-                if existing_group_data is None:
-                    logger.error(f"Group {groupId} not found in Okta before update.")
-                    raise Exception(f"Group {groupId} not found in Okta before update.")
+        assert group is not None
 
-                # Extract Existing Profile
-                existing_profile = {}
-                if existing_group_data.profile:
-                    # Using __dict__ can be fragile if Okta changes internal representation.
-                    # If specific profile attributes are known, accessing them directly might be safer.
-                    # Filter out None values if needed by Okta API or desired.
-                    existing_profile = {k: v for k, v in existing_group_data.profile.__dict__.items() if v is not None}
+        return Group(group)
 
-                # Merge Updated Profile Data
-                new_profile = {**existing_profile}  # Start with a copy of the existing profile
-                new_profile["name"] = name  # Update/set the name
-                new_profile["description"] = (
-                    description if description is not None else ""
-                )  # Update/set the description (handle None)
-
-                # Construct the New Payload
-                group_payload = OktaGroupType({"profile": new_profile})
-
-                # Modify the Update Call to use the new payload
-                group, _, error = await OktaService._retry(
-                    client.update_group,
-                    groupId,
-                    group_payload,
-                )
-
-            if error is not None:
-                raise Exception(error)
-
-            assert group is not None
-
-            return Group(group)
-
-        return asyncio.run(_update_group(groupId, name, description))
-
-    async def async_add_user_to_group(self, groupId: str, userId: str) -> None:
+    async def add_user_to_group(self, groupId: str, userId: str) -> None:
         if groupId is None or groupId == "":
             logger.warning(f"cannot add user to groupId of {groupId}")
             return
@@ -237,10 +224,7 @@ class OktaService:
         except OktaTimeout:
             logger.warning(f"Timed out adding user {userId} to group {groupId}")
 
-    def add_user_to_group(self, groupId: str, userId: str) -> None:
-        asyncio.run(self.async_add_user_to_group(groupId, userId))
-
-    async def async_remove_user_from_group(self, groupId: str, userId: str) -> None:
+    async def remove_user_from_group(self, groupId: str, userId: str) -> None:
         if groupId is None or groupId == "":
             logger.warning(f"cannot remove user from groupId of {groupId}")
             return
@@ -258,46 +242,37 @@ class OktaService:
         except OktaTimeout:
             logger.warning(f"Timed out removing user {userId} from group {groupId}")
 
-    def remove_user_from_group(self, groupId: str, userId: str) -> None:
-        asyncio.run(self.async_remove_user_from_group(groupId, userId))
-
     # TODO: Implement fetching group membership count for fast syncing
     # GET https://{yourOktaDomain}.com/api/v1/groups/<group_id>?expand=app,stats
-    def get_group(self, groupId: str) -> Group:
-        async def _get_group(groupId: str) -> Group:
-            async with self._okta_client() as client:
-                group, _, error = await OktaService._retry(client.get_group, groupId)
+    async def get_group(self, groupId: str) -> Group:
+        async with self._okta_client() as client:
+            group, _, error = await OktaService._retry(client.get_group, groupId)
 
-            if error is not None:
-                raise Exception(error)
+        if error is not None:
+            raise Exception(error)
 
-            assert group is not None
+        assert group is not None
 
-            return Group(group)
-
-        return asyncio.run(_get_group(groupId))
+        return Group(group)
 
     DEFAULT_QUERY_PARAMS = {"filter": 'type eq "BUILT_IN" or type eq "OKTA_GROUP"'}
 
-    def list_groups(self, *, query_params: dict[str, str] = DEFAULT_QUERY_PARAMS) -> list[Group]:
-        async def _list_groups(query_params: dict[str, str]) -> list[Group]:
-            async with self._okta_client() as client:
-                groups, resp, error = await OktaService._retry(client.list_groups, query_params=query_params)
+    async def list_groups(self, *, query_params: dict[str, str] = DEFAULT_QUERY_PARAMS) -> list[Group]:
+        async with self._okta_client() as client:
+            groups, resp, error = await OktaService._retry(client.list_groups, query_params=query_params)
 
-                if error is not None:
-                    raise Exception(error)
-                assert groups is not None and resp is not None
+            if error is not None:
+                raise Exception(error)
+            assert groups is not None and resp is not None
 
-                while resp.has_next():
-                    more_groups, _ = await OktaService._retry(resp.next)
-                    groups.extend(more_groups)
+            while resp.has_next():
+                more_groups, _ = await OktaService._retry(resp.next)
+                groups.extend(more_groups)
 
-            return list(map(lambda group: Group(group), groups))
+        return list(map(lambda group: Group(group), groups))
 
-        return asyncio.run(_list_groups(query_params))
-
-    def list_groups_with_active_rules(self) -> dict[str, list[OktaGroupRuleType]]:
-        group_rules = self.list_group_rules()
+    async def list_groups_with_active_rules(self) -> dict[str, list[OktaGroupRuleType]]:
+        group_rules = await self.list_group_rules()
         group_ids_with_group_rules = {}  # type: dict[str, list[OktaGroupRuleType]]
         for group_rule in group_rules:
             if group_rule.status == "ACTIVE":
@@ -305,65 +280,53 @@ class OktaService:
                     group_ids_with_group_rules.setdefault(id, []).append(group_rule)
         return group_ids_with_group_rules
 
-    def list_group_rules(self, *, query_params: dict[str, str] = {}) -> list[OktaGroupRuleType]:
-        async def _list_group_rules(query_params: dict[str, str]) -> list[OktaGroupRuleType]:
-            async with self._okta_client() as client:
-                group_rules, resp, error = await OktaService._retry(client.list_group_rules, query_params=query_params)
+    async def list_group_rules(self, *, query_params: dict[str, str] = {}) -> list[OktaGroupRuleType]:
+        async with self._okta_client() as client:
+            group_rules, resp, error = await OktaService._retry(client.list_group_rules, query_params=query_params)
 
-                if error is not None:
-                    raise Exception(error)
+            if error is not None:
+                raise Exception(error)
 
-                assert group_rules is not None and resp is not None
+            assert group_rules is not None and resp is not None
 
-                while resp.has_next():
-                    more_group_rules, _ = await OktaService._retry(resp.next)
-                    group_rules.extend(more_group_rules)
+            while resp.has_next():
+                more_group_rules, _ = await OktaService._retry(resp.next)
+                group_rules.extend(more_group_rules)
 
-            return group_rules
+        return group_rules
 
-        return asyncio.run(_list_group_rules(query_params))
+    async def list_users_for_group(self, groupId: str) -> list[User]:
+        async with self._okta_client() as client:
+            users, resp, error = await OktaService._retry(client.list_group_users, groupId)
 
-    def list_users_for_group(self, groupId: str) -> list[User]:
-        async def _list_users_for_group(groupId: str) -> list[User]:
-            async with self._okta_client() as client:
-                users, resp, error = await OktaService._retry(client.list_group_users, groupId)
+            if error is not None:
+                raise Exception(error)
+            assert users is not None and resp is not None
 
-                if error is not None:
-                    raise Exception(error)
-                assert users is not None and resp is not None
+            while resp.has_next():
+                more_users, _ = await OktaService._retry(resp.next)
+                users.extend(more_users)
 
-                while resp.has_next():
-                    more_users, _ = await OktaService._retry(resp.next)
-                    users.extend(more_users)
+        return list(map(lambda user: User(user), users))
 
-            return list(map(lambda user: User(user), users))
-
-        return asyncio.run(_list_users_for_group(groupId))
-
-    async def async_delete_group(self, groupId: str) -> None:
+    async def delete_group(self, groupId: str) -> None:
         async with self._okta_client() as client:
             _, error = await OktaService._retry(client.delete_group, groupId)
 
         if error is not None:
             raise Exception(error)
 
-    def delete_group(self, groupId: str) -> None:
-        asyncio.run(self.async_delete_group(groupId))
-
     # Below are custom API endpoints that are not supported by the Okta Python SDK
     # https://github.com/okta/okta-sdk-python#call-other-api-endpoints
 
     # https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Group/#tag/Group/operation/assignGroupOwner
-    def add_owner_to_group(self, groupId: str, userId: str) -> None:
+    async def add_owner_to_group(self, groupId: str, userId: str) -> None:
         if groupId is None or groupId == "":
             logger.warning(f"cannot add owner to groupId of {groupId}")
             return
         if userId is None or userId == "":
             logger.warning(f"cannot add owner to userId of {userId}")
             return
-        asyncio.run(self.async_add_owner_to_group(groupId, userId))
-
-    async def async_add_owner_to_group(self, groupId: str, userId: str) -> None:
         if not self.use_group_owners_api:
             return
 
@@ -392,16 +355,13 @@ class OktaService:
         return
 
     # https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Group/#tag/Group/operation/deleteGroupOwner
-    def remove_owner_from_group(self, groupId: str, userId: str) -> None:
+    async def remove_owner_from_group(self, groupId: str, userId: str) -> None:
         if groupId is None or groupId == "":
             logger.warning(f"cannot to remove owner from groupId of {groupId}")
             return
         if userId is None or userId == "":
             logger.warning(f"cannot remove owner from userId of {userId}")
             return
-        asyncio.run(self.async_remove_owner_from_group(groupId, userId))
-
-    async def async_remove_owner_from_group(self, groupId: str, userId: str) -> None:
         if not self.use_group_owners_api:
             return
 
@@ -429,39 +389,36 @@ class OktaService:
         return
 
     # https://developer.okta.com/docs/api/openapi/okta-management/management/tag/Group/#tag/Group/operation/listGroupOwners
-    def list_owners_for_group(self, groupId: str) -> list[User]:
+    async def list_owners_for_group(self, groupId: str) -> list[User]:
         if groupId is None or groupId == "":
             logger.warning(f"cannot to list owners for groupId of {groupId}")
             return []
         if not self.use_group_owners_api:
             return []
 
-        async def _list_owners_for_group(groupId: str) -> list[User]:
-            async with self._okta_client() as client:
-                request_executor = client.get_request_executor()
-                request, error = await request_executor.create_request(
-                    method="GET",
-                    url="/api/v1/groups/{groupId}/owners".format(groupId=groupId),
-                    body={},
-                    headers={},
-                    oauth=False,
-                )
-
-                if error is not None:
-                    raise Exception(error)
-
-                response, error = await OktaService._retry(request_executor.execute, request, OktaUserType)
+        async with self._okta_client() as client:
+            request_executor = client.get_request_executor()
+            request, error = await request_executor.create_request(
+                method="GET",
+                url="/api/v1/groups/{groupId}/owners".format(groupId=groupId),
+                body={},
+                headers={},
+                oauth=False,
+            )
 
             if error is not None:
                 raise Exception(error)
-            assert response is not None
 
-            result = []
-            for user in response.get_body():
-                result.append(User(OktaUserType(user)))
-            return result
+            response, error = await OktaService._retry(request_executor.execute, request, OktaUserType)
 
-        return asyncio.run(_list_owners_for_group(groupId))
+        if error is not None:
+            raise Exception(error)
+        assert response is not None
+
+        result = []
+        for user in response.get_body():
+            result.append(User(OktaUserType(user)))
+        return result
 
 
 # Wrapper class for the Okta API user model

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -1,8 +1,10 @@
+import functools
 import logging
 from collections import defaultdict
 from datetime import date, datetime, timedelta, timezone
 from typing import List
 
+import anyio.to_thread
 from sqlalchemy import and_, func, or_, select
 from api.config import settings
 from sqlalchemy.orm import (
@@ -40,26 +42,28 @@ from api.services.okta_service import OktaTimeout, is_managed_group
 logger = logging.getLogger(__name__)
 
 
-def sync_users() -> None:
+async def sync_users() -> None:
     logger.info("User sync starting")
 
     # Get all users from okta
-    users = okta.list_users()
+    users = await okta.list_users()
     user_type_to_user_attrs_to_titles = {}
 
     # Hydrate all users into sql alchemy context at once
     # to avoid a roundtrip for each user
-    _ = db.session.scalars(select(OktaUser)).all()
+    _ = (await db.session.scalars(select(OktaUser))).all()
 
     for user in users:
         logger.info(f"Syncing user {user.id}")
 
         if user.type.id not in user_type_to_user_attrs_to_titles:
-            user_type_to_user_attrs_to_titles[user.type.id] = okta.get_user_schema(user.type.id).user_attrs_to_titles()
+            user_type_to_user_attrs_to_titles[user.type.id] = (
+                await okta.get_user_schema(user.type.id)
+            ).user_attrs_to_titles()
 
         user_attrs_to_titles = user_type_to_user_attrs_to_titles[user.type.id]
 
-        db_user = db.session.get(OktaUser, user.id)
+        db_user = await db.session.get(OktaUser, user.id)
 
         if db_user is None:
             logger.info(f"Creating user in DB {user.id}")
@@ -69,47 +73,53 @@ def sync_users() -> None:
             # User was found. Let's update
             user.update_okta_user(db_user, user_attrs_to_titles)
 
-    db.session.commit()
+    await db.session.commit()
 
     # Delete users and end all group memberships in the DB for users that are suspended/deactivated in Okta
     deleted_user_ids = [u.id for u in filter(lambda u: u.get_deleted_at() is not None, users)]
 
-    users_to_delete = db.session.scalars(
-        select(OktaUser).where(OktaUser.id.in_(deleted_user_ids)).where(OktaUser.deleted_at.is_(None))
+    users_to_delete = (
+        await db.session.scalars(
+            select(OktaUser).where(OktaUser.id.in_(deleted_user_ids)).where(OktaUser.deleted_at.is_(None))
+        )
     ).all()
 
     for db_user in users_to_delete:
         logger.info(f"Deleting user in DB {db_user.id} that was suspended/deactivated in Okta")
-        DeleteUser(user=db_user.id).execute()
+        await DeleteUser(user=db_user.id).execute()
 
     # Delete users and end all group memberships in the DB for users that are deleted in Okta
     active_user_ids = [u.id for u in filter(lambda u: u.get_deleted_at() is None, users)]
 
-    more_users_to_delete = db.session.scalars(
-        select(OktaUser).where(OktaUser.id.not_in(active_user_ids)).where(OktaUser.deleted_at.is_(None))
+    more_users_to_delete = (
+        await db.session.scalars(
+            select(OktaUser).where(OktaUser.id.not_in(active_user_ids)).where(OktaUser.deleted_at.is_(None))
+        )
     ).all()
 
     for db_user in more_users_to_delete:
         logger.info(f"Deleting user in DB {db_user.id} that was deleted in Okta")
-        DeleteUser(user=db_user.id, sync_to_okta=False).execute()
+        await DeleteUser(user=db_user.id, sync_to_okta=False).execute()
 
     # End all active group memberships in the DB for users that were previously deleted
-    db_deleted_users_with_access = db.session.scalars(
-        select(OktaUserGroupMember)
-        .join(OktaUserGroupMember.user)
-        .where(OktaUser.deleted_at.isnot(None))
-        .where(or_(OktaUserGroupMember.ended_at.is_(None), OktaUserGroupMember.ended_at > func.now()))
+    db_deleted_users_with_access = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .join(OktaUserGroupMember.user)
+            .where(OktaUser.deleted_at.isnot(None))
+            .where(or_(OktaUserGroupMember.ended_at.is_(None), OktaUserGroupMember.ended_at > func.now()))
+        )
     ).all()
     for user_id in set([u.user_id for u in db_deleted_users_with_access]):
         logger.info(f"Ending active group ownerships/memberships for deleted user in DB {user_id}")
-        DeleteUser(user=user_id).execute()
+        await DeleteUser(user=user_id).execute()
 
     # Sync manager foreign keys, as Okta only gives us employee numbers
     users_by_employee_number = {
         user.profile.employee_number: user for user in filter(lambda u: u.profile.employee_number is not None, users)
     }
     for user in users:
-        db_user = db.session.get(OktaUser, user.id)
+        db_user = await db.session.get(OktaUser, user.id)
         if db_user is None:
             # The user iteration just upserted this row, so a None here
             # would only happen if Okta returned a duplicate id mid-iteration.
@@ -117,18 +127,18 @@ def sync_users() -> None:
         manager = users_by_employee_number.get(user.profile.manager_id, None)
         db_user.manager_id = getattr(manager, "id", None)
 
-    db.session.commit()
+    await db.session.commit()
 
     logger.info("User sync finished.")
 
 
-def sync_groups(act_as_authority: bool) -> None:
+async def sync_groups(act_as_authority: bool) -> None:
     logger.info("Group sync starting")
 
-    groups_in_okta = okta.list_groups()
-    db_group_ids = set(db.session.scalars(select(OktaGroup.id).where(OktaGroup.deleted_at.is_(None))).all())
+    groups_in_okta = await okta.list_groups()
+    db_group_ids = set((await db.session.scalars(select(OktaGroup.id).where(OktaGroup.deleted_at.is_(None)))).all())
 
-    group_ids_with_group_rules = okta.list_groups_with_active_rules()
+    group_ids_with_group_rules = await okta.list_groups_with_active_rules()
 
     for group in groups_in_okta:
         logger.info(f"Syncing group {group.id}")
@@ -136,13 +146,13 @@ def sync_groups(act_as_authority: bool) -> None:
         # Remove found groups from deleted group ids
         db_group_ids.discard(group.id)
 
-        db_group = db.session.get(OktaGroup, group.id)
+        db_group = await db.session.get(OktaGroup, group.id)
 
         # Handle the case where the group is in okta but not in the DB.
         if db_group is None:
             if act_as_authority:
                 logger.info(f"A new group {group.id} was added directly through okta. Deleting.")
-                okta.delete_group(group.id)
+                await okta.delete_group(group.id)
             else:
                 logger.info(f"A new group {group.id} was added directly through okta. Adding to DB.")
                 db.session.add(group.update_okta_group(OktaGroup(), group_ids_with_group_rules))
@@ -151,7 +161,7 @@ def sync_groups(act_as_authority: bool) -> None:
         elif db_group.deleted_at:
             if act_as_authority:
                 logger.info(f"Group {group.id} is marked as deleted, but still exists in okta. Deleting.")
-                DeleteGroup(group=group.id).execute()
+                await DeleteGroup(group=group.id).execute()
             else:
                 logger.info(f"Group {group.id} is marked as deleted, but still exists in okta. Resurrecting.")
                 db_group.deleted_at = None
@@ -163,7 +173,7 @@ def sync_groups(act_as_authority: bool) -> None:
                 db_group = group.update_okta_group(db_group, group_ids_with_group_rules)
 
                 if not db_group.is_managed and was_previously_managed:
-                    UnmanageGroup(group=db_group).execute()
+                    await UnmanageGroup(group=db_group).execute()
 
     # Any remaining group ids have been deleted from okta's side.
     if len(db_group_ids) > 0:
@@ -172,21 +182,21 @@ def sync_groups(act_as_authority: bool) -> None:
         )
 
         for group_id in db_group_ids:
-            DeleteGroup(group=group_id, sync_to_okta=False).execute()
+            await DeleteGroup(group=group_id, sync_to_okta=False).execute()
 
-    db.session.commit()
+    await db.session.commit()
     logger.info("Group sync finished.")
 
 
-def sync_group_memberships(act_as_authority: bool) -> None:
+async def sync_group_memberships(act_as_authority: bool) -> None:
     logger.info("Membership sync started.")
-    groups = okta.list_groups()
+    groups = await okta.list_groups()
 
     # Hydrate all groups into sql alchemy context at once
     # to avoid a roundtrip for each group
-    _ = db.session.scalars(select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))).all()
+    _ = (await db.session.scalars(select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup])))).all()
 
-    group_ids_with_group_rules = okta.list_groups_with_active_rules()
+    group_ids_with_group_rules = await okta.list_groups_with_active_rules()
 
     for group in groups:
         try:
@@ -196,13 +206,13 @@ def sync_group_memberships(act_as_authority: bool) -> None:
 
             logger.info(f"Syncing group {group.id}. act_authoritatively: {act_authoritatively}")
 
-            members = okta.list_users_for_group(group.id)
+            members = await okta.list_users_for_group(group.id)
 
             logger.info(f"Fetched users list for group {group.id}")
 
             db_all_group_members = {
                 row.id: row.user_id
-                for row in db.session.execute(
+                for row in await db.session.execute(
                     select(
                         OktaUserGroupMember.user_id,
                         OktaUserGroupMember.id,
@@ -223,14 +233,14 @@ def sync_group_memberships(act_as_authority: bool) -> None:
                     logger.info(f"User {member.id} is not in the group in our DB.")
 
                     if act_authoritatively:
-                        okta.remove_user_from_group(group.id, member.id)
+                        await okta.remove_user_from_group(group.id, member.id)
                     else:
                         reason = (
                             "User in Okta group but not in Access group."
                             if is_managed
                             else "User added via Okta group rule."
                         )
-                        ModifyGroupUsers(
+                        await ModifyGroupUsers(
                             group=group.id,
                             members_to_add=[member.id],
                             created_reason=reason,
@@ -253,32 +263,32 @@ def sync_group_memberships(act_as_authority: bool) -> None:
                 if act_authoritatively:
                     # Create in okta
                     for member_id in distinct_member_ids:
-                        okta.add_user_to_group(group.id, member_id)
+                        await okta.add_user_to_group(group.id, member_id)
                 else:
                     # Remove the direct group memberships to this group in our DB
                     # This will not affect group memberships that are via other group roles
-                    ModifyGroupUsers(group=group.id, members_to_remove=list(distinct_member_ids)).execute()
+                    await ModifyGroupUsers(group=group.id, members_to_remove=list(distinct_member_ids)).execute()
 
             logger.info("Members in DB synced to Okta.")
 
-            db.session.commit()
+            await db.session.commit()
         except OktaTimeout:
             logger.warning(f"Timed out syncing memberships for group {group.id}, skipping.", exc_info=True)
-            db.session.rollback()
+            await db.session.rollback()
             continue
         except Exception:
             logger.exception(f"Failed to sync memberships for group {group.id}, skipping.")
-            db.session.rollback()
+            await db.session.rollback()
             continue
 
     logger.info("Membership sync finished.")
 
 
-def sync_group_ownerships(act_as_authority: bool) -> None:
+async def sync_group_ownerships(act_as_authority: bool) -> None:
     logger.info("Ownership sync started.")
-    groups = okta.list_groups()
+    groups = await okta.list_groups()
 
-    group_ids_with_group_rules = okta.list_groups_with_active_rules()
+    group_ids_with_group_rules = await okta.list_groups_with_active_rules()
 
     for group in groups:
         try:
@@ -288,11 +298,11 @@ def sync_group_ownerships(act_as_authority: bool) -> None:
 
             logger.info(f"Syncing group {group.id}. act_authoritatively: {act_authoritatively}")
 
-            owners = okta.list_owners_for_group(group.id)
+            owners = await okta.list_owners_for_group(group.id)
 
             db_all_group_owners = {
                 row.id: row.user_id
-                for row in db.session.execute(
+                for row in await db.session.execute(
                     select(
                         OktaUserGroupMember.user_id,
                         OktaUserGroupMember.id,
@@ -310,20 +320,22 @@ def sync_group_ownerships(act_as_authority: bool) -> None:
             # If the group ownership is managed by Access and there are no owners for it
             # check to see if it's an AppGroup and if so, add the app owners as owners in Okta
             if act_authoritatively and len(db_all_group_owners) == 0:
-                app_group = db.session.scalars(
-                    select(AppGroup)
-                    .options(
-                        joinedload(AppGroup.app).options(selectinload(App.active_owner_app_groups)),
+                app_group = (
+                    await db.session.scalars(
+                        select(AppGroup)
+                        .options(
+                            joinedload(AppGroup.app).options(selectinload(App.active_owner_app_groups)),
+                        )
+                        .where(AppGroup.deleted_at.is_(None))
+                        .where(AppGroup.id == group.id)
                     )
-                    .where(AppGroup.deleted_at.is_(None))
-                    .where(AppGroup.id == group.id)
                 ).first()
 
                 if app_group is not None and not app_group.is_owner:
                     app_owner_group_ids = [g.id for g in app_group.app.active_owner_app_groups]
                     db_all_group_owners = {
                         row.id: row.user_id
-                        for row in db.session.execute(
+                        for row in await db.session.execute(
                             select(
                                 OktaUserGroupMember.user_id,
                                 OktaUserGroupMember.id,
@@ -344,14 +356,14 @@ def sync_group_ownerships(act_as_authority: bool) -> None:
                     logger.info(f"User {owner.id} is not in the group in our DB.")
 
                     if act_authoritatively:
-                        okta.remove_owner_from_group(group.id, owner.id)
+                        await okta.remove_owner_from_group(group.id, owner.id)
                     else:
                         reason = (
                             "User in Okta group but not in Access group."
                             if is_managed
                             else "User was added via Okta group rule."
                         )
-                        ModifyGroupUsers(
+                        await ModifyGroupUsers(
                             group=group.id,
                             owners_to_add=[owner.id],
                             created_reason=reason,
@@ -372,51 +384,56 @@ def sync_group_ownerships(act_as_authority: bool) -> None:
                 if act_authoritatively:
                     # Create in okta
                     for owner_id in distinct_owner_ids:
-                        okta.add_owner_to_group(group.id, owner_id)
+                        await okta.add_owner_to_group(group.id, owner_id)
                 else:
                     # Remove the direct group ownerships to this group in our DB
                     # This will not affect group ownerships that are via other group roles
-                    ModifyGroupUsers(group=group.id, owners_to_remove=list(distinct_owner_ids)).execute()
+                    await ModifyGroupUsers(group=group.id, owners_to_remove=list(distinct_owner_ids)).execute()
 
-            db.session.commit()
+            await db.session.commit()
         except OktaTimeout:
             logger.warning(f"Timed out syncing ownerships for group {group.id}, skipping.", exc_info=True)
-            db.session.rollback()
+            await db.session.rollback()
             continue
         except Exception:
             logger.exception(f"Failed to sync ownerships for group {group.id}, skipping.")
-            db.session.rollback()
+            await db.session.rollback()
             continue
 
     logger.info("Ownership sync finished.")
 
 
-def expire_access_requests() -> None:
+async def expire_access_requests() -> None:
     logger.info("Access request expiration started.")
     MAX_ACCESS_REQUEST_AGE_SECONDS = settings.MAX_ACCESS_REQUEST_AGE_SECONDS
 
-    older_than_max = db.session.scalars(
-        select(AccessRequest)
-        .where(AccessRequest.status == AccessRequestStatus.PENDING)
-        .where(AccessRequest.resolved_at.is_(None))
-        .where(
-            AccessRequest.created_at < datetime.now(timezone.utc) - timedelta(seconds=MAX_ACCESS_REQUEST_AGE_SECONDS)
+    older_than_max = (
+        await db.session.scalars(
+            select(AccessRequest)
+            .where(AccessRequest.status == AccessRequestStatus.PENDING)
+            .where(AccessRequest.resolved_at.is_(None))
+            .where(
+                AccessRequest.created_at
+                < datetime.now(timezone.utc) - timedelta(seconds=MAX_ACCESS_REQUEST_AGE_SECONDS)
+            )
         )
     ).all()
     for access_request in older_than_max:
-        RejectAccessRequest(
+        await RejectAccessRequest(
             access_request=access_request,
             rejection_reason="Closed because the request expired",
         ).execute()
 
-    older_than_request = db.session.scalars(
-        select(AccessRequest)
-        .where(AccessRequest.status == AccessRequestStatus.PENDING)
-        .where(AccessRequest.resolved_at.is_(None))
-        .where(AccessRequest.request_ending_at < func.now())
+    older_than_request = (
+        await db.session.scalars(
+            select(AccessRequest)
+            .where(AccessRequest.status == AccessRequestStatus.PENDING)
+            .where(AccessRequest.resolved_at.is_(None))
+            .where(AccessRequest.request_ending_at < func.now())
+        )
     ).all()
     for access_request in older_than_request:
-        RejectAccessRequest(
+        await RejectAccessRequest(
             access_request=access_request,
             rejection_reason="Closed because the request expired",
         ).execute()
@@ -424,7 +441,7 @@ def expire_access_requests() -> None:
     logger.info("Access request expiration finished.")
 
 
-def expiring_access_notifications_user() -> None:
+async def expiring_access_notifications_user() -> None:
     logger.info("Expiring access notifications for users started.")
     notification_hook = get_notification_hook()
 
@@ -435,24 +452,28 @@ def expiring_access_notifications_user() -> None:
         next_day = day + timedelta(days=3)
         weekend_notif_tomorrow = True
 
-    db_memberships_expiring_tomorrow = db.session.scalars(
-        select(OktaUserGroupMember)
-        .options(joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group))
-        .join(OktaUserGroupMember.active_user)
-        .join(OktaUserGroupMember.active_group)
-        .where(OktaGroup.is_managed.is_(True))
-        .where(and_(OktaUserGroupMember.ended_at >= day, OktaUserGroupMember.ended_at < next_day))
-        .where(OktaUserGroupMember.role_group_map_id.is_(None))
-        .where(OktaUserGroupMember.should_expire.is_(False))
+    db_memberships_expiring_tomorrow = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .options(joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group))
+            .join(OktaUserGroupMember.active_user)
+            .join(OktaUserGroupMember.active_group)
+            .where(OktaGroup.is_managed.is_(True))
+            .where(and_(OktaUserGroupMember.ended_at >= day, OktaUserGroupMember.ended_at < next_day))
+            .where(OktaUserGroupMember.role_group_map_id.is_(None))
+            .where(OktaUserGroupMember.should_expire.is_(False))
+        )
     ).all()
 
     # remove OktaUserGroupMembers from the list where there's a role that grants the same access
-    db_memberships_roles = db.session.scalars(
-        select(OktaUserGroupMember)
-        .options(joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group))
-        .join(OktaUserGroupMember.active_user)
-        .join(OktaUserGroupMember.active_group)
-        .where(OktaUserGroupMember.role_group_map_id.is_not(None))
+    db_memberships_roles = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .options(joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group))
+            .join(OktaUserGroupMember.active_user)
+            .join(OktaUserGroupMember.active_group)
+            .where(OktaUserGroupMember.role_group_map_id.is_not(None))
+        )
     ).all()
 
     user_id_group_id_roles = set((member.user_id, member.group_id) for member in db_memberships_roles)
@@ -479,15 +500,17 @@ def expiring_access_notifications_user() -> None:
         next_day = day + timedelta(days=3)
         weekend_notif_week = True
 
-    db_memberships_expiring_next_week = db.session.scalars(
-        select(OktaUserGroupMember)
-        .options(joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group))
-        .join(OktaUserGroupMember.active_user)
-        .join(OktaUserGroupMember.active_group)
-        .where(OktaGroup.is_managed.is_(True))
-        .where(and_(OktaUserGroupMember.ended_at >= day, OktaUserGroupMember.ended_at < next_day))
-        .where(OktaUserGroupMember.role_group_map_id.is_(None))
-        .where(OktaUserGroupMember.should_expire.is_(False))
+    db_memberships_expiring_next_week = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .options(joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group))
+            .join(OktaUserGroupMember.active_user)
+            .join(OktaUserGroupMember.active_group)
+            .where(OktaGroup.is_managed.is_(True))
+            .where(and_(OktaUserGroupMember.ended_at >= day, OktaUserGroupMember.ended_at < next_day))
+            .where(OktaUserGroupMember.role_group_map_id.is_(None))
+            .where(OktaUserGroupMember.should_expire.is_(False))
+        )
     ).all()
 
     # remove OktaUserGroupMembers from the list where there's a role that grants the same access
@@ -509,30 +532,41 @@ def expiring_access_notifications_user() -> None:
     for user in grouped_tomorrow:
         # If the user has access expiring both tomorrow and in a week, only send one message
         if user in grouped_next_week:
-            notification_hook.access_expiring_user(
-                # TODO eventually clean this up, leaving for now for backwards compatibility
-                groups=grouped_tomorrow_old[user] + grouped_next_week_old[user],
-                user=user,
-                expiration_datetime=None,
-                okta_user_group_members=grouped_tomorrow[user] + grouped_next_week[user],
+            # Notification hooks are sync plugin code that may perform blocking
+            # network I/O, so run them on a worker thread.
+            await anyio.to_thread.run_sync(
+                functools.partial(
+                    notification_hook.access_expiring_user,
+                    # TODO eventually clean this up, leaving for now for backwards compatibility
+                    groups=grouped_tomorrow_old[user] + grouped_next_week_old[user],
+                    user=user,
+                    expiration_datetime=None,
+                    okta_user_group_members=grouped_tomorrow[user] + grouped_next_week[user],
+                )
             )
         else:
-            notification_hook.access_expiring_user(
-                # TODO eventually clean this up, leaving for now for backwards compatibility
-                groups=grouped_tomorrow_old[user],
-                user=user,
-                expiration_datetime=None if weekend_notif_tomorrow else datetime.now() + timedelta(days=1),
-                okta_user_group_members=grouped_tomorrow[user],
+            await anyio.to_thread.run_sync(
+                functools.partial(
+                    notification_hook.access_expiring_user,
+                    # TODO eventually clean this up, leaving for now for backwards compatibility
+                    groups=grouped_tomorrow_old[user],
+                    user=user,
+                    expiration_datetime=None if weekend_notif_tomorrow else datetime.now() + timedelta(days=1),
+                    okta_user_group_members=grouped_tomorrow[user],
+                )
             )
 
     for user in grouped_next_week:
         if user not in grouped_tomorrow:
-            notification_hook.access_expiring_user(
-                # TODO eventually clean this up, leaving for now for backwards compatibility
-                groups=grouped_next_week_old[user],
-                user=user,
-                expiration_datetime=None if weekend_notif_week else datetime.now() + timedelta(weeks=1),
-                okta_user_group_members=grouped_next_week[user],
+            await anyio.to_thread.run_sync(
+                functools.partial(
+                    notification_hook.access_expiring_user,
+                    # TODO eventually clean this up, leaving for now for backwards compatibility
+                    groups=grouped_next_week_old[user],
+                    user=user,
+                    expiration_datetime=None if weekend_notif_week else datetime.now() + timedelta(weeks=1),
+                    okta_user_group_members=grouped_next_week[user],
+                )
             )
 
     logger.info("Expiring access notifications for users finished.")
@@ -546,7 +580,7 @@ class GroupsAndUsers:
         self.users: List[OktaUser] = []
 
 
-def expiring_access_notifications_owner() -> None:
+async def expiring_access_notifications_owner() -> None:
     logger.info("Expiring access notifications for owners started.")
     notification_hook = get_notification_hook()
 
@@ -554,27 +588,29 @@ def expiring_access_notifications_owner() -> None:
     next_week = day + timedelta(weeks=1)
 
     # Expiring groups
-    db_memberships_expiring_this_week = db.session.scalars(
-        select(OktaUserGroupMember)
-        .options(joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group))
-        .join(OktaUserGroupMember.active_user)
-        .join(OktaUserGroupMember.active_group)
-        .where(OktaGroup.is_managed.is_(True))
-        .where(and_(OktaUserGroupMember.ended_at >= day, OktaUserGroupMember.ended_at < next_week))
-        .where(OktaUserGroupMember.role_group_map_id.is_(None))
-        .where(OktaUserGroupMember.should_expire.is_(False))
+    db_memberships_expiring_this_week = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .options(joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group))
+            .join(OktaUserGroupMember.active_user)
+            .join(OktaUserGroupMember.active_group)
+            .where(OktaGroup.is_managed.is_(True))
+            .where(and_(OktaUserGroupMember.ended_at >= day, OktaUserGroupMember.ended_at < next_week))
+            .where(OktaUserGroupMember.role_group_map_id.is_(None))
+            .where(OktaUserGroupMember.should_expire.is_(False))
+        )
     ).all()
 
-    access_owners = get_access_owners()
+    access_owners = await get_access_owners()
 
     # Map of group owners -> list[OktaUserGroupMember]
     owner_expiring_groups_this: defaultdict[OktaUser, list[OktaUserGroupMember]] = defaultdict(list)
     for okta_user_group_member in db_memberships_expiring_this_week:
-        owners = get_group_managers(okta_user_group_member.group_id)
+        owners = await get_group_managers(okta_user_group_member.group_id)
 
         if len(owners) == 0:
             owners += (
-                get_app_managers(okta_user_group_member.group.app_id)
+                (await get_app_managers(okta_user_group_member.group.app_id))
                 if type(okta_user_group_member.group) is AppGroup
                 else []
             )
@@ -596,10 +632,10 @@ def expiring_access_notifications_owner() -> None:
     # Map of group owners -> (number of groups with expiring memberships, number of users with expiring memberships)
     owner_expiring_groups_this_old: defaultdict[OktaUser, GroupsAndUsers] = defaultdict(GroupsAndUsers)
     for group in users_per_group:
-        owners = get_group_managers(group.id)
+        owners = await get_group_managers(group.id)
 
         if len(owners) == 0:
-            owners += get_app_managers(group.app_id) if type(group) is AppGroup else []
+            owners += (await get_app_managers(group.app_id)) if type(group) is AppGroup else []
 
         if len(owners) == 0:
             owners = access_owners
@@ -613,25 +649,27 @@ def expiring_access_notifications_owner() -> None:
     one_week = date.today() + timedelta(weeks=1)
     two_weeks = one_week + timedelta(weeks=1)
 
-    db_memberships_expiring_next_week = db.session.scalars(
-        select(OktaUserGroupMember)
-        .options(joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group))
-        .join(OktaUserGroupMember.active_user)
-        .join(OktaUserGroupMember.active_group)
-        .where(OktaGroup.is_managed.is_(True))
-        .where(and_(OktaUserGroupMember.ended_at >= one_week, OktaUserGroupMember.ended_at < two_weeks))
-        .where(OktaUserGroupMember.role_group_map_id.is_(None))
-        .where(OktaUserGroupMember.should_expire.is_(False))
+    db_memberships_expiring_next_week = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .options(joinedload(OktaUserGroupMember.active_user), joinedload(OktaUserGroupMember.active_group))
+            .join(OktaUserGroupMember.active_user)
+            .join(OktaUserGroupMember.active_group)
+            .where(OktaGroup.is_managed.is_(True))
+            .where(and_(OktaUserGroupMember.ended_at >= one_week, OktaUserGroupMember.ended_at < two_weeks))
+            .where(OktaUserGroupMember.role_group_map_id.is_(None))
+            .where(OktaUserGroupMember.should_expire.is_(False))
+        )
     ).all()
 
     # Map of group owners -> list[OktaUserGroupMember]
     owner_expiring_groups_next: defaultdict[OktaUser, list[OktaUserGroupMember]] = defaultdict(list)
     for okta_user_group_member in db_memberships_expiring_next_week:
-        owners = get_group_managers(okta_user_group_member.group_id)
+        owners = await get_group_managers(okta_user_group_member.group_id)
 
         if len(owners) == 0:
             owners += (
-                get_app_managers(okta_user_group_member.group.app_id)
+                (await get_app_managers(okta_user_group_member.group.app_id))
                 if type(okta_user_group_member.group) is AppGroup
                 else []
             )
@@ -653,10 +691,10 @@ def expiring_access_notifications_owner() -> None:
     # Map of group owners -> (number of groups with expiring memberships, number of users with expiring memberships)
     owner_expiring_groups_next_old: defaultdict[OktaUser, GroupsAndUsers] = defaultdict(GroupsAndUsers)
     for group in users_per_group:
-        owners = get_group_managers(group.id)
+        owners = await get_group_managers(group.id)
 
         if len(owners) == 0:
-            owners += get_app_managers(group.app_id) if type(group) is AppGroup else []
+            owners += (await get_app_managers(group.app_id)) if type(group) is AppGroup else []
 
         if len(owners) == 0:
             owners = access_owners
@@ -670,42 +708,53 @@ def expiring_access_notifications_owner() -> None:
     for owner in owner_expiring_groups_this:
         # If the owner has members with access expiring both this week and next week, only send one message
         if owner in owner_expiring_groups_next:
-            notification_hook.access_expiring_owner(
-                owner=owner,
-                # TODO eventually clean this up, leaving for now for backwards compatibility
-                groups=owner_expiring_groups_this_old[owner].groups + owner_expiring_groups_next_old[owner].groups,
-                roles=None,
-                # TODO eventually clean this up, leaving for now for backwards compatibility
-                users=owner_expiring_groups_this_old[owner].users + owner_expiring_groups_next_old[owner].users,
-                expiration_datetime=None,
-                group_user_associations=owner_expiring_groups_this[owner] + owner_expiring_groups_next[owner],
-                role_group_associations=None,
+            # Notification hooks are sync plugin code that may perform blocking
+            # network I/O, so run them on a worker thread.
+            await anyio.to_thread.run_sync(
+                functools.partial(
+                    notification_hook.access_expiring_owner,
+                    owner=owner,
+                    # TODO eventually clean this up, leaving for now for backwards compatibility
+                    groups=owner_expiring_groups_this_old[owner].groups + owner_expiring_groups_next_old[owner].groups,
+                    roles=None,
+                    # TODO eventually clean this up, leaving for now for backwards compatibility
+                    users=owner_expiring_groups_this_old[owner].users + owner_expiring_groups_next_old[owner].users,
+                    expiration_datetime=None,
+                    group_user_associations=owner_expiring_groups_this[owner] + owner_expiring_groups_next[owner],
+                    role_group_associations=None,
+                )
             )
         else:
-            notification_hook.access_expiring_owner(
-                owner=owner,
-                # TODO eventually clean this up, leaving for now for backwards compatibility
-                groups=owner_expiring_groups_this_old[owner].groups,
-                roles=None,
-                # TODO eventually clean this up, leaving for now for backwards compatibility
-                users=owner_expiring_groups_this_old[owner].users,
-                expiration_datetime=datetime.now(),
-                group_user_associations=owner_expiring_groups_this[owner],
-                role_group_associations=None,
+            await anyio.to_thread.run_sync(
+                functools.partial(
+                    notification_hook.access_expiring_owner,
+                    owner=owner,
+                    # TODO eventually clean this up, leaving for now for backwards compatibility
+                    groups=owner_expiring_groups_this_old[owner].groups,
+                    roles=None,
+                    # TODO eventually clean this up, leaving for now for backwards compatibility
+                    users=owner_expiring_groups_this_old[owner].users,
+                    expiration_datetime=datetime.now(),
+                    group_user_associations=owner_expiring_groups_this[owner],
+                    role_group_associations=None,
+                )
             )
 
     for owner in owner_expiring_groups_next:
         if owner not in owner_expiring_groups_this:
-            notification_hook.access_expiring_owner(
-                owner=owner,
-                # TODO eventually clean this up, leaving for now for backwards compatibility
-                groups=owner_expiring_groups_next_old[owner].groups,
-                roles=None,
-                # TODO eventually clean this up, leaving for now for backwards compatibility
-                users=owner_expiring_groups_next_old[owner].users,
-                expiration_datetime=datetime.now() + timedelta(weeks=1),
-                group_user_associations=owner_expiring_groups_next[owner],
-                role_group_associations=None,
+            await anyio.to_thread.run_sync(
+                functools.partial(
+                    notification_hook.access_expiring_owner,
+                    owner=owner,
+                    # TODO eventually clean this up, leaving for now for backwards compatibility
+                    groups=owner_expiring_groups_next_old[owner].groups,
+                    roles=None,
+                    # TODO eventually clean this up, leaving for now for backwards compatibility
+                    users=owner_expiring_groups_next_old[owner].users,
+                    expiration_datetime=datetime.now() + timedelta(weeks=1),
+                    group_user_associations=owner_expiring_groups_next[owner],
+                    role_group_associations=None,
+                )
             )
 
     all_group_types = with_polymorphic(OktaGroup, [AppGroup, RoleGroup], flat=True)
@@ -715,25 +764,30 @@ def expiring_access_notifications_owner() -> None:
     day = date.today()
     next_week = day + timedelta(weeks=1)
 
-    db_roles_expiring_this_week = db.session.scalars(
-        select(RoleGroupMap)
-        .options(
-            joinedload(RoleGroupMap.active_role_group), joinedload(RoleGroupMap.active_group.of_type(all_group_types))
+    db_roles_expiring_this_week = (
+        await db.session.scalars(
+            select(RoleGroupMap)
+            .options(
+                joinedload(RoleGroupMap.active_role_group),
+                joinedload(RoleGroupMap.active_group.of_type(all_group_types)),
+            )
+            .join(RoleGroupMap.active_role_group.of_type(role_group_alias))
+            .join(RoleGroupMap.active_group)
+            .where(OktaGroup.is_managed.is_(True))
+            .where(and_(RoleGroupMap.ended_at >= day, RoleGroupMap.ended_at < next_week))
+            .where(RoleGroupMap.should_expire.is_(False))
         )
-        .join(RoleGroupMap.active_role_group.of_type(role_group_alias))
-        .join(RoleGroupMap.active_group)
-        .where(OktaGroup.is_managed.is_(True))
-        .where(and_(RoleGroupMap.ended_at >= day, RoleGroupMap.ended_at < next_week))
-        .where(RoleGroupMap.should_expire.is_(False))
     ).all()
 
     # Map of group owners -> list[RoleGroupMap]
     owner_expiring_roles_this: defaultdict[OktaUser, list[RoleGroupMap]] = defaultdict(list)
     for role_group_map in db_roles_expiring_this_week:
-        owners = get_group_managers(role_group_map.group_id)
+        owners = await get_group_managers(role_group_map.group_id)
 
         if len(owners) == 0:
-            owners += get_app_managers(role_group_map.group.app_id) if type(role_group_map.group) is AppGroup else []
+            owners += (
+                (await get_app_managers(role_group_map.group.app_id)) if type(role_group_map.group) is AppGroup else []
+            )
 
         if len(owners) == 0:
             owners = access_owners
@@ -751,10 +805,10 @@ def expiring_access_notifications_owner() -> None:
     # Map of group owners -> (number of groups with expiring memberships, number of users with expiring memberships)
     owner_expiring_roles_this_old: defaultdict[OktaUser, GroupsAndUsers] = defaultdict(GroupsAndUsers)
     for group in roles_per_group:
-        owners = get_group_managers(group.id)
+        owners = await get_group_managers(group.id)
 
         if len(owners) == 0:
-            owners += get_app_managers(group.app_id) if type(group) is AppGroup else []
+            owners += (await get_app_managers(group.app_id)) if type(group) is AppGroup else []
 
         if len(owners) == 0:
             owners = access_owners
@@ -766,25 +820,30 @@ def expiring_access_notifications_owner() -> None:
     one_week = date.today() + timedelta(weeks=1)
     two_weeks = one_week + timedelta(weeks=1)
 
-    db_roles_expiring_next_week = db.session.scalars(
-        select(RoleGroupMap)
-        .options(
-            joinedload(RoleGroupMap.active_role_group), joinedload(RoleGroupMap.active_group.of_type(all_group_types))
+    db_roles_expiring_next_week = (
+        await db.session.scalars(
+            select(RoleGroupMap)
+            .options(
+                joinedload(RoleGroupMap.active_role_group),
+                joinedload(RoleGroupMap.active_group.of_type(all_group_types)),
+            )
+            .join(RoleGroupMap.active_role_group.of_type(role_group_alias))
+            .join(RoleGroupMap.active_group)
+            .where(OktaGroup.is_managed.is_(True))
+            .where(and_(RoleGroupMap.ended_at >= one_week, RoleGroupMap.ended_at < two_weeks))
+            .where(RoleGroupMap.should_expire.is_(False))
         )
-        .join(RoleGroupMap.active_role_group.of_type(role_group_alias))
-        .join(RoleGroupMap.active_group)
-        .where(OktaGroup.is_managed.is_(True))
-        .where(and_(RoleGroupMap.ended_at >= one_week, RoleGroupMap.ended_at < two_weeks))
-        .where(RoleGroupMap.should_expire.is_(False))
     ).all()
 
     # Map of group owners -> list[RoleGroupMap]
     owner_expiring_roles_next: defaultdict[OktaUser, list[RoleGroupMap]] = defaultdict(list)
     for role_group_map in db_roles_expiring_next_week:
-        owners = get_group_managers(role_group_map.group_id)
+        owners = await get_group_managers(role_group_map.group_id)
 
         if len(owners) == 0:
-            owners += get_app_managers(role_group_map.group.app_id) if type(role_group_map.group) is AppGroup else []
+            owners += (
+                (await get_app_managers(role_group_map.group.app_id)) if type(role_group_map.group) is AppGroup else []
+            )
 
         if len(owners) == 0:
             owners = access_owners
@@ -802,10 +861,10 @@ def expiring_access_notifications_owner() -> None:
     # Map of group owners -> (number of groups with expiring memberships, number of users with expiring memberships)
     owner_expiring_roles_next_old: defaultdict[OktaUser, GroupsAndUsers] = defaultdict(GroupsAndUsers)
     for group in roles_per_group:
-        owners = get_group_managers(group.id)
+        owners = await get_group_managers(group.id)
 
         if len(owners) == 0:
-            owners += get_app_managers(group.app_id) if type(group) is AppGroup else []
+            owners += (await get_app_managers(group.app_id)) if type(group) is AppGroup else []
 
         if len(owners) == 0:
             owners = access_owners
@@ -817,52 +876,61 @@ def expiring_access_notifications_owner() -> None:
     for owner in owner_expiring_roles_this:
         # If the owner has members with access expiring both this week and next week, only send one message
         if owner in owner_expiring_roles_next:
-            notification_hook.access_expiring_owner(
-                owner=owner,
-                # TODO eventually clean this up, leaving for now for backwards compatibility
-                groups=owner_expiring_roles_this_old[owner].groups + owner_expiring_roles_next_old[owner].groups,
-                # TODO eventually clean this up, leaving for now for backwards compatibility
-                roles=owner_expiring_roles_this_old[owner].roles + owner_expiring_roles_next_old[owner].roles,
-                users=None,
-                expiration_datetime=None,
-                group_user_associations=None,
-                role_group_associations=owner_expiring_roles_this[owner] + owner_expiring_roles_next[owner],
+            await anyio.to_thread.run_sync(
+                functools.partial(
+                    notification_hook.access_expiring_owner,
+                    owner=owner,
+                    # TODO eventually clean this up, leaving for now for backwards compatibility
+                    groups=owner_expiring_roles_this_old[owner].groups + owner_expiring_roles_next_old[owner].groups,
+                    # TODO eventually clean this up, leaving for now for backwards compatibility
+                    roles=owner_expiring_roles_this_old[owner].roles + owner_expiring_roles_next_old[owner].roles,
+                    users=None,
+                    expiration_datetime=None,
+                    group_user_associations=None,
+                    role_group_associations=owner_expiring_roles_this[owner] + owner_expiring_roles_next[owner],
+                )
             )
         else:
-            notification_hook.access_expiring_owner(
-                owner=owner,
-                # TODO eventually clean this up, leaving for now for backwards compatibility
-                groups=owner_expiring_roles_this_old[owner].groups,
-                # TODO eventually clean this up, leaving for now for backwards compatibility
-                roles=owner_expiring_roles_this_old[owner].roles,
-                users=None,
-                expiration_datetime=datetime.now(),
-                group_user_associations=None,
-                role_group_associations=owner_expiring_roles_this[owner],
+            await anyio.to_thread.run_sync(
+                functools.partial(
+                    notification_hook.access_expiring_owner,
+                    owner=owner,
+                    # TODO eventually clean this up, leaving for now for backwards compatibility
+                    groups=owner_expiring_roles_this_old[owner].groups,
+                    # TODO eventually clean this up, leaving for now for backwards compatibility
+                    roles=owner_expiring_roles_this_old[owner].roles,
+                    users=None,
+                    expiration_datetime=datetime.now(),
+                    group_user_associations=None,
+                    role_group_associations=owner_expiring_roles_this[owner],
+                )
             )
 
     for owner in owner_expiring_roles_next:
         if owner not in owner_expiring_roles_this:
-            notification_hook.access_expiring_owner(
-                owner=owner,
-                # TODO eventually clean this up, leaving for now for backwards compatibility
-                groups=owner_expiring_roles_next_old[owner].groups,
-                # TODO eventually clean this up, leaving for now for backwards compatibility
-                roles=owner_expiring_roles_next_old[owner].roles,
-                users=None,
-                expiration_datetime=datetime.now() + timedelta(weeks=1),
-                group_user_associations=None,
-                role_group_associations=owner_expiring_roles_next[owner],
+            await anyio.to_thread.run_sync(
+                functools.partial(
+                    notification_hook.access_expiring_owner,
+                    owner=owner,
+                    # TODO eventually clean this up, leaving for now for backwards compatibility
+                    groups=owner_expiring_roles_next_old[owner].groups,
+                    # TODO eventually clean this up, leaving for now for backwards compatibility
+                    roles=owner_expiring_roles_next_old[owner].roles,
+                    users=None,
+                    expiration_datetime=datetime.now() + timedelta(weeks=1),
+                    group_user_associations=None,
+                    role_group_associations=owner_expiring_roles_next[owner],
+                )
             )
 
     logger.info("Expiring access notifications for owners finished.")
 
 
-def expiring_access_notifications_role_owner() -> None:
+async def expiring_access_notifications_role_owner() -> None:
     logger.info("Expiring access notifications for role owners started.")
     notification_hook = get_notification_hook()
 
-    access_owners = get_access_owners()
+    access_owners = await get_access_owners()
 
     all_group_types = with_polymorphic(OktaGroup, [AppGroup, RoleGroup], flat=True)
     role_group_alias = aliased(RoleGroup)
@@ -874,22 +942,25 @@ def expiring_access_notifications_role_owner() -> None:
         next_day = day + timedelta(days=3)
         weekend_notif_tomorrow = True
 
-    db_roles_expiring_tomorrow = db.session.scalars(
-        select(RoleGroupMap)
-        .options(
-            joinedload(RoleGroupMap.active_role_group), joinedload(RoleGroupMap.active_group.of_type(all_group_types))
+    db_roles_expiring_tomorrow = (
+        await db.session.scalars(
+            select(RoleGroupMap)
+            .options(
+                joinedload(RoleGroupMap.active_role_group),
+                joinedload(RoleGroupMap.active_group.of_type(all_group_types)),
+            )
+            .join(RoleGroupMap.active_role_group.of_type(role_group_alias))
+            .join(RoleGroupMap.active_group)
+            .where(OktaGroup.is_managed.is_(True))
+            .where(and_(RoleGroupMap.ended_at >= day, RoleGroupMap.ended_at < next_day))
+            .where(RoleGroupMap.should_expire.is_(False))
         )
-        .join(RoleGroupMap.active_role_group.of_type(role_group_alias))
-        .join(RoleGroupMap.active_group)
-        .where(OktaGroup.is_managed.is_(True))
-        .where(and_(RoleGroupMap.ended_at >= day, RoleGroupMap.ended_at < next_day))
-        .where(RoleGroupMap.should_expire.is_(False))
     ).all()
 
     # Map of role owners -> list[RoleGroupMap]
     role_owner_expiring_roles_tomorrow: defaultdict[OktaUser, list[RoleGroupMap]] = defaultdict(list)
     for role_group_map in db_roles_expiring_tomorrow:
-        owners = get_group_managers(role_group_map.role_group.id)
+        owners = await get_group_managers(role_group_map.role_group.id)
 
         if len(owners) == 0:
             owners = access_owners
@@ -904,22 +975,25 @@ def expiring_access_notifications_role_owner() -> None:
         next_day = day + timedelta(days=3)
         weekend_notif_week = True
 
-    db_roles_expiring_next_week = db.session.scalars(
-        select(RoleGroupMap)
-        .options(
-            joinedload(RoleGroupMap.active_role_group), joinedload(RoleGroupMap.active_group.of_type(all_group_types))
+    db_roles_expiring_next_week = (
+        await db.session.scalars(
+            select(RoleGroupMap)
+            .options(
+                joinedload(RoleGroupMap.active_role_group),
+                joinedload(RoleGroupMap.active_group.of_type(all_group_types)),
+            )
+            .join(RoleGroupMap.active_role_group.of_type(role_group_alias))
+            .join(RoleGroupMap.active_group)
+            .where(OktaGroup.is_managed.is_(True))
+            .where(and_(RoleGroupMap.ended_at >= day, RoleGroupMap.ended_at < next_day))
+            .where(RoleGroupMap.should_expire.is_(False))
         )
-        .join(RoleGroupMap.active_role_group.of_type(role_group_alias))
-        .join(RoleGroupMap.active_group)
-        .where(OktaGroup.is_managed.is_(True))
-        .where(and_(RoleGroupMap.ended_at >= day, RoleGroupMap.ended_at < next_day))
-        .where(RoleGroupMap.should_expire.is_(False))
     ).all()
 
     # Map of role owners -> list[RoleGroupMap]
     role_owner_expiring_roles_next: defaultdict[OktaUser, list[RoleGroupMap]] = defaultdict(list)
     for role_group_map in db_roles_expiring_next_week:
-        owners = get_group_managers(role_group_map.role_group.id)
+        owners = await get_group_managers(role_group_map.role_group.id)
 
         if len(owners) == 0:
             owners = access_owners
@@ -930,24 +1004,35 @@ def expiring_access_notifications_role_owner() -> None:
     for owner in role_owner_expiring_roles_tomorrow:
         # If the role owner has roles they own with access expiring both this week and next week, only send one message
         if owner in role_owner_expiring_roles_next:
-            notification_hook.access_expiring_role_owner(
-                owner=owner,
-                roles=role_owner_expiring_roles_tomorrow[owner] + role_owner_expiring_roles_next[owner],
-                expiration_datetime=None,
+            # Notification hooks are sync plugin code that may perform blocking
+            # network I/O, so run them on a worker thread.
+            await anyio.to_thread.run_sync(
+                functools.partial(
+                    notification_hook.access_expiring_role_owner,
+                    owner=owner,
+                    roles=role_owner_expiring_roles_tomorrow[owner] + role_owner_expiring_roles_next[owner],
+                    expiration_datetime=None,
+                )
             )
         else:
-            notification_hook.access_expiring_role_owner(
-                owner=owner,
-                roles=role_owner_expiring_roles_tomorrow[owner],
-                expiration_datetime=None if weekend_notif_tomorrow else datetime.now() + timedelta(days=1),
+            await anyio.to_thread.run_sync(
+                functools.partial(
+                    notification_hook.access_expiring_role_owner,
+                    owner=owner,
+                    roles=role_owner_expiring_roles_tomorrow[owner],
+                    expiration_datetime=None if weekend_notif_tomorrow else datetime.now() + timedelta(days=1),
+                )
             )
 
     for owner in role_owner_expiring_roles_next:
         if owner not in role_owner_expiring_roles_tomorrow:
-            notification_hook.access_expiring_role_owner(
-                owner=owner,
-                roles=role_owner_expiring_roles_next[owner],
-                expiration_datetime=None if weekend_notif_week else datetime.now() + timedelta(weeks=1),
+            await anyio.to_thread.run_sync(
+                functools.partial(
+                    notification_hook.access_expiring_role_owner,
+                    owner=owner,
+                    roles=role_owner_expiring_roles_next[owner],
+                    expiration_datetime=None if weekend_notif_week else datetime.now() + timedelta(weeks=1),
+                )
             )
 
     logger.info("Expiring access notifications for role owners finished.")

--- a/examples/kubernetes/cron-job-notify-owners.yaml
+++ b/examples/kubernetes/cron-job-notify-owners.yaml
@@ -25,7 +25,7 @@ spec:
                 - name: OKTA_DOMAIN
                   value: mydomain.okta.com # Replace with your Okta domain
                 - name: DATABASE_URI
-                  value: postgresql+pg8000:// # Replace with your database URI
+                  value: postgresql:// # Replace with your database URI
                 - name: OKTA_API_TOKEN
                   valueFrom:
                     secretKeyRef:

--- a/examples/kubernetes/cron-job-notify-users.yaml
+++ b/examples/kubernetes/cron-job-notify-users.yaml
@@ -24,7 +24,7 @@ spec:
                 - name: OKTA_DOMAIN
                   value: mydomain.okta.com # Replace with your Okta domain
                 - name: DATABASE_URI
-                  value: postgresql+pg8000:// # Replace with your database URI
+                  value: postgresql:// # Replace with your database URI
                 - name: OKTA_API_TOKEN
                   valueFrom:
                     secretKeyRef:

--- a/examples/kubernetes/cron-job-syncer.yaml
+++ b/examples/kubernetes/cron-job-syncer.yaml
@@ -25,7 +25,7 @@ spec:
                 - name: OKTA_DOMAIN
                   value: mydomain.okta.com # Replace with your Okta domain
                 - name: DATABASE_URI
-                  value: postgresql+pg8000:// # Replace with your database URI
+                  value: postgresql:// # Replace with your database URI
                 - name: OKTA_API_TOKEN
                   valueFrom:
                     secretKeyRef:

--- a/examples/kubernetes/deployment.yaml
+++ b/examples/kubernetes/deployment.yaml
@@ -46,7 +46,7 @@ spec:
             - name: OKTA_DOMAIN
               value: mydomain.okta.com # Replace with your Okta domain
             - name: DATABASE_URI
-              value: postgresql+pg8000:// # Replace with your database URI
+              value: postgresql:// # Replace with your database URI
             - name: USER_DISPLAY_CUSTOM_ATTRIBUTES
               value: Title,Department,Work Location # Replace with the Custom Okta User Attributes you want to display
             - name: OKTA_API_TOKEN

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -9,7 +9,7 @@ from alembic import context
 from sqlalchemy import JSON
 
 from api.config import settings
-from api.database import build_engine
+from api.database import build_async_engine
 from api.extensions import Base
 
 # Make sure all models are imported so Base.metadata is populated
@@ -49,7 +49,7 @@ def compare_type(context, inspected_column, metadata_column, inspected_type, met
     return None
 
 
-def run_migrations_online() -> None:
+def _do_run_migrations(connection) -> None:
     def process_revision_directives(context, revision, directives):
         if getattr(config.cmd_opts, "autogenerate", False):
             script = directives[0]
@@ -57,17 +57,33 @@ def run_migrations_online() -> None:
                 directives[:] = []
                 logger.info("No changes in schema detected.")
 
-    connectable = build_engine()
-    with connectable.connect() as connection:
-        context.configure(
-            connection=connection,
-            target_metadata=target_metadata,
-            process_revision_directives=process_revision_directives,
-            compare_type=compare_type,
-            render_as_batch=connection.dialect.name == "sqlite",
-        )
-        with context.begin_transaction():
-            context.run_migrations()
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        process_revision_directives=process_revision_directives,
+        compare_type=compare_type,
+        render_as_batch=connection.dialect.name == "sqlite",
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations through the async engine.
+
+    Alembic's migration machinery is synchronous; `connection.run_sync`
+    bridges it onto the AsyncEngine so the same engine builder (including
+    the Cloud SQL IAM connector path) serves the app and migrations.
+    """
+    import asyncio
+
+    async def _run() -> None:
+        connectable = build_async_engine()
+        async with connectable.connect() as connection:
+            await connection.run_sync(_do_run_migrations)
+        await connectable.dispose()
+
+    asyncio.run(_run())
 
 
 if context.is_offline_mode():

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -6,7 +6,7 @@ import logging
 from logging.config import fileConfig
 
 from alembic import context
-from sqlalchemy import JSON
+from sqlalchemy import JSON, Connection
 
 from api.config import settings
 from api.database import build_async_engine
@@ -49,7 +49,7 @@ def compare_type(context, inspected_column, metadata_column, inspected_type, met
     return None
 
 
-def _do_run_migrations(connection) -> None:
+def _do_run_migrations(connection: Connection) -> None:
     def process_revision_directives(context, revision, directives):
         if getattr(config.cmd_opts, "autogenerate", False):
             script = directives[0]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
   pytest==9.0.3
+  pytest-asyncio==1.4.0
   pytest-runner==6.0.1
   pytest-factoryboy==2.8.1
   pytest-mock==3.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ sqlalchemy-json==0.7.0
 asyncpg==0.31.0
 aiosqlite==0.22.1
 cloud-sql-python-connector[asyncpg]==1.20.3
-pg8000==1.31.5
 
 # HTTP
 httpx==0.28.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,13 @@
 """FastAPI test harness.
 
 - The `app` fixture returns a `FastAPI` instance.
-- The `client` fixture returns a `fastapi.testclient.TestClient`.
-- The `db` fixture binds a sqlite-in-memory engine via `db.init_app(...)`,
-  creates tables, and seeds the bootstrap "Access" app + admin user.
+- The `client` fixture returns an `httpx.AsyncClient` over `ASGITransport`,
+  so requests run on the test's own event loop (required: the aiosqlite
+  engine is bound to that loop — a sync `TestClient` would drive the app
+  from its portal thread's loop and explode with cross-loop futures).
+- The `db` fixture binds a sqlite-in-memory aiosqlite engine via
+  `db.init_app(...)`, creates tables, and seeds the bootstrap "Access" app
+  + admin user.
 - The `mock_user` factory fixture overrides
   `app.dependency_overrides[get_current_user_id]` to switch the acting user.
 - The `url_for` fixture maps the legacy `"<bp>.<endpoint>"` name passed to
@@ -14,20 +18,20 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Callable, Generator
+from typing import Any, AsyncGenerator, Callable, Generator
 from urllib.parse import urlencode
 
+import httpx
 import pytest
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
 from pytest_factoryboy import register
-from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.pool import StaticPool
 
 from api.app import create_app
 from api.auth.dependencies import get_current_user_id
 from api.config import settings
-from api.extensions import Db, _session_scope, db as _db
+from api.extensions import Base, Db, _session_scope, db as _db
 from api.models import App, AppGroup, OktaUserGroupMember
 from tests.factories import (
     AccessRequestFactory,
@@ -50,15 +54,29 @@ register(RoleRequestFactory, "role_request")
 register(TagFactory, "tag")
 
 
+def _async_test_uri() -> str:
+    """Resolve TEST_DATABASE_URI to an async driver.
+
+    Defaults to in-memory SQLite over aiosqlite. Legacy sync driver names in
+    a stale env var keep working (mirrors `api.database.to_async_url`).
+    """
+    uri = os.environ.get("TEST_DATABASE_URI", "sqlite+aiosqlite://")
+    uri = uri.replace("postgresql+pg8000://", "postgresql+asyncpg://")
+    if uri.startswith("postgresql://"):
+        uri = uri.replace("postgresql://", "postgresql+asyncpg://", 1)
+    if uri in ("sqlite://", "sqlite:///:memory:"):
+        uri = "sqlite+aiosqlite://"
+    return uri
+
+
 @pytest.fixture(scope="session")
 def app(request: pytest.FixtureRequest) -> FastAPI:
     # Build the shared app with MCP disabled regardless of the ambient
     # ENABLE_MCP (e.g. a local .env that sets it true). This app is
-    # session-scoped, but the `client` fixture re-enters its lifespan on
-    # every test, and the MCP StreamableHTTPSessionManager's run() may only
-    # be entered once per process — an MCP-enabled shared app would crash
-    # every test after the first. MCP is exercised by test_mcp.py, which
-    # builds its own app and manages the singleton.
+    # session-scoped; MCP is exercised by test_mcp.py, which builds its own
+    # app and manages the singleton. Building the app is not loop-bound
+    # (no engine is bound when testing=True and no lifespan without MCP),
+    # so a sync session-scoped fixture is safe under per-test event loops.
     prev_mcp = settings.ENABLE_MCP
     settings.ENABLE_MCP = False
     try:
@@ -72,25 +90,26 @@ def app(request: pytest.FixtureRequest) -> FastAPI:
 
 
 @pytest.fixture
-def db(app: FastAPI) -> Generator[Db, None, None]:
+async def db(app: FastAPI) -> AsyncGenerator[Db, None]:
     """Bind a test engine, create tables, and seed bootstrap data.
 
-    Defaults to in-memory SQLite. Set `TEST_DATABASE_URI` to point at any
-    other database (e.g. `postgresql+pg8000://postgres:postgres@localhost:5433/access_test`)
+    Defaults to in-memory SQLite (aiosqlite). Set `TEST_DATABASE_URI` to
+    point at any other database (e.g.
+    `postgresql+asyncpg://postgres:postgres@localhost:5433/access_test`)
     to verify Postgres-only behaviour.
     """
-    db_uri = os.environ.get("TEST_DATABASE_URI", "sqlite://")
+    db_uri = _async_test_uri()
     if db_uri.startswith("sqlite"):
-        engine = create_engine(
-            db_uri,
-            connect_args={"check_same_thread": False},
-            poolclass=StaticPool,
-        )
+        # StaticPool shares the single in-memory connection; aiosqlite
+        # funnels all operations through one worker thread, so
+        # check_same_thread is unnecessary.
+        engine = create_async_engine(db_uri, poolclass=StaticPool)
     else:
-        engine = create_engine(db_uri)
+        engine = create_async_engine(db_uri)
     _db.init_app(engine=engine)
-    _db.drop_all()
-    _db.create_all()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)
 
     token = _session_scope.set("test-session")
     try:
@@ -113,31 +132,36 @@ def db(app: FastAPI) -> Generator[Db, None, None]:
         _db.session.add(access_app)
         _db.session.add(access_app_owner_group)
         _db.session.add(access_app_owner_group_membership)
-        _db.session.commit()
+        await _db.session.commit()
 
         yield _db
     finally:
         try:
-            _db.session.rollback()
+            await _db.session.rollback()
         except Exception:
             pass
-        _db.drop_all()
-        _db.remove()
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await _db.remove()
+        # Close the aiosqlite worker thread / asyncpg connections on the
+        # loop that created them.
+        await engine.dispose()
         _session_scope.reset(token)
 
 
-class _DatetimeAwareTestClient(TestClient):
-    """TestClient that serializes datetimes in `json=` payloads to ISO strings.
+class DatetimeAwareAsyncClient(httpx.AsyncClient):
+    """AsyncClient that serializes datetimes in `json=` payloads to ISO strings.
 
     httpx's stdlib JSON encoder rejects raw datetime objects, so we
     pre-process the payload — many tests pass timezone-aware datetimes
-    directly to `client.post(..., json=...)`."""
+    directly to `client.post(..., json=...)`. All verb helpers funnel
+    through `request()`."""
 
-    def request(self, method: str, url: str, **kwargs: Any) -> Any:
+    async def request(self, method: str, url: Any, **kwargs: Any) -> httpx.Response:
         json_payload = kwargs.get("json")
         if json_payload is not None:
             kwargs["json"] = _stringify_datetimes(json_payload)
-        return super().request(method, url, **kwargs)
+        return await super().request(method, url, **kwargs)
 
 
 def _stringify_datetimes(obj: Any) -> Any:
@@ -157,10 +181,20 @@ def _stringify_datetimes(obj: Any) -> Any:
 
 
 @pytest.fixture
-def client(app: FastAPI, db: Db) -> Generator[TestClient, None, None]:
-    """Return a FastAPI TestClient that shares the test database session."""
+async def client(app: FastAPI, db: Db) -> AsyncGenerator[httpx.AsyncClient, None]:
+    """Return an in-process async client that shares the test database session.
+
+    `raise_app_exceptions=False` matches the old
+    `TestClient(raise_server_exceptions=False)`; `follow_redirects=True`
+    matches TestClient's default (httpx defaults to False).
+    """
     app.state.current_user_email = settings.CURRENT_OKTA_USER_EMAIL
-    with _DatetimeAwareTestClient(app, raise_server_exceptions=False) as c:
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+    async with DatetimeAwareAsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+        follow_redirects=True,
+    ) as c:
         yield c
     app.dependency_overrides.pop(get_current_user_id, None)
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -9,6 +9,7 @@ from okta.models.group_profile import GroupProfile
 from okta.models.user import User
 from okta.models.user_profile import UserProfile
 from okta.models.user_schema import UserSchema
+from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
 from api.extensions import db
@@ -57,10 +58,17 @@ class GroupFactory(factory.Factory[Group]):
         exclude = "is_deleted"
 
     @staticmethod
-    def create_access_owner_group() -> Group:
+    async def create_access_owner_group() -> Group:
         access_app = (
-            db.session.query(App).options(joinedload(App.active_owner_app_groups)).filter(App.name == "Access").first()
+            (
+                await db.session.scalars(
+                    select(App).options(joinedload(App.active_owner_app_groups)).where(App.name == "Access")
+                )
+            )
+            .unique()
+            .first()
         )
+        assert access_app is not None
         access_owner_group = access_app.active_owner_app_groups[0]
         okta_access_owner_group = GroupFactory.build()
         okta_access_owner_group.profile.name = access_owner_group.name

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,17 @@
+"""Shared async test helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def db_count(session: AsyncSession, stmt: Select[Any]) -> int:
+    """Async replacement for the legacy `Query.count()` test idiom.
+
+    Wraps the statement in a count-over-subquery, matching legacy
+    `Query.count()` semantics exactly (joins/distinct included).
+    """
+    return (await session.scalar(select(func.count()).select_from(stmt.subquery()))) or 0

--- a/tests/test_access_request.py
+++ b/tests/test_access_request.py
@@ -1,7 +1,8 @@
 from datetime import datetime, timedelta
 from typing import Any
 
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
+from sqlalchemy import select
 from pytest_mock import MockerFixture
 from fastapi import FastAPI
 
@@ -30,15 +31,16 @@ from api.operations import (
 from api.plugins import ConditionalAccessResponse, get_conditional_access_hook, get_notification_hook
 from api.services import okta
 from tests.factories import AccessRequestFactory, AppGroupFactory, OktaGroupFactory, OktaUserFactory
+from tests.helpers import db_count
 
 SEVEN_DAYS_IN_SECONDS = 7 * 24 * 60 * 60
 THREE_DAYS_IN_SECONDS = 3 * 24 * 60 * 60
 ONE_DAY_IN_SECONDS = 24 * 60 * 60
 
 
-def test_get_access_request(
+async def test_get_access_request(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     okta_group: OktaGroup,
@@ -48,19 +50,19 @@ def test_get_access_request(
 ) -> None:
     # test 404
     access_request_url = url_for("api-access-requests.access_request_by_id", access_request_id="randomid")
-    rep = client.get(access_request_url)
+    rep = await client.get(access_request_url)
     assert rep.status_code == 404
 
     db.session.add(user)
     db.session.add(okta_group)
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyRoleGroups(
+    await ModifyRoleGroups(
         role_group=role_group, groups_to_add=[okta_group.id], owner_groups_to_add=[okta_group.id], sync_to_okta=False
     ).execute()
 
-    okta_group_access_request = CreateAccessRequest(
+    okta_group_access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=okta_group,
         request_ownership=False,
@@ -68,7 +70,7 @@ def test_get_access_request(
     ).execute()
     assert okta_group_access_request is not None
 
-    role_group_access_request = CreateAccessRequest(
+    role_group_access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=role_group,
         request_ownership=False,
@@ -80,7 +82,7 @@ def test_get_access_request(
     access_request_url = url_for(
         "api-access-requests.access_request_by_id", access_request_id=okta_group_access_request.id
     )
-    rep = client.get(access_request_url)
+    rep = await client.get(access_request_url)
     assert rep.status_code == 200
 
     data = rep.json()
@@ -90,19 +92,21 @@ def test_get_access_request(
     assert data["request_reason"] == okta_group_access_request.request_reason
     assert data["request_ownership"] == okta_group_access_request.request_ownership
 
-    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
 
-    okta_group_access_request = ApproveAccessRequest(
+    okta_group_access_request = await ApproveAccessRequest(
         access_request=okta_group_access_request, approver_user=access_owner
     ).execute()
 
     assert add_user_to_group_spy.call_count == 1
     assert add_owner_to_group_spy.call_count == 0
 
-    rep = client.get(access_request_url)
+    rep = await client.get(access_request_url)
     assert rep.status_code == 200
 
     data = rep.json()
@@ -118,7 +122,7 @@ def test_get_access_request(
     access_request_url = url_for(
         "api-access-requests.access_request_by_id", access_request_id=role_group_access_request.id
     )
-    rep = client.get(access_request_url)
+    rep = await client.get(access_request_url)
     assert rep.status_code == 200
 
     data = rep.json()
@@ -128,19 +132,21 @@ def test_get_access_request(
     assert data["request_reason"] == role_group_access_request.request_reason
     assert data["request_ownership"] == role_group_access_request.request_ownership
 
-    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
 
-    role_group_access_request = ApproveAccessRequest(
+    role_group_access_request = await ApproveAccessRequest(
         access_request=role_group_access_request, approver_user=access_owner
     ).execute()
 
     assert add_user_to_group_spy.call_count == 2
     assert add_owner_to_group_spy.call_count == 1
 
-    rep = client.get(access_request_url)
+    rep = await client.get(access_request_url)
     assert rep.status_code == 200
 
     data = rep.json()
@@ -151,9 +157,9 @@ def test_get_access_request(
     assert data["request_ownership"] == role_group_access_request.request_ownership
 
 
-def test_put_access_request(
+async def test_put_access_request(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     access_request: AccessRequest,
@@ -165,35 +171,37 @@ def test_put_access_request(
     # body shape returns 404. (PUT with no body returns 400 because the
     # ResolveAccessRequestBody schema rejects the missing `approved` field.)
     access_request_url = url_for("api-access-requests.access_request_by_id", access_request_id="randomid")
-    rep = client.put(access_request_url, json={"approved": True})
+    rep = await client.put(access_request_url, json={"approved": True})
     assert rep.status_code == 404
 
     db.session.add(user)
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
     access_request.requested_group_id = okta_group.id
     access_request.requester_user_id = user.id
     db.session.add(access_request)
-    db.session.commit()
+    await db.session.commit()
 
     # test missing data
     data: dict[str, Any] = {}
     access_request_url = url_for("api-access-requests.access_request_by_id", access_request_id=access_request.id)
-    rep = client.put(access_request_url, json=data)
+    rep = await client.put(access_request_url, json=data)
     assert rep.status_code == 400
 
     # test update access_request
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
 
     data = {"approved": True, "reason": "test reason"}
 
-    rep = client.put(access_request_url, json=data)
+    rep = await client.put(access_request_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert add_owner_to_group_spy.call_count == 0
 
-    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     data = rep.json()
     assert data["requester"]["email"] == user.email
@@ -205,9 +213,9 @@ def test_put_access_request(
     assert data["resolver"]["email"] == access_owner.email
     assert data["resolution_reason"] == access_request.resolution_reason
 
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 2
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 2
 
-    access_request2 = CreateAccessRequest(
+    access_request2 = await CreateAccessRequest(
         requester_user=user,
         requested_group=okta_group,
         request_ownership=True,
@@ -221,12 +229,14 @@ def test_put_access_request(
     data = {"approved": False, "reason": "test reason"}
 
     access_request_url = url_for("api-access-requests.access_request_by_id", access_request_id=access_request.id)
-    rep = client.put(access_request_url, json=data)
+    rep = await client.put(access_request_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
 
-    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     data = rep.json()
     assert data["requester"]["email"] == user.email
@@ -238,35 +248,35 @@ def test_put_access_request(
     assert data["resolver"]["email"] == access_owner.email
     assert data["resolution_reason"] == access_request.resolution_reason
 
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 2
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 2
 
 
-def test_put_access_request_by_non_owner(
-    client: TestClient, app: FastAPI, db: Db, okta_group: OktaGroup, user: OktaUser, url_for: Any
+async def test_put_access_request_by_non_owner(
+    client: AsyncClient, app: FastAPI, db: Db, okta_group: OktaGroup, user: OktaUser, url_for: Any
 ) -> None:
     access_owner = settings.CURRENT_OKTA_USER_EMAIL
 
     db.session.add(user)
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
 
-    access_request_by_owner = CreateAccessRequest(
-        requester_user=db.session.query(OktaUser).filter(OktaUser.email == access_owner).first(),
+    access_request_by_owner = await CreateAccessRequest(
+        requester_user=(await db.session.scalars(select(OktaUser).where(OktaUser.email == access_owner))).first(),
         requested_group=okta_group,
         request_ownership=False,
         request_reason="test reason",
     ).execute()
 
-    access_request_by_non_owner = CreateAccessRequest(
+    access_request_by_non_owner = await CreateAccessRequest(
         requester_user=user,
         requested_group=okta_group,
         request_ownership=False,
         request_reason="test reason",
     ).execute()
 
-    db.session.commit()
+    await db.session.commit()
 
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 1
 
     assert access_request_by_owner is not None
     assert access_request_by_owner.status == AccessRequestStatus.PENDING
@@ -280,43 +290,48 @@ def test_put_access_request_by_non_owner(
         "api-access-requests.access_request_by_id", access_request_id=access_request_by_owner.id
     )
     data = {"approved": True, "reason": "test approval"}
-    rep = client.put(access_request_url, json=data)
+    rep = await client.put(access_request_url, json=data)
     assert rep.status_code == 403
 
+    # The failed request's rollback on the shared session expired the
+    # identity map; reload before reading ORM attributes.
+    await db.session.refresh(access_request_by_non_owner)
     assert access_request_by_non_owner.status == AccessRequestStatus.PENDING
     assert access_request_by_non_owner.resolved_at is None
     assert access_request_by_non_owner.resolver_user_id is None
 
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 1
 
     data = {"approved": False, "reason": "test rejection"}
 
-    rep = client.put(access_request_url, json=data)
+    rep = await client.put(access_request_url, json=data)
     assert rep.status_code == 403
 
+    await db.session.refresh(access_request_by_non_owner)
     assert access_request_by_non_owner.status == AccessRequestStatus.PENDING
     assert access_request_by_non_owner.resolved_at is None
     assert access_request_by_non_owner.resolver_user_id is None
 
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 1
 
     access_request_url = url_for(
         "api-access-requests.access_request_by_id", access_request_id=access_request_by_non_owner.id
     )
 
     data = {"approved": True, "reason": "test approval"}
-    rep = client.put(access_request_url, json=data)
+    rep = await client.put(access_request_url, json=data)
     assert rep.status_code == 403
 
+    await db.session.refresh(access_request_by_non_owner)
     assert access_request_by_non_owner.status == AccessRequestStatus.PENDING
     assert access_request_by_non_owner.resolved_at is None
     assert access_request_by_non_owner.resolver_user_id is None
 
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 1
 
     data = {"approved": False, "reason": "test rejection"}
 
-    rep = client.put(access_request_url, json=data)
+    rep = await client.put(access_request_url, json=data)
     assert rep.status_code == 200
 
     data = rep.json()
@@ -331,18 +346,20 @@ def test_put_access_request_by_non_owner(
     assert access_request_by_non_owner.resolved_at is not None
     assert access_request_by_non_owner.resolver_user_id == user.id
 
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 1
 
 
-def test_create_access_request(app: FastAPI, client: TestClient, db: Db, okta_group: OktaGroup, url_for: Any) -> None:
+async def test_create_access_request(
+    app: FastAPI, client: AsyncClient, db: Db, okta_group: OktaGroup, url_for: Any
+) -> None:
     # test bad data
     access_requests_url = url_for("api-access-requests.access_requests")
     data: dict[str, Any] = {}
-    rep = client.post(access_requests_url, json=data)
+    rep = await client.post(access_requests_url, json=data)
     assert rep.status_code == 400
 
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
 
     data = {
         "group_id": okta_group.id,
@@ -350,12 +367,14 @@ def test_create_access_request(app: FastAPI, client: TestClient, db: Db, okta_gr
         "reason": "test reason",
     }
 
-    rep = client.post(access_requests_url, json=data)
+    rep = await client.post(access_requests_url, json=data)
     assert rep.status_code == 201
 
     data = rep.json()
-    access_request = db.session.get(AccessRequest, data["id"])
-    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_request = await db.session.get(AccessRequest, data["id"])
+    access_owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     assert data["requester"]["email"] == access_owner.email
     assert data["requested_group"]["name"] == okta_group.name
@@ -365,15 +384,15 @@ def test_create_access_request(app: FastAPI, client: TestClient, db: Db, okta_gr
     assert data["request_ownership"] == access_request.request_ownership
 
 
-def test_create_access_request_with_rfc822_ending_at(
-    app: FastAPI, client: TestClient, db: Db, okta_group: OktaGroup, url_for: Any
+async def test_create_access_request_with_rfc822_ending_at(
+    app: FastAPI, client: AsyncClient, db: Db, okta_group: OktaGroup, url_for: Any
 ) -> None:
     """Frontend sends ending_at as RFC822 (e.g. "Sun, 10 May 2026 19:09:02 -0700");
     the router must parse the wire string into a datetime before it hits the
     SQLAlchemy DateTime column."""
     access_requests_url = url_for("api-access-requests.access_requests")
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
 
     data = {
         "group_id": okta_group.id,
@@ -381,11 +400,11 @@ def test_create_access_request_with_rfc822_ending_at(
         "reason": "test reason",
         "ending_at": "Sun, 10 May 2026 19:09:02 -0700",
     }
-    rep = client.post(access_requests_url, json=data)
+    rep = await client.post(access_requests_url, json=data)
     assert rep.status_code == 201, rep.text
 
     response_data = rep.json()
-    access_request = db.session.get(AccessRequest, response_data["id"])
+    access_request = await db.session.get(AccessRequest, response_data["id"])
     assert access_request is not None
     assert access_request.request_ending_at is not None
     # 2026-05-10 19:09:02 -0700 normalizes to 2026-05-11 02:09:02 UTC.
@@ -394,26 +413,26 @@ def test_create_access_request_with_rfc822_ending_at(
     assert access_request.request_ending_at.day == 11
 
 
-def test_get_all_access_request(
-    client: TestClient, db: Db, okta_group: OktaGroup, user: OktaUser, url_for: Any
+async def test_get_all_access_request(
+    client: AsyncClient, db: Db, okta_group: OktaGroup, user: OktaUser, url_for: Any
 ) -> None:
     access_requests_url = url_for("api-access-requests.access_requests")
     db.session.add(user)
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
 
     access_requests = AccessRequestFactory.create_batch(10, requester_user_id=user.id, requested_group_id=okta_group.id)
     db.session.add_all(access_requests)
-    db.session.commit()
+    await db.session.commit()
 
-    rep = client.get(access_requests_url)
+    rep = await client.get(access_requests_url)
     assert rep.status_code == 200
 
     results = rep.json()
     for access_request in access_requests:
         assert any(u["id"] == access_request.id for u in results["items"])
 
-    rep = client.get(access_requests_url, params={"q": "pend"})
+    rep = await client.get(access_requests_url, params={"q": "pend"})
     assert rep.status_code == 200
 
     results = rep.json()
@@ -421,21 +440,23 @@ def test_get_all_access_request(
         assert any(u["id"] == access_request.id for u in results["items"])
 
 
-def test_create_access_request_notification(
+async def test_create_access_request_notification(
     app: FastAPI, db: Db, okta_group: OktaGroup, user: OktaUser, mocker: MockerFixture
 ) -> None:
     db.session.add(user)
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(
+        group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
 
     hook = get_notification_hook()
     request_created_notification_spy = mocker.patch.object(hook, "access_request_created")
     request_completed_notification_spy = mocker.patch.object(hook, "access_request_completed")
-    add_membership_spy = mocker.patch.object(okta, "async_add_user_to_group")
+    add_membership_spy = mocker.patch.object(okta, "add_user_to_group")
 
-    access_request = CreateAccessRequest(
+    access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=okta_group,
         request_ownership=False,
@@ -445,27 +466,29 @@ def test_create_access_request_notification(
     assert access_request is not None
     assert request_created_notification_spy.call_count == 1
 
-    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
-    ApproveAccessRequest(access_request=access_request, approver_user=access_owner).execute()
+    await ApproveAccessRequest(access_request=access_request, approver_user=access_owner).execute()
 
     assert add_membership_spy.call_count == 1
     assert request_completed_notification_spy.call_count == 1
 
     access_request.status = AccessRequestStatus.PENDING
     access_request.resolved_at = None
-    db.session.commit()
+    await db.session.commit()
 
     add_membership_spy.reset_mock()
     request_completed_notification_spy.reset_mock()
 
-    RejectAccessRequest(access_request=access_request, current_user_id=access_owner).execute()
+    await RejectAccessRequest(access_request=access_request, current_user_id=access_owner).execute()
 
     assert add_membership_spy.call_count == 0
     assert request_completed_notification_spy.call_count == 1
 
 
-def test_create_app_access_request_notification(
+async def test_create_app_access_request_notification(
     app: FastAPI, db: Db, access_app: App, app_group: AppGroup, user: OktaUser, mocker: MockerFixture
 ) -> None:
     # test bad data
@@ -479,7 +502,7 @@ def test_create_app_access_request_notification(
     db.session.add(app_owner_user)
     db.session.add(user)
 
-    db.session.commit()
+    await db.session.commit()
 
     # Add app group that no one owns
     app_group.app_id = access_app.id
@@ -491,19 +514,19 @@ def test_create_app_access_request_notification(
     app_owner_group.is_owner = True
     db.session.add(app_owner_group)
 
-    db.session.commit()
+    await db.session.commit()
 
     # Add app_owner_user to the owner group
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=app_owner_group, members_to_add=[], owners_to_add=[app_owner_user.id], sync_to_okta=False
     ).execute()
 
     hook = get_notification_hook()
     request_created_notification_spy = mocker.patch.object(hook, "access_request_created")
     request_completed_notification_spy = mocker.patch.object(hook, "access_request_completed")
-    add_membership_spy = mocker.patch.object(okta, "async_add_user_to_group")
+    add_membership_spy = mocker.patch.object(okta, "add_user_to_group")
 
-    access_request = CreateAccessRequest(
+    access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=app_group,
         request_ownership=False,
@@ -517,9 +540,11 @@ def test_create_app_access_request_notification(
     assert kwargs["group"] == app_group
     assert kwargs["requester"] == user
 
-    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
-    ApproveAccessRequest(access_request=access_request, approver_user=access_owner).execute()
+    await ApproveAccessRequest(access_request=access_request, approver_user=access_owner).execute()
 
     assert add_membership_spy.call_count == 1
     assert request_completed_notification_spy.call_count == 1
@@ -530,12 +555,12 @@ def test_create_app_access_request_notification(
 
     access_request.status = AccessRequestStatus.PENDING
     access_request.resolved_at = None
-    db.session.commit()
+    await db.session.commit()
 
     add_membership_spy.reset_mock()
     request_completed_notification_spy.reset_mock()
 
-    RejectAccessRequest(access_request=access_request, current_user_id=access_owner).execute()
+    await RejectAccessRequest(access_request=access_request, current_user_id=access_owner).execute()
 
     assert add_membership_spy.call_count == 0
     assert request_completed_notification_spy.call_count == 1
@@ -545,12 +570,14 @@ def test_create_app_access_request_notification(
     assert kwargs["requester"] == user
 
 
-def test_get_all_possible_request_approvers(app: FastAPI, mocker: MockerFixture, db: Db) -> None:
-    access_admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+async def test_get_all_possible_request_approvers(app: FastAPI, mocker: MockerFixture, db: Db) -> None:
+    access_admin = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     users = OktaUserFactory.build_batch(3)
     db.session.add_all(users)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch(
         "api.models.access_request.get_group_managers",
@@ -565,7 +592,7 @@ def test_get_all_possible_request_approvers(app: FastAPI, mocker: MockerFixture,
     req = AccessRequest()
     req.requested_group = AppGroupFactory.create()
 
-    approvers = get_all_possible_request_approvers(req)
+    approvers = await get_all_possible_request_approvers(req)
 
     # Assert that the access admin and 3 users are returned with no duplicates
     assert len(approvers) == 4
@@ -575,10 +602,12 @@ def test_get_all_possible_request_approvers(app: FastAPI, mocker: MockerFixture,
     assert users[2] in approvers
 
 
-def test_resolve_app_access_request_notification(
+async def test_resolve_app_access_request_notification(
     app: FastAPI, db: Db, access_app: App, app_group: AppGroup, user: OktaUser, mocker: MockerFixture
 ) -> None:
-    access_admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_admin = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     app_owner_user1 = OktaUserFactory.build()
     app_owner_user2 = OktaUserFactory.build()
@@ -592,7 +621,7 @@ def test_resolve_app_access_request_notification(
     db.session.add(app_owner_user2)
     db.session.add(user)  # Future group owner
 
-    db.session.commit()
+    await db.session.commit()
 
     # Add app group that no one owns
     app_group.app_id = access_app.id
@@ -604,10 +633,10 @@ def test_resolve_app_access_request_notification(
     app_owner_group.is_owner = True
     db.session.add(app_owner_group)
 
-    db.session.commit()
+    await db.session.commit()
 
     # Add app_owner_user to the owner group
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=app_owner_group,
         members_to_add=[],
         owners_to_add=[app_owner_user1.id, app_owner_user2.id],
@@ -617,9 +646,9 @@ def test_resolve_app_access_request_notification(
     hook = get_notification_hook()
     request_created_notification_spy = mocker.patch.object(hook, "access_request_created")
     request_completed_notification_spy = mocker.patch.object(hook, "access_request_completed")
-    add_ownership_spy = mocker.patch.object(okta, "async_add_owner_to_group")
+    add_ownership_spy = mocker.patch.object(okta, "add_owner_to_group")
 
-    access_request = CreateAccessRequest(
+    access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=app_group,
         request_ownership=True,
@@ -636,7 +665,7 @@ def test_resolve_app_access_request_notification(
     assert app_owner_user1 in kwargs["approvers"]
     assert app_owner_user2 in kwargs["approvers"]
 
-    ApproveAccessRequest(access_request=access_request, approver_user=app_owner_user1).execute()
+    await ApproveAccessRequest(access_request=access_request, approver_user=app_owner_user1).execute()
 
     assert add_ownership_spy.call_count == 1
     assert request_completed_notification_spy.call_count == 1
@@ -653,12 +682,12 @@ def test_resolve_app_access_request_notification(
     # Reset the access request so we can test the reject path
     access_request.status = AccessRequestStatus.PENDING
     access_request.resolved_at = None
-    db.session.commit()
+    await db.session.commit()
 
     add_ownership_spy.reset_mock()
     request_completed_notification_spy.reset_mock()
 
-    RejectAccessRequest(access_request=access_request, current_user_id=app_owner_user1).execute()
+    await RejectAccessRequest(access_request=access_request, current_user_id=app_owner_user1).execute()
 
     assert add_ownership_spy.call_count == 0
     assert request_completed_notification_spy.call_count == 1
@@ -673,16 +702,16 @@ def test_resolve_app_access_request_notification(
     assert user in kwargs["approvers"]
 
 
-def test_auto_resolve_create_access_request(
+async def test_auto_resolve_create_access_request(
     app: FastAPI, db: Db, okta_group: OktaGroup, user: OktaUser, tag: Tag, mocker: MockerFixture
 ) -> None:
     db.session.add(user)
     db.session.add(okta_group)
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
     db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    db.session.commit()
+    await db.session.commit()
 
     notification_hook = get_notification_hook()
     request_created_notification_spy = mocker.patch.object(notification_hook, "access_request_created")
@@ -693,9 +722,9 @@ def test_auto_resolve_create_access_request(
         "access_request_created",
         return_value=[ConditionalAccessResponse(approved=True, reason="Auto-Approved")],
     )
-    add_membership_spy = mocker.patch.object(okta, "async_add_user_to_group")
+    add_membership_spy = mocker.patch.object(okta, "add_user_to_group")
 
-    access_request = CreateAccessRequest(
+    access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=okta_group,
         request_ownership=False,
@@ -703,6 +732,8 @@ def test_auto_resolve_create_access_request(
     ).execute()
 
     assert access_request is not None
+    # The auto-approval's bulk update expired the resolution columns; reload.
+    await db.session.refresh(access_request)
     assert access_request.status == AccessRequestStatus.APPROVED
     assert access_request.resolved_at is not None
     assert access_request.resolver_user_id is None
@@ -730,7 +761,7 @@ def test_auto_resolve_create_access_request(
         return_value=[ConditionalAccessResponse(approved=False, reason="Auto-Rejected")],
     )
 
-    access_request = CreateAccessRequest(
+    access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=okta_group,
         request_ownership=False,
@@ -738,6 +769,7 @@ def test_auto_resolve_create_access_request(
     ).execute()
 
     assert access_request is not None
+    await db.session.refresh(access_request)
     assert access_request.status == AccessRequestStatus.REJECTED
     assert access_request.resolved_at is not None
     assert access_request.resolver_user_id is None
@@ -763,7 +795,7 @@ def test_auto_resolve_create_access_request(
         request_hook, "access_request_created", return_value=[None]
     )
 
-    access_request = CreateAccessRequest(
+    access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=okta_group,
         request_ownership=False,
@@ -788,7 +820,7 @@ def test_auto_resolve_create_access_request(
     assert tag in kwargs["group_tags"]
 
 
-def test_auto_resolve_create_access_request_with_time_limit_constraint_tag(
+async def test_auto_resolve_create_access_request_with_time_limit_constraint_tag(
     app: FastAPI, db: Db, okta_group: OktaGroup, user: OktaUser, tag: Tag, mocker: MockerFixture
 ) -> None:
     db.session.add(user)
@@ -798,10 +830,10 @@ def test_auto_resolve_create_access_request_with_time_limit_constraint_tag(
         Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: THREE_DAYS_IN_SECONDS,
     }
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
     db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    db.session.commit()
+    await db.session.commit()
 
     notification_hook = get_notification_hook()
     request_created_notification_spy = mocker.patch.object(notification_hook, "access_request_created")
@@ -818,9 +850,9 @@ def test_auto_resolve_create_access_request_with_time_limit_constraint_tag(
             ),
         ],
     )
-    add_membership_spy = mocker.patch.object(okta, "async_add_user_to_group")
+    add_membership_spy = mocker.patch.object(okta, "add_user_to_group")
 
-    access_request = CreateAccessRequest(
+    access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=okta_group,
         request_ownership=False,
@@ -828,6 +860,8 @@ def test_auto_resolve_create_access_request_with_time_limit_constraint_tag(
     ).execute()
 
     assert access_request is not None
+    # The auto-approval's bulk update expired the resolution columns; reload.
+    await db.session.refresh(access_request)
     assert access_request.status == AccessRequestStatus.APPROVED
     assert access_request.resolved_at is not None
     assert access_request.resolver_user_id is None
@@ -845,8 +879,8 @@ def test_auto_resolve_create_access_request_with_time_limit_constraint_tag(
     assert tag in kwargs["group_tags"]
 
 
-def test_q_search_covers_all_fields_via_http(
-    client: TestClient, db: Db, okta_group: OktaGroup, user: OktaUser, url_for: Any
+async def test_q_search_covers_all_fields_via_http(
+    client: AsyncClient, db: Db, okta_group: OktaGroup, user: OktaUser, url_for: Any
 ) -> None:
     """The `q` search must hit requester email+name, requested group
     name+description, and the request id prefix. Previously only `status`
@@ -859,15 +893,15 @@ def test_q_search_covers_all_fields_via_http(
     target_group = OktaGroupFactory.create(name="ZeldaTargetGroup", description="zd-desc")
     other_group = OktaGroupFactory.create(name="OtherNoiseGroup", description="on-desc")
     db.session.add_all([target_user, other_user, target_group, other_group])
-    db.session.commit()
+    await db.session.commit()
 
-    target_ar = CreateAccessRequest(
+    target_ar = await CreateAccessRequest(
         requester_user=target_user,
         requested_group=target_group,
         request_ownership=False,
         request_reason="dummy",
     ).execute()
-    other_ar = CreateAccessRequest(
+    other_ar = await CreateAccessRequest(
         requester_user=other_user,
         requested_group=other_group,
         request_ownership=False,
@@ -881,38 +915,38 @@ def test_q_search_covers_all_fields_via_http(
         return [r["id"] for r in rep.json()["items"]]
 
     # Requester email substring.
-    rep = client.get(requests_url, params={"q": "zelda-target"})
+    rep = await client.get(requests_url, params={"q": "zelda-target"})
     assert rep.status_code == 200
     found = ids(rep)
     assert target_ar.id in found and other_ar.id not in found
 
     # Requester first/last name substring.
-    rep = client.get(requests_url, params={"q": "Zelda"})
+    rep = await client.get(requests_url, params={"q": "Zelda"})
     assert rep.status_code == 200
     found = ids(rep)
     assert target_ar.id in found and other_ar.id not in found
 
     # Requested group name substring.
-    rep = client.get(requests_url, params={"q": "ZeldaTargetGroup"})
+    rep = await client.get(requests_url, params={"q": "ZeldaTargetGroup"})
     assert rep.status_code == 200
     found = ids(rep)
     assert target_ar.id in found and other_ar.id not in found
 
     # Requested group description substring.
-    rep = client.get(requests_url, params={"q": "zd-desc"})
+    rep = await client.get(requests_url, params={"q": "zd-desc"})
     assert rep.status_code == 200
     found = ids(rep)
     assert target_ar.id in found and other_ar.id not in found
 
     # AccessRequest id prefix.
-    rep = client.get(requests_url, params={"q": target_ar.id[:6]})
+    rep = await client.get(requests_url, params={"q": target_ar.id[:6]})
     assert rep.status_code == 200
     found = ids(rep)
     assert target_ar.id in found
 
 
-def test_post_access_request_403_for_deleted_user(
-    client: TestClient, db: Db, okta_group: OktaGroup, mock_user: Any, url_for: Any
+async def test_post_access_request_403_for_deleted_user(
+    client: AsyncClient, db: Db, okta_group: OktaGroup, mock_user: Any, url_for: Any
 ) -> None:
     """Flask returned 403 (not 404) when current_user_id resolves to a
     soft-deleted user."""
@@ -921,18 +955,18 @@ def test_post_access_request_403_for_deleted_user(
     deleted_user = OktaUserFactory.create(deleted_at=datetime.now(timezone.utc))
     db.session.add(deleted_user)
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
     mock_user(deleted_user.id)
 
-    rep = client.post(
+    rep = await client.post(
         url_for("api-access-requests.access_requests_create"),
         json={"group_id": okta_group.id, "group_owner": False, "reason": "test"},
     )
     assert rep.status_code == 403
 
 
-def test_post_access_request_for_role_group_with_associated_groups(
-    app: FastAPI, client: TestClient, db: Db, url_for: Any
+async def test_post_access_request_for_role_group_with_associated_groups(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any
 ) -> None:
     """POST /api/requests for a RoleGroup that owns and is a member of
     several AppGroups must succeed. Without the polymorphic + tag +
@@ -947,7 +981,7 @@ def test_post_access_request_for_role_group_with_associated_groups(
     test_app = AppFactory.create(name="AssocTestApp")
     db.session.add(role)
     db.session.add(test_app)
-    db.session.commit()
+    await db.session.commit()
 
     associated_app_groups = [
         AppGroupFactory.create(
@@ -967,16 +1001,16 @@ def test_post_access_request_for_role_group_with_associated_groups(
     ]
     for ag in associated_app_groups + associated_owner_groups:
         db.session.add(ag)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyRoleGroups(
+    await ModifyRoleGroups(
         role_group=role,
         groups_to_add=[g.id for g in associated_app_groups],
         owner_groups_to_add=[g.id for g in associated_owner_groups],
         sync_to_okta=False,
     ).execute()
 
-    rep = client.post(
+    rep = await client.post(
         url_for("api-access-requests.access_requests_create"),
         json={"group_id": role.id, "group_owner": False, "reason": "want role membership"},
     )
@@ -986,8 +1020,8 @@ def test_post_access_request_for_role_group_with_associated_groups(
     assert body["status"] == AccessRequestStatus.PENDING
 
 
-def test_get_access_request_detail_requested_group_for_role_group(
-    client: TestClient,
+async def test_get_access_request_detail_requested_group_for_role_group(
+    client: AsyncClient,
     db: Db,
     okta_group: OktaGroup,
     role_group: RoleGroup,
@@ -1003,7 +1037,7 @@ def test_get_access_request_detail_requested_group_for_role_group(
     db.session.add(user)
     db.session.add(okta_group)
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
 
     # Wire the role to one member-group and one owner-group so both
     # association arrays have content.
@@ -1011,15 +1045,15 @@ def test_get_access_request_detail_requested_group_for_role_group(
     owner_group = OktaGroupFactory.create()
     db.session.add(member_group)
     db.session.add(owner_group)
-    db.session.commit()
-    ModifyRoleGroups(
+    await db.session.commit()
+    await ModifyRoleGroups(
         role_group=role_group,
         groups_to_add=[member_group.id],
         owner_groups_to_add=[owner_group.id],
         sync_to_okta=False,
     ).execute()
 
-    ar = CreateAccessRequest(
+    ar = await CreateAccessRequest(
         requester_user=user,
         requested_group=role_group,
         request_ownership=False,
@@ -1029,8 +1063,10 @@ def test_get_access_request_detail_requested_group_for_role_group(
 
     # drop identity-map state staled by the ops above (expire_on_commit=False)
     db.session.expire_all()
+    # ... then reload the request before reading its id in this task context.
+    await db.session.refresh(ar)
 
-    rep = client.get(url_for("api-access-requests.access_request_by_id", access_request_id=ar.id))
+    rep = await client.get(url_for("api-access-requests.access_request_by_id", access_request_id=ar.id))
     assert rep.status_code == 200, rep.text
     data = rep.json()
     rg = data["requested_group"]
@@ -1052,8 +1088,8 @@ def test_get_access_request_detail_requested_group_for_role_group(
     assert owner_group.id in owner_ids
 
 
-def test_get_access_request_detail_requested_group_for_app_group(
-    client: TestClient,
+async def test_get_access_request_detail_requested_group_for_app_group(
+    client: AsyncClient,
     db: Db,
     access_app: App,
     app_group: AppGroup,
@@ -1069,16 +1105,16 @@ def test_get_access_request_detail_requested_group_for_app_group(
     access_app.app_group_lifecycle_plugin = "noop"
     db.session.add(user)
     db.session.add(access_app)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     app_group.is_owner = False
     db.session.add(app_group)
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag.id))
-    db.session.commit()
+    await db.session.commit()
 
-    ar = CreateAccessRequest(
+    ar = await CreateAccessRequest(
         requester_user=user,
         requested_group=app_group,
         request_ownership=False,
@@ -1086,7 +1122,7 @@ def test_get_access_request_detail_requested_group_for_app_group(
     ).execute()
     assert ar is not None
 
-    rep = client.get(url_for("api-access-requests.access_request_by_id", access_request_id=ar.id))
+    rep = await client.get(url_for("api-access-requests.access_request_by_id", access_request_id=ar.id))
     assert rep.status_code == 200, rep.text
     data = rep.json()
     rg = data["requested_group"]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,7 +2,8 @@ from typing import Any, Protocol, cast
 
 import pytest
 from factory import Faker
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
+from sqlalchemy import select
 from okta.models.group import Group
 from pytest_mock import MockerFixture
 from fastapi import FastAPI
@@ -23,14 +24,15 @@ from api.models import (
 from api.operations import ModifyGroupUsers, ModifyRoleGroups
 from api.services import okta
 from tests.factories import AppFactory, AppGroupFactory, OktaGroupFactory
+from tests.helpers import db_count
 
 
-def test_get_access_app_includes_owner_group(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_get_access_app_includes_owner_group(client: AsyncClient, db: Db, url_for: Any) -> None:
     """The conftest seeds the built-in Access app + App-Access-Owners group.
     Hitting /api/apps/Access must return the owner group under
     active_owner_app_groups so the React /apps/Access page can render it."""
     access_app_url = url_for("api-apps.app_by_id", app_id=App.ACCESS_APP_RESERVED_NAME)
-    rep = client.get(access_app_url)
+    rep = await client.get(access_app_url)
     assert rep.status_code == 200, rep.text
     data = rep.json()
     assert data["name"] == App.ACCESS_APP_RESERVED_NAME
@@ -48,8 +50,8 @@ def test_get_access_app_includes_owner_group(client: TestClient, db: Db, url_for
         assert g["is_owner"] is True
 
 
-def test_get_app(
-    client: TestClient,
+async def test_get_app(
+    client: AsyncClient,
     db: Db,
     access_app: App,
     app_group: AppGroup,
@@ -59,20 +61,24 @@ def test_get_app(
 ) -> None:
     # test 404
     app_url = url_for("api-apps.app_by_id", app_id="randomid")
-    rep = client.get(app_url)
+    rep = await client.get(app_url)
     assert rep.status_code == 404
 
     db.session.add(access_app)
     db.session.add(user)
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=app_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyRoleGroups(
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(
+        group=app_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyRoleGroups(
         role_group=role_group, groups_to_add=[app_group.id], owner_groups_to_add=[app_group.id], sync_to_okta=False
     ).execute()
 
@@ -86,7 +92,7 @@ def test_get_app(
 
     # test get app
     app_url = url_for("api-apps.app_by_id", app_id=app_id)
-    rep = client.get(app_url)
+    rep = await client.get(app_url)
     assert rep.status_code == 200
 
     data = rep.json()
@@ -94,29 +100,29 @@ def test_get_app(
     assert data["description"] == app_description
 
     app_url = url_for("api-apps.app_by_id", app_id=app_group_id)
-    rep = client.get(app_url)
+    rep = await client.get(app_url)
     assert rep.status_code == 404
 
     app_url = url_for("api-apps.app_by_id", app_id=role_group_id)
-    rep = client.get(app_url)
+    rep = await client.get(app_url)
     assert rep.status_code == 404
 
 
-def test_put_app(
-    client: TestClient, db: Db, mocker: MockerFixture, access_app: App, app_group: AppGroup, tag: Tag, url_for: Any
+async def test_put_app(
+    client: AsyncClient, db: Db, mocker: MockerFixture, access_app: App, app_group: AppGroup, tag: Tag, url_for: Any
 ) -> None:
     # test 404
     app_url = url_for("api-apps.app_by_id", app_id="randomid")
-    rep = client.put(app_url)
+    rep = await client.put(app_url)
     assert rep.status_code == 404
 
     db.session.add(access_app)
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     app_group.name = f"{AppGroup.APP_GROUP_NAME_PREFIX}{access_app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}group"
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
     old_app_group_id = app_group.id
 
@@ -126,7 +132,7 @@ def test_put_app(
     data = {"name": "Updated", "description": "new description", "tags_to_add": [tag.id]}
 
     app_url = url_for("api-apps.app_by_id", app_id=access_app.id)
-    rep = client.put(app_url, json=data)
+    rep = await client.put(app_url, json=data)
     assert rep.status_code == 200
     assert update_group_spy.call_count == 1
 
@@ -135,16 +141,15 @@ def test_put_app(
     assert data["description"] == "new description"
     assert data["id"] == access_app.id
     assert (
-        db.session.get(AppGroup, old_app_group_id).name
-        == f"{AppGroup.APP_GROUP_NAME_PREFIX}Updated{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}group"
-    )
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
-    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 1
+        await db.session.get(AppGroup, old_app_group_id)
+    ).name == f"{AppGroup.APP_GROUP_NAME_PREFIX}Updated{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}group"
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 1
+    assert await db_count(db.session, select(AppTagMap).where(AppTagMap.ended_at.is_(None))) == 1
 
     update_group_spy.reset_mock()
 
     data = {"name": "Updated", "tags_to_add": [tag.id], "tags_to_remove": []}
-    rep = client.put(app_url, json=data)
+    rep = await client.put(app_url, json=data)
     assert rep.status_code == 200
     assert update_group_spy.call_count == 0
 
@@ -152,13 +157,13 @@ def test_put_app(
     assert data["name"] == "Updated"
     assert data["description"] == "new description"
     assert data["id"] == access_app.id
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
-    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 1
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 1
+    assert await db_count(db.session, select(AppTagMap).where(AppTagMap.ended_at.is_(None))) == 1
 
     update_group_spy.reset_mock()
 
     data = {"name": "Updated", "tags_to_remove": [tag.id]}
-    rep = client.put(app_url, json=data)
+    rep = await client.put(app_url, json=data)
     assert rep.status_code == 200
     assert update_group_spy.call_count == 0
 
@@ -166,23 +171,31 @@ def test_put_app(
     assert data["name"] == "Updated"
     assert data["description"] == "new description"
     assert data["id"] == access_app.id
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
-    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 0
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 0
+    assert await db_count(db.session, select(AppTagMap).where(AppTagMap.ended_at.is_(None))) == 0
 
     # Updating the name of the built-in Access app should fail
-    builtin_access_app = db.session.query(App).filter(App.name == App.ACCESS_APP_RESERVED_NAME).first()
+    builtin_access_app = (await db.session.scalars(select(App).where(App.name == App.ACCESS_APP_RESERVED_NAME))).first()
     builtin_access_owners_group = (
-        db.session.query(AppGroup).filter(AppGroup.app_id == builtin_access_app.id, AppGroup.is_owner.is_(True)).first()
-    )
+        await db.session.scalars(
+            select(AppGroup).where(AppGroup.app_id == builtin_access_app.id, AppGroup.is_owner.is_(True))
+        )
+    ).first()
     app_url = url_for("api-apps.app_by_id", app_id=builtin_access_app.id)
     data = {"name": "UpdatedAccess"}
-    rep = client.put(app_url, json=data)
+    rep = await client.put(app_url, json=data)
     assert rep.status_code == 400
+
+    # The failed request's rollback on the shared session expired the
+    # identity map; reload before reading ORM attributes.
+    await db.session.refresh(tag)
+    await db.session.refresh(builtin_access_app)
+    await db.session.refresh(builtin_access_owners_group)
 
     # Updating tags is allowed, but nothing else
     data = {"name": "UpdatedAccess", "description": "new description", "tags_to_add": [tag.id]}
     update_group_spy.reset_mock()
-    rep = client.put(app_url, json=data)
+    rep = await client.put(app_url, json=data)
     assert rep.status_code == 200
     assert update_group_spy.call_count == 0
 
@@ -191,16 +204,16 @@ def test_put_app(
     assert data["description"] != "new description"
     assert data["id"] == builtin_access_app.id
     assert (
-        db.session.get(AppGroup, builtin_access_owners_group.id).name
+        (await db.session.get(AppGroup, builtin_access_owners_group.id)).name
         == f"{AppGroup.APP_GROUP_NAME_PREFIX}{App.ACCESS_APP_RESERVED_NAME}"
         + f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
     )
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
-    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 1
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 1
+    assert await db_count(db.session, select(AppTagMap).where(AppTagMap.ended_at.is_(None))) == 1
 
     data = {"name": "UpdatedAccess", "description": "new description", "tags_to_remove": [tag.id]}
     update_group_spy.reset_mock()
-    rep = client.put(app_url, json=data)
+    rep = await client.put(app_url, json=data)
     assert rep.status_code == 200
     assert update_group_spy.call_count == 0
 
@@ -209,66 +222,74 @@ def test_put_app(
     assert data["description"] != "new description"
     assert data["id"] == builtin_access_app.id
     assert (
-        db.session.get(AppGroup, builtin_access_owners_group.id).name
+        (await db.session.get(AppGroup, builtin_access_owners_group.id)).name
         == f"{AppGroup.APP_GROUP_NAME_PREFIX}{App.ACCESS_APP_RESERVED_NAME}"
         + f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
     )
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
-    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 0
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 0
+    assert await db_count(db.session, select(AppTagMap).where(AppTagMap.ended_at.is_(None))) == 0
 
 
-def test_delete_app(client: TestClient, db: Db, mocker: MockerFixture, access_app: App, tag: Tag, url_for: Any) -> None:
+async def test_delete_app(
+    client: AsyncClient, db: Db, mocker: MockerFixture, access_app: App, tag: Tag, url_for: Any
+) -> None:
     # test 404
     app_url = url_for("api-apps.app_by_id", app_id="100000")
-    rep = client.delete(app_url)
+    rep = await client.delete(app_url)
     assert rep.status_code == 404
 
     app_groups = AppGroupFactory.create_batch(3, app=access_app)
     db.session.add(access_app)
     db.session.add_all(app_groups)
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
     app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tag.id)
     db.session.add(app_tag_map)
-    db.session.commit()
+    await db.session.commit()
     for app_group in app_groups:
         db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag.id, app_tag_map_id=app_tag_map.id))
-    db.session.commit()
+    await db.session.commit()
 
     app_id = access_app.id
     app_group_id = app_groups[0].id
 
     # test delete app
-    delete_group_spy = mocker.patch.object(okta, "async_delete_group")
+    delete_group_spy = mocker.patch.object(okta, "delete_group")
 
     app_url = url_for("api-apps.app_by_id", app_id=access_app.id)
-    rep = client.delete(app_url)
+    rep = await client.delete(app_url)
     assert rep.status_code == 200
     assert delete_group_spy.call_count == 3
-    assert db.session.get(App, app_id).deleted_at is not None
-    assert db.session.get(AppGroup, app_group_id).deleted_at is not None
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
-    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 0
+    # The delete request's bulk update expired deleted_at on the identity-map
+    # instances; expire fully so the get() calls below reload them.
+    db.session.expire_all()
+    assert (await db.session.get(App, app_id)).deleted_at is not None
+    assert (await db.session.get(AppGroup, app_group_id)).deleted_at is not None
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 0
+    assert await db_count(db.session, select(AppTagMap).where(AppTagMap.ended_at.is_(None))) == 0
 
 
-def test_get_app_excludes_soft_deleted(
-    client: TestClient, db: Db, mocker: MockerFixture, access_app: App, url_for: Any
+async def test_get_app_excludes_soft_deleted(
+    client: AsyncClient, db: Db, mocker: MockerFixture, access_app: App, url_for: Any
 ) -> None:
     db.session.add(access_app)
-    db.session.commit()
+    await db.session.commit()
     app_id = access_app.id
     app_name = access_app.name
 
-    mocker.patch.object(okta, "async_delete_group")
-    rep = client.delete(url_for("api-apps.app_by_id", app_id=app_id))
+    mocker.patch.object(okta, "delete_group")
+    rep = await client.delete(url_for("api-apps.app_by_id", app_id=app_id))
     assert rep.status_code == 200
-    assert db.session.get(App, app_id).deleted_at is not None
+    # The delete request's bulk update expired deleted_at on the identity-map
+    # instance; expire fully so the get() below reloads it.
+    db.session.expire_all()
+    assert (await db.session.get(App, app_id)).deleted_at is not None
 
-    rep = client.get(url_for("api-apps.app_by_id", app_id=app_id))
+    rep = await client.get(url_for("api-apps.app_by_id", app_id=app_id))
     assert rep.status_code == 404
 
-    rep = client.get(url_for("api-apps.app_by_id", app_id=app_name))
+    rep = await client.get(url_for("api-apps.app_by_id", app_id=app_name))
     assert rep.status_code == 404
 
 
@@ -277,8 +298,8 @@ class FakerWithPyStr(Protocol):
     def pystr(self) -> str: ...
 
 
-def test_create_app(
-    client: TestClient,
+async def test_create_app(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -288,47 +309,49 @@ def test_create_app(
     # test bad data
     apps_url = url_for("api-apps.apps")
     data: dict[str, Any] = {}
-    rep = client.post(apps_url, json=data)
+    rep = await client.post(apps_url, json=data)
     assert rep.status_code == 400
 
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
     create_group_spy = mocker.patch.object(
         okta, "create_group", return_value=Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
 
     data = {"name": "Created", "tags_to_add": [tag.id]}
 
-    rep = client.post(apps_url, json=data)
+    rep = await client.post(apps_url, json=data)
     assert rep.status_code == 201
     assert create_group_spy.call_count == 1
     assert add_user_to_group_spy.call_count == 1
     assert add_owner_to_group_spy.call_count == 1
 
     data = rep.json()
-    assert db.session.get(App, data["id"]) is not None
+    assert await db.session.get(App, data["id"]) is not None
 
     assert data["name"] == "Created"
     assert data["description"] == ""
     assert data["active_app_tags"][0]["active_tag"]["id"] == tag.id
 
-    app_groups = db.session.query(AppGroup).filter(AppGroup.app_id == data["id"]).all()
+    app_groups = (await db.session.scalars(select(AppGroup).where(AppGroup.app_id == data["id"]))).all()
     assert len(app_groups) == 1
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
-    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 1
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 1
+    assert await db_count(db.session, select(AppTagMap).where(AppTagMap.ended_at.is_(None))) == 1
 
     test_app_group = (
-        db.session.query(AppGroup).filter(AppGroup.name == "App-Created-Owners", AppGroup.app_id == data["id"]).first()
-    )
+        await db.session.scalars(
+            select(AppGroup).where(AppGroup.name == "App-Created-Owners", AppGroup.app_id == data["id"])
+        )
+    ).first()
     assert test_app_group is not None
     assert test_app_group.is_owner is True
 
 
-def test_create_app_with_initial_owners(
-    client: TestClient,
+async def test_create_app_with_initial_owners(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -338,58 +361,69 @@ def test_create_app_with_initial_owners(
 ) -> None:
     db.session.add(role_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     create_group_spy = mocker.patch.object(
         okta, "create_group", return_value=Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
 
     data = {"name": "Created", "initial_owner_id": user.id, "initial_owner_role_ids": [role_group.id]}
 
     apps_url = url_for("api-apps.apps")
-    rep = client.post(apps_url, json=data)
+    rep = await client.post(apps_url, json=data)
     assert rep.status_code == 201
     assert create_group_spy.call_count == 1
     assert add_user_to_group_spy.call_count == 1
     assert add_owner_to_group_spy.call_count == 1
 
+    # The create-app request staled the identity-map entries on the shared
+    # session; reload before reading ORM attributes.
+    await db.session.refresh(user)
+    await db.session.refresh(role_group)
+
     data = rep.json()
-    assert db.session.get(App, data["id"]) is not None
+    assert await db.session.get(App, data["id"]) is not None
 
     assert data["name"] == "Created"
     assert data["description"] == ""
 
-    app_groups = db.session.query(AppGroup).filter(AppGroup.app_id == data["id"]).all()
+    app_groups = (await db.session.scalars(select(AppGroup).where(AppGroup.app_id == data["id"]))).all()
     assert len(app_groups) == 1
 
     test_app_group = (
-        db.session.query(AppGroup).filter(AppGroup.name == "App-Created-Owners", AppGroup.app_id == data["id"]).first()
-    )
+        await db.session.scalars(
+            select(AppGroup).where(AppGroup.name == "App-Created-Owners", AppGroup.app_id == data["id"])
+        )
+    ).first()
     assert test_app_group is not None
     assert test_app_group.is_owner is True
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == test_app_group.id)
-        .filter(OktaUserGroupMember.user_id == user.id)
-        .filter(OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == test_app_group.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+            .where(OktaUserGroupMember.ended_at.is_(None)),
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.group_id == test_app_group.id)
-        .filter(RoleGroupMap.role_group_id == role_group.id)
-        .filter(RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(RoleGroupMap)
+            .where(RoleGroupMap.group_id == test_app_group.id)
+            .where(RoleGroupMap.role_group_id == role_group.id)
+            .where(RoleGroupMap.ended_at.is_(None)),
+        )
         == 2
     )
 
 
-def test_create_app_with_additional_groups(
-    client: TestClient,
+async def test_create_app_with_additional_groups(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -403,7 +437,7 @@ def test_create_app_with_additional_groups(
             {"name": "Test", "description": "test"},
         ],
     }
-    rep = client.post(apps_url, json=data)
+    rep = await client.post(apps_url, json=data)
     assert rep.status_code == 400
 
     data = {
@@ -412,7 +446,7 @@ def test_create_app_with_additional_groups(
             {"name": "App-WrongApp-Test", "description": "test"},
         ],
     }
-    rep = client.post(apps_url, json=data)
+    rep = await client.post(apps_url, json=data)
     assert rep.status_code == 400
 
     data = {
@@ -421,14 +455,14 @@ def test_create_app_with_additional_groups(
             {},
         ],
     }
-    rep = client.post(apps_url, json=data)
+    rep = await client.post(apps_url, json=data)
     assert rep.status_code == 400
 
     create_group_spy = mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
 
     data = {
         "name": "Created",
@@ -439,37 +473,41 @@ def test_create_app_with_additional_groups(
     }
 
     apps_url = url_for("api-apps.apps")
-    rep = client.post(apps_url, json=data)
+    rep = await client.post(apps_url, json=data)
     assert rep.status_code == 201
     assert create_group_spy.call_count == 3
     assert add_user_to_group_spy.call_count == 1
     assert add_owner_to_group_spy.call_count == 1
 
     data = rep.json()
-    assert db.session.get(App, data["id"]) is not None
+    assert await db.session.get(App, data["id"]) is not None
 
     assert data["name"] == "Created"
     assert data["description"] == ""
 
-    app_groups = db.session.query(AppGroup).filter(AppGroup.app_id == data["id"]).all()
+    app_groups = (await db.session.scalars(select(AppGroup).where(AppGroup.app_id == data["id"]))).all()
     assert len(app_groups) == 3
 
     test_app_group = (
-        db.session.query(AppGroup).filter(AppGroup.name == "App-Created-Owners", AppGroup.app_id == data["id"]).first()
-    )
+        await db.session.scalars(
+            select(AppGroup).where(AppGroup.name == "App-Created-Owners", AppGroup.app_id == data["id"])
+        )
+    ).first()
     assert test_app_group is not None
     assert test_app_group.is_owner is True
 
     test_app_group = (
-        db.session.query(AppGroup).filter(AppGroup.name == "App-Created-Test", AppGroup.app_id == data["id"]).first()
-    )
+        await db.session.scalars(
+            select(AppGroup).where(AppGroup.name == "App-Created-Test", AppGroup.app_id == data["id"])
+        )
+    ).first()
     assert test_app_group is not None
     assert test_app_group.description == "test"
     assert test_app_group.is_owner is False
 
 
-def test_create_app_with_name_collision(
-    client: TestClient,
+async def test_create_app_with_name_collision(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -479,42 +517,46 @@ def test_create_app_with_name_collision(
     app = AppFactory.create()
     app.name = "Test-Staging"
     db.session.add(app)
-    db.session.commit()
+    await db.session.commit()
 
     app_group.app_id = app.id
     app_group.name = "App-Test-Staging-Group"
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
     create_group_spy = mocker.patch.object(
         okta, "create_group", return_value=Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
 
     data = {"name": "Test"}
 
     apps_url = url_for("api-apps.apps")
-    rep = client.post(apps_url, json=data)
+    rep = await client.post(apps_url, json=data)
     assert rep.status_code == 201
     assert create_group_spy.call_count == 1
     assert add_user_to_group_spy.call_count == 1
     assert add_owner_to_group_spy.call_count == 1
 
     data = rep.json()
-    assert db.session.get(App, data["id"]) is not None
+    assert await db.session.get(App, data["id"]) is not None
     assert data["name"] == "Test"
 
     # Make sure new app doesn't end up with additional app groups from name collision
-    app_groups = db.session.query(AppGroup).filter(AppGroup.app_id == data["id"]).all()
+    app_groups = (await db.session.scalars(select(AppGroup).where(AppGroup.app_id == data["id"]))).all()
     assert len(app_groups) == 1
+
+    # The create-app request staled the original app's identity-map entry on
+    # the shared session; reload before reading its id.
+    await db.session.refresh(app)
 
     # Make sure original app still has its app group
-    app_groups = db.session.query(AppGroup).filter(AppGroup.app_id == app.id).all()
+    app_groups = (await db.session.scalars(select(AppGroup).where(AppGroup.app_id == app.id))).all()
     assert len(app_groups) == 1
 
 
-def test_get_all_app(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_get_all_app(client: AsyncClient, db: Db, url_for: Any) -> None:
     apps_url = url_for("api-apps.apps")
     apps = AppFactory.create_batch(10)
 
@@ -523,16 +565,16 @@ def test_get_all_app(client: TestClient, db: Db, url_for: Any) -> None:
         app.name = f"A{app.name}"
 
     db.session.add_all(apps)
-    db.session.commit()
+    await db.session.commit()
 
-    rep = client.get(apps_url)
+    rep = await client.get(apps_url)
     assert rep.status_code == 200
 
     results = rep.json()
     for app in apps:
         assert any(u["id"] == app.id for u in results["items"])
 
-    rep = client.get(apps_url, params={"q": "a"})
+    rep = await client.get(apps_url, params={"q": "a"})
     assert rep.status_code == 200
 
     results = rep.json()
@@ -541,9 +583,9 @@ def test_get_all_app(client: TestClient, db: Db, url_for: Any) -> None:
 
 
 @pytest.mark.parametrize("app", [False, True], indirect=True)
-def test_create_app_with_and_without_description(
+async def test_create_app_with_and_without_description(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -555,14 +597,14 @@ def test_create_app_with_and_without_description(
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     apps_url = url_for("api-apps.apps")
 
     # Test creating app without description
     data: dict[str, Any] = {"name": "TestAppNoDesc"}
-    rep = client.post(apps_url, json=data)
+    rep = await client.post(apps_url, json=data)
     if require_descriptions:
         # Should fail when REQUIRE_DESCRIPTIONS=True
         assert rep.status_code == 400
@@ -577,7 +619,7 @@ def test_create_app_with_and_without_description(
 
     # Test creating app with empty description
     data = {"name": "TestAppEmptyDesc", "description": ""}
-    rep = client.post(apps_url, json=data)
+    rep = await client.post(apps_url, json=data)
     if require_descriptions:
         # Should fail - empty description fails length validation
         assert rep.status_code == 400
@@ -592,7 +634,7 @@ def test_create_app_with_and_without_description(
 
     # Test creating app with a description should always succeed
     data = {"name": "TestAppWithDesc", "description": "This has a description"}
-    rep = client.post(apps_url, json=data)
+    rep = await client.post(apps_url, json=data)
     assert rep.status_code == 201
 
     result = rep.json()
@@ -601,8 +643,8 @@ def test_create_app_with_and_without_description(
 
 
 @pytest.mark.parametrize("app", [False, True], indirect=True)
-def test_partial_app_update_preserves_description(
-    app: FastAPI, client: TestClient, db: Db, mocker: MockerFixture, access_app: App, app_group: AppGroup, url_for: Any
+async def test_partial_app_update_preserves_description(
+    app: FastAPI, client: AsyncClient, db: Db, mocker: MockerFixture, access_app: App, app_group: AppGroup, url_for: Any
 ) -> None:
     """Test that app updates handle descriptions correctly based on REQUIRE_DESCRIPTIONS setting"""
     require_descriptions = settings.REQUIRE_DESCRIPTIONS
@@ -610,10 +652,10 @@ def test_partial_app_update_preserves_description(
     # Set up the app with a description
     access_app.description = "Original description"
     db.session.add(access_app)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(okta, "update_group")
 
@@ -621,7 +663,7 @@ def test_partial_app_update_preserves_description(
 
     # Test updating with empty description
     data = {"name": "UpdatedWithEmpty", "description": ""}
-    rep = client.put(app_url, json=data)
+    rep = await client.put(app_url, json=data)
     if require_descriptions:
         # Should fail - empty description fails length validation
         assert rep.status_code == 400
@@ -638,12 +680,12 @@ def test_partial_app_update_preserves_description(
     if not require_descriptions:
         # Need to reset since empty description succeeded above
         data = {"name": "UpdatedWithEmpty", "description": "Original description"}
-        rep = client.put(app_url, json=data)
+        rep = await client.put(app_url, json=data)
         assert rep.status_code == 200
 
     # Test partial update without description should preserve existing description
     data = {"name": "UpdatedName"}
-    rep = client.put(app_url, json=data)
+    rep = await client.put(app_url, json=data)
     assert rep.status_code == 200
     result = rep.json()
     assert result["name"] == "UpdatedName"
@@ -651,15 +693,15 @@ def test_partial_app_update_preserves_description(
 
     # Test updating with valid description should succeed
     data = {"name": "UpdatedName2", "description": "Updated description"}
-    rep = client.put(app_url, json=data)
+    rep = await client.put(app_url, json=data)
     assert rep.status_code == 200
     result = rep.json()
     assert result["name"] == "UpdatedName2"
     assert result["description"] == "Updated description"
 
 
-def test_create_app_fails_when_preexisting_owner_group_is_occupied(
-    client: TestClient,
+async def test_create_app_fails_when_preexisting_owner_group_is_occupied(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -667,13 +709,13 @@ def test_create_app_fails_when_preexisting_owner_group_is_occupied(
     url_for: Any,
 ) -> None:
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     owner_group_name = (
         f"{AppGroup.APP_GROUP_NAME_PREFIX}Payments"
@@ -681,19 +723,21 @@ def test_create_app_fails_when_preexisting_owner_group_is_occupied(
     )
     squatted_group = OktaGroupFactory.create(name=owner_group_name)
     db.session.add(squatted_group)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaUserGroupMember(user_id=user.id, group_id=squatted_group.id, is_owner=True))
-    db.session.commit()
+    await db.session.commit()
 
     apps_url = url_for("api-apps.apps")
-    rep = client.post(apps_url, json={"name": "Payments"})
+    rep = await client.post(apps_url, json={"name": "Payments"})
     assert rep.status_code == 409
 
-    assert db.session.query(App).filter(App.name == "Payments").filter(App.deleted_at.is_(None)).first() is None
+    assert (
+        await db.session.scalars(select(App).where(App.name == "Payments").where(App.deleted_at.is_(None)))
+    ).first() is None
 
 
-def test_create_app_succeeds_with_empty_preexisting_owner_group(
-    client: TestClient,
+async def test_create_app_succeeds_with_empty_preexisting_owner_group(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -702,8 +746,8 @@ def test_create_app_succeeds_with_empty_preexisting_owner_group(
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     owner_group_name = (
         f"{AppGroup.APP_GROUP_NAME_PREFIX}Payments"
@@ -711,19 +755,21 @@ def test_create_app_succeeds_with_empty_preexisting_owner_group(
     )
     empty_group = OktaGroupFactory.create(name=owner_group_name)
     db.session.add(empty_group)
-    db.session.commit()
+    await db.session.commit()
 
     apps_url = url_for("api-apps.apps")
-    rep = client.post(apps_url, json={"name": "Payments"})
+    rep = await client.post(apps_url, json={"name": "Payments"})
     assert rep.status_code == 201
 
     data = rep.json()
     assert data["name"] == "Payments"
-    assert db.session.query(App).filter(App.name == "Payments").filter(App.deleted_at.is_(None)).first() is not None
+    assert (
+        await db.session.scalars(select(App).where(App.name == "Payments").where(App.deleted_at.is_(None)))
+    ).first() is not None
 
 
-def test_create_app_succeeds_with_members_only_preexisting_owner_group(
-    client: TestClient,
+async def test_create_app_succeeds_with_members_only_preexisting_owner_group(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -731,13 +777,13 @@ def test_create_app_succeeds_with_members_only_preexisting_owner_group(
     url_for: Any,
 ) -> None:
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     owner_group_name = (
         f"{AppGroup.APP_GROUP_NAME_PREFIX}Payments"
@@ -745,30 +791,32 @@ def test_create_app_succeeds_with_members_only_preexisting_owner_group(
     )
     group_with_members = OktaGroupFactory.create(name=owner_group_name)
     db.session.add(group_with_members)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaUserGroupMember(user_id=user.id, group_id=group_with_members.id, is_owner=False))
-    db.session.commit()
+    await db.session.commit()
 
     apps_url = url_for("api-apps.apps")
-    rep = client.post(apps_url, json={"name": "Payments"})
+    rep = await client.post(apps_url, json={"name": "Payments"})
     assert rep.status_code == 201
 
     data = rep.json()
     assert data["name"] == "Payments"
-    assert db.session.query(App).filter(App.name == "Payments").filter(App.deleted_at.is_(None)).first() is not None
+    assert (
+        await db.session.scalars(select(App).where(App.name == "Payments").where(App.deleted_at.is_(None)))
+    ).first() is not None
 
 
-def test_delete_reserved_access_app_blocked(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_delete_reserved_access_app_blocked(client: AsyncClient, db: Db, url_for: Any) -> None:
     """The built-in Access app underpins admin auth, so DELETE must refuse
     it even for an admin caller."""
     app_url = url_for("api-apps.app_by_id", app_id=App.ACCESS_APP_RESERVED_NAME)
-    rep = client.delete(app_url)
+    rep = await client.delete(app_url)
     assert rep.status_code == 400
     assert "cannot be deleted" in rep.text
 
 
-def test_put_app_logs_audit_on_rename(
-    client: TestClient,
+async def test_put_app_logs_audit_on_rename(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     access_app: App,
@@ -779,13 +827,13 @@ def test_put_app_logs_audit_on_rename(
     handler must continue to do so."""
     mocker.patch.object(okta, "update_group")
     db.session.add(access_app)
-    db.session.commit()
+    await db.session.commit()
     old_name = access_app.name
 
     app_url = url_for("api-apps.app_by_id_put", app_id=access_app.id)
     new_name = f"{old_name}Renamed"
     with caplog.at_level("INFO", logger="access.audit"):
-        rep = client.put(app_url, json={"name": new_name})
+        rep = await client.put(app_url, json={"name": new_name})
     assert rep.status_code == 200, rep.text
 
     audit_messages = [r.getMessage() for r in caplog.records if r.name == "access.audit"]
@@ -793,30 +841,30 @@ def test_put_app_logs_audit_on_rename(
     assert any(old_name in m for m in audit_messages), audit_messages
 
 
-def test_post_app_validation_via_http(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_post_app_validation_via_http(client: AsyncClient, db: Db, url_for: Any) -> None:
     """Body validation enforced at the HTTP layer (not just Pydantic-level).
     The project's request_validation_handler converts 422 → 400 with the
     RFC 9457 problem-detail envelope."""
     apps_url = url_for("api-apps.apps")
 
-    rep = client.post(apps_url, json={"name": ""})
+    rep = await client.post(apps_url, json={"name": ""})
     assert rep.status_code == 400
     body = rep.json()
     assert body["status"] == 400
     assert "detail" in body
 
-    rep = client.post(apps_url, json={"name": "MyApp", "description": "x" * 1025})
+    rep = await client.post(apps_url, json={"name": "MyApp", "description": "x" * 1025})
     assert rep.status_code == 400
 
-    rep = client.post(
+    rep = await client.post(
         apps_url,
         json={"name": "MyApp", "initial_additional_app_groups": [{"name": "wrong-prefix"}]},
     )
     assert rep.status_code == 400
 
 
-def test_post_app_require_descriptions_enforced_via_http(
-    client: TestClient,
+async def test_post_app_require_descriptions_enforced_via_http(
+    client: AsyncClient,
     db: Db,
     url_for: Any,
     monkeypatch: pytest.MonkeyPatch,
@@ -826,21 +874,21 @@ def test_post_app_require_descriptions_enforced_via_http(
     monkeypatch.setattr(settings, "REQUIRE_DESCRIPTIONS", True)
     apps_url = url_for("api-apps.apps")
 
-    rep = client.post(apps_url, json={"name": "DescRequired"})
+    rep = await client.post(apps_url, json={"name": "DescRequired"})
     assert rep.status_code == 400
-    rep = client.post(apps_url, json={"name": "DescRequired", "description": ""})
+    rep = await client.post(apps_url, json={"name": "DescRequired", "description": ""})
     assert rep.status_code == 400
 
 
-def test_get_apps_q_via_http(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_get_apps_q_via_http(client: AsyncClient, db: Db, url_for: Any) -> None:
     """`q` is honored end-to-end on /api/apps."""
     a1 = AppFactory.create(name="ZelaPaymentsApp", description="Handles money flows")
     a2 = AppFactory.create(name="LoggingApp", description="Stores logs")
     db.session.add_all([a1, a2])
-    db.session.commit()
+    await db.session.commit()
 
     apps_url = url_for("api-apps.apps")
-    rep = client.get(apps_url, params={"q": "ZelaPayments"})
+    rep = await client.get(apps_url, params={"q": "ZelaPayments"})
     assert rep.status_code == 200
     names = [a["name"] for a in rep.json()["items"]]
     assert "ZelaPaymentsApp" in names

--- a/tests/test_app_group_lifecycle_plugin.py
+++ b/tests/test_app_group_lifecycle_plugin.py
@@ -13,7 +13,7 @@ from typing import Any, Generator
 
 import pytest
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
 from pytest_mock import MockerFixture
 from sqlalchemy.orm import Session
 
@@ -246,10 +246,10 @@ class TestPluginRegistration:
 class TestPluginAPIEndpoints:
     """Tests for plugin-related API endpoints."""
 
-    def test_list_plugins(self, client: TestClient, db: Db, test_plugin: DummyPlugin, url_for: Any) -> None:
+    async def test_list_plugins(self, client: AsyncClient, db: Db, test_plugin: DummyPlugin, url_for: Any) -> None:
         """Test GET /api/plugins/app-group-lifecycle returns all plugins."""
         url = url_for("api-plugins.app_group_lifecycle_plugins")
-        response = client.get(url)
+        response = await client.get(url)
         assert response.status_code == 200
 
         data = response.json()
@@ -257,12 +257,12 @@ class TestPluginAPIEndpoints:
         plugin_ids = [p["id"] for p in data]
         assert DummyPlugin.ID in plugin_ids
 
-    def test_get_app_config_properties(
-        self, client: TestClient, db: Db, test_plugin: DummyPlugin, url_for: Any
+    async def test_get_app_config_properties(
+        self, client: AsyncClient, db: Db, test_plugin: DummyPlugin, url_for: Any
     ) -> None:
         """Test GET /api/plugins/app-group-lifecycle/<plugin_id>/app-config-props."""
         url = url_for("api-plugins.app_group_lifecycle_plugin_app_config_props", plugin_id=DummyPlugin.ID)
-        response = client.get(url)
+        response = await client.get(url)
         assert response.status_code == 200
 
         data = response.json()
@@ -270,47 +270,47 @@ class TestPluginAPIEndpoints:
         assert "category" in data
         assert data["enabled"]["required"] is True
 
-    def test_get_group_config_properties(
-        self, client: TestClient, db: Db, test_plugin: DummyPlugin, url_for: Any
+    async def test_get_group_config_properties(
+        self, client: AsyncClient, db: Db, test_plugin: DummyPlugin, url_for: Any
     ) -> None:
         """Test GET /api/plugins/app-group-lifecycle/<plugin_id>/group-config-props."""
         url = url_for("api-plugins.app_group_lifecycle_plugin_group_config_props", plugin_id=DummyPlugin.ID)
-        response = client.get(url)
+        response = await client.get(url)
         assert response.status_code == 200
 
         data = response.json()
         assert "group_id" in data
         assert data["group_id"]["required"] is True
 
-    def test_get_app_status_properties(
-        self, client: TestClient, db: Db, test_plugin: DummyPlugin, url_for: Any
+    async def test_get_app_status_properties(
+        self, client: AsyncClient, db: Db, test_plugin: DummyPlugin, url_for: Any
     ) -> None:
         """Test GET /api/plugins/app-group-lifecycle/<plugin_id>/app-status-props."""
         url = url_for("api-plugins.app_group_lifecycle_plugin_app_status_props", plugin_id=DummyPlugin.ID)
-        response = client.get(url)
+        response = await client.get(url)
         assert response.status_code == 200
 
         data = response.json()
         assert "last_sync" in data
 
-    def test_get_group_status_properties(
-        self, client: TestClient, db: Db, test_plugin: DummyPlugin, url_for: Any
+    async def test_get_group_status_properties(
+        self, client: AsyncClient, db: Db, test_plugin: DummyPlugin, url_for: Any
     ) -> None:
         """Test GET /api/plugins/app-group-lifecycle/<plugin_id>/group-status-props."""
         url = url_for("api-plugins.app_group_lifecycle_plugin_group_status_props", plugin_id=DummyPlugin.ID)
-        response = client.get(url)
+        response = await client.get(url)
         assert response.status_code == 200
 
         data = response.json()
         assert "member_count" in data
 
-    def test_get_nonexistent_plugin(self, client: TestClient, db: Db, url_for: Any) -> None:
+    async def test_get_nonexistent_plugin(self, client: AsyncClient, db: Db, url_for: Any) -> None:
         """Test that requesting a non-existent plugin returns 404."""
         url = url_for("api-plugins.app_group_lifecycle_plugin_app_config_props", plugin_id="nonexistent_plugin")
-        response = client.get(url)
+        response = await client.get(url)
         assert response.status_code == 404
 
-    def test_plugin_not_found_returns_error_envelope(self, client: TestClient, db: Db, url_for: Any) -> None:
+    async def test_plugin_not_found_returns_error_envelope(self, client: AsyncClient, db: Db, url_for: Any) -> None:
         """The plugin endpoints' 404 path must respond with
         `{"error": "..."}` (the React client reads the `error` field).
         The plugin router raises `PluginNotFoundError`, which the
@@ -324,7 +324,7 @@ class TestPluginAPIEndpoints:
             "api-plugins.app_group_lifecycle_plugin_group_status_props",
         ):
             url = url_for(endpoint, plugin_id="does-not-exist")
-            response = client.get(url)
+            response = await client.get(url)
             assert response.status_code == 404
             body = response.json()
             assert body == {"error": "Plugin 'does-not-exist' not found"}
@@ -335,8 +335,8 @@ class TestPluginAPIEndpoints:
 class TestPluginConfigAuthorization:
     """Tests for plugin configuration authorization - positive cases (should succeed)."""
 
-    def test_access_admin_can_configure_plugin_at_app_level(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, url_for: Any
+    async def test_access_admin_can_configure_plugin_at_app_level(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, url_for: Any
     ) -> None:
         """Test that Access admins can configure plugins on apps."""
         # Use the default Access admin user (wumpus@discord.com) created in conftest
@@ -344,7 +344,7 @@ class TestPluginConfigAuthorization:
         test_app = AppFactory.build(name="TestApp", description="Test App")
 
         db.session.add(test_app)
-        db.session.commit()
+        await db.session.commit()
 
         # Configure plugin on the test app
         url = url_for("api-apps.app_by_id", app_id=test_app.id)
@@ -354,15 +354,15 @@ class TestPluginConfigAuthorization:
             "plugin_data": {DummyPlugin.ID: {"configuration": {"enabled": True, "category": "test_id"}}},
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
 
         response_data = response.json()
         assert response_data["app_group_lifecycle_plugin"] == DummyPlugin.ID
         assert response_data["plugin_data"][DummyPlugin.ID]["configuration"]["enabled"] is True
 
-    def test_app_owner_cannot_configure_plugin_at_app_level(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, url_for: Any
+    async def test_app_owner_cannot_configure_plugin_at_app_level(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, url_for: Any
     ) -> None:
         """Test that app owners (non-Access admins) cannot configure plugins on apps."""
         # Create app owner user
@@ -382,7 +382,7 @@ class TestPluginConfigAuthorization:
         # Make the user an owner of the test app (but not Access admin) by directly adding membership
         membership = OktaUserGroupMember(user_id=app_owner.id, group_id=test_app_owner_group.id, is_owner=True)
         db.session.add(membership)
-        db.session.commit()
+        await db.session.commit()
 
         # Set current user to app owner
         app.state.current_user_email = app_owner.email
@@ -395,11 +395,11 @@ class TestPluginConfigAuthorization:
             "plugin_data": {DummyPlugin.ID: {"configuration": {"enabled": True, "category": "test_id"}}},
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 403
 
-    def test_app_owner_cannot_modify_existing_plugin_config_at_app_level(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, url_for: Any
+    async def test_app_owner_cannot_modify_existing_plugin_config_at_app_level(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, url_for: Any
     ) -> None:
         """Test that app owners cannot modify existing plugin configuration."""
         # Create app owner
@@ -424,7 +424,7 @@ class TestPluginConfigAuthorization:
         # Make app_owner an owner of the test app by directly adding membership
         membership = OktaUserGroupMember(user_id=app_owner.id, group_id=test_app_owner_group.id, is_owner=True)
         db.session.add(membership)
-        db.session.commit()
+        await db.session.commit()
 
         # Set current user to app owner
         app.state.current_user_email = app_owner.email
@@ -443,11 +443,11 @@ class TestPluginConfigAuthorization:
             },
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 403
 
-    def test_access_admin_can_configure_plugin_at_group_level(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
+    async def test_access_admin_can_configure_plugin_at_group_level(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
     ) -> None:
         """Test that Access admins can configure plugins on groups."""
         # Use the default Access admin user (wumpus@discord.com) created in conftest
@@ -461,7 +461,7 @@ class TestPluginConfigAuthorization:
 
         db.session.add(test_app)
         db.session.add(test_group)
-        db.session.commit()
+        await db.session.commit()
 
         # Mock Okta update_group call
         mocker.patch.object(okta, "update_group")
@@ -476,11 +476,11 @@ class TestPluginConfigAuthorization:
             "plugin_data": {DummyPlugin.ID: {"configuration": {"group_id": "external_group_123"}}},
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
 
-    def test_app_owner_can_configure_plugin_at_group_level(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
+    async def test_app_owner_can_configure_plugin_at_group_level(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
     ) -> None:
         """Test that app owners can configure plugins on their app's groups."""
         # Create app owner
@@ -507,7 +507,7 @@ class TestPluginConfigAuthorization:
         # Make user app owner by directly adding membership
         membership = OktaUserGroupMember(user_id=app_owner.id, group_id=test_app_owner_group.id, is_owner=True)
         db.session.add(membership)
-        db.session.commit()
+        await db.session.commit()
 
         # Set current user
         app.state.current_user_email = app_owner.email
@@ -525,11 +525,11 @@ class TestPluginConfigAuthorization:
             "plugin_data": {DummyPlugin.ID: {"configuration": {"group_id": "external_group_456"}}},
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
 
-    def test_group_owner_cannot_configure_plugin_at_group_level(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, url_for: Any
+    async def test_group_owner_cannot_configure_plugin_at_group_level(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, url_for: Any
     ) -> None:
         """Test that group owners (non-app owners) cannot configure plugins on groups."""
         # Create group owner (but not app owner)
@@ -550,7 +550,7 @@ class TestPluginConfigAuthorization:
         # Make user a group owner (not app owner) by directly adding membership
         membership = OktaUserGroupMember(user_id=group_owner.id, group_id=test_group.id, is_owner=True)
         db.session.add(membership)
-        db.session.commit()
+        await db.session.commit()
 
         # Set current user
         app.state.current_user_email = group_owner.email
@@ -565,21 +565,21 @@ class TestPluginConfigAuthorization:
             "plugin_data": {DummyPlugin.ID: {"configuration": {"group_id": "external_group_789"}}},
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 403
 
 
 class TestPluginHelperFunctions:
     """Tests for plugin helper functions like get_config_value, set_status_value, etc."""
 
-    def test_get_config_value(self, db: Db, test_plugin: DummyPlugin) -> None:
+    async def test_get_config_value(self, db: Db, test_plugin: DummyPlugin) -> None:
         """Test getting configuration values from plugin data."""
         test_app = AppFactory.build(
             name="TestApp7",
             plugin_data={DummyPlugin.ID: {"configuration": {"enabled": True, "category": "test_id_123"}}},
         )
         db.session.add(test_app)
-        db.session.commit()
+        await db.session.commit()
 
         enabled = get_config_value(test_app, "enabled", DummyPlugin.ID)
         category = get_config_value(test_app, "category", DummyPlugin.ID)
@@ -587,14 +587,14 @@ class TestPluginHelperFunctions:
         assert enabled is True
         assert category == "test_id_123"
 
-    def test_get_status_value(self, db: Db, test_plugin: DummyPlugin) -> None:
+    async def test_get_status_value(self, db: Db, test_plugin: DummyPlugin) -> None:
         """Test getting status values from plugin data."""
         test_app = AppFactory.build(
             name="TestApp8",
             plugin_data={DummyPlugin.ID: {"status": {"last_sync": "2025-01-15T10:30:00Z", "sync_count": 42}}},
         )
         db.session.add(test_app)
-        db.session.commit()
+        await db.session.commit()
 
         last_sync = get_status_value(test_app, "last_sync", DummyPlugin.ID)
         sync_count = get_status_value(test_app, "sync_count", DummyPlugin.ID)
@@ -602,17 +602,17 @@ class TestPluginHelperFunctions:
         assert last_sync == "2025-01-15T10:30:00Z"
         assert sync_count == 42
 
-    def test_set_status_value(self, db: Db, test_plugin: DummyPlugin) -> None:
+    async def test_set_status_value(self, db: Db, test_plugin: DummyPlugin) -> None:
         """Test setting status values in plugin data."""
         test_app = AppFactory.build(name="TestApp9", plugin_data={})
         db.session.add(test_app)
-        db.session.commit()
+        await db.session.commit()
 
         set_status_value(test_app, "last_sync", "2025-01-15T11:00:00Z", DummyPlugin.ID)
-        db.session.commit()
+        await db.session.commit()
 
-        # Refresh from DB
-        db.session.expire(test_app)
+        # Refresh from DB (expire + sync lazy read would raise under async)
+        await db.session.refresh(test_app)
 
         last_sync = get_status_value(test_app, "last_sync", DummyPlugin.ID)
         assert last_sync == "2025-01-15T11:00:00Z"
@@ -621,14 +621,14 @@ class TestPluginHelperFunctions:
 class TestPluginValidation:
     """Tests for plugin configuration validation."""
 
-    def test_valid_app_config(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, url_for: Any
+    async def test_valid_app_config(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, url_for: Any
     ) -> None:
         """Test that valid app configuration is accepted."""
         test_app = AppFactory.build(name="TestApp10")
 
         db.session.add(test_app)
-        db.session.commit()
+        await db.session.commit()
 
         # Valid configuration
         url = url_for("api-apps.app_by_id", app_id=test_app.id)
@@ -638,17 +638,17 @@ class TestPluginValidation:
             "plugin_data": {DummyPlugin.ID: {"configuration": {"enabled": True, "category": "valid_id"}}},
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
 
-    def test_invalid_app_config(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, url_for: Any
+    async def test_invalid_app_config(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, url_for: Any
     ) -> None:
         """Test that invalid app configuration is rejected."""
         test_app = AppFactory.build(name="TestApp11")
 
         db.session.add(test_app)
-        db.session.commit()
+        await db.session.commit()
 
         # Invalid configuration (missing required 'enabled' field)
         url = url_for("api-apps.app_by_id", app_id=test_app.id)
@@ -665,12 +665,12 @@ class TestPluginValidation:
             },
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 400
         assert "enabled" in str(response.json())
 
-    def test_valid_group_config(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
+    async def test_valid_group_config(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
     ) -> None:
         """Test that valid group configuration is accepted."""
         test_app = AppFactory.build(name="TestApp12", app_group_lifecycle_plugin=DummyPlugin.ID)
@@ -681,7 +681,7 @@ class TestPluginValidation:
 
         db.session.add(test_app)
         db.session.add(test_group)
-        db.session.commit()
+        await db.session.commit()
 
         # Mock Okta update_group call
         mocker.patch.object(okta, "update_group")
@@ -696,11 +696,11 @@ class TestPluginValidation:
             "plugin_data": {DummyPlugin.ID: {"configuration": {"group_id": "external_123"}}},
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
 
-    def test_invalid_group_config(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, url_for: Any
+    async def test_invalid_group_config(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, url_for: Any
     ) -> None:
         """Test that invalid group configuration is rejected."""
         test_app = AppFactory.build(name="TestApp13", app_group_lifecycle_plugin=DummyPlugin.ID)
@@ -711,7 +711,7 @@ class TestPluginValidation:
 
         db.session.add(test_app)
         db.session.add(test_group)
-        db.session.commit()
+        await db.session.commit()
 
         # Invalid configuration (missing required 'group_id' field)
         url = url_for("api-groups.group_by_id", group_id=test_group.id)
@@ -729,7 +729,7 @@ class TestPluginValidation:
             },
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 400
         assert "group_id" in str(response.json())
 
@@ -737,12 +737,12 @@ class TestPluginValidation:
 class TestPluginDataRestore:
     """Tests for the restore_unchanged_app_lifecycle_plugin_data function."""
 
-    def test_restore_unchanged_app_data(self, db: Db, test_plugin: DummyPlugin) -> None:
+    async def test_restore_unchanged_app_data(self, db: Db, test_plugin: DummyPlugin) -> None:
         """Test that restore function merges configuration updates while preserving status."""
         # Create an app with existing plugin data (this simulates the OLD state before update)
         test_app = AppFactory.build(name="TestAppRestore1")
         db.session.add(test_app)
-        db.session.commit()
+        await db.session.commit()
 
         # Save the OLD complete plugin data (before the update)
         old_plugin_data = {
@@ -771,7 +771,7 @@ class TestPluginDataRestore:
         assert test_app.plugin_data[DummyPlugin.ID]["status"]["last_sync"] == "2025-01-01T00:00:00Z"
         assert test_app.plugin_data[DummyPlugin.ID]["status"]["sync_count"] == 10
 
-    def test_restore_unchanged_group_data(self, db: Db, test_plugin: DummyPlugin) -> None:
+    async def test_restore_unchanged_group_data(self, db: Db, test_plugin: DummyPlugin) -> None:
         """Test that restore function works with app groups."""
         test_app = AppFactory.build(name="TestAppRestore2", app_group_lifecycle_plugin=DummyPlugin.ID)
         test_group = AppGroupFactory.build(
@@ -780,7 +780,7 @@ class TestPluginDataRestore:
         )
         db.session.add(test_app)
         db.session.add(test_group)
-        db.session.commit()
+        await db.session.commit()
 
         # Save the OLD complete plugin data (before the update)
         old_plugin_data = {
@@ -802,11 +802,11 @@ class TestPluginDataRestore:
         # Check status was preserved from old data
         assert test_group.plugin_data[DummyPlugin.ID]["status"]["member_count"] == 5
 
-    def test_restore_ignores_non_plugin_data(self, db: Db, test_plugin: DummyPlugin) -> None:
+    async def test_restore_ignores_non_plugin_data(self, db: Db, test_plugin: DummyPlugin) -> None:
         """Test that restore function only processes registered plugin IDs."""
         test_app = AppFactory.build(name="TestAppRestore3")
         db.session.add(test_app)
-        db.session.commit()
+        await db.session.commit()
 
         # OLD data includes both a non-existent plugin and the valid plugin
         old_plugin_data = {
@@ -890,8 +890,8 @@ class TestPluginDirectFunctions:
 class TestPluginGroupUpdatedHook:
     """Tests for the group_updated lifecycle hook fired via the group PUT endpoint."""
 
-    def test_name_change_fires_hook(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
+    async def test_name_change_fires_hook(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
     ) -> None:
         """Test that renaming an app group fires the group_updated hook with old name."""
         test_app = AppFactory.build(
@@ -906,7 +906,7 @@ class TestPluginGroupUpdatedHook:
         )
         db.session.add(test_app)
         db.session.add(test_group)
-        db.session.commit()
+        await db.session.commit()
 
         old_name = test_group.name
         mocker.patch.object(okta, "update_group")
@@ -920,7 +920,7 @@ class TestPluginGroupUpdatedHook:
             "app_id": test_group.app_id,
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
 
         assert len(test_plugin.group_updated_calls) == 1
@@ -929,8 +929,8 @@ class TestPluginGroupUpdatedHook:
         assert hook_old_name == old_name
         assert hook_old_desc == "Same description"
 
-    def test_description_change_fires_hook(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
+    async def test_description_change_fires_hook(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
     ) -> None:
         """Test that changing an app group's description fires the group_updated hook."""
         test_app = AppFactory.build(
@@ -945,7 +945,7 @@ class TestPluginGroupUpdatedHook:
         )
         db.session.add(test_app)
         db.session.add(test_group)
-        db.session.commit()
+        await db.session.commit()
 
         mocker.patch.object(okta, "update_group")
 
@@ -957,7 +957,7 @@ class TestPluginGroupUpdatedHook:
             "app_id": test_group.app_id,
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
 
         assert len(test_plugin.group_updated_calls) == 1
@@ -965,8 +965,8 @@ class TestPluginGroupUpdatedHook:
         assert hook_old_name == test_group.name
         assert hook_old_desc == "Old description"
 
-    def test_no_change_does_not_fire_hook(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
+    async def test_no_change_does_not_fire_hook(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
     ) -> None:
         """Test that updating a group without changing name or description does not fire the hook."""
         test_app = AppFactory.build(
@@ -981,7 +981,7 @@ class TestPluginGroupUpdatedHook:
         )
         db.session.add(test_app)
         db.session.add(test_group)
-        db.session.commit()
+        await db.session.commit()
 
         mocker.patch.object(okta, "update_group")
 
@@ -993,13 +993,13 @@ class TestPluginGroupUpdatedHook:
             "app_id": test_group.app_id,
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
 
         assert len(test_plugin.group_updated_calls) == 0
 
-    def test_hook_not_fired_without_lifecycle_plugin(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
+    async def test_hook_not_fired_without_lifecycle_plugin(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
     ) -> None:
         """Test that group_updated hook does not fire when the app has no lifecycle plugin configured."""
         test_app = AppFactory.build(
@@ -1013,7 +1013,7 @@ class TestPluginGroupUpdatedHook:
         )
         db.session.add(test_app)
         db.session.add(test_group)
-        db.session.commit()
+        await db.session.commit()
 
         mocker.patch.object(okta, "update_group")
 
@@ -1025,13 +1025,13 @@ class TestPluginGroupUpdatedHook:
             "app_id": test_group.app_id,
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
 
         assert len(test_plugin.group_updated_calls) == 0
 
-    def test_null_description_normalized(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
+    async def test_null_description_normalized(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
     ) -> None:
         """Test that a group with NULL description is treated as empty string for comparison."""
         test_app = AppFactory.build(
@@ -1046,7 +1046,7 @@ class TestPluginGroupUpdatedHook:
         )
         db.session.add(test_app)
         db.session.add(test_group)
-        db.session.commit()
+        await db.session.commit()
 
         mocker.patch.object(okta, "update_group")
 
@@ -1058,7 +1058,7 @@ class TestPluginGroupUpdatedHook:
             "app_id": test_group.app_id,
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
 
         # NULL -> "" should not be considered a change
@@ -1068,8 +1068,8 @@ class TestPluginGroupUpdatedHook:
 class TestPluginGroupDeletedOnTypeChange:
     """Tests for the group_deleted hook fired when an AppGroup's type is changed to Group or Role."""
 
-    def test_app_group_to_okta_group_fires_group_deleted(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
+    async def test_app_group_to_okta_group_fires_group_deleted(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
     ) -> None:
         """Test that converting an AppGroup to a plain Group fires the group_deleted hook."""
         test_app = AppFactory.build(
@@ -1084,7 +1084,7 @@ class TestPluginGroupDeletedOnTypeChange:
         )
         db.session.add(test_app)
         db.session.add(test_group)
-        db.session.commit()
+        await db.session.commit()
 
         group_id = test_group.id
         mocker.patch.object(okta, "update_group")
@@ -1096,15 +1096,15 @@ class TestPluginGroupDeletedOnTypeChange:
             "description": "Now a plain group",
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
         assert response.json()["type"] == "okta_group"
 
         assert len(test_plugin.group_deleted_calls) == 1
         assert test_plugin.group_deleted_calls[0] == group_id
 
-    def test_app_group_to_role_group_fires_group_deleted(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
+    async def test_app_group_to_role_group_fires_group_deleted(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
     ) -> None:
         """Test that converting an AppGroup to a Role fires the group_deleted hook."""
         test_app = AppFactory.build(
@@ -1119,7 +1119,7 @@ class TestPluginGroupDeletedOnTypeChange:
         )
         db.session.add(test_app)
         db.session.add(test_group)
-        db.session.commit()
+        await db.session.commit()
 
         group_id = test_group.id
         mocker.patch.object(okta, "update_group")
@@ -1131,15 +1131,15 @@ class TestPluginGroupDeletedOnTypeChange:
             "description": "Now a role",
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
         assert response.json()["type"] == "role_group"
 
         assert len(test_plugin.group_deleted_calls) == 1
         assert test_plugin.group_deleted_calls[0] == group_id
 
-    def test_no_hook_without_lifecycle_plugin(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
+    async def test_no_hook_without_lifecycle_plugin(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
     ) -> None:
         """Test that group_deleted hook does not fire when the app has no lifecycle plugin."""
         test_app = AppFactory.build(
@@ -1153,7 +1153,7 @@ class TestPluginGroupDeletedOnTypeChange:
         )
         db.session.add(test_app)
         db.session.add(test_group)
-        db.session.commit()
+        await db.session.commit()
 
         mocker.patch.object(okta, "update_group")
 
@@ -1164,7 +1164,7 @@ class TestPluginGroupDeletedOnTypeChange:
             "description": "No plugin",
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
 
         assert len(test_plugin.group_deleted_calls) == 0
@@ -1173,8 +1173,8 @@ class TestPluginGroupDeletedOnTypeChange:
 class TestPluginGroupCreatedOnTypeChange:
     """Tests for the group_created hook fired when a Group or Role is converted to an AppGroup."""
 
-    def test_okta_group_to_app_group_fires_group_created(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
+    async def test_okta_group_to_app_group_fires_group_created(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
     ) -> None:
         """Test that converting an OktaGroup to an AppGroup fires the group_created hook."""
         test_app = AppFactory.build(
@@ -1185,7 +1185,7 @@ class TestPluginGroupCreatedOnTypeChange:
         test_group = OktaGroupFactory.build(name="PlainGroup-ToAppGroup")
         db.session.add(test_app)
         db.session.add(test_group)
-        db.session.commit()
+        await db.session.commit()
 
         group_id = test_group.id
         mocker.patch.object(okta, "update_group")
@@ -1198,15 +1198,15 @@ class TestPluginGroupCreatedOnTypeChange:
             "app_id": test_app.id,
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
         assert response.json()["type"] == "app_group"
 
         assert len(test_plugin.group_created_calls) == 1
         assert test_plugin.group_created_calls[0] == group_id
 
-    def test_role_group_to_app_group_fires_group_created(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
+    async def test_role_group_to_app_group_fires_group_created(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
     ) -> None:
         """Test that converting a RoleGroup to an AppGroup fires the group_created hook."""
         test_app = AppFactory.build(
@@ -1217,7 +1217,7 @@ class TestPluginGroupCreatedOnTypeChange:
         test_group = RoleGroupFactory.build(name="Role-ToAppGroup")
         db.session.add(test_app)
         db.session.add(test_group)
-        db.session.commit()
+        await db.session.commit()
 
         group_id = test_group.id
         mocker.patch.object(okta, "update_group")
@@ -1230,15 +1230,15 @@ class TestPluginGroupCreatedOnTypeChange:
             "app_id": test_app.id,
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
         assert response.json()["type"] == "app_group"
 
         assert len(test_plugin.group_created_calls) == 1
         assert test_plugin.group_created_calls[0] == group_id
 
-    def test_no_hook_without_lifecycle_plugin(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
+    async def test_no_hook_without_lifecycle_plugin(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
     ) -> None:
         """Test that group_created hook does not fire when the app has no lifecycle plugin."""
         test_app = AppFactory.build(
@@ -1248,7 +1248,7 @@ class TestPluginGroupCreatedOnTypeChange:
         test_group = OktaGroupFactory.build(name="PlainGroup-NoPlugin")
         db.session.add(test_app)
         db.session.add(test_group)
-        db.session.commit()
+        await db.session.commit()
 
         mocker.patch.object(okta, "update_group")
 
@@ -1260,7 +1260,7 @@ class TestPluginGroupCreatedOnTypeChange:
             "app_id": test_app.id,
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
 
         assert len(test_plugin.group_created_calls) == 0
@@ -1269,7 +1269,7 @@ class TestPluginGroupCreatedOnTypeChange:
 class TestPluginMembershipHooks:
     """Tests for plugin lifecycle hooks when members are added/removed."""
 
-    def test_direct_member_removed_loses_all_access(
+    async def test_direct_member_removed_loses_all_access(
         self, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture
     ) -> None:
         """Test hook is called when a member is removed and loses all access to the group."""
@@ -1289,29 +1289,29 @@ class TestPluginMembershipHooks:
         db.session.add(test_app)
         db.session.add(test_group)
         db.session.add(user)
-        db.session.commit()
+        await db.session.commit()
 
         # Mock Okta calls
-        mocker.patch.object(okta, "async_add_user_to_group", return_value=None)
-        mocker.patch.object(okta, "async_remove_user_from_group", return_value=None)
+        mocker.patch.object(okta, "add_user_to_group", return_value=None)
+        mocker.patch.object(okta, "remove_user_from_group", return_value=None)
 
         # Add the user to the group (this will trigger members_added hook)
         from api.operations import ModifyGroupUsers
 
-        ModifyGroupUsers(group=test_group, members_to_add=[user.id], sync_to_okta=False).execute()
+        await ModifyGroupUsers(group=test_group, members_to_add=[user.id], sync_to_okta=False).execute()
 
         # Clear the hook calls from adding
         test_plugin.members_added_calls.clear()
         test_plugin.members_removed_calls.clear()
 
         # Remove the user from the group (user has no other access paths)
-        ModifyGroupUsers(group=test_group, members_to_remove=[user.id], sync_to_okta=False).execute()
+        await ModifyGroupUsers(group=test_group, members_to_remove=[user.id], sync_to_okta=False).execute()
 
         # Assert: Hook should be called because user lost all access
         assert len(test_plugin.members_removed_calls) == 1
         assert test_plugin.members_removed_calls[0] == (test_group.id, [user.id])
 
-    def test_direct_member_removed_but_has_redundant_access(
+    async def test_direct_member_removed_but_has_redundant_access(
         self, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture
     ) -> None:
         """Test hook is NOT called when trying to remove direct access but user only has role-based access."""
@@ -1336,17 +1336,17 @@ class TestPluginMembershipHooks:
         db.session.add(test_group)
         db.session.add(role_group)
         db.session.add(user)
-        db.session.commit()
+        await db.session.commit()
 
         # Mock Okta calls
-        mocker.patch.object(okta, "async_add_user_to_group", return_value=None)
-        mocker.patch.object(okta, "async_remove_user_from_group", return_value=None)
+        mocker.patch.object(okta, "add_user_to_group", return_value=None)
+        mocker.patch.object(okta, "remove_user_from_group", return_value=None)
 
         # Associate the app group with a role
-        ModifyRoleGroups(role_group=role_group, groups_to_add=[test_group.id], sync_to_okta=False).execute()
+        await ModifyRoleGroups(role_group=role_group, groups_to_add=[test_group.id], sync_to_okta=False).execute()
 
         # Add the user to the role (gives them access to the group via role)
-        ModifyGroupUsers(group=role_group, members_to_add=[user.id], sync_to_okta=False).execute()
+        await ModifyGroupUsers(group=role_group, members_to_add=[user.id], sync_to_okta=False).execute()
 
         # Clear the hook calls from adding
         test_plugin.members_added_calls.clear()
@@ -1354,12 +1354,12 @@ class TestPluginMembershipHooks:
 
         # Try to remove direct membership (but user only has role-based access, no direct access to remove)
         # This should not trigger the hook because user still has role-based access
-        ModifyGroupUsers(group=test_group, members_to_remove=[user.id], sync_to_okta=False).execute()
+        await ModifyGroupUsers(group=test_group, members_to_remove=[user.id], sync_to_okta=False).execute()
 
         # Assert: Hook should NOT be called because user still has access via role
         assert len(test_plugin.members_removed_calls) == 0
 
-    def test_direct_member_added_gains_first_access(
+    async def test_direct_member_added_gains_first_access(
         self, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture
     ) -> None:
         """Test hook is called when a member is added for the first time."""
@@ -1379,21 +1379,21 @@ class TestPluginMembershipHooks:
         db.session.add(test_app)
         db.session.add(test_group)
         db.session.add(user)
-        db.session.commit()
+        await db.session.commit()
 
         # Mock Okta calls
-        mocker.patch.object(okta, "async_add_user_to_group", return_value=None)
+        mocker.patch.object(okta, "add_user_to_group", return_value=None)
 
         # Add the user to the group for the first time
         from api.operations import ModifyGroupUsers
 
-        ModifyGroupUsers(group=test_group, members_to_add=[user.id], sync_to_okta=False).execute()
+        await ModifyGroupUsers(group=test_group, members_to_add=[user.id], sync_to_okta=False).execute()
 
         # Assert: Hook should be called because user gained first access
         assert len(test_plugin.members_added_calls) == 1
         assert test_plugin.members_added_calls[0] == (test_group.id, [user.id])
 
-    def test_direct_member_added_but_already_has_access(
+    async def test_direct_member_added_but_already_has_access(
         self, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture
     ) -> None:
         """Test hook is NOT called when a member is added directly but already has access via a role."""
@@ -1418,27 +1418,27 @@ class TestPluginMembershipHooks:
         db.session.add(test_group)
         db.session.add(role_group)
         db.session.add(user)
-        db.session.commit()
+        await db.session.commit()
 
         # Mock Okta calls
-        mocker.patch.object(okta, "async_add_user_to_group", return_value=None)
+        mocker.patch.object(okta, "add_user_to_group", return_value=None)
 
         # Associate the app group with a role
-        ModifyRoleGroups(role_group=role_group, groups_to_add=[test_group.id], sync_to_okta=False).execute()
+        await ModifyRoleGroups(role_group=role_group, groups_to_add=[test_group.id], sync_to_okta=False).execute()
 
         # Add the user to the role (gives them access to the group)
-        ModifyGroupUsers(group=role_group, members_to_add=[user.id], sync_to_okta=False).execute()
+        await ModifyGroupUsers(group=role_group, members_to_add=[user.id], sync_to_okta=False).execute()
 
         # Clear the hook calls from adding via role
         test_plugin.members_added_calls.clear()
 
         # Add the user directly to the group (they already have access via role)
-        ModifyGroupUsers(group=test_group, members_to_add=[user.id], sync_to_okta=False).execute()
+        await ModifyGroupUsers(group=test_group, members_to_add=[user.id], sync_to_okta=False).execute()
 
         # Assert: Hook should NOT be called because user already had access via role
         assert len(test_plugin.members_added_calls) == 0
 
-    def test_role_member_removed_loses_all_access_to_associated_group(
+    async def test_role_member_removed_loses_all_access_to_associated_group(
         self, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture
     ) -> None:
         """Test hook is called when a role member is removed and loses all access to role-associated groups."""
@@ -1463,30 +1463,30 @@ class TestPluginMembershipHooks:
         db.session.add(test_group)
         db.session.add(role_group)
         db.session.add(user)
-        db.session.commit()
+        await db.session.commit()
 
         # Mock Okta calls
-        mocker.patch.object(okta, "async_add_user_to_group", return_value=None)
-        mocker.patch.object(okta, "async_remove_user_from_group", return_value=None)
+        mocker.patch.object(okta, "add_user_to_group", return_value=None)
+        mocker.patch.object(okta, "remove_user_from_group", return_value=None)
 
         # Associate the app group with the role as a member group
-        ModifyRoleGroups(role_group=role_group, groups_to_add=[test_group.id], sync_to_okta=False).execute()
+        await ModifyRoleGroups(role_group=role_group, groups_to_add=[test_group.id], sync_to_okta=False).execute()
 
         # Add the user to the role (which gives them access to the associated group)
-        ModifyGroupUsers(group=role_group, members_to_add=[user.id], sync_to_okta=False).execute()
+        await ModifyGroupUsers(group=role_group, members_to_add=[user.id], sync_to_okta=False).execute()
 
         # Clear the hook calls from adding
         test_plugin.members_added_calls.clear()
         test_plugin.members_removed_calls.clear()
 
         # Remove the user from the role (user loses access to associated group)
-        ModifyGroupUsers(group=role_group, members_to_remove=[user.id], sync_to_okta=False).execute()
+        await ModifyGroupUsers(group=role_group, members_to_remove=[user.id], sync_to_okta=False).execute()
 
         # Assert: Hook should be called for the associated group because user lost all access
         assert len(test_plugin.members_removed_calls) == 1
         assert test_plugin.members_removed_calls[0] == (test_group.id, [user.id])
 
-    def test_role_member_removed_but_has_redundant_access_via_another_role(
+    async def test_role_member_removed_but_has_redundant_access_via_another_role(
         self, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture
     ) -> None:
         """Test hook is NOT called when a role member is removed but still has access via another role."""
@@ -1513,31 +1513,31 @@ class TestPluginMembershipHooks:
         db.session.add(role_group_1)
         db.session.add(role_group_2)
         db.session.add(user)
-        db.session.commit()
+        await db.session.commit()
 
         # Mock Okta calls
-        mocker.patch.object(okta, "async_add_user_to_group", return_value=None)
-        mocker.patch.object(okta, "async_remove_user_from_group", return_value=None)
+        mocker.patch.object(okta, "add_user_to_group", return_value=None)
+        mocker.patch.object(okta, "remove_user_from_group", return_value=None)
 
         # Associate the app group with both roles as member groups
-        ModifyRoleGroups(role_group=role_group_1, groups_to_add=[test_group.id], sync_to_okta=False).execute()
-        ModifyRoleGroups(role_group=role_group_2, groups_to_add=[test_group.id], sync_to_okta=False).execute()
+        await ModifyRoleGroups(role_group=role_group_1, groups_to_add=[test_group.id], sync_to_okta=False).execute()
+        await ModifyRoleGroups(role_group=role_group_2, groups_to_add=[test_group.id], sync_to_okta=False).execute()
 
         # Add the user to both roles (gives them redundant access to the associated group)
-        ModifyGroupUsers(group=role_group_1, members_to_add=[user.id], sync_to_okta=False).execute()
-        ModifyGroupUsers(group=role_group_2, members_to_add=[user.id], sync_to_okta=False).execute()
+        await ModifyGroupUsers(group=role_group_1, members_to_add=[user.id], sync_to_okta=False).execute()
+        await ModifyGroupUsers(group=role_group_2, members_to_add=[user.id], sync_to_okta=False).execute()
 
         # Clear the hook calls from adding
         test_plugin.members_added_calls.clear()
         test_plugin.members_removed_calls.clear()
 
         # Remove the user from one role (user still has access via the other role)
-        ModifyGroupUsers(group=role_group_1, members_to_remove=[user.id], sync_to_okta=False).execute()
+        await ModifyGroupUsers(group=role_group_1, members_to_remove=[user.id], sync_to_okta=False).execute()
 
         # Assert: Hook should NOT be called because user still has access via role_group_2
         assert len(test_plugin.members_removed_calls) == 0
 
-    def test_role_member_added_gains_first_access_to_associated_group(
+    async def test_role_member_added_gains_first_access_to_associated_group(
         self, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture
     ) -> None:
         """Test hook is called when a role member is added and gains first access to role-associated groups."""
@@ -1562,22 +1562,22 @@ class TestPluginMembershipHooks:
         db.session.add(test_group)
         db.session.add(role_group)
         db.session.add(user)
-        db.session.commit()
+        await db.session.commit()
 
         # Mock Okta calls
-        mocker.patch.object(okta, "async_add_user_to_group", return_value=None)
+        mocker.patch.object(okta, "add_user_to_group", return_value=None)
 
         # Associate the app group with the role as a member group
-        ModifyRoleGroups(role_group=role_group, groups_to_add=[test_group.id], sync_to_okta=False).execute()
+        await ModifyRoleGroups(role_group=role_group, groups_to_add=[test_group.id], sync_to_okta=False).execute()
 
         # Add the user to the role (gives them first access to the associated group)
-        ModifyGroupUsers(group=role_group, members_to_add=[user.id], sync_to_okta=False).execute()
+        await ModifyGroupUsers(group=role_group, members_to_add=[user.id], sync_to_okta=False).execute()
 
         # Assert: Hook should be called for the associated group because user gained first access
         assert len(test_plugin.members_added_calls) == 1
         assert test_plugin.members_added_calls[0] == (test_group.id, [user.id])
 
-    def test_role_member_added_but_already_has_access_to_associated_group(
+    async def test_role_member_added_but_already_has_access_to_associated_group(
         self, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture
     ) -> None:
         """Test hook is NOT called when a role member is added but already has access to role-associated groups."""
@@ -1602,25 +1602,25 @@ class TestPluginMembershipHooks:
         db.session.add(test_group)
         db.session.add(role_group)
         db.session.add(user)
-        db.session.commit()
+        await db.session.commit()
 
         # Mock Okta calls
-        mocker.patch.object(okta, "async_add_user_to_group", return_value=None)
+        mocker.patch.object(okta, "add_user_to_group", return_value=None)
 
         # First, give the user direct access to the group
-        ModifyGroupUsers(group=test_group, members_to_add=[user.id], sync_to_okta=False).execute()
+        await ModifyGroupUsers(group=test_group, members_to_add=[user.id], sync_to_okta=False).execute()
 
         # Clear the hook calls from first add
         test_plugin.members_added_calls.clear()
 
         # Now associate the app group with a role and add the user to the role
-        ModifyRoleGroups(role_group=role_group, groups_to_add=[test_group.id], sync_to_okta=False).execute()
-        ModifyGroupUsers(group=role_group, members_to_add=[user.id], sync_to_okta=False).execute()
+        await ModifyRoleGroups(role_group=role_group, groups_to_add=[test_group.id], sync_to_okta=False).execute()
+        await ModifyGroupUsers(group=role_group, members_to_add=[user.id], sync_to_okta=False).execute()
 
         # Assert: Hook should NOT be called for the associated group because user already had access
         assert len(test_plugin.members_added_calls) == 0
 
-    def test_role_removed_from_group_user_loses_all_access(
+    async def test_role_removed_from_group_user_loses_all_access(
         self, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture
     ) -> None:
         """Test hook is called when a role is removed from a group and user loses all access."""
@@ -1645,30 +1645,30 @@ class TestPluginMembershipHooks:
         db.session.add(test_group)
         db.session.add(role_group)
         db.session.add(user)
-        db.session.commit()
+        await db.session.commit()
 
         # Mock Okta calls
-        mocker.patch.object(okta, "async_add_user_to_group", return_value=None)
-        mocker.patch.object(okta, "async_remove_user_from_group", return_value=None)
+        mocker.patch.object(okta, "add_user_to_group", return_value=None)
+        mocker.patch.object(okta, "remove_user_from_group", return_value=None)
 
         # Associate the app group with the role
-        ModifyRoleGroups(role_group=role_group, groups_to_add=[test_group.id], sync_to_okta=False).execute()
+        await ModifyRoleGroups(role_group=role_group, groups_to_add=[test_group.id], sync_to_okta=False).execute()
 
         # Add the user to the role (gives them access to the group via role)
-        ModifyGroupUsers(group=role_group, members_to_add=[user.id], sync_to_okta=False).execute()
+        await ModifyGroupUsers(group=role_group, members_to_add=[user.id], sync_to_okta=False).execute()
 
         # Clear the hook calls from adding
         test_plugin.members_added_calls.clear()
         test_plugin.members_removed_calls.clear()
 
         # Remove the group from the role (user loses all access to the group)
-        ModifyRoleGroups(role_group=role_group, groups_to_remove=[test_group.id], sync_to_okta=False).execute()
+        await ModifyRoleGroups(role_group=role_group, groups_to_remove=[test_group.id], sync_to_okta=False).execute()
 
         # Assert: Hook should be called because user lost all access
         assert len(test_plugin.members_removed_calls) == 1
         assert test_plugin.members_removed_calls[0] == (test_group.id, [user.id])
 
-    def test_role_removed_from_group_user_has_redundant_access(
+    async def test_role_removed_from_group_user_has_redundant_access(
         self, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture
     ) -> None:
         """Test hook is NOT called when a role is removed from a group but user has direct access."""
@@ -1693,30 +1693,30 @@ class TestPluginMembershipHooks:
         db.session.add(test_group)
         db.session.add(role_group)
         db.session.add(user)
-        db.session.commit()
+        await db.session.commit()
 
         # Mock Okta calls
-        mocker.patch.object(okta, "async_add_user_to_group", return_value=None)
-        mocker.patch.object(okta, "async_remove_user_from_group", return_value=None)
+        mocker.patch.object(okta, "add_user_to_group", return_value=None)
+        mocker.patch.object(okta, "remove_user_from_group", return_value=None)
 
         # Give the user direct access to the group
-        ModifyGroupUsers(group=test_group, members_to_add=[user.id], sync_to_okta=False).execute()
+        await ModifyGroupUsers(group=test_group, members_to_add=[user.id], sync_to_okta=False).execute()
 
         # Also give them role-based access
-        ModifyRoleGroups(role_group=role_group, groups_to_add=[test_group.id], sync_to_okta=False).execute()
-        ModifyGroupUsers(group=role_group, members_to_add=[user.id], sync_to_okta=False).execute()
+        await ModifyRoleGroups(role_group=role_group, groups_to_add=[test_group.id], sync_to_okta=False).execute()
+        await ModifyGroupUsers(group=role_group, members_to_add=[user.id], sync_to_okta=False).execute()
 
         # Clear the hook calls from adding
         test_plugin.members_added_calls.clear()
         test_plugin.members_removed_calls.clear()
 
         # Remove the group from the role (user still has direct access to the group)
-        ModifyRoleGroups(role_group=role_group, groups_to_remove=[test_group.id], sync_to_okta=False).execute()
+        await ModifyRoleGroups(role_group=role_group, groups_to_remove=[test_group.id], sync_to_okta=False).execute()
 
         # Assert: Hook should NOT be called because user still has direct access
         assert len(test_plugin.members_removed_calls) == 0
 
-    def test_role_added_to_group_user_gains_first_access(
+    async def test_role_added_to_group_user_gains_first_access(
         self, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture
     ) -> None:
         """Test hook is called when a role is added to a group and user gains first access."""
@@ -1741,26 +1741,26 @@ class TestPluginMembershipHooks:
         db.session.add(test_group)
         db.session.add(role_group)
         db.session.add(user)
-        db.session.commit()
+        await db.session.commit()
 
         # Mock Okta calls
-        mocker.patch.object(okta, "async_add_user_to_group", return_value=None)
+        mocker.patch.object(okta, "add_user_to_group", return_value=None)
 
         # Add the user to the role first (before associating the group with the role)
-        ModifyGroupUsers(group=role_group, members_to_add=[user.id], sync_to_okta=False).execute()
+        await ModifyGroupUsers(group=role_group, members_to_add=[user.id], sync_to_okta=False).execute()
 
         # Clear the hook calls from adding user to role
         test_plugin.members_added_calls.clear()
         test_plugin.members_removed_calls.clear()
 
         # Now associate the app group with the role (user gains first access to the group)
-        ModifyRoleGroups(role_group=role_group, groups_to_add=[test_group.id], sync_to_okta=False).execute()
+        await ModifyRoleGroups(role_group=role_group, groups_to_add=[test_group.id], sync_to_okta=False).execute()
 
         # Assert: Hook should be called because user gained first access
         assert len(test_plugin.members_added_calls) == 1
         assert test_plugin.members_added_calls[0] == (test_group.id, [user.id])
 
-    def test_role_added_to_group_user_already_has_access(
+    async def test_role_added_to_group_user_already_has_access(
         self, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture
     ) -> None:
         """Test hook is NOT called when a role is added to a group but user already has direct access."""
@@ -1785,23 +1785,23 @@ class TestPluginMembershipHooks:
         db.session.add(test_group)
         db.session.add(role_group)
         db.session.add(user)
-        db.session.commit()
+        await db.session.commit()
 
         # Mock Okta calls
-        mocker.patch.object(okta, "async_add_user_to_group", return_value=None)
+        mocker.patch.object(okta, "add_user_to_group", return_value=None)
 
         # Give the user direct access to the group first
-        ModifyGroupUsers(group=test_group, members_to_add=[user.id], sync_to_okta=False).execute()
+        await ModifyGroupUsers(group=test_group, members_to_add=[user.id], sync_to_okta=False).execute()
 
         # Add the user to the role
-        ModifyGroupUsers(group=role_group, members_to_add=[user.id], sync_to_okta=False).execute()
+        await ModifyGroupUsers(group=role_group, members_to_add=[user.id], sync_to_okta=False).execute()
 
         # Clear the hook calls from adding
         test_plugin.members_added_calls.clear()
         test_plugin.members_removed_calls.clear()
 
         # Now associate the app group with the role (user already has direct access)
-        ModifyRoleGroups(role_group=role_group, groups_to_add=[test_group.id], sync_to_okta=False).execute()
+        await ModifyRoleGroups(role_group=role_group, groups_to_add=[test_group.id], sync_to_okta=False).execute()
 
         # Assert: Hook should NOT be called because user already had access
         assert len(test_plugin.members_added_calls) == 0
@@ -1810,8 +1810,8 @@ class TestPluginMembershipHooks:
 class TestPluginAuditLogging:
     """Tests for plugin configuration audit logging."""
 
-    def test_audit_log_plugin_assignment_at_app_level(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, caplog: Any, url_for: Any
+    async def test_audit_log_plugin_assignment_at_app_level(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, caplog: Any, url_for: Any
     ) -> None:
         """Test that assigning a plugin to an app creates an audit log entry."""
         import json
@@ -1823,7 +1823,7 @@ class TestPluginAuditLogging:
 
         test_app = AppFactory.build(name="TestApp", description="Test App")
         db.session.add(test_app)
-        db.session.commit()
+        await db.session.commit()
 
         # Assign plugin to the app
         url = url_for("api-apps.app_by_id", app_id=test_app.id)
@@ -1832,7 +1832,7 @@ class TestPluginAuditLogging:
             "app_group_lifecycle_plugin": DummyPlugin.ID,
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
 
         # Check audit log
@@ -1849,8 +1849,8 @@ class TestPluginAuditLogging:
         assert log_data["old_app_group_lifecycle_plugin"] is None
         assert log_data["current_user_email"] == settings.CURRENT_OKTA_USER_EMAIL
 
-    def test_audit_log_plugin_configuration_change_at_app_level(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, caplog: Any, url_for: Any
+    async def test_audit_log_plugin_configuration_change_at_app_level(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, caplog: Any, url_for: Any
     ) -> None:
         """Test that changing app-level plugin configuration creates an audit log entry."""
         import json
@@ -1867,7 +1867,7 @@ class TestPluginAuditLogging:
             plugin_data={DummyPlugin.ID: {"configuration": {"enabled": True, "category": "original"}}},
         )
         db.session.add(test_app)
-        db.session.commit()
+        await db.session.commit()
 
         caplog.clear()
 
@@ -1878,7 +1878,7 @@ class TestPluginAuditLogging:
             "plugin_data": {DummyPlugin.ID: {"configuration": {"enabled": False, "category": "updated"}}},
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
 
         # Check audit log
@@ -1896,8 +1896,8 @@ class TestPluginAuditLogging:
         assert log_data["old_plugin_data"][DummyPlugin.ID]["configuration"]["category"] == "original"
         assert log_data["current_user_email"] == settings.CURRENT_OKTA_USER_EMAIL
 
-    def test_audit_log_plugin_removal_at_app_level(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, caplog: Any, url_for: Any
+    async def test_audit_log_plugin_removal_at_app_level(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, caplog: Any, url_for: Any
     ) -> None:
         """Test that removing a plugin from an app creates an audit log entry."""
         import json
@@ -1914,7 +1914,7 @@ class TestPluginAuditLogging:
             plugin_data={DummyPlugin.ID: {"configuration": {"enabled": True}}},
         )
         db.session.add(test_app)
-        db.session.commit()
+        await db.session.commit()
 
         caplog.clear()
 
@@ -1922,7 +1922,7 @@ class TestPluginAuditLogging:
         url = url_for("api-apps.app_by_id", app_id=test_app.id)
         data = {"name": test_app.name, "app_group_lifecycle_plugin": None}
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
 
         # Check audit log
@@ -1938,9 +1938,9 @@ class TestPluginAuditLogging:
         assert log_data["old_app_group_lifecycle_plugin"] == DummyPlugin.ID
         assert log_data["current_user_email"] == settings.CURRENT_OKTA_USER_EMAIL
 
-    def test_audit_log_plugin_configuration_change_at_group_level(
+    async def test_audit_log_plugin_configuration_change_at_group_level(
         self,
-        client: TestClient,
+        client: AsyncClient,
         db: Db,
         app: FastAPI,
         test_plugin: DummyPlugin,
@@ -1970,7 +1970,7 @@ class TestPluginAuditLogging:
 
         db.session.add(test_app)
         db.session.add(test_group)
-        db.session.commit()
+        await db.session.commit()
 
         caplog.clear()
 
@@ -1986,7 +1986,7 @@ class TestPluginAuditLogging:
             "plugin_data": {DummyPlugin.ID: {"configuration": {"group_id": "external-456"}}},
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
 
         # Check audit log
@@ -2003,8 +2003,8 @@ class TestPluginAuditLogging:
         assert log_data["old_plugin_data"][DummyPlugin.ID]["configuration"]["custom_tag"] == "original"
         assert log_data["current_user_email"] == settings.CURRENT_OKTA_USER_EMAIL
 
-    def test_no_audit_log_when_plugin_unchanged_at_app_level(
-        self, client: TestClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, caplog: Any, url_for: Any
+    async def test_no_audit_log_when_plugin_unchanged_at_app_level(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, caplog: Any, url_for: Any
     ) -> None:
         """Test that no audit log is created when plugin configuration is unchanged."""
         import logging
@@ -2019,7 +2019,7 @@ class TestPluginAuditLogging:
             app_group_lifecycle_plugin=DummyPlugin.ID,
         )
         db.session.add(test_app)
-        db.session.commit()
+        await db.session.commit()
 
         caplog.clear()
 
@@ -2027,7 +2027,7 @@ class TestPluginAuditLogging:
         url = url_for("api-apps.app_by_id", app_id=test_app.id)
         data = {"name": test_app.name, "description": "Updated description"}
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
 
         # Check that no plugin audit log was created
@@ -2035,9 +2035,9 @@ class TestPluginAuditLogging:
         plugin_logs = [log for log in audit_logs if EventType.app_modify_plugin.value in log.message]
         assert len(plugin_logs) == 0
 
-    def test_no_audit_log_when_plugin_unchanged_at_group_level(
+    async def test_no_audit_log_when_plugin_unchanged_at_group_level(
         self,
-        client: TestClient,
+        client: AsyncClient,
         db: Db,
         app: FastAPI,
         test_plugin: DummyPlugin,
@@ -2065,7 +2065,7 @@ class TestPluginAuditLogging:
 
         db.session.add(test_app)
         db.session.add(test_group)
-        db.session.commit()
+        await db.session.commit()
 
         caplog.clear()
 
@@ -2081,7 +2081,7 @@ class TestPluginAuditLogging:
             "description": "Updated description",
         }
 
-        response = client.put(url, json=data)
+        response = await client.put(url, json=data)
         assert response.status_code == 200
 
         # Check that no plugin audit log was created

--- a/tests/test_approve_reject_stale_state.py
+++ b/tests/test_approve_reject_stale_state.py
@@ -18,14 +18,13 @@ Postgres; the single-connection sqlite harness shares one connection, so these
 simulate the stale/already-resolved state deterministically instead.
 """
 
-import asyncio
 import uuid
 
 import pytest
 from fastapi import FastAPI
 from okta.models import Group
 from pytest_mock import MockerFixture
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select, update
 from starlette.requests import Request
 
 from api.config import settings
@@ -52,6 +51,7 @@ from api.operations import (
     RejectAccessRequest,
 )
 from api.services import okta
+from tests.helpers import db_count
 
 
 @pytest.fixture(autouse=True)
@@ -59,27 +59,29 @@ def _mock_okta(mocker: MockerFixture) -> None:
     # The approve path pushes membership to Okta via ModifyGroupUsers; stub it
     # so these tests never hit the network. patch.object auto-detects the async
     # functions and substitutes AsyncMocks.
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
     # Group-request approval creates a group in Okta; stub it.
     mocker.patch.object(okta, "create_group", side_effect=lambda name, desc: Group({"id": uuid.uuid4().hex}))
 
 
-def _access_owner(db: Db) -> OktaUser:
-    owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+async def _access_owner(db: Db) -> OktaUser:
+    owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
     assert owner is not None
     return owner
 
 
-def _active_direct_member_count(db: Db, *, user_id: str, group_id: str, is_owner: bool = False) -> int:
-    return (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.user_id == user_id)
-        .filter(OktaUserGroupMember.group_id == group_id)
-        .filter(OktaUserGroupMember.is_owner.is_(is_owner))
-        .filter(OktaUserGroupMember.role_group_map_id.is_(None))
-        .filter(or_(OktaUserGroupMember.ended_at.is_(None), OktaUserGroupMember.ended_at > func.now()))
-        .count()
+async def _active_direct_member_count(db: Db, *, user_id: str, group_id: str, is_owner: bool = False) -> int:
+    return await db_count(
+        db.session,
+        select(OktaUserGroupMember)
+        .where(OktaUserGroupMember.user_id == user_id)
+        .where(OktaUserGroupMember.group_id == group_id)
+        .where(OktaUserGroupMember.is_owner.is_(is_owner))
+        .where(OktaUserGroupMember.role_group_map_id.is_(None))
+        .where(or_(OktaUserGroupMember.ended_at.is_(None), OktaUserGroupMember.ended_at > func.now())),
     )
 
 
@@ -88,13 +90,13 @@ def _active_direct_member_count(db: Db, *, user_id: str, group_id: str, is_owner
 # ---------------------------------------------------------------------------
 
 
-def test_approve_already_resolved_access_request_conflicts(db: Db, user: OktaUser, okta_group: OktaGroup) -> None:
+async def test_approve_already_resolved_access_request_conflicts(db: Db, user: OktaUser, okta_group: OktaGroup) -> None:
     db.session.add(user)
     db.session.add(okta_group)
-    db.session.commit()
-    owner = _access_owner(db)
+    await db.session.commit()
+    owner = await _access_owner(db)
 
-    request = CreateAccessRequest(
+    request = await CreateAccessRequest(
         requester_user=user,
         requested_group=okta_group,
         request_ownership=False,
@@ -102,25 +104,25 @@ def test_approve_already_resolved_access_request_conflicts(db: Db, user: OktaUse
     ).execute()
     assert request is not None
 
-    ApproveAccessRequest(access_request=request.id, approver_user=owner, approval_reason="ok").execute()
-    assert _active_direct_member_count(db, user_id=user.id, group_id=okta_group.id) == 1
+    await ApproveAccessRequest(access_request=request.id, approver_user=owner, approval_reason="ok").execute()
+    assert await _active_direct_member_count(db, user_id=user.id, group_id=okta_group.id) == 1
 
     # A second approval of the now-APPROVED request must conflict, not no-op.
     with pytest.raises(AccessException) as exc:
-        ApproveAccessRequest(access_request=request.id, approver_user=owner, approval_reason="again").execute()
+        await ApproveAccessRequest(access_request=request.id, approver_user=owner, approval_reason="again").execute()
     assert exc.value.status_code == 409
 
     # And it must not have created a duplicate grant.
-    assert _active_direct_member_count(db, user_id=user.id, group_id=okta_group.id) == 1
+    assert await _active_direct_member_count(db, user_id=user.id, group_id=okta_group.id) == 1
 
 
-def test_reject_already_resolved_access_request_conflicts(db: Db, user: OktaUser, okta_group: OktaGroup) -> None:
+async def test_reject_already_resolved_access_request_conflicts(db: Db, user: OktaUser, okta_group: OktaGroup) -> None:
     db.session.add(user)
     db.session.add(okta_group)
-    db.session.commit()
-    owner = _access_owner(db)
+    await db.session.commit()
+    owner = await _access_owner(db)
 
-    request = CreateAccessRequest(
+    request = await CreateAccessRequest(
         requester_user=user,
         requested_group=okta_group,
         request_ownership=False,
@@ -128,11 +130,11 @@ def test_reject_already_resolved_access_request_conflicts(db: Db, user: OktaUser
     ).execute()
     assert request is not None
 
-    ApproveAccessRequest(access_request=request.id, approver_user=owner, approval_reason="ok").execute()
+    await ApproveAccessRequest(access_request=request.id, approver_user=owner, approval_reason="ok").execute()
 
     # Rejecting an already-approved request must conflict, not silently no-op.
     with pytest.raises(AccessException) as exc:
-        RejectAccessRequest(
+        await RejectAccessRequest(
             access_request=request.id,
             rejection_reason="too late",
             current_user_id=owner.id,
@@ -140,13 +142,15 @@ def test_reject_already_resolved_access_request_conflicts(db: Db, user: OktaUser
     assert exc.value.status_code == 409
 
 
-def test_approve_access_request_with_deleted_requester_errors(db: Db, user: OktaUser, okta_group: OktaGroup) -> None:
+async def test_approve_access_request_with_deleted_requester_errors(
+    db: Db, user: OktaUser, okta_group: OktaGroup
+) -> None:
     db.session.add(user)
     db.session.add(okta_group)
-    db.session.commit()
-    owner = _access_owner(db)
+    await db.session.commit()
+    owner = await _access_owner(db)
 
-    request = CreateAccessRequest(
+    request = await CreateAccessRequest(
         requester_user=user,
         requested_group=okta_group,
         request_ownership=False,
@@ -156,28 +160,34 @@ def test_approve_access_request_with_deleted_requester_errors(db: Db, user: Okta
 
     # Requester is soft-deleted before the approval is processed.
     user.deleted_at = func.now()
-    db.session.commit()
+    await db.session.commit()
+    # The server-generated deleted_at is expired by the flush; reload it on
+    # the async session so the operation's plain attribute read doesn't
+    # trigger a sync lazy-load.
+    await db.session.refresh(user)
 
     with pytest.raises(AccessException) as exc:
-        ApproveAccessRequest(access_request=request.id, approver_user=owner, approval_reason="ok").execute()
+        await ApproveAccessRequest(access_request=request.id, approver_user=owner, approval_reason="ok").execute()
     assert exc.value.status_code in (400, 410)
 
     # The error is surfaced (not a silent success) and no grant is created.
     # The request stays PENDING — the approver gets a clear 4xx rather than the
     # operation quietly resolving a request it can't fulfil.
-    assert _active_direct_member_count(db, user_id=user.id, group_id=okta_group.id) == 0
-    refreshed = db.session.get(AccessRequest, request.id)
+    assert await _active_direct_member_count(db, user_id=user.id, group_id=okta_group.id) == 0
+    refreshed = await db.session.get(AccessRequest, request.id)
     assert refreshed is not None
     assert refreshed.status == AccessRequestStatus.PENDING
 
 
-def test_approve_access_request_with_unmanaged_group_errors(db: Db, user: OktaUser, okta_group: OktaGroup) -> None:
+async def test_approve_access_request_with_unmanaged_group_errors(
+    db: Db, user: OktaUser, okta_group: OktaGroup
+) -> None:
     db.session.add(user)
     db.session.add(okta_group)
-    db.session.commit()
-    owner = _access_owner(db)
+    await db.session.commit()
+    owner = await _access_owner(db)
 
-    request = CreateAccessRequest(
+    request = await CreateAccessRequest(
         requester_user=user,
         requested_group=okta_group,
         request_ownership=False,
@@ -187,25 +197,25 @@ def test_approve_access_request_with_unmanaged_group_errors(db: Db, user: OktaUs
 
     # Target group becomes externally managed before the approval is processed.
     okta_group.is_managed = False
-    db.session.commit()
+    await db.session.commit()
 
     with pytest.raises(AccessException) as exc:
-        ApproveAccessRequest(access_request=request.id, approver_user=owner, approval_reason="ok").execute()
+        await ApproveAccessRequest(access_request=request.id, approver_user=owner, approval_reason="ok").execute()
     assert exc.value.status_code in (400, 410)
-    assert _active_direct_member_count(db, user_id=user.id, group_id=okta_group.id) == 0
+    assert await _active_direct_member_count(db, user_id=user.id, group_id=okta_group.id) == 0
 
 
-def test_stale_resolution_then_approve_conflicts_without_granting(
+async def test_stale_resolution_then_approve_conflicts_without_granting(
     db: Db, user: OktaUser, okta_group: OktaGroup
 ) -> None:
     """Approver loads a PENDING request; another actor resolves it; the
     approver's execute() must conflict (409) and grant nothing."""
     db.session.add(user)
     db.session.add(okta_group)
-    db.session.commit()
-    owner = _access_owner(db)
+    await db.session.commit()
+    owner = await _access_owner(db)
 
-    request = CreateAccessRequest(
+    request = await CreateAccessRequest(
         requester_user=user,
         requested_group=okta_group,
         request_ownership=False,
@@ -218,21 +228,27 @@ def test_stale_resolution_then_approve_conflicts_without_granting(
 
     # A concurrent actor resolves the request out from under it (direct DB flip
     # mirrors the row another approver's transaction would have committed).
-    db.session.query(AccessRequest).filter(AccessRequest.id == request.id).update(
-        {AccessRequest.status: AccessRequestStatus.APPROVED, AccessRequest.resolved_at: func.now()},
-        synchronize_session=False,
+    await db.session.execute(
+        update(AccessRequest)
+        .where(AccessRequest.id == request.id)
+        .values(status=AccessRequestStatus.APPROVED, resolved_at=func.now())
+        .execution_options(synchronize_session=False)
     )
-    db.session.commit()
+    await db.session.commit()
 
     # drop identity-map state staled by the ops above (expire_on_commit=False)
     db.session.expire_all()
+    # expire_all also expired the objects this test still reads directly;
+    # reload them on the async session so plain attribute access works.
+    for obj in (owner, user, okta_group):
+        await db.session.refresh(obj)
 
     with pytest.raises(AccessException) as exc:
-        op.execute()
+        await op.execute()
     assert exc.value.status_code == 409
 
     # The stale approver must not have slipped in a grant.
-    assert _active_direct_member_count(db, user_id=user.id, group_id=okta_group.id) == 0
+    assert await _active_direct_member_count(db, user_id=user.id, group_id=okta_group.id) == 0
 
 
 # ---------------------------------------------------------------------------
@@ -240,19 +256,21 @@ def test_stale_resolution_then_approve_conflicts_without_granting(
 # ---------------------------------------------------------------------------
 
 
-def test_approve_already_resolved_role_request_conflicts(
+async def test_approve_already_resolved_role_request_conflicts(
     db: Db, user: OktaUser, okta_group: OktaGroup, role_group: RoleGroup
 ) -> None:
     db.session.add(user)
     db.session.add(okta_group)
     db.session.add(role_group)
-    db.session.commit()
-    owner = _access_owner(db)
+    await db.session.commit()
+    owner = await _access_owner(db)
 
     # Requester must own the role to file a role request for it.
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
 
-    request = CreateRoleRequest(
+    request = await CreateRoleRequest(
         requester_user=user,
         requester_role=role_group,
         requested_group=okta_group,
@@ -261,19 +279,19 @@ def test_approve_already_resolved_role_request_conflicts(
     ).execute()
     assert request is not None
 
-    ApproveRoleRequest(role_request=request.id, approver_user=owner, approval_reason="ok").execute()
+    await ApproveRoleRequest(role_request=request.id, approver_user=owner, approval_reason="ok").execute()
 
-    active_maps = (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.role_group_id == role_group.id)
-        .filter(RoleGroupMap.group_id == okta_group.id)
-        .filter(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
-        .count()
+    active_maps = await db_count(
+        db.session,
+        select(RoleGroupMap)
+        .where(RoleGroupMap.role_group_id == role_group.id)
+        .where(RoleGroupMap.group_id == okta_group.id)
+        .where(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now())),
     )
     assert active_maps == 1
 
     with pytest.raises(AccessException) as exc:
-        ApproveRoleRequest(role_request=request.id, approver_user=owner, approval_reason="again").execute()
+        await ApproveRoleRequest(role_request=request.id, approver_user=owner, approval_reason="again").execute()
     assert exc.value.status_code == 409
 
 
@@ -282,12 +300,12 @@ def test_approve_already_resolved_role_request_conflicts(
 # ---------------------------------------------------------------------------
 
 
-def test_approve_already_resolved_group_request_conflicts(db: Db, user: OktaUser) -> None:
+async def test_approve_already_resolved_group_request_conflicts(db: Db, user: OktaUser) -> None:
     db.session.add(user)
-    db.session.commit()
-    owner = _access_owner(db)
+    await db.session.commit()
+    owner = await _access_owner(db)
 
-    request = CreateGroupRequest(
+    request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="Test Group",
         requested_group_description="Test Description",
@@ -296,10 +314,10 @@ def test_approve_already_resolved_group_request_conflicts(db: Db, user: OktaUser
     ).execute()
     assert request is not None
 
-    ApproveGroupRequest(group_request=request.id, approver_user=owner, approval_reason="ok").execute()
+    await ApproveGroupRequest(group_request=request.id, approver_user=owner, approval_reason="ok").execute()
 
     with pytest.raises(AccessException) as exc:
-        ApproveGroupRequest(group_request=request.id, approver_user=owner, approval_reason="again").execute()
+        await ApproveGroupRequest(group_request=request.id, approver_user=owner, approval_reason="again").execute()
     assert exc.value.status_code == 409
 
 
@@ -308,7 +326,7 @@ def test_approve_already_resolved_group_request_conflicts(db: Db, user: OktaUser
 # ---------------------------------------------------------------------------
 
 
-def test_access_exception_handler_maps_status_and_envelope() -> None:
+async def test_access_exception_handler_maps_status_and_envelope() -> None:
     req = Request({"type": "http", "method": "GET", "path": "/api/x", "headers": [], "query_string": b""})
     cases = [
         (ConflictError("nope"), 409),
@@ -317,7 +335,7 @@ def test_access_exception_handler_maps_status_and_envelope() -> None:
         (AccessException("teapot", status_code=418), 418),  # constructor override
     ]
     for exc, expected in cases:
-        resp = asyncio.run(access_exception_handler(req, exc))
+        resp = await access_exception_handler(req, exc)
         assert resp.status_code == expected
         assert resp.media_type == "application/problem+json"
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta, timezone
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
+from sqlalchemy import select
 
 from api.models import (
     App,
@@ -19,11 +20,11 @@ from tests.factories import OktaGroupFactory, OktaUserFactory, RoleGroupFactory
 from typing import Any
 
 
-def test_user_audit_resolves_at_me(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_user_audit_resolves_at_me(client: AsyncClient, db: Db, url_for: Any) -> None:
     """`?user_id=@me` is the reserved alias the React Expiring page uses;
     it must resolve to the authenticated user's id, not 404."""
     user_url = url_for("api-audit.users_and_groups")
-    rep = client.get(
+    rep = await client.get(
         user_url,
         params={"user_id": "@me", "page": 1, "size": 20, "order_by": "created_at", "order_desc": "true"},
     )
@@ -31,7 +32,7 @@ def test_user_audit_resolves_at_me(client: TestClient, db: Db, url_for: Any) -> 
     assert "items" in rep.json()
 
 
-def test_group_audit_resolves_at_me_role_owner(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_group_audit_resolves_at_me_role_owner(client: AsyncClient, db: Db, url_for: Any) -> None:
     """`?role_owner_id=@me` and `?owner_id=@me` should both resolve to the
     authenticated user."""
     url = url_for("api-audit.groups_and_roles")
@@ -39,12 +40,12 @@ def test_group_audit_resolves_at_me_role_owner(client: TestClient, db: Db, url_f
         {"role_owner_id": "@me"},
         {"owner_id": "@me"},
     ):
-        rep = client.get(url, params={**params, "page": 1, "size": 20})
+        rep = await client.get(url, params={**params, "page": 1, "size": 20})
         assert rep.status_code == 200, rep.text
 
 
-def test_user_audit_returns_nested_objects(
-    client: TestClient,
+async def test_user_audit_returns_nested_objects(
+    client: AsyncClient,
     db: Db,
     user: OktaUser,
     okta_group: OktaGroup,
@@ -54,10 +55,10 @@ def test_user_audit_returns_nested_objects(
     row.role_group_mapping etc. Confirm the audit endpoint emits these."""
     db.session.add(user)
     db.session.add(okta_group)
-    db.session.commit()
-    ModifyGroupUsers(group=okta_group, members_to_add=[user.id], sync_to_okta=False).execute()
+    await db.session.commit()
+    await ModifyGroupUsers(group=okta_group, members_to_add=[user.id], sync_to_okta=False).execute()
 
-    rep = client.get(url_for("api-audit.users_and_groups"), params={"user_id": user.id})
+    rep = await client.get(url_for("api-audit.users_and_groups"), params={"user_id": user.id})
     assert rep.status_code == 200
     rows = rep.json()["items"]
     assert len(rows) >= 1
@@ -69,8 +70,8 @@ def test_user_audit_returns_nested_objects(
     assert row["group"]["type"] == "okta_group"
 
 
-def test_group_audit_returns_nested_role_and_group(
-    client: TestClient,
+async def test_group_audit_returns_nested_role_and_group(
+    client: AsyncClient,
     db: Db,
     role_group: RoleGroup,
     okta_group: OktaGroup,
@@ -80,10 +81,10 @@ def test_group_audit_returns_nested_role_and_group(
     these the page renders blank role/group names."""
     db.session.add(role_group)
     db.session.add(okta_group)
-    db.session.commit()
-    ModifyRoleGroups(role_group=role_group, groups_to_add=[okta_group.id], sync_to_okta=False).execute()
+    await db.session.commit()
+    await ModifyRoleGroups(role_group=role_group, groups_to_add=[okta_group.id], sync_to_okta=False).execute()
 
-    rep = client.get(url_for("api-audit.groups_and_roles"), params={"role_id": role_group.id})
+    rep = await client.get(url_for("api-audit.groups_and_roles"), params={"role_id": role_group.id})
     assert rep.status_code == 200
     rows = rep.json()["items"]
     assert len(rows) >= 1
@@ -94,8 +95,8 @@ def test_group_audit_returns_nested_role_and_group(
     assert row["group"]["name"] == okta_group.name
 
 
-def test_user_audit_row_includes_group_active_group_tags(
-    client: TestClient,
+async def test_user_audit_row_includes_group_active_group_tags(
+    client: AsyncClient,
     db: Db,
     user: OktaUser,
     okta_group: OktaGroup,
@@ -106,12 +107,12 @@ def test_user_audit_row_includes_group_active_group_tags(
     db.session.add(user)
     db.session.add(okta_group)
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    db.session.commit()
-    ModifyGroupUsers(group=okta_group, members_to_add=[user.id], sync_to_okta=False).execute()
+    await db.session.commit()
+    await ModifyGroupUsers(group=okta_group, members_to_add=[user.id], sync_to_okta=False).execute()
 
-    rep = client.get(url_for("api-audit.users_and_groups"), params={"user_id": user.id})
+    rep = await client.get(url_for("api-audit.users_and_groups"), params={"user_id": user.id})
     assert rep.status_code == 200, rep.text
     rows = rep.json()["items"]
     assert len(rows) >= 1
@@ -121,8 +122,8 @@ def test_user_audit_row_includes_group_active_group_tags(
     assert tag.id in tag_ids
 
 
-def test_get_user_audit(
-    client: TestClient,
+async def test_get_user_audit(
+    client: AsyncClient,
     db: Db,
     user: OktaUser,
     access_app: App,
@@ -133,22 +134,28 @@ def test_get_user_audit(
 ) -> None:
     # test 404
     user_url = url_for("api-audit.users_and_groups")
-    rep = client.get(user_url, params={"user_id": "randomid"})
+    rep = await client.get(user_url, params={"user_id": "randomid"})
     assert rep.status_code == 404
 
     db.session.add(access_app)
     db.session.add(okta_group)
     db.session.add(user)
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=app_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyRoleGroups(
+    await ModifyGroupUsers(
+        group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(
+        group=app_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyRoleGroups(
         role_group=role_group,
         groups_to_add=[okta_group.id, app_group.id],
         owner_groups_to_add=[okta_group.id, app_group.id],
@@ -160,7 +167,7 @@ def test_get_user_audit(
     db.session.expunge_all()
 
     # test get user
-    rep = client.get(user_url, params={"user_id": user_id})
+    rep = await client.get(user_url, params={"user_id": user_id})
     assert rep.status_code == 200
 
     data = rep.json()
@@ -169,7 +176,7 @@ def test_get_user_audit(
 
     db.session.expunge_all()
 
-    rep = client.get(user_url, params={"user_id": user_id, "owner": True})
+    rep = await client.get(user_url, params={"user_id": user_id, "owner": True})
     assert rep.status_code == 200
 
     data = rep.json()
@@ -178,7 +185,7 @@ def test_get_user_audit(
 
     db.session.expunge_all()
 
-    rep = client.get(user_url, params={"user_id": user_id, "q": "App-"})
+    rep = await client.get(user_url, params={"user_id": user_id, "q": "App-"})
     assert rep.status_code == 200
 
     data = rep.json()
@@ -186,8 +193,8 @@ def test_get_user_audit(
     assert data["total"] == 4
 
 
-def test_get_group_audit(
-    client: TestClient,
+async def test_get_group_audit(
+    client: AsyncClient,
     db: Db,
     access_app: App,
     app_group: AppGroup,
@@ -199,7 +206,7 @@ def test_get_group_audit(
 ) -> None:
     # test 404
     group_url = url_for("api-audit.users_and_groups")
-    rep = client.get(group_url, params={"group_id": "randomid"})
+    rep = await client.get(group_url, params={"group_id": "randomid"})
     assert rep.status_code == 404
 
     db.session.add(access_app)
@@ -207,23 +214,29 @@ def test_get_group_audit(
     db.session.add(user)
     db.session.add(role_group)
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
     db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
     db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tag.id))
     app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tag.id)
     db.session.add(app_tag_map)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag.id, app_tag_map_id=app_tag_map.id))
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=app_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyRoleGroups(
+    await ModifyGroupUsers(
+        group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(
+        group=app_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyRoleGroups(
         role_group=role_group,
         groups_to_add=[okta_group.id, app_group.id],
         owner_groups_to_add=[okta_group.id, app_group.id],
@@ -237,7 +250,7 @@ def test_get_group_audit(
 
     db.session.expunge_all()
 
-    rep = client.get(group_url, params={"group_id": role_group_id})
+    rep = await client.get(group_url, params={"group_id": role_group_id})
     assert rep.status_code == 200
 
     data = rep.json()
@@ -247,7 +260,7 @@ def test_get_group_audit(
     db.session.expunge_all()
 
     # test get group
-    rep = client.get(group_url, params={"group_id": okta_group_id})
+    rep = await client.get(group_url, params={"group_id": okta_group_id})
     assert rep.status_code == 200
 
     data = rep.json()
@@ -256,7 +269,7 @@ def test_get_group_audit(
 
     db.session.expunge_all()
 
-    rep = client.get(group_url, params={"group_id": okta_group_id, "owner": True})
+    rep = await client.get(group_url, params={"group_id": okta_group_id, "owner": True})
     assert rep.status_code == 200
 
     data = rep.json()
@@ -265,7 +278,7 @@ def test_get_group_audit(
 
     db.session.expunge_all()
 
-    rep = client.get(group_url, params={"group_id": okta_group_id, "q": user_email})
+    rep = await client.get(group_url, params={"group_id": okta_group_id, "q": user_email})
     assert rep.status_code == 200
 
     data = rep.json()
@@ -274,7 +287,7 @@ def test_get_group_audit(
 
     db.session.expunge_all()
 
-    rep = client.get(group_url, params={"group_id": role_group_id})
+    rep = await client.get(group_url, params={"group_id": role_group_id})
     assert rep.status_code == 200
 
     data = rep.json()
@@ -283,7 +296,7 @@ def test_get_group_audit(
 
     db.session.expunge_all()
 
-    rep = client.get(group_url, params={"group_id": role_group_id, "owner": True})
+    rep = await client.get(group_url, params={"group_id": role_group_id, "owner": True})
     assert rep.status_code == 200
 
     data = rep.json()
@@ -292,7 +305,7 @@ def test_get_group_audit(
 
     db.session.expunge_all()
 
-    rep = client.get(group_url, params={"group_id": role_group_id, "q": user_email})
+    rep = await client.get(group_url, params={"group_id": role_group_id, "q": user_email})
     assert rep.status_code == 200
 
     data = rep.json()
@@ -301,7 +314,7 @@ def test_get_group_audit(
 
     db.session.expunge_all()
 
-    rep = client.get(group_url, params={"group_id": app_group_id})
+    rep = await client.get(group_url, params={"group_id": app_group_id})
     assert rep.status_code == 200
 
     data = rep.json()
@@ -310,7 +323,7 @@ def test_get_group_audit(
 
     db.session.expunge_all()
 
-    rep = client.get(group_url, params={"group_id": app_group_id, "owner": True})
+    rep = await client.get(group_url, params={"group_id": app_group_id, "owner": True})
     assert rep.status_code == 200
 
     data = rep.json()
@@ -319,7 +332,7 @@ def test_get_group_audit(
 
     db.session.expunge_all()
 
-    rep = client.get(group_url, params={"group_id": app_group_id, "q": user_email})
+    rep = await client.get(group_url, params={"group_id": app_group_id, "q": user_email})
     assert rep.status_code == 200
 
     data = rep.json()
@@ -327,8 +340,8 @@ def test_get_group_audit(
     assert data["total"] == 4
 
 
-def test_get_role_audit(
-    client: TestClient,
+async def test_get_role_audit(
+    client: AsyncClient,
     db: Db,
     role_group: RoleGroup,
     access_app: App,
@@ -339,22 +352,28 @@ def test_get_role_audit(
 ) -> None:
     # test 404
     role_url = url_for("api-audit.groups_and_roles")
-    rep = client.get(role_url, params={"role_id": "randomid"})
+    rep = await client.get(role_url, params={"role_id": "randomid"})
     assert rep.status_code == 404
 
     db.session.add(access_app)
     db.session.add(okta_group)
     db.session.add(user)
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=app_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyRoleGroups(
+    await ModifyGroupUsers(
+        group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(
+        group=app_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyRoleGroups(
         role_group=role_group,
         groups_to_add=[
             okta_group.id,
@@ -374,7 +393,7 @@ def test_get_role_audit(
     db.session.expunge_all()
 
     # test get role
-    rep = client.get(role_url, params={"role_id": role_group_id})
+    rep = await client.get(role_url, params={"role_id": role_group_id})
     assert rep.status_code == 200
 
     data = rep.json()
@@ -383,7 +402,7 @@ def test_get_role_audit(
 
     db.session.expunge_all()
 
-    rep = client.get(role_url, params={"role_id": role_group_id, "owner": True})
+    rep = await client.get(role_url, params={"role_id": role_group_id, "owner": True})
     assert rep.status_code == 200
 
     data = rep.json()
@@ -392,7 +411,7 @@ def test_get_role_audit(
 
     db.session.expunge_all()
 
-    rep = client.get(role_url, params={"role_id": role_group_id, "q": "App-"})
+    rep = await client.get(role_url, params={"role_id": role_group_id, "q": "App-"})
     assert rep.status_code == 200
 
     data = rep.json()
@@ -401,16 +420,16 @@ def test_get_role_audit(
 
     db.session.expunge_all()
 
-    rep = client.get(role_url, params={"role_id": app_group_id})
+    rep = await client.get(role_url, params={"role_id": app_group_id})
     assert rep.status_code == 404
 
     db.session.expunge_all()
 
-    rep = client.get(role_url, params={"role_id": okta_group_id})
+    rep = await client.get(role_url, params={"role_id": okta_group_id})
     assert rep.status_code == 404
 
 
-def test_audit_users_default_order_is_newest_first(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_audit_users_default_order_is_newest_first(client: AsyncClient, db: Db, url_for: Any) -> None:
     """Without `order_by` / `order_desc`, /api/audit/users must default to
     `created_at DESC`. Flask's Marshmallow schema declared
     `order_desc=True`; the FastAPI Query Model mirrors that. Seed three
@@ -419,8 +438,8 @@ def test_audit_users_default_order_is_newest_first(client: TestClient, db: Db, u
     group = OktaGroupFactory.create()
     u_old, u_mid, u_new = (OktaUserFactory.create() for _ in range(3))
     db.session.add_all([group, u_old, u_mid, u_new])
-    db.session.commit()
-    ModifyGroupUsers(
+    await db.session.commit()
+    await ModifyGroupUsers(
         group=group,
         members_to_add=[u_old.id, u_mid.id, u_new.id],
         sync_to_okta=False,
@@ -432,27 +451,29 @@ def test_audit_users_default_order_is_newest_first(client: TestClient, db: Db, u
         u_mid.id: base + timedelta(days=2),
         u_new.id: base + timedelta(days=4),
     }
-    for ugm in db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.group_id == group.id).all():
+    for ugm in (
+        await db.session.scalars(select(OktaUserGroupMember).where(OktaUserGroupMember.group_id == group.id))
+    ).all():
         if ugm.user_id in pinned:
             ugm.created_at = pinned[ugm.user_id]
-    db.session.commit()
+    await db.session.commit()
 
-    rep = client.get(url_for("api-audit.users_and_groups"), params={"group_id": group.id})
+    rep = await client.get(url_for("api-audit.users_and_groups"), params={"group_id": group.id})
     assert rep.status_code == 200
     rows = rep.json()["items"]
     seeded_rows = [r for r in rows if r["user_id"] in pinned]
     assert [r["user_id"] for r in seeded_rows] == [u_new.id, u_mid.id, u_old.id]
 
 
-def test_audit_groups_default_order_is_newest_first(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_audit_groups_default_order_is_newest_first(client: AsyncClient, db: Db, url_for: Any) -> None:
     """Same direction-of-default contract as `users` — seed three
     `RoleGroupMap` rows at controlled `created_at` and confirm the
     response order is newest-first when no order params are provided."""
     role = RoleGroupFactory.create()
     g_old, g_mid, g_new = (OktaGroupFactory.create() for _ in range(3))
     db.session.add_all([role, g_old, g_mid, g_new])
-    db.session.commit()
-    ModifyRoleGroups(
+    await db.session.commit()
+    await ModifyRoleGroups(
         role_group=role,
         groups_to_add=[g_old.id, g_mid.id, g_new.id],
         sync_to_okta=False,
@@ -464,12 +485,12 @@ def test_audit_groups_default_order_is_newest_first(client: TestClient, db: Db, 
         g_mid.id: base + timedelta(days=2),
         g_new.id: base + timedelta(days=4),
     }
-    for rgm in db.session.query(RoleGroupMap).filter(RoleGroupMap.role_group_id == role.id).all():
+    for rgm in (await db.session.scalars(select(RoleGroupMap).where(RoleGroupMap.role_group_id == role.id))).all():
         if rgm.group_id in pinned:
             rgm.created_at = pinned[rgm.group_id]
-    db.session.commit()
+    await db.session.commit()
 
-    rep = client.get(url_for("api-audit.groups_and_roles"), params={"role_id": role.id})
+    rep = await client.get(url_for("api-audit.groups_and_roles"), params={"role_id": role.id})
     assert rep.status_code == 200
     rows = rep.json()["items"]
     seeded_rows = [r for r in rows if r["group_id"] in pinned]
@@ -479,7 +500,7 @@ def test_audit_groups_default_order_is_newest_first(client: TestClient, db: Db, 
 # --- Fix 4 parity tests --------------------------------------------------------
 
 
-def test_users_audit_q_with_user_id_searches_only_groups(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_users_audit_q_with_user_id_searches_only_groups(client: AsyncClient, db: Db, url_for: Any) -> None:
     """When `user_id` is pinned, the free-text `q` filter must narrow to
     *group* columns only — `?user_id=...&q=Alice` should match group
     names but not user profile fields (the user is already pinned)."""
@@ -487,14 +508,14 @@ def test_users_audit_q_with_user_id_searches_only_groups(client: TestClient, db:
     matching_group = OktaGroupFactory.create(name="MatchableGroup", description="contains Alice")
     other_group = OktaGroupFactory.create(name="UnrelatedGroup", description="no match")
     db.session.add_all([user, matching_group, other_group])
-    db.session.commit()
-    ModifyGroupUsers(group=matching_group, members_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=other_group, members_to_add=[user.id], sync_to_okta=False).execute()
+    await db.session.commit()
+    await ModifyGroupUsers(group=matching_group, members_to_add=[user.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=other_group, members_to_add=[user.id], sync_to_okta=False).execute()
 
     # Searching `Alice` with the user filter pinned should only match the
     # group whose description contains "Alice" — not the other group, even
     # though the user's first_name is "Alice".
-    rep = client.get(url_for("api-audit.users_and_groups"), params={"user_id": user.id, "q": "Alice"})
+    rep = await client.get(url_for("api-audit.users_and_groups"), params={"user_id": user.id, "q": "Alice"})
     assert rep.status_code == 200
     rows = rep.json()["items"]
     matched_group_ids = {r["group_id"] for r in rows}
@@ -502,7 +523,7 @@ def test_users_audit_q_with_user_id_searches_only_groups(client: TestClient, db:
     assert other_group.id not in matched_group_ids
 
 
-def test_users_audit_q_with_group_id_searches_only_users(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_users_audit_q_with_group_id_searches_only_users(client: AsyncClient, db: Db, url_for: Any) -> None:
     """Symmetric: with `group_id` set, `q` must restrict to user columns
     so the response excludes memberships whose user doesn't match — even
     if the group name does."""
@@ -510,10 +531,10 @@ def test_users_audit_q_with_group_id_searches_only_users(client: TestClient, db:
     other_user = OktaUserFactory.create(email="other@example.com", first_name="Other")
     group = OktaGroupFactory.create(name="GroupZlatan", description="zlatan-themed")
     db.session.add_all([matching_user, other_user, group])
-    db.session.commit()
-    ModifyGroupUsers(group=group, members_to_add=[matching_user.id, other_user.id], sync_to_okta=False).execute()
+    await db.session.commit()
+    await ModifyGroupUsers(group=group, members_to_add=[matching_user.id, other_user.id], sync_to_okta=False).execute()
 
-    rep = client.get(url_for("api-audit.users_and_groups"), params={"group_id": group.id, "q": "zlatan"})
+    rep = await client.get(url_for("api-audit.users_and_groups"), params={"group_id": group.id, "q": "zlatan"})
     assert rep.status_code == 200
     rows = rep.json()["items"]
     matched_user_ids = {r["user_id"] for r in rows}
@@ -521,21 +542,21 @@ def test_users_audit_q_with_group_id_searches_only_users(client: TestClient, db:
     assert other_user.id not in matched_user_ids
 
 
-def test_groups_audit_q_with_role_id_searches_only_groups(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_groups_audit_q_with_role_id_searches_only_groups(client: AsyncClient, db: Db, url_for: Any) -> None:
     """When `role_id` is set on /api/audit/groups, `q` must restrict to
     the *associated group* columns and ignore the role columns."""
     role = RoleGroupFactory.create(name="ZebraRole")
     matching_group = OktaGroupFactory.create(name="ZebraStripeGroup")
     other_group = OktaGroupFactory.create(name="UnrelatedGroup")
     db.session.add_all([role, matching_group, other_group])
-    db.session.commit()
-    ModifyRoleGroups(
+    await db.session.commit()
+    await ModifyRoleGroups(
         role_group=role,
         groups_to_add=[matching_group.id, other_group.id],
         sync_to_okta=False,
     ).execute()
 
-    rep = client.get(url_for("api-audit.groups_and_roles"), params={"role_id": role.id, "q": "Zebra"})
+    rep = await client.get(url_for("api-audit.groups_and_roles"), params={"role_id": role.id, "q": "Zebra"})
     assert rep.status_code == 200
     rows = rep.json()["items"]
     matched_group_ids = {r["group_id"] for r in rows}
@@ -545,7 +566,7 @@ def test_groups_audit_q_with_role_id_searches_only_groups(client: TestClient, db
     assert other_group.id not in matched_group_ids
 
 
-def test_users_audit_owner_id_excludes_owner_self_membership(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_users_audit_owner_id_excludes_owner_self_membership(client: AsyncClient, db: Db, url_for: Any) -> None:
     """When filtering /api/audit/users by `owner_id`, the response must
     exclude the owner's own memberships. The frontend's "expiring access"
     review surface is meant to show *other* users' access the owner owes
@@ -554,17 +575,17 @@ def test_users_audit_owner_id_excludes_owner_self_membership(client: TestClient,
     other = OktaUserFactory.create(email="other@example.com")
     group = OktaGroupFactory.create(name="OwnedGroup")
     db.session.add_all([owner, other, group])
-    db.session.commit()
+    await db.session.commit()
     # Owner is owner of group; owner is also a regular member of the same
     # group; another user is also a member.
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=group,
         members_to_add=[owner.id, other.id],
         owners_to_add=[owner.id],
         sync_to_okta=False,
     ).execute()
 
-    rep = client.get(url_for("api-audit.users_and_groups"), params={"owner_id": owner.id})
+    rep = await client.get(url_for("api-audit.users_and_groups"), params={"owner_id": owner.id})
     assert rep.status_code == 200
     rows = rep.json()["items"]
     user_ids_in_response = {r["user_id"] for r in rows}
@@ -572,8 +593,8 @@ def test_users_audit_owner_id_excludes_owner_self_membership(client: TestClient,
     assert other.id in user_ids_in_response
 
 
-def test_users_audit_includes_role_associated_group_mappings_when_unfiltered(
-    client: TestClient, db: Db, url_for: Any
+async def test_users_audit_includes_role_associated_group_mappings_when_unfiltered(
+    client: AsyncClient, db: Db, url_for: Any
 ) -> None:
     """When neither `user_id` nor `group_id` is set, rows whose group is a
     RoleGroup must surface `active_role_associated_group_member_mappings`
@@ -583,14 +604,14 @@ def test_users_audit_includes_role_associated_group_mappings_when_unfiltered(
     associated = OktaGroupFactory.create(name="UnfilteredAssociatedGroup")
     user = OktaUserFactory.create()
     db.session.add_all([role, associated, user])
-    db.session.commit()
-    ModifyRoleGroups(role_group=role, groups_to_add=[associated.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=role, members_to_add=[user.id], sync_to_okta=False).execute()
+    await db.session.commit()
+    await ModifyRoleGroups(role_group=role, groups_to_add=[associated.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=role, members_to_add=[user.id], sync_to_okta=False).execute()
 
     # drop identity-map state staled by the ops above (expire_on_commit=False)
     db.session.expire_all()
 
-    rep = client.get(url_for("api-audit.users_and_groups"))
+    rep = await client.get(url_for("api-audit.users_and_groups"))
     assert rep.status_code == 200, rep.text
     rows = rep.json()["items"]
     role_rows = [r for r in rows if r.get("group", {}).get("id") == role.id]
@@ -603,8 +624,8 @@ def test_users_audit_includes_role_associated_group_mappings_when_unfiltered(
     ), f"associated group missing from member mappings: {member_maps}"
 
 
-def test_users_audit_omits_role_associated_group_mappings_when_user_filter(
-    client: TestClient, db: Db, url_for: Any
+async def test_users_audit_omits_role_associated_group_mappings_when_user_filter(
+    client: AsyncClient, db: Db, url_for: Any
 ) -> None:
     """With `user_id` pinned, `active_role_associated_group_*_mappings`
     must be suppressed on the response (eager-loading them under a
@@ -614,11 +635,11 @@ def test_users_audit_omits_role_associated_group_mappings_when_user_filter(
     associated = OktaGroupFactory.create(name="FilteredAssociatedGroup")
     user = OktaUserFactory.create()
     db.session.add_all([role, associated, user])
-    db.session.commit()
-    ModifyRoleGroups(role_group=role, groups_to_add=[associated.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=role, members_to_add=[user.id], sync_to_okta=False).execute()
+    await db.session.commit()
+    await ModifyRoleGroups(role_group=role, groups_to_add=[associated.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=role, members_to_add=[user.id], sync_to_okta=False).execute()
 
-    rep = client.get(url_for("api-audit.users_and_groups"), params={"user_id": user.id})
+    rep = await client.get(url_for("api-audit.users_and_groups"), params={"user_id": user.id})
     assert rep.status_code == 200, rep.text
     rows = rep.json()["items"]
     role_rows = [r for r in rows if r.get("group", {}).get("id") == role.id]
@@ -630,7 +651,7 @@ def test_users_audit_omits_role_associated_group_mappings_when_user_filter(
     assert not sample.get("active_role_associated_group_owner_mappings")
 
 
-def test_users_audit_direct_flag_reorders(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_users_audit_direct_flag_reorders(client: AsyncClient, db: Db, url_for: Any) -> None:
     """When `direct` is present and neither `user_id` nor `owner_id` is
     supplied, the order_by re-applies using the email/created_at compound
     shape: with `?direct=true&order_by=moniker`, rows come back ordered
@@ -639,13 +660,13 @@ def test_users_audit_direct_flag_reorders(client: TestClient, db: Db, url_for: A
     u_z = OktaUserFactory.create(email="zara@example.com")
     u_a = OktaUserFactory.create(email="alpha@example.com")
     db.session.add_all([group, u_a, u_z])
-    db.session.commit()
+    await db.session.commit()
     # Insert in non-alphabetical order so a default unordered query would
     # surface them in insertion order rather than sorted.
-    ModifyGroupUsers(group=group, members_to_add=[u_z.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=group, members_to_add=[u_a.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=group, members_to_add=[u_z.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=group, members_to_add=[u_a.id], sync_to_okta=False).execute()
 
-    rep = client.get(
+    rep = await client.get(
         url_for("api-audit.users_and_groups"),
         params={"direct": "true", "order_by": "moniker", "order_desc": "false"},
     )
@@ -657,7 +678,9 @@ def test_users_audit_direct_flag_reorders(client: TestClient, db: Db, url_for: A
     assert seeded_emails == ["alpha@example.com", "zara@example.com"]
 
 
-def test_users_audit_q_with_user_and_owner_pin_ands_narrow_and_broad(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_users_audit_q_with_user_and_owner_pin_ands_narrow_and_broad(
+    client: AsyncClient, db: Db, url_for: Any
+) -> None:
     """`user_id` + `owner_id` pinned: the narrow group-only `q` filter
     AND-applies on top of the broad either-side filter. A search term that
     matches user columns but no group columns must return zero rows."""
@@ -665,15 +688,15 @@ def test_users_audit_q_with_user_and_owner_pin_ands_narrow_and_broad(client: Tes
     owner = OktaUserFactory.create(email="owner-pin@example.com", first_name="Pin", last_name="Owner")
     group = OktaGroupFactory.create(name="GroupA", description="alpha")
     db.session.add_all([user, owner, group])
-    db.session.commit()
-    ModifyGroupUsers(
+    await db.session.commit()
+    await ModifyGroupUsers(
         group=group,
         members_to_add=[user.id],
         owners_to_add=[owner.id],
         sync_to_okta=False,
     ).execute()
 
-    rep = client.get(
+    rep = await client.get(
         url_for("api-audit.users_and_groups"),
         params={"user_id": user.id, "owner_id": owner.id, "q": "Zzqterm"},
     )
@@ -682,8 +705,8 @@ def test_users_audit_q_with_user_and_owner_pin_ands_narrow_and_broad(client: Tes
     assert all(r["group"]["id"] != group.id for r in rows)
 
 
-def test_users_audit_q_with_user_and_group_pin_ands_both_narrow_filters(
-    client: TestClient, db: Db, url_for: Any
+async def test_users_audit_q_with_user_and_group_pin_ands_both_narrow_filters(
+    client: AsyncClient, db: Db, url_for: Any
 ) -> None:
     """`user_id` + `group_id` pinned: both narrow filters compose. A `q`
     that matches user columns but no group columns must filter out the
@@ -691,10 +714,10 @@ def test_users_audit_q_with_user_and_group_pin_ands_both_narrow_filters(
     user = OktaUserFactory.create(email="qtfirst@example.com", first_name="Qtfirst", last_name="X")
     group = OktaGroupFactory.create(name="GroupBeta", description="beta")
     db.session.add_all([user, group])
-    db.session.commit()
-    ModifyGroupUsers(group=group, members_to_add=[user.id], sync_to_okta=False).execute()
+    await db.session.commit()
+    await ModifyGroupUsers(group=group, members_to_add=[user.id], sync_to_okta=False).execute()
 
-    rep = client.get(
+    rep = await client.get(
         url_for("api-audit.users_and_groups"),
         params={"user_id": user.id, "group_id": group.id, "q": "Qtfirst"},
     )
@@ -703,7 +726,7 @@ def test_users_audit_q_with_user_and_group_pin_ands_both_narrow_filters(
     assert rows == []
 
 
-def test_groups_audit_q_with_role_and_owner_pin(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_groups_audit_q_with_role_and_owner_pin(client: AsyncClient, db: Db, url_for: Any) -> None:
     """On `/api/audit/groups`, `role_id` + `owner_id` pinned: the narrow
     associated-group `q` filter AND-applies on top of the broad either-side
     filter. A `q` that matches role columns but no group columns must
@@ -712,11 +735,11 @@ def test_groups_audit_q_with_role_and_owner_pin(client: TestClient, db: Db, url_
     associated = OktaGroupFactory.create(name="GroupGamma", description="gamma")
     owner = OktaUserFactory.create(email="role-pin-owner@example.com", first_name="Pin", last_name="Owner")
     db.session.add_all([role, associated, owner])
-    db.session.commit()
-    ModifyRoleGroups(role_group=role, groups_to_add=[associated.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=associated, owners_to_add=[owner.id], sync_to_okta=False).execute()
+    await db.session.commit()
+    await ModifyRoleGroups(role_group=role, groups_to_add=[associated.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=associated, owners_to_add=[owner.id], sync_to_okta=False).execute()
 
-    rep = client.get(
+    rep = await client.get(
         url_for("api-audit.groups_and_roles"),
         params={"role_id": role.id, "owner_id": owner.id, "q": "Zqx"},
     )
@@ -725,7 +748,7 @@ def test_groups_audit_q_with_role_and_owner_pin(client: TestClient, db: Db, url_
     assert all(r.get("group", {}).get("id") != associated.id for r in rows)
 
 
-def test_users_audit_returns_rows_when_user_is_soft_deleted(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_users_audit_returns_rows_when_user_is_soft_deleted(client: AsyncClient, db: Db, url_for: Any) -> None:
     """`/api/audit/users` must surface every membership in a group's history,
     including those whose user has since been soft-deleted. Pre-fix the query
     eager-loaded `OktaUserGroupMember.active_user`, whose relationship carries
@@ -734,13 +757,13 @@ def test_users_audit_returns_rows_when_user_is_soft_deleted(client: TestClient, 
     group = OktaGroupFactory.create()
     user = OktaUserFactory.create()
     db.session.add_all([group, user])
-    db.session.commit()
-    ModifyGroupUsers(group=group, members_to_add=[user.id], sync_to_okta=False).execute()
+    await db.session.commit()
+    await ModifyGroupUsers(group=group, members_to_add=[user.id], sync_to_okta=False).execute()
 
     user.deleted_at = datetime.now(timezone.utc)
-    db.session.commit()
+    await db.session.commit()
 
-    rep = client.get(url_for("api-audit.users_and_groups"), params={"group_id": group.id})
+    rep = await client.get(url_for("api-audit.users_and_groups"), params={"group_id": group.id})
     assert rep.status_code == 200, rep.text
     rows = rep.json()["items"]
     matching = [r for r in rows if r["user_id"] == user.id]
@@ -753,7 +776,9 @@ def test_users_audit_returns_rows_when_user_is_soft_deleted(client: TestClient, 
         assert absent not in row, f"audit row should not include {absent!r}"
 
 
-def test_groups_audit_returns_rows_when_role_group_is_soft_deleted(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_groups_audit_returns_rows_when_role_group_is_soft_deleted(
+    client: AsyncClient, db: Db, url_for: Any
+) -> None:
     """Mirror regression for `/api/audit/groups`. The migration added
     `joinedload(RoleGroupMap.active_role_group)`, and that relationship has
     the same `innerjoin=True` + `deleted_at IS NULL` shape, so audit rows
@@ -761,13 +786,13 @@ def test_groups_audit_returns_rows_when_role_group_is_soft_deleted(client: TestC
     role = RoleGroupFactory.create()
     group = OktaGroupFactory.create()
     db.session.add_all([role, group])
-    db.session.commit()
-    ModifyRoleGroups(role_group=role, groups_to_add=[group.id], sync_to_okta=False).execute()
+    await db.session.commit()
+    await ModifyRoleGroups(role_group=role, groups_to_add=[group.id], sync_to_okta=False).execute()
 
     role.deleted_at = datetime.now(timezone.utc)
-    db.session.commit()
+    await db.session.commit()
 
-    rep = client.get(url_for("api-audit.groups_and_roles"), params={"group_id": group.id})
+    rep = await client.get(url_for("api-audit.groups_and_roles"), params={"group_id": group.id})
     assert rep.status_code == 200, rep.text
     rows = rep.json()["items"]
     matching = [r for r in rows if r["role_group_id"] == role.id]

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -9,7 +9,7 @@ from typing import Any, Generator
 
 import pytest
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
 from pytest_mock import MockerFixture
 
 from api.auth.dependencies import require_authenticated
@@ -37,8 +37,8 @@ def with_real_dsn(production_env: None, monkeypatch: pytest.MonkeyPatch) -> None
     monkeypatch.setattr(settings, "REACT_SENTRY_DSN", _REAL_DSN)
 
 
-def test_sentry_envelope_is_forwarded_with_dsn_rewritten(
-    client: TestClient, with_real_dsn: None, mocker: MockerFixture
+async def test_sentry_envelope_is_forwarded_with_dsn_rewritten(
+    client: AsyncClient, with_real_dsn: None, mocker: MockerFixture
 ) -> None:
     captured: dict[str, Any] = {}
 
@@ -56,7 +56,9 @@ def test_sentry_envelope_is_forwarded_with_dsn_rewritten(
 
     mocker.patch("api.routers.bugs.httpx.AsyncClient", _FakeAsyncClient)
 
-    rep = client.post("/api/bugs/sentry", content=_ENVELOPE, headers={"Content-Type": "application/x-sentry-envelope"})
+    rep = await client.post(
+        "/api/bugs/sentry", content=_ENVELOPE, headers={"Content-Type": "application/x-sentry-envelope"}
+    )
     assert rep.status_code == 200
     assert rep.json() == {}
 
@@ -67,22 +69,22 @@ def test_sentry_envelope_is_forwarded_with_dsn_rewritten(
     assert captured["headers"]["Content-Type"] == "application/x-sentry-envelope"
 
 
-def test_sentry_skips_in_dev(client: TestClient, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture) -> None:
+async def test_sentry_skips_in_dev(client: AsyncClient, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture) -> None:
     # Default test env is "test"; override DSN but keep ENV → expect skip.
     monkeypatch.setattr(settings, "REACT_SENTRY_DSN", _REAL_DSN)
     spy = mocker.patch("api.routers.bugs.httpx.AsyncClient")
 
-    rep = client.post("/api/bugs/sentry", content=_ENVELOPE)
+    rep = await client.post("/api/bugs/sentry", content=_ENVELOPE)
     assert rep.status_code == 200
     spy.assert_not_called()
 
 
-def test_sentry_skips_when_dsn_unset(
-    client: TestClient, production_env: None, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+async def test_sentry_skips_when_dsn_unset(
+    client: AsyncClient, production_env: None, monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
 ) -> None:
     monkeypatch.setattr(settings, "REACT_SENTRY_DSN", None)
     spy = mocker.patch("api.routers.bugs.httpx.AsyncClient")
 
-    rep = client.post("/api/bugs/sentry", content=_ENVELOPE)
+    rep = await client.post("/api/bugs/sentry", content=_ENVELOPE)
     assert rep.status_code == 200
     spy.assert_not_called()

--- a/tests/test_disallow_self_add_constraint.py
+++ b/tests/test_disallow_self_add_constraint.py
@@ -1,10 +1,11 @@
 from typing import Any
 
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
 from pytest_mock import MockerFixture
 
 from fastapi import FastAPI
 
+from sqlalchemy import select
 from api.config import settings
 from api.extensions import Db
 from api.models import (
@@ -21,12 +22,13 @@ from api.models import (
 )
 from api.operations import ModifyGroupUsers, ModifyRoleGroups
 from api.services import okta
+from tests.helpers import db_count
 from tests.factories import OktaUserFactory, RoleGroupFactory, TagFactory
 
 
-def test_disallow_self_add_modify_group_users(
+async def test_disallow_self_add_modify_group_users(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     access_app: App,
@@ -61,12 +63,12 @@ def test_disallow_self_add_modify_group_users(
     db.session.add(role_group)
     db.session.add(user)
     db.session.add(current_user)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyRoleGroups(
+    await ModifyRoleGroups(
         role_group=role_group,
         groups_to_add=[
             okta_group.id,
@@ -86,33 +88,42 @@ def test_disallow_self_add_modify_group_users(
     db.session.add(app_tag_map)
     app_tag_map2 = AppTagMap(app_id=access_app.id, tag_id=tags[2].id)
     db.session.add(app_tag_map2)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[1].id, app_tag_map_id=app_tag_map.id))
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id))
-    db.session.commit()
+    await db.session.commit()
 
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    remove_user_from_group_spy = mocker.patch.object(okta, "async_remove_user_from_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
-    remove_owner_from_group_spy = mocker.patch.object(okta, "async_remove_owner_from_group")
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    remove_user_from_group_spy = mocker.patch.object(okta, "remove_user_from_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
+    remove_owner_from_group_spy = mocker.patch.object(okta, "remove_owner_from_group")
 
     # drop identity-map state staled by the ops above (expire_on_commit=False)
     db.session.expire_all()
+    # reload the objects read below — sync lazy-loads of expired state raise under async
+    await db.session.refresh(okta_group)
+    await db.session.refresh(current_user)
 
     # Add non-admin current_user as the owner of okta_group
-    ModifyGroupUsers(group=okta_group, owners_to_add=[current_user.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=okta_group, owners_to_add=[current_user.id], sync_to_okta=False).execute()
 
     # Establish a baseline of user memberships/ownerships
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
 
@@ -124,21 +135,30 @@ def test_disallow_self_add_modify_group_users(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=okta_group.id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
+
+    # reload state expired by the 400 response's rollback
+    await db.session.refresh(current_user)
 
     # Add the current user to the okta group as member and owner
     data = {
@@ -147,21 +167,30 @@ def test_disallow_self_add_modify_group_users(
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
+
+    # reload state expired by the 400 response's rollback
+    await db.session.refresh(user)
 
     # Add another user to the okta group as owner and member
     data = {
@@ -170,7 +199,7 @@ def test_disallow_self_add_modify_group_users(
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -182,15 +211,21 @@ def test_disallow_self_add_modify_group_users(
     assert len(data["owners"]) == 2
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
 
@@ -199,8 +234,12 @@ def test_disallow_self_add_modify_group_users(
     add_owner_to_group_spy.reset_mock()
     remove_owner_from_group_spy.reset_mock()
 
+    # reload state expired by the earlier 400 response's rollback
+    await db.session.refresh(app_group)
+    await db.session.refresh(current_user)
+
     # Add non-admin current_user as app group owner
-    ModifyGroupUsers(group=app_group, owners_to_add=[current_user.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=app_group, owners_to_add=[current_user.id], sync_to_okta=False).execute()
 
     # Add the current user to the app group as member
     data = {
@@ -210,7 +249,7 @@ def test_disallow_self_add_modify_group_users(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=app_group.id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -222,15 +261,21 @@ def test_disallow_self_add_modify_group_users(
     assert len(data["owners"]) == 1
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
 
@@ -246,21 +291,30 @@ def test_disallow_self_add_modify_group_users(
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
+
+    # reload state expired by the 400 response's rollback
+    await db.session.refresh(current_user)
 
     # Add the user to the app group as member and owner
     data = {
@@ -269,21 +323,30 @@ def test_disallow_self_add_modify_group_users(
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
+
+    # reload state expired by the 400 response's rollback
+    await db.session.refresh(user)
 
     # Add another user to the app group as member and owner
     data = {
@@ -292,7 +355,7 @@ def test_disallow_self_add_modify_group_users(
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -304,15 +367,21 @@ def test_disallow_self_add_modify_group_users(
     assert len(data["owners"]) == 2
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
 
@@ -321,8 +390,12 @@ def test_disallow_self_add_modify_group_users(
     add_owner_to_group_spy.reset_mock()
     remove_owner_from_group_spy.reset_mock()
 
+    # reload state expired by the earlier 400 response's rollback
+    await db.session.refresh(role_group)
+    await db.session.refresh(current_user)
+
     # Add non-admin current_user as app group owner
-    ModifyGroupUsers(group=role_group, owners_to_add=[current_user.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=role_group, owners_to_add=[current_user.id], sync_to_okta=False).execute()
 
     # Add the current user to the role group as member
     data = {
@@ -332,21 +405,30 @@ def test_disallow_self_add_modify_group_users(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=role_group.id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 5
     )
+
+    # reload state expired by the 400 response's rollback
+    await db.session.refresh(current_user)
 
     # Add the user to the role group as member and owner
     data = {
@@ -355,21 +437,30 @@ def test_disallow_self_add_modify_group_users(
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 5
     )
+
+    # reload state expired by the 400 response's rollback
+    await db.session.refresh(user)
 
     # Add another user to the role group as member and owner
     data = {
@@ -378,7 +469,7 @@ def test_disallow_self_add_modify_group_users(
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 3
     assert remove_user_from_group_spy.call_count == 0
@@ -390,22 +481,28 @@ def test_disallow_self_add_modify_group_users(
     assert len(data["owners"]) == 2
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 7
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 8
     )
 
 
-def test_disallow_self_add_modify_role_groups(
+async def test_disallow_self_add_modify_role_groups(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     access_app: App,
@@ -441,16 +538,18 @@ def test_disallow_self_add_modify_role_groups(
     db.session.add_all(role_groups)
     db.session.add(user)
     db.session.add(current_user)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=role_groups[0], members_to_add=[current_user.id], owners_to_add=[], sync_to_okta=False
     ).execute()
 
-    ModifyGroupUsers(group=role_groups[1], members_to_add=[user.id], owners_to_add=[], sync_to_okta=False).execute()
+    await ModifyGroupUsers(
+        group=role_groups[1], members_to_add=[user.id], owners_to_add=[], sync_to_okta=False
+    ).execute()
 
     db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tags[0].id))
     db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tags[2].id))
@@ -460,40 +559,50 @@ def test_disallow_self_add_modify_role_groups(
     db.session.add(app_tag_map)
     app_tag_map2 = AppTagMap(app_id=access_app.id, tag_id=tags[2].id)
     db.session.add(app_tag_map2)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[1].id, app_tag_map_id=app_tag_map.id))
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id))
-    db.session.commit()
+    await db.session.commit()
 
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    remove_user_from_group_spy = mocker.patch.object(okta, "async_remove_user_from_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
-    remove_owner_from_group_spy = mocker.patch.object(okta, "async_remove_owner_from_group")
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    remove_user_from_group_spy = mocker.patch.object(okta, "remove_user_from_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
+    remove_owner_from_group_spy = mocker.patch.object(okta, "remove_owner_from_group")
 
     # Establish a baseline of user memberships/ownerships
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 0
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 0
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 0
     )
 
     # Add current_user as owner of role_groups[0]
-    ModifyGroupUsers(group=okta_group, owners_to_add=[current_user.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=okta_group, owners_to_add=[current_user.id], sync_to_okta=False).execute()
 
     # Add the current user role group as a member to the okta group
     data: dict[str, Any] = {
@@ -503,29 +612,42 @@ def test_disallow_self_add_modify_role_groups(
         "owner_groups_to_remove": [],
     }
     current_user_role_url = url_for("api-roles.role_members_by_id", role_id=role_groups[0].id)
-    rep = client.put(current_user_role_url, json=data)
+    rep = await client.put(current_user_role_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 0
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 0
     )
+
+    # reload state expired by the 400 response's rollback
+    await db.session.refresh(okta_group)
 
     # Add the current user role group as a owner to the okta group
     data = {
@@ -534,7 +656,7 @@ def test_disallow_self_add_modify_role_groups(
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(current_user_role_url, json=data)
+    rep = await client.put(current_user_role_url, json=data)
     assert rep.status_code == 200
 
     assert add_user_to_group_spy.call_count == 0
@@ -542,23 +664,33 @@ def test_disallow_self_add_modify_role_groups(
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 0
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 1
     )
 
@@ -574,27 +706,37 @@ def test_disallow_self_add_modify_role_groups(
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(current_user_role_url, json=data)
+    rep = await client.put(current_user_role_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 0
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 1
     )
 
@@ -602,6 +744,10 @@ def test_disallow_self_add_modify_role_groups(
     remove_user_from_group_spy.reset_mock()
     add_owner_to_group_spy.reset_mock()
     remove_owner_from_group_spy.reset_mock()
+
+    # reload state expired by the 400 response's rollback
+    await db.session.refresh(okta_group)
+    await db.session.refresh(role_groups[1])
 
     # Add the user role group as a member to the okta group
     data = {
@@ -611,7 +757,7 @@ def test_disallow_self_add_modify_role_groups(
         "owner_groups_to_remove": [],
     }
     user_role_url = url_for("api-roles.role_members_by_id", role_id=role_groups[1].id)
-    rep = client.put(user_role_url, json=data)
+    rep = await client.put(user_role_url, json=data)
     assert rep.status_code == 200
 
     assert add_user_to_group_spy.call_count == 1
@@ -620,23 +766,33 @@ def test_disallow_self_add_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 1
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 1
     )
 
@@ -652,7 +808,7 @@ def test_disallow_self_add_modify_role_groups(
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(user_role_url, json=data)
+    rep = await client.put(user_role_url, json=data)
     assert rep.status_code == 200
 
     assert add_user_to_group_spy.call_count == 0
@@ -661,23 +817,33 @@ def test_disallow_self_add_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 1
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 2
     )
 
@@ -693,7 +859,7 @@ def test_disallow_self_add_modify_role_groups(
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(user_role_url, json=data)
+    rep = await client.put(user_role_url, json=data)
     assert rep.status_code == 200
 
     assert add_user_to_group_spy.call_count == 1
@@ -702,23 +868,33 @@ def test_disallow_self_add_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 1
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 2
     )
 
@@ -727,8 +903,12 @@ def test_disallow_self_add_modify_role_groups(
     add_owner_to_group_spy.reset_mock()
     remove_owner_from_group_spy.reset_mock()
 
+    # reload state expired by the earlier 400 response's rollback
+    await db.session.refresh(app_group)
+    await db.session.refresh(current_user)
+
     # Add current_user as owner of the app group
-    ModifyGroupUsers(group=app_group, owners_to_add=[current_user.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=app_group, owners_to_add=[current_user.id], sync_to_okta=False).execute()
 
     # Add the current user role group as a member to the app group
     data = {
@@ -737,7 +917,7 @@ def test_disallow_self_add_modify_role_groups(
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(current_user_role_url, json=data)
+    rep = await client.put(current_user_role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -745,23 +925,33 @@ def test_disallow_self_add_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 5
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 2
     )
 
@@ -777,29 +967,42 @@ def test_disallow_self_add_modify_role_groups(
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(current_user_role_url, json=data)
+    rep = await client.put(current_user_role_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 5
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 2
     )
+
+    # reload state expired by the 400 response's rollback
+    await db.session.refresh(app_group)
 
     # Add the current user role group as a member and owner to the app group
     data = {
@@ -808,29 +1011,42 @@ def test_disallow_self_add_modify_role_groups(
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(current_user_role_url, json=data)
+    rep = await client.put(current_user_role_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 5
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 2
     )
+
+    # reload state expired by the 400 response's rollback
+    await db.session.refresh(app_group)
 
     # Add the user role group as a member to the app group
     data = {
@@ -839,7 +1055,7 @@ def test_disallow_self_add_modify_role_groups(
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(user_role_url, json=data)
+    rep = await client.put(user_role_url, json=data)
     assert rep.status_code == 200
 
     assert add_user_to_group_spy.call_count == 1
@@ -848,23 +1064,33 @@ def test_disallow_self_add_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 6
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 3
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 2
     )
 
@@ -880,7 +1106,7 @@ def test_disallow_self_add_modify_role_groups(
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(user_role_url, json=data)
+    rep = await client.put(user_role_url, json=data)
     assert rep.status_code == 200
 
     assert add_user_to_group_spy.call_count == 0
@@ -889,23 +1115,33 @@ def test_disallow_self_add_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 6
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 5
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 3
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 3
     )
 
@@ -921,7 +1157,7 @@ def test_disallow_self_add_modify_role_groups(
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(user_role_url, json=data)
+    rep = await client.put(user_role_url, json=data)
     assert rep.status_code == 200
 
     assert add_user_to_group_spy.call_count == 1
@@ -930,31 +1166,41 @@ def test_disallow_self_add_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 6
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 5
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 3
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 3
     )
 
 
 # Admin should be allowed to bypass the constraints in all cases
-def test_disallow_self_add_admin_modify_group_users(
+async def test_disallow_self_add_admin_modify_group_users(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     access_app: App,
@@ -964,7 +1210,9 @@ def test_disallow_self_add_admin_modify_group_users(
     user: OktaUser,
     url_for: Any,
 ) -> None:
-    current_user = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    current_user = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     tags = TagFactory.create_batch(
         3,
@@ -987,12 +1235,12 @@ def test_disallow_self_add_admin_modify_group_users(
     db.session.add(access_app)
     db.session.add(role_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyRoleGroups(
+    await ModifyRoleGroups(
         role_group=role_group,
         groups_to_add=[
             okta_group.id,
@@ -1012,27 +1260,33 @@ def test_disallow_self_add_admin_modify_group_users(
     db.session.add(app_tag_map)
     app_tag_map2 = AppTagMap(app_id=access_app.id, tag_id=tags[2].id)
     db.session.add(app_tag_map2)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[1].id, app_tag_map_id=app_tag_map.id))
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id))
-    db.session.commit()
+    await db.session.commit()
 
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    remove_user_from_group_spy = mocker.patch.object(okta, "async_remove_user_from_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
-    remove_owner_from_group_spy = mocker.patch.object(okta, "async_remove_owner_from_group")
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    remove_user_from_group_spy = mocker.patch.object(okta, "remove_user_from_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
+    remove_owner_from_group_spy = mocker.patch.object(okta, "remove_owner_from_group")
 
     # Establish a baseline of user memberships/ownerships
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 0
     )
 
@@ -1044,19 +1298,25 @@ def test_disallow_self_add_admin_modify_group_users(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=okta_group.id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 0
     )
 
@@ -1067,7 +1327,7 @@ def test_disallow_self_add_admin_modify_group_users(
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -1079,15 +1339,21 @@ def test_disallow_self_add_admin_modify_group_users(
     assert len(data["owners"]) == 1
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
 
@@ -1103,7 +1369,7 @@ def test_disallow_self_add_admin_modify_group_users(
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -1111,15 +1377,21 @@ def test_disallow_self_add_admin_modify_group_users(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
 
@@ -1135,7 +1407,7 @@ def test_disallow_self_add_admin_modify_group_users(
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -1147,15 +1419,21 @@ def test_disallow_self_add_admin_modify_group_users(
     assert len(data["owners"]) == 2
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
 
@@ -1172,7 +1450,7 @@ def test_disallow_self_add_admin_modify_group_users(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=app_group.id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -1184,15 +1462,21 @@ def test_disallow_self_add_admin_modify_group_users(
     assert len(data["owners"]) == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
 
@@ -1208,7 +1492,7 @@ def test_disallow_self_add_admin_modify_group_users(
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
@@ -1216,15 +1500,21 @@ def test_disallow_self_add_admin_modify_group_users(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
 
@@ -1240,7 +1530,7 @@ def test_disallow_self_add_admin_modify_group_users(
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -1248,15 +1538,21 @@ def test_disallow_self_add_admin_modify_group_users(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
 
@@ -1272,7 +1568,7 @@ def test_disallow_self_add_admin_modify_group_users(
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -1284,15 +1580,21 @@ def test_disallow_self_add_admin_modify_group_users(
     assert len(data["owners"]) == 2
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 5
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
 
@@ -1309,7 +1611,7 @@ def test_disallow_self_add_admin_modify_group_users(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=role_group.id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 3
     assert remove_user_from_group_spy.call_count == 0
@@ -1317,15 +1619,21 @@ def test_disallow_self_add_admin_modify_group_users(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 8
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 6
     )
 
@@ -1341,7 +1649,7 @@ def test_disallow_self_add_admin_modify_group_users(
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
@@ -1353,15 +1661,21 @@ def test_disallow_self_add_admin_modify_group_users(
     assert len(data["owners"]) == 1
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 8
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 7
     )
 
@@ -1377,7 +1691,7 @@ def test_disallow_self_add_admin_modify_group_users(
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 3
     assert remove_user_from_group_spy.call_count == 0
@@ -1385,15 +1699,21 @@ def test_disallow_self_add_admin_modify_group_users(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 8
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 7
     )
 
@@ -1409,7 +1729,7 @@ def test_disallow_self_add_admin_modify_group_users(
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 3
     assert remove_user_from_group_spy.call_count == 0
@@ -1421,23 +1741,29 @@ def test_disallow_self_add_admin_modify_group_users(
     assert len(data["owners"]) == 2
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 11
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 10
     )
 
 
 # Admin should be allowed to bypass the constraints in all cases
-def test_disallow_self_add_admin_modify_role_groups(
+async def test_disallow_self_add_admin_modify_role_groups(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     access_app: App,
@@ -1446,7 +1772,9 @@ def test_disallow_self_add_admin_modify_role_groups(
     user: OktaUser,
     url_for: Any,
 ) -> None:
-    current_user = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    current_user = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     role_groups = RoleGroupFactory.create_batch(2)
 
@@ -1471,16 +1799,18 @@ def test_disallow_self_add_admin_modify_role_groups(
     db.session.add(access_app)
     db.session.add_all(role_groups)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=role_groups[0], members_to_add=[current_user.id], owners_to_add=[], sync_to_okta=False
     ).execute()
 
-    ModifyGroupUsers(group=role_groups[1], members_to_add=[user.id], owners_to_add=[], sync_to_okta=False).execute()
+    await ModifyGroupUsers(
+        group=role_groups[1], members_to_add=[user.id], owners_to_add=[], sync_to_okta=False
+    ).execute()
 
     db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tags[0].id))
     db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tags[2].id))
@@ -1490,35 +1820,45 @@ def test_disallow_self_add_admin_modify_role_groups(
     db.session.add(app_tag_map)
     app_tag_map2 = AppTagMap(app_id=access_app.id, tag_id=tags[2].id)
     db.session.add(app_tag_map2)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[1].id, app_tag_map_id=app_tag_map.id))
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id))
-    db.session.commit()
+    await db.session.commit()
 
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    remove_user_from_group_spy = mocker.patch.object(okta, "async_remove_user_from_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
-    remove_owner_from_group_spy = mocker.patch.object(okta, "async_remove_owner_from_group")
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    remove_user_from_group_spy = mocker.patch.object(okta, "remove_user_from_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
+    remove_owner_from_group_spy = mocker.patch.object(okta, "remove_owner_from_group")
 
     # Establish a baseline of user memberships/ownerships
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 0
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 0
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 0
     )
 
@@ -1530,7 +1870,7 @@ def test_disallow_self_add_admin_modify_role_groups(
         "owner_groups_to_remove": [],
     }
     current_user_role_url = url_for("api-roles.role_members_by_id", role_id=role_groups[0].id)
-    rep = client.put(current_user_role_url, json=data)
+    rep = await client.put(current_user_role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -1538,23 +1878,33 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 0
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 1
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 0
     )
 
@@ -1570,7 +1920,7 @@ def test_disallow_self_add_admin_modify_role_groups(
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(current_user_role_url, json=data)
+    rep = await client.put(current_user_role_url, json=data)
     assert rep.status_code == 200
 
     assert add_user_to_group_spy.call_count == 0
@@ -1578,23 +1928,33 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 1
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 1
     )
 
@@ -1610,27 +1970,37 @@ def test_disallow_self_add_admin_modify_role_groups(
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(current_user_role_url, json=data)
+    rep = await client.put(current_user_role_url, json=data)
     assert rep.status_code == 200
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 1
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 1
     )
 
@@ -1647,7 +2017,7 @@ def test_disallow_self_add_admin_modify_role_groups(
         "owner_groups_to_remove": [],
     }
     user_role_url = url_for("api-roles.role_members_by_id", role_id=role_groups[1].id)
-    rep = client.put(user_role_url, json=data)
+    rep = await client.put(user_role_url, json=data)
     assert rep.status_code == 200
 
     assert add_user_to_group_spy.call_count == 1
@@ -1656,23 +2026,33 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 5
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 1
     )
 
@@ -1688,7 +2068,7 @@ def test_disallow_self_add_admin_modify_role_groups(
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(user_role_url, json=data)
+    rep = await client.put(user_role_url, json=data)
     assert rep.status_code == 200
 
     assert add_user_to_group_spy.call_count == 0
@@ -1697,23 +2077,33 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 5
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 2
     )
 
@@ -1729,7 +2119,7 @@ def test_disallow_self_add_admin_modify_role_groups(
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(user_role_url, json=data)
+    rep = await client.put(user_role_url, json=data)
     assert rep.status_code == 200
 
     assert add_user_to_group_spy.call_count == 1
@@ -1738,23 +2128,33 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 5
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 2
     )
 
@@ -1770,7 +2170,7 @@ def test_disallow_self_add_admin_modify_role_groups(
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(current_user_role_url, json=data)
+    rep = await client.put(current_user_role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -1778,23 +2178,33 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 6
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 3
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 2
     )
 
@@ -1810,7 +2220,7 @@ def test_disallow_self_add_admin_modify_role_groups(
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(current_user_role_url, json=data)
+    rep = await client.put(current_user_role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
@@ -1818,23 +2228,33 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 6
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 3
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 3
     )
 
@@ -1850,7 +2270,7 @@ def test_disallow_self_add_admin_modify_role_groups(
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(current_user_role_url, json=data)
+    rep = await client.put(current_user_role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -1858,23 +2278,33 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 6
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 3
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 3
     )
 
@@ -1885,7 +2315,7 @@ def test_disallow_self_add_admin_modify_role_groups(
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(user_role_url, json=data)
+    rep = await client.put(user_role_url, json=data)
     assert rep.status_code == 200
 
     assert add_user_to_group_spy.call_count == 2
@@ -1894,23 +2324,33 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 7
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 4
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 3
     )
 
@@ -1926,7 +2366,7 @@ def test_disallow_self_add_admin_modify_role_groups(
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(user_role_url, json=data)
+    rep = await client.put(user_role_url, json=data)
     assert rep.status_code == 200
 
     assert add_user_to_group_spy.call_count == 0
@@ -1935,23 +2375,33 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 7
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 4
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 4
     )
 
@@ -1967,7 +2417,7 @@ def test_disallow_self_add_admin_modify_role_groups(
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(user_role_url, json=data)
+    rep = await client.put(user_role_url, json=data)
     assert rep.status_code == 200
 
     assert add_user_to_group_spy.call_count == 1
@@ -1976,22 +2426,32 @@ def test_disallow_self_add_admin_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(False), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 7
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.is_owner.is_(True), OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(False), RoleGroupMap.ended_at.is_(None))
+        )
         == 4
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None)).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.is_owner.is_(True), RoleGroupMap.ended_at.is_(None))
+        )
         == 4
     )

--- a/tests/test_expire_access_request.py
+++ b/tests/test_expire_access_request.py
@@ -6,64 +6,72 @@ from api.extensions import Db
 from api.syncer import expire_access_requests
 
 
-def test_no_expire_new_access_request(
+async def test_no_expire_new_access_request(
     db: Db, access_request: AccessRequest, okta_group: OktaGroup, user: OktaUser
 ) -> None:
     db.session.add(user)
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
     access_request.requested_group_id = okta_group.id
     access_request.requester_user_id = user.id
     db.session.add(access_request)
-    db.session.commit()
+    await db.session.commit()
 
     access_request_id = access_request.id
 
-    expire_access_requests()
+    await expire_access_requests()
 
-    access_request = db.session.get(AccessRequest, access_request_id)
+    access_request = await db.session.get(AccessRequest, access_request_id)
     assert access_request.status == AccessRequestStatus.PENDING
     assert access_request.resolved_at is None
 
 
-def test_expire_old_access_request(
+async def test_expire_old_access_request(
     db: Db, access_request: AccessRequest, okta_group: OktaGroup, user: OktaUser
 ) -> None:
     db.session.add(user)
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
     access_request.created_at = datetime.now(timezone.utc) - timedelta(days=30)
     access_request.requested_group_id = okta_group.id
     access_request.requester_user_id = user.id
     db.session.add(access_request)
-    db.session.commit()
+    await db.session.commit()
 
     access_request_id = access_request.id
 
-    expire_access_requests()
+    await expire_access_requests()
 
-    access_request = db.session.get(AccessRequest, access_request_id)
+    # The reject operation expired this row's attributes via a
+    # synchronize_session="fetch" UPDATE; expire_all so the awaited get()
+    # refreshes it instead of lazy-loading on attribute access.
+    db.session.expire_all()
+    access_request = await db.session.get(AccessRequest, access_request_id)
     assert access_request.status == AccessRequestStatus.REJECTED
     assert access_request.resolved_at is not None
 
 
-def test_expire_old_temporary_access_request(
+async def test_expire_old_temporary_access_request(
     db: Db, access_request: AccessRequest, okta_group: OktaGroup, user: OktaUser
 ) -> None:
     db.session.add(user)
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
     access_request.created_at = datetime.now(timezone.utc) - timedelta(days=1)
     access_request.request_ending_at = datetime.now(timezone.utc) - timedelta(hours=12)
     access_request.requested_group_id = okta_group.id
     access_request.requester_user_id = user.id
     db.session.add(access_request)
-    db.session.commit()
+    await db.session.commit()
 
     access_request_id = access_request.id
 
-    expire_access_requests()
+    await expire_access_requests()
 
-    access_request = db.session.get(AccessRequest, access_request_id)
+    # The reject operation expired this row's attributes via a
+    # synchronize_session="fetch" UPDATE; expire_all so the awaited get()
+    # refreshes it instead of lazy-loading on attribute access.
+    db.session.expire_all()
+    access_request = await db.session.get(AccessRequest, access_request_id)
     assert access_request.status == AccessRequestStatus.REJECTED
     assert access_request.resolved_at is not None

--- a/tests/test_expiring_access_notifications.py
+++ b/tests/test_expiring_access_notifications.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 
 from pytest_mock import MockerFixture
+from sqlalchemy import select
 
 from api.models import OktaGroup, OktaUser, OktaUserGroupMember, RoleGroup, RoleGroupMap
 from api.extensions import Db
@@ -18,40 +19,42 @@ from tests.factories import OktaGroupFactory, OktaUserFactory, RoleGroupFactory
 
 
 # Test with one user who has two memberships expiring tomorrow
-def test_individual_expiring_access_notifications(
+async def test_individual_expiring_access_notifications(
     db: Db, mocker: MockerFixture, user: OktaUser, okta_group: OktaGroup, role_group: RoleGroup
 ) -> None:
     db.session.add(okta_group)
     db.session.add(role_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     expiration_datetime = datetime.now() + timedelta(days=1)
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=okta_group, users_added_ended_at=expiration_datetime, members_to_add=[user.id], sync_to_okta=False
     ).execute()
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=role_group, users_added_ended_at=expiration_datetime, members_to_add=[user.id], sync_to_okta=False
     ).execute()
 
     membership1 = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.user_id == user.id)
-        .filter(OktaUserGroupMember.group_id == okta_group.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.user_id == user.id)
+            .where(OktaUserGroupMember.group_id == okta_group.id)
+        )
+    ).first()
     membership2 = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.user_id == user.id)
-        .filter(OktaUserGroupMember.group_id == role_group.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.user_id == user.id)
+            .where(OktaUserGroupMember.group_id == role_group.id)
+        )
+    ).first()
 
     hook = get_notification_hook()
     expiring_access_notification_spy = mocker.patch.object(hook, "access_expiring_user")
 
-    expiring_access_notifications_user()
+    await expiring_access_notifications_user()
 
     assert expiring_access_notification_spy.call_count == 1
     _, kwargs = expiring_access_notification_spy.call_args
@@ -70,41 +73,43 @@ def test_individual_expiring_access_notifications(
 
 
 # Test with one user who has a membership expiring tomorrow and one in a week
-def test_individual_expiring_access_notifications_week(
+async def test_individual_expiring_access_notifications_week(
     db: Db, mocker: MockerFixture, user: OktaUser, okta_group: OktaGroup, role_group: RoleGroup
 ) -> None:
     db.session.add(okta_group)
     db.session.add(role_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     expiration_datetime1 = datetime.now() + timedelta(days=1)
     expiration_datetime2 = datetime.now() + timedelta(weeks=1)
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=okta_group, users_added_ended_at=expiration_datetime1, members_to_add=[user.id], sync_to_okta=False
     ).execute()
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=role_group, users_added_ended_at=expiration_datetime2, members_to_add=[user.id], sync_to_okta=False
     ).execute()
 
     membership1 = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.user_id == user.id)
-        .filter(OktaUserGroupMember.group_id == okta_group.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.user_id == user.id)
+            .where(OktaUserGroupMember.group_id == okta_group.id)
+        )
+    ).first()
     membership2 = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.user_id == user.id)
-        .filter(OktaUserGroupMember.group_id == role_group.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.user_id == user.id)
+            .where(OktaUserGroupMember.group_id == role_group.id)
+        )
+    ).first()
 
     hook = get_notification_hook()
     expiring_access_notification_spy = mocker.patch.object(hook, "access_expiring_user")
 
-    expiring_access_notifications_user()
+    await expiring_access_notifications_user()
 
     assert expiring_access_notification_spy.call_count == 1
     _, kwargs = expiring_access_notification_spy.call_args
@@ -120,67 +125,67 @@ def test_individual_expiring_access_notifications_week(
 
 
 # Test with one user who has one direct membership expiring tomorrow and a role membership for the same group
-def test_individual_expiring_direct_with_role(
+async def test_individual_expiring_direct_with_role(
     db: Db, mocker: MockerFixture, user: OktaUser, okta_group: OktaGroup, role_group: RoleGroup
 ) -> None:
     db.session.add(okta_group)
     db.session.add(role_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     expiration_datetime = datetime.now() + timedelta(days=1)
     other_date = datetime.now() + timedelta(days=90)
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=okta_group, users_added_ended_at=expiration_datetime, members_to_add=[user.id], sync_to_okta=False
     ).execute()
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=role_group, users_added_ended_at=other_date, members_to_add=[user.id], sync_to_okta=False
     ).execute()
-    ModifyRoleGroups(
+    await ModifyRoleGroups(
         role_group=role_group, groups_added_ended_at=other_date, groups_to_add=[okta_group.id], sync_to_okta=False
     ).execute()
 
     hook = get_notification_hook()
     expiring_access_notification_spy = mocker.patch.object(hook, "access_expiring_user")
 
-    expiring_access_notifications_user()
+    await expiring_access_notifications_user()
 
     assert expiring_access_notification_spy.call_count == 0
 
 
 # Test with one user who has one direct membership expiring in a week and a role membership for the same group
-def test_individual_expiring_direct_with_role_week(
+async def test_individual_expiring_direct_with_role_week(
     db: Db, mocker: MockerFixture, user: OktaUser, okta_group: OktaGroup, role_group: RoleGroup
 ) -> None:
     db.session.add(okta_group)
     db.session.add(role_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     expiration_datetime = datetime.now() + timedelta(weeks=1)
     other_date = datetime.now() + timedelta(days=90)
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=okta_group, users_added_ended_at=expiration_datetime, members_to_add=[user.id], sync_to_okta=False
     ).execute()
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=role_group, users_added_ended_at=other_date, members_to_add=[user.id], sync_to_okta=False
     ).execute()
-    ModifyRoleGroups(
+    await ModifyRoleGroups(
         role_group=role_group, groups_added_ended_at=other_date, groups_to_add=[okta_group.id], sync_to_okta=False
     ).execute()
 
     hook = get_notification_hook()
     expiring_access_notification_spy = mocker.patch.object(hook, "access_expiring_user")
 
-    expiring_access_notifications_user()
+    await expiring_access_notifications_user()
 
     assert expiring_access_notification_spy.call_count == 0
 
 
 # Test with one owner who owns two groups, each group has a member whose access expires this week
-def test_owner_expiring_access_notifications(db: Db, mocker: MockerFixture) -> None:
+async def test_owner_expiring_access_notifications(db: Db, mocker: MockerFixture) -> None:
     group1 = OktaGroupFactory.create()
     group2 = OktaGroupFactory.create()
     user1 = OktaUserFactory.create()
@@ -193,34 +198,36 @@ def test_owner_expiring_access_notifications(db: Db, mocker: MockerFixture) -> N
     db.session.add(user1)
     db.session.add(user2)
     db.session.add(owner)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=group1, users_added_ended_at=expiration_datetime, members_to_add=[user1.id], sync_to_okta=False
     ).execute()
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=group2, users_added_ended_at=expiration_datetime, members_to_add=[user2.id], sync_to_okta=False
     ).execute()
-    ModifyGroupUsers(group=group1, owners_to_add=[owner.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=group2, owners_to_add=[owner.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=group1, owners_to_add=[owner.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=group2, owners_to_add=[owner.id], sync_to_okta=False).execute()
 
     membership1 = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == group1.id)
-        .filter(OktaUserGroupMember.user_id == user1.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == group1.id)
+            .where(OktaUserGroupMember.user_id == user1.id)
+        )
+    ).first()
     membership2 = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == group2.id)
-        .filter(OktaUserGroupMember.user_id == user2.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == group2.id)
+            .where(OktaUserGroupMember.user_id == user2.id)
+        )
+    ).first()
 
     hook = get_notification_hook()
     expiring_access_notification_spy = mocker.patch.object(hook, "access_expiring_owner")
 
-    expiring_access_notifications_owner()
+    await expiring_access_notifications_owner()
 
     assert expiring_access_notification_spy.call_count == 1
     _, kwargs = expiring_access_notification_spy.call_args
@@ -239,31 +246,31 @@ def test_owner_expiring_access_notifications(db: Db, mocker: MockerFixture) -> N
 
 
 # Test with one owner who owns one group, the owner is a member of the group and their access is expiring this week
-def test_owner_expiring_access_notifications_owner_only_member(db: Db, mocker: MockerFixture) -> None:
+async def test_owner_expiring_access_notifications_owner_only_member(db: Db, mocker: MockerFixture) -> None:
     group = OktaGroupFactory.create()
     owner = OktaUserFactory.create()
     expiration_datetime = datetime.now() + timedelta(days=2)
 
     db.session.add(group)
     db.session.add(owner)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=group, users_added_ended_at=expiration_datetime, members_to_add=[owner.id], sync_to_okta=False
     ).execute()
-    ModifyGroupUsers(group=group, owners_to_add=[owner.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=group, owners_to_add=[owner.id], sync_to_okta=False).execute()
 
     hook = get_notification_hook()
     expiring_access_notification_spy = mocker.patch.object(hook, "access_expiring_owner")
 
-    expiring_access_notifications_owner()
+    await expiring_access_notifications_owner()
 
     assert expiring_access_notification_spy.call_count == 0
 
 
 # Test with one owner who owns two groups, each group has a member whose access expires this week
 # The owner is also a group member with expiring access but their own access should not be included.
-def test_owner_expiring_access_notifications_owner_member(db: Db, mocker: MockerFixture) -> None:
+async def test_owner_expiring_access_notifications_owner_member(db: Db, mocker: MockerFixture) -> None:
     group1 = OktaGroupFactory.create()
     group2 = OktaGroupFactory.create()
     user1 = OktaUserFactory.create()
@@ -276,40 +283,43 @@ def test_owner_expiring_access_notifications_owner_member(db: Db, mocker: Mocker
     db.session.add(user1)
     db.session.add(user2)
     db.session.add(owner)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=group1, users_added_ended_at=expiration_datetime, members_to_add=[user1.id, owner.id], sync_to_okta=False
     ).execute()
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=group2, users_added_ended_at=expiration_datetime, members_to_add=[user2.id], sync_to_okta=False
     ).execute()
-    ModifyGroupUsers(group=group1, owners_to_add=[owner.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=group2, owners_to_add=[owner.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=group1, owners_to_add=[owner.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=group2, owners_to_add=[owner.id], sync_to_okta=False).execute()
 
     membership1 = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == group1.id)
-        .filter(OktaUserGroupMember.user_id == user1.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == group1.id)
+            .where(OktaUserGroupMember.user_id == user1.id)
+        )
+    ).first()
     membership2 = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == group1.id)
-        .filter(OktaUserGroupMember.user_id == owner.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == group1.id)
+            .where(OktaUserGroupMember.user_id == owner.id)
+        )
+    ).first()
     membership3 = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == group2.id)
-        .filter(OktaUserGroupMember.user_id == user2.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == group2.id)
+            .where(OktaUserGroupMember.user_id == user2.id)
+        )
+    ).first()
 
     hook = get_notification_hook()
     expiring_access_notification_spy = mocker.patch.object(hook, "access_expiring_owner")
 
-    expiring_access_notifications_owner()
+    await expiring_access_notifications_owner()
 
     assert expiring_access_notification_spy.call_count == 1
     _, kwargs = expiring_access_notification_spy.call_args
@@ -329,7 +339,7 @@ def test_owner_expiring_access_notifications_owner_member(db: Db, mocker: Mocker
 
 
 # Test with one owner who owns two groups, each group has a member whose access expires next week
-def test_owner_expiring_access_notifications_week(db: Db, mocker: MockerFixture) -> None:
+async def test_owner_expiring_access_notifications_week(db: Db, mocker: MockerFixture) -> None:
     group1 = OktaGroupFactory.create()
     group2 = OktaGroupFactory.create()
     user1 = OktaUserFactory.create()
@@ -342,34 +352,36 @@ def test_owner_expiring_access_notifications_week(db: Db, mocker: MockerFixture)
     db.session.add(user1)
     db.session.add(user2)
     db.session.add(owner)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=group1, users_added_ended_at=expiration_datetime, members_to_add=[user1.id], sync_to_okta=False
     ).execute()
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=group2, users_added_ended_at=expiration_datetime, members_to_add=[user2.id], sync_to_okta=False
     ).execute()
-    ModifyGroupUsers(group=group1, owners_to_add=[owner.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=group2, owners_to_add=[owner.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=group1, owners_to_add=[owner.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=group2, owners_to_add=[owner.id], sync_to_okta=False).execute()
 
     membership1 = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == group1.id)
-        .filter(OktaUserGroupMember.user_id == user1.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == group1.id)
+            .where(OktaUserGroupMember.user_id == user1.id)
+        )
+    ).first()
     membership2 = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == group2.id)
-        .filter(OktaUserGroupMember.user_id == user2.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == group2.id)
+            .where(OktaUserGroupMember.user_id == user2.id)
+        )
+    ).first()
 
     hook = get_notification_hook()
     expiring_access_notification_spy = mocker.patch.object(hook, "access_expiring_owner")
 
-    expiring_access_notifications_owner()
+    await expiring_access_notifications_owner()
 
     assert expiring_access_notification_spy.call_count == 1
     _, kwargs = expiring_access_notification_spy.call_args
@@ -388,31 +400,31 @@ def test_owner_expiring_access_notifications_week(db: Db, mocker: MockerFixture)
 
 
 # Test with one owner who owns one group, the owner is a member of the group and their access is expiring next week
-def test_owner_expiring_access_notifications_owner_only_member_week(db: Db, mocker: MockerFixture) -> None:
+async def test_owner_expiring_access_notifications_owner_only_member_week(db: Db, mocker: MockerFixture) -> None:
     group = OktaGroupFactory.create()
     owner = OktaUserFactory.create()
     expiration_datetime = datetime.now() + timedelta(days=9)
 
     db.session.add(group)
     db.session.add(owner)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=group, users_added_ended_at=expiration_datetime, members_to_add=[owner.id], sync_to_okta=False
     ).execute()
-    ModifyGroupUsers(group=group, owners_to_add=[owner.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=group, owners_to_add=[owner.id], sync_to_okta=False).execute()
 
     hook = get_notification_hook()
     expiring_access_notification_spy = mocker.patch.object(hook, "access_expiring_owner")
 
-    expiring_access_notifications_owner()
+    await expiring_access_notifications_owner()
 
     assert expiring_access_notification_spy.call_count == 0
 
 
 # Test with one owner who owns two groups, each group has a member whose access expires next week
 # The owner is also a group member with expiring access but their own access should not be included.
-def test_owner_expiring_access_notifications_owner_member_week(db: Db, mocker: MockerFixture) -> None:
+async def test_owner_expiring_access_notifications_owner_member_week(db: Db, mocker: MockerFixture) -> None:
     group1 = OktaGroupFactory.create()
     group2 = OktaGroupFactory.create()
     user1 = OktaUserFactory.create()
@@ -425,40 +437,43 @@ def test_owner_expiring_access_notifications_owner_member_week(db: Db, mocker: M
     db.session.add(user1)
     db.session.add(user2)
     db.session.add(owner)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=group1, users_added_ended_at=expiration_datetime, members_to_add=[user1.id, owner.id], sync_to_okta=False
     ).execute()
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=group2, users_added_ended_at=expiration_datetime, members_to_add=[user2.id], sync_to_okta=False
     ).execute()
-    ModifyGroupUsers(group=group1, owners_to_add=[owner.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=group2, owners_to_add=[owner.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=group1, owners_to_add=[owner.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=group2, owners_to_add=[owner.id], sync_to_okta=False).execute()
 
     membership1 = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == group1.id)
-        .filter(OktaUserGroupMember.user_id == user1.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == group1.id)
+            .where(OktaUserGroupMember.user_id == user1.id)
+        )
+    ).first()
     membership2 = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == group1.id)
-        .filter(OktaUserGroupMember.user_id == owner.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == group1.id)
+            .where(OktaUserGroupMember.user_id == owner.id)
+        )
+    ).first()
     membership3 = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == group2.id)
-        .filter(OktaUserGroupMember.user_id == user2.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == group2.id)
+            .where(OktaUserGroupMember.user_id == user2.id)
+        )
+    ).first()
 
     hook = get_notification_hook()
     expiring_access_notification_spy = mocker.patch.object(hook, "access_expiring_owner")
 
-    expiring_access_notifications_owner()
+    await expiring_access_notifications_owner()
 
     assert expiring_access_notification_spy.call_count == 1
     _, kwargs = expiring_access_notification_spy.call_args
@@ -478,7 +493,7 @@ def test_owner_expiring_access_notifications_owner_member_week(db: Db, mocker: M
 
 
 # Test with one owner who owns a groups, the group has a role member whose access expires this week
-def test_owner_expiring_access_notifications_role(db: Db, mocker: MockerFixture) -> None:
+async def test_owner_expiring_access_notifications_role(db: Db, mocker: MockerFixture) -> None:
     group1 = RoleGroupFactory.create()
     group2 = OktaGroupFactory.create()
     user1 = OktaUserFactory.create()
@@ -489,25 +504,28 @@ def test_owner_expiring_access_notifications_role(db: Db, mocker: MockerFixture)
     db.session.add(group2)
     db.session.add(user1)
     db.session.add(owner)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=group1, users_added_ended_at=None, members_to_add=[user1.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=group2, owners_to_add=[owner.id], sync_to_okta=False).execute()
-    ModifyRoleGroups(
+    await ModifyGroupUsers(
+        group=group1, users_added_ended_at=None, members_to_add=[user1.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(group=group2, owners_to_add=[owner.id], sync_to_okta=False).execute()
+    await ModifyRoleGroups(
         role_group=group1, groups_added_ended_at=expiration_datetime, groups_to_add=[group2.id], sync_to_okta=False
     ).execute()
 
     membership1 = (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.group_id == group2.id)
-        .filter(RoleGroupMap.role_group_id == group1.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(RoleGroupMap)
+            .where(RoleGroupMap.group_id == group2.id)
+            .where(RoleGroupMap.role_group_id == group1.id)
+        )
+    ).first()
 
     hook = get_notification_hook()
     expiring_access_notification_spy = mocker.patch.object(hook, "access_expiring_owner")
 
-    expiring_access_notifications_owner()
+    await expiring_access_notifications_owner()
 
     assert expiring_access_notification_spy.call_count == 1
     _, kwargs = expiring_access_notification_spy.call_args
@@ -522,7 +540,7 @@ def test_owner_expiring_access_notifications_role(db: Db, mocker: MockerFixture)
 
 
 # Test with one owner who owns two groups, each group has a role member whose access expires next week
-def test_owner_expiring_access_notifications_role_week(db: Db, mocker: MockerFixture) -> None:
+async def test_owner_expiring_access_notifications_role_week(db: Db, mocker: MockerFixture) -> None:
     role = RoleGroupFactory.create()
     group1 = OktaGroupFactory.create()
     group2 = OktaGroupFactory.create()
@@ -535,12 +553,14 @@ def test_owner_expiring_access_notifications_role_week(db: Db, mocker: MockerFix
     db.session.add(group2)
     db.session.add(user1)
     db.session.add(owner)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=role, users_added_ended_at=None, members_to_add=[user1.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=group1, owners_to_add=[owner.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=group2, owners_to_add=[owner.id], sync_to_okta=False).execute()
-    ModifyRoleGroups(
+    await ModifyGroupUsers(
+        group=role, users_added_ended_at=None, members_to_add=[user1.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(group=group1, owners_to_add=[owner.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=group2, owners_to_add=[owner.id], sync_to_okta=False).execute()
+    await ModifyRoleGroups(
         role_group=role,
         groups_added_ended_at=expiration_datetime,
         groups_to_add=[group1.id, group2.id],
@@ -548,22 +568,20 @@ def test_owner_expiring_access_notifications_role_week(db: Db, mocker: MockerFix
     ).execute()
 
     membership1 = (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.group_id == group1.id)
-        .filter(RoleGroupMap.role_group_id == role.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(RoleGroupMap).where(RoleGroupMap.group_id == group1.id).where(RoleGroupMap.role_group_id == role.id)
+        )
+    ).first()
     membership2 = (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.group_id == group2.id)
-        .filter(RoleGroupMap.role_group_id == role.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(RoleGroupMap).where(RoleGroupMap.group_id == group2.id).where(RoleGroupMap.role_group_id == role.id)
+        )
+    ).first()
 
     hook = get_notification_hook()
     expiring_access_notification_spy = mocker.patch.object(hook, "access_expiring_owner")
 
-    expiring_access_notifications_owner()
+    await expiring_access_notifications_owner()
 
     assert expiring_access_notification_spy.call_count == 1
     _, kwargs = expiring_access_notification_spy.call_args
@@ -580,40 +598,41 @@ def test_owner_expiring_access_notifications_role_week(db: Db, mocker: MockerFix
 
 
 # Test should not renew funtionality for individual notifications
-def test_individual_do_not_renew_notification_behavior(
+async def test_individual_do_not_renew_notification_behavior(
     db: Db, mocker: MockerFixture, user: OktaUser, okta_group: OktaGroup, role_group: RoleGroup
 ) -> None:
     db.session.add(okta_group)
     db.session.add(role_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     expiration_datetime = datetime.now() + timedelta(days=1)
 
     # Add user to two groups
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=okta_group, users_added_ended_at=expiration_datetime, members_to_add=[user.id], sync_to_okta=False
     ).execute()
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=role_group, users_added_ended_at=expiration_datetime, members_to_add=[user.id], sync_to_okta=False
     ).execute()
 
     # Get the OktaUserGroupMember for the user's membership to role_group
     membership = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.user_id == user.id)
-        .filter(OktaUserGroupMember.group_id == role_group.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.user_id == user.id)
+            .where(OktaUserGroupMember.group_id == role_group.id)
+        )
+    ).first()
     assert membership is not None
 
     # Mark one membership as 'should_expire'
-    ModifyGroupUsers(group=role_group, members_should_expire=[membership.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=role_group, members_should_expire=[membership.id], sync_to_okta=False).execute()
 
     hook = get_notification_hook()
     expiring_access_notification_spy = mocker.patch.object(hook, "access_expiring_user")
 
-    expiring_access_notifications_user()
+    await expiring_access_notifications_user()
 
     assert expiring_access_notification_spy.call_count == 1
     _, kwargs = expiring_access_notification_spy.call_args
@@ -627,7 +646,7 @@ def test_individual_do_not_renew_notification_behavior(
 
 
 # Test owner notifications for should not renew funtionality
-def test_owner_role_do_not_renew_notification_behavior(
+async def test_owner_role_do_not_renew_notification_behavior(
     db: Db, mocker: MockerFixture, role_group: RoleGroup, okta_group: OktaGroup
 ) -> None:
     user1 = OktaUserFactory.create()
@@ -638,16 +657,16 @@ def test_owner_role_do_not_renew_notification_behavior(
     db.session.add(okta_group)
     db.session.add(user1)
     db.session.add(owner)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=role_group, users_added_ended_at=expiration_datetime, members_to_add=[user1.id], sync_to_okta=False
     ).execute()
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=role_group, users_added_ended_at=None, owners_to_add=[owner.id], sync_to_okta=False
     ).execute()
-    ModifyGroupUsers(group=okta_group, owners_to_add=[owner.id], sync_to_okta=False).execute()
-    ModifyRoleGroups(
+    await ModifyGroupUsers(group=okta_group, owners_to_add=[owner.id], sync_to_okta=False).execute()
+    await ModifyRoleGroups(
         role_group=role_group,
         groups_added_ended_at=expiration_datetime,
         groups_to_add=[okta_group.id],
@@ -656,37 +675,41 @@ def test_owner_role_do_not_renew_notification_behavior(
 
     # Get the OktaUserGroupMember for the user's membership to role_group
     membership = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.user_id == user1.id)
-        .filter(OktaUserGroupMember.group_id == role_group.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.user_id == user1.id)
+            .where(OktaUserGroupMember.group_id == role_group.id)
+        )
+    ).first()
     assert membership is not None
     # Get RoleGroupMap
     role_membership = (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.role_group_id == role_group.id)
-        .filter(RoleGroupMap.group_id == okta_group.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(RoleGroupMap)
+            .where(RoleGroupMap.role_group_id == role_group.id)
+            .where(RoleGroupMap.group_id == okta_group.id)
+        )
+    ).first()
     assert role_membership is not None
 
     # Mark user as do not renew
-    ModifyGroupUsers(group=role_group, members_should_expire=[membership.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=role_group, members_should_expire=[membership.id], sync_to_okta=False).execute()
 
     # Mark role as do not renew
-    ModifyRoleGroups(role_group=role_group, groups_should_expire=[role_membership.id], sync_to_okta=False).execute()
+    await ModifyRoleGroups(
+        role_group=role_group, groups_should_expire=[role_membership.id], sync_to_okta=False
+    ).execute()
 
     hook = get_notification_hook()
     expiring_access_notification_spy = mocker.patch.object(hook, "access_expiring_owner")
 
-    expiring_access_notifications_owner()
+    await expiring_access_notifications_owner()
 
     assert expiring_access_notification_spy.call_count == 0
 
 
 # Test with one owner who owns two role, each role is a member of a group and its access expires tomorrow
-def test_role_owner_expiring_access_notifications_role_tomorrow(db: Db, mocker: MockerFixture) -> None:
+async def test_role_owner_expiring_access_notifications_role_tomorrow(db: Db, mocker: MockerFixture) -> None:
     role1 = RoleGroupFactory.create()
     role2 = RoleGroupFactory.create()
     group = OktaGroupFactory.create()
@@ -699,34 +722,32 @@ def test_role_owner_expiring_access_notifications_role_tomorrow(db: Db, mocker: 
     db.session.add(group)
     db.session.add(user1)
     db.session.add(owner)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=role1, owners_to_add=[owner.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=role2, owners_to_add=[owner.id], sync_to_okta=False).execute()
-    ModifyRoleGroups(
+    await ModifyGroupUsers(group=role1, owners_to_add=[owner.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=role2, owners_to_add=[owner.id], sync_to_okta=False).execute()
+    await ModifyRoleGroups(
         role_group=role1, groups_added_ended_at=expiration_datetime, groups_to_add=[group.id], sync_to_okta=False
     ).execute()
-    ModifyRoleGroups(
+    await ModifyRoleGroups(
         role_group=role2, groups_added_ended_at=expiration_datetime, groups_to_add=[group.id], sync_to_okta=False
     ).execute()
 
     membership1 = (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.role_group_id == role1.id)
-        .filter(RoleGroupMap.group_id == group.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(RoleGroupMap).where(RoleGroupMap.role_group_id == role1.id).where(RoleGroupMap.group_id == group.id)
+        )
+    ).first()
     membership2 = (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.role_group_id == role2.id)
-        .filter(RoleGroupMap.group_id == group.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(RoleGroupMap).where(RoleGroupMap.role_group_id == role2.id).where(RoleGroupMap.group_id == group.id)
+        )
+    ).first()
 
     hook = get_notification_hook()
     expiring_access_notification_spy = mocker.patch.object(hook, "access_expiring_role_owner")
 
-    expiring_access_notifications_role_owner()
+    await expiring_access_notifications_role_owner()
 
     assert expiring_access_notification_spy.call_count == 1
     _, kwargs = expiring_access_notification_spy.call_args
@@ -741,7 +762,7 @@ def test_role_owner_expiring_access_notifications_role_tomorrow(db: Db, mocker: 
 
 # Test with one owner who owns two role, each role is a member of one or more groups and its
 # access expires tomorrow or next week
-def test_role_owner_expiring_access_notifications_role_multiple_dates(db: Db, mocker: MockerFixture) -> None:
+async def test_role_owner_expiring_access_notifications_role_multiple_dates(db: Db, mocker: MockerFixture) -> None:
     role1 = RoleGroupFactory.create()
     role2 = RoleGroupFactory.create()
     group1 = OktaGroupFactory.create()
@@ -757,43 +778,40 @@ def test_role_owner_expiring_access_notifications_role_multiple_dates(db: Db, mo
     db.session.add(group2)
     db.session.add(user1)
     db.session.add(owner)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=role1, owners_to_add=[owner.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=role2, owners_to_add=[owner.id], sync_to_okta=False).execute()
-    ModifyRoleGroups(
+    await ModifyGroupUsers(group=role1, owners_to_add=[owner.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=role2, owners_to_add=[owner.id], sync_to_okta=False).execute()
+    await ModifyRoleGroups(
         role_group=role1, groups_added_ended_at=expiration_datetime, groups_to_add=[group1.id], sync_to_okta=False
     ).execute()
-    ModifyRoleGroups(
+    await ModifyRoleGroups(
         role_group=role2, groups_added_ended_at=expiration_datetime2, groups_to_add=[group1.id], sync_to_okta=False
     ).execute()
-    ModifyRoleGroups(
+    await ModifyRoleGroups(
         role_group=role2, groups_added_ended_at=expiration_datetime, groups_to_add=[group2.id], sync_to_okta=False
     ).execute()
 
     membership1 = (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.role_group_id == role1.id)
-        .filter(RoleGroupMap.group_id == group1.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(RoleGroupMap).where(RoleGroupMap.role_group_id == role1.id).where(RoleGroupMap.group_id == group1.id)
+        )
+    ).first()
     membership2 = (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.role_group_id == role2.id)
-        .filter(RoleGroupMap.group_id == group1.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(RoleGroupMap).where(RoleGroupMap.role_group_id == role2.id).where(RoleGroupMap.group_id == group1.id)
+        )
+    ).first()
     membership3 = (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.role_group_id == role2.id)
-        .filter(RoleGroupMap.group_id == group2.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(RoleGroupMap).where(RoleGroupMap.role_group_id == role2.id).where(RoleGroupMap.group_id == group2.id)
+        )
+    ).first()
 
     hook = get_notification_hook()
     expiring_access_notification_spy = mocker.patch.object(hook, "access_expiring_role_owner")
 
-    expiring_access_notifications_role_owner()
+    await expiring_access_notifications_role_owner()
 
     assert expiring_access_notification_spy.call_count == 1
     _, kwargs = expiring_access_notification_spy.call_args
@@ -806,40 +824,45 @@ def test_role_owner_expiring_access_notifications_role_multiple_dates(db: Db, mo
 
 # Test with an externally managed group and a non-externally managed group. The Access admin should only be notified about
 # expiring access for the non-externally managed group
-def test_owner_expiring_access_notifications_managed_group_admin(db: Db, app: FastAPI, mocker: MockerFixture) -> None:
+async def test_owner_expiring_access_notifications_managed_group_admin(
+    db: Db, app: FastAPI, mocker: MockerFixture
+) -> None:
     # Create an externally managed group and an Access managed group
     group1 = OktaGroupFactory.create()
     group1.is_managed = False
     group2 = OktaGroupFactory.create()
 
     user = OktaUserFactory.create()
-    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     expiration_datetime = datetime.now() + timedelta(days=2)
 
     db.session.add(group1)
     db.session.add(group2)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=group1, users_added_ended_at=expiration_datetime, members_to_add=[user.id], sync_to_okta=False
     ).execute()
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=group2, users_added_ended_at=expiration_datetime, members_to_add=[user.id], sync_to_okta=False
     ).execute()
 
     membership = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == group2.id)
-        .filter(OktaUserGroupMember.user_id == user.id)
-        .first()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == group2.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+        )
+    ).first()
 
     hook = get_notification_hook()
     expiring_access_notification_spy = mocker.patch.object(hook, "access_expiring_owner")
 
-    expiring_access_notifications_owner()
+    await expiring_access_notifications_owner()
 
     # Access admin should only be notified about expiring access for the Access managed group
     assert expiring_access_notification_spy.call_count == 1

--- a/tests/test_fanout_task_errors.py
+++ b/tests/test_fanout_task_errors.py
@@ -1,0 +1,131 @@
+"""Failures in the Okta/notification task fan-out are logged, not swallowed.
+
+The fan-out operations drain their `asyncio.create_task` lists through
+`api.operations._fan_out.drain_fan_out_tasks`, which logs each failed task
+with operation context instead of dropping the exception (the old
+`asyncio.wait` idiom) — and never fails the request, because the local DB
+state is committed before the tasks are awaited.
+"""
+
+import asyncio
+import logging
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient
+from pytest_mock import MockerFixture
+from sqlalchemy import select
+
+from api.extensions import Db
+from api.models import OktaGroup, OktaUser, OktaUserGroupMember
+from api.operations import DeleteGroup
+from api.operations._fan_out import drain_fan_out_tasks
+from api.services import okta
+from tests.helpers import db_count
+
+
+async def test_drain_logs_failures_and_awaits_all_tasks(caplog: pytest.LogCaptureFixture) -> None:
+    completed = []
+
+    async def _ok() -> None:
+        completed.append("ok")
+
+    async def _boom() -> None:
+        raise RuntimeError("fan-out task exploded")
+
+    tasks = [asyncio.create_task(_boom()), asyncio.create_task(_ok())]
+    with caplog.at_level(logging.ERROR, logger="api"):
+        await drain_fan_out_tasks(tasks, "UnitTestOp for thing thing-1")
+
+    # The failure neither propagated nor cancelled the sibling task.
+    assert completed == ["ok"]
+    failures = [r for r in caplog.records if "UnitTestOp for thing thing-1" in r.getMessage()]
+    assert len(failures) == 1
+    assert failures[0].exc_info is not None
+    assert "fan-out task exploded" in str(failures[0].exc_info[1])
+
+
+async def test_drain_no_tasks_is_a_noop(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.ERROR, logger="api"):
+        await drain_fan_out_tasks([], "UnitTestOp for nothing")
+    assert not [r for r in caplog.records if "UnitTestOp" in r.getMessage()]
+
+
+async def test_failing_okta_call_is_logged_and_does_not_fail_request(
+    app: FastAPI,
+    client: AsyncClient,
+    db: Db,
+    mocker: MockerFixture,
+    user: OktaUser,
+    okta_group: OktaGroup,
+    url_for: Any,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    db.session.add(okta_group)
+    db.session.add(user)
+    await db.session.commit()
+
+    mocker.patch.object(okta, "add_user_to_group", side_effect=Exception("okta add blew up"))
+    add_owner_spy = mocker.patch.object(okta, "add_owner_to_group")
+    mocker.patch.object(okta, "remove_user_from_group")
+    mocker.patch.object(okta, "remove_owner_from_group")
+
+    data: dict[str, Any] = {
+        "members_to_add": [user.id],
+        "owners_to_add": [user.id],
+        "members_to_remove": [],
+        "owners_to_remove": [],
+    }
+    group_url = url_for("api-groups.group_members_by_id", group_id=okta_group.id)
+    with caplog.at_level(logging.ERROR, logger="api"):
+        rep = await client.put(group_url, json=data)
+
+    # The Okta failure does not fail the request - the membership committed.
+    assert rep.status_code == 200
+    assert (
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.user_id == user.id)
+            .where(OktaUserGroupMember.group_id == okta_group.id)
+            .where(OktaUserGroupMember.ended_at.is_(None)),
+        )
+        == 2
+    )
+    # The sibling owner-add task still ran.
+    assert add_owner_spy.call_count == 1
+
+    failures = [r for r in caplog.records if f"ModifyGroupUsers for group {okta_group.id}" in r.getMessage()]
+    assert len(failures) == 1
+    assert failures[0].exc_info is not None
+    assert "okta add blew up" in str(failures[0].exc_info[1])
+
+
+async def test_failing_okta_delete_is_logged_and_group_still_deleted(
+    db: Db,
+    mocker: MockerFixture,
+    okta_group: OktaGroup,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    db.session.add(okta_group)
+    await db.session.commit()
+    group_id = okta_group.id
+
+    mocker.patch.object(okta, "delete_group", side_effect=Exception("okta delete blew up"))
+    mocker.patch.object(okta, "remove_user_from_group")
+    mocker.patch.object(okta, "remove_owner_from_group")
+
+    with caplog.at_level(logging.ERROR, logger="api"):
+        await DeleteGroup(group=group_id).execute()
+
+    # The local soft-delete committed despite the Okta failure.
+    db.session.expire_all()
+    deleted_group = await db.session.get(OktaGroup, group_id)
+    assert deleted_group is not None
+    assert deleted_group.deleted_at is not None
+
+    failures = [r for r in caplog.records if f"DeleteGroup for group {group_id}" in r.getMessage()]
+    assert len(failures) == 1
+    assert failures[0].exc_info is not None
+    assert "okta delete blew up" in str(failures[0].exc_info[1])

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -4,12 +4,12 @@ from unittest.mock import Mock
 
 import pytest
 from factory import Faker
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
 from okta.models.group import Group
 from pytest_mock import MockerFixture
 from fastapi import FastAPI
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select
 from api.auth import permissions as AuthorizationHelpers
 from api.extensions import Db, db
 from api.config import settings
@@ -29,6 +29,7 @@ from api.models import (
 from api.operations import CreateAccessRequest, ModifyGroupUsers, ModifyRoleGroups
 from api.services import okta
 from tests.factories import AppFactory, AppGroupFactory, OktaGroupFactory, OktaUserFactory, RoleGroupFactory
+from tests.helpers import db_count
 
 
 # Define a Protocol that includes the pystr method
@@ -36,8 +37,8 @@ class FakerWithPyStr(Protocol):
     def pystr(self) -> str: ...
 
 
-def test_get_group(
-    client: TestClient,
+async def test_get_group(
+    client: AsyncClient,
     db: Db,
     access_app: App,
     app_group: AppGroup,
@@ -48,22 +49,28 @@ def test_get_group(
 ) -> None:
     # test 404
     group_url = url_for("api-groups.group_by_id", group_id="randomid")
-    rep = client.get(group_url)
+    rep = await client.get(group_url)
     assert rep.status_code == 404
 
     db.session.add(access_app)
     db.session.add(okta_group)
     db.session.add(user)
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=app_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyRoleGroups(
+    await ModifyGroupUsers(
+        group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(
+        group=app_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyRoleGroups(
         role_group=role_group,
         groups_to_add=[okta_group.id, app_group.id],
         owner_groups_to_add=[okta_group.id, app_group.id],
@@ -72,40 +79,42 @@ def test_get_group(
 
     # test get group
     group_url = url_for("api-groups.group_by_id", group_id=okta_group.id)
-    rep = client.get(group_url)
+    rep = await client.get(group_url)
     assert rep.status_code == 200
 
     data = rep.json()
     assert data["name"] == okta_group.name
 
     group_url = url_for("api-groups.group_by_id", group_id=role_group.id)
-    rep = client.get(group_url)
+    rep = await client.get(group_url)
     assert rep.status_code == 200
 
     data = rep.json()
     assert data["name"] == role_group.name
 
     group_url = url_for("api-groups.group_by_id", group_id=app_group.id)
-    rep = client.get(group_url)
+    rep = await client.get(group_url)
     assert rep.status_code == 200
 
     data = rep.json()
     assert data["name"] == app_group.name
 
 
-def test_get_group_members(client: TestClient, db: Db, okta_group: OktaGroup, user: OktaUser, url_for: Any) -> None:
+async def test_get_group_members(
+    client: AsyncClient, db: Db, okta_group: OktaGroup, user: OktaUser, url_for: Any
+) -> None:
     # test 404
     group_url = url_for("api-groups.group_members_by_id", group_id="randomid")
-    rep = client.get(group_url)
+    rep = await client.get(group_url)
     assert rep.status_code == 404
 
     db.session.add(okta_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     # test get group members
     group_url = url_for("api-groups.group_members_by_id", group_id=okta_group.id)
-    rep = client.get(group_url)
+    rep = await client.get(group_url)
     assert rep.status_code == 200
 
     data = rep.json()
@@ -113,10 +122,10 @@ def test_get_group_members(client: TestClient, db: Db, okta_group: OktaGroup, us
     assert len(data["owners"]) == 0
 
     db.session.add(OktaUserGroupMember(user_id=user.id, group_id=okta_group.id))
-    db.session.commit()
+    await db.session.commit()
 
     group_url = url_for("api-groups.group_members_by_id", group_id=okta_group.id)
-    rep = client.get(group_url)
+    rep = await client.get(group_url)
     assert rep.status_code == 200
 
     data = rep.json()
@@ -125,10 +134,10 @@ def test_get_group_members(client: TestClient, db: Db, okta_group: OktaGroup, us
     assert len(data["owners"]) == 0
 
     db.session.add(OktaUserGroupMember(user_id=user.id, group_id=okta_group.id, is_owner=True))
-    db.session.commit()
+    await db.session.commit()
 
     group_url = url_for("api-groups.group_members_by_id", group_id=okta_group.id)
-    rep = client.get(group_url)
+    rep = await client.get(group_url)
     assert rep.status_code == 200
 
     data = rep.json()
@@ -138,21 +147,21 @@ def test_get_group_members(client: TestClient, db: Db, okta_group: OktaGroup, us
     assert data["owners"][0] == user.id
 
 
-def test_put_group(
-    client: TestClient, db: Db, mocker: MockerFixture, okta_group: OktaGroup, access_app: App, tag: Tag, url_for: Any
+async def test_put_group(
+    client: AsyncClient, db: Db, mocker: MockerFixture, okta_group: OktaGroup, access_app: App, tag: Tag, url_for: Any
 ) -> None:
     # test 404 — PUT against a non-existent group_id with a valid body shape
     # returns 404. UpdateGroupBody is a discriminated union on `type`, so the
     # body must include the discriminator for the schema to parse; missing or
     # empty bodies fail validation with a 400 instead.
     group_url = url_for("api-groups.group_by_id", group_id="randomid")
-    rep = client.put(group_url, json={"type": "okta_group"})
+    rep = await client.put(group_url, json={"type": "okta_group"})
     assert rep.status_code == 404
 
     db.session.add(okta_group)
     db.session.add(access_app)
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
     # Store IDs before requests — expunge_all() in ModifyGroupType can
     # detach fixture objects, causing DetachedInstanceError on access.
@@ -166,10 +175,10 @@ def test_put_group(
     # test update group
     update_group_spy = mocker.patch.object(okta, "update_group")
 
-    _update_group_type(
+    await _update_group_type(
         client, okta_group, update_group_spy, "okta_group", {"tags_to_add": [tag_id]}, 1, url_for=url_for
     )
-    _update_group_type(
+    await _update_group_type(
         client,
         okta_group,
         update_group_spy,
@@ -182,7 +191,7 @@ def test_put_group(
         1,
         url_for=url_for,
     )
-    _update_group_type(
+    await _update_group_type(
         client,
         okta_group,
         update_group_spy,
@@ -194,8 +203,8 @@ def test_put_group(
         },
         url_for=url_for,
     )
-    _update_group_type(client, okta_group, update_group_spy, "okta_group", url_for=url_for)
-    _update_group_type(
+    await _update_group_type(client, okta_group, update_group_spy, "okta_group", url_for=url_for)
+    await _update_group_type(
         client,
         okta_group,
         update_group_spy,
@@ -208,7 +217,7 @@ def test_put_group(
         1,
         url_for=url_for,
     )
-    _update_group_type(
+    await _update_group_type(
         client,
         okta_group,
         update_group_spy,
@@ -221,7 +230,7 @@ def test_put_group(
         2,
         url_for=url_for,
     )
-    _update_group_type(
+    await _update_group_type(
         client,
         okta_group,
         update_group_spy,
@@ -239,8 +248,10 @@ def test_put_group(
         + f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
     )
     builtin_access_owners_group = (
-        db.session.query(AppGroup).filter(AppGroup.name == builtin_access_owners_group_name, AppGroup.is_owner).first()
-    )
+        await db.session.scalars(
+            select(AppGroup).where(AppGroup.name == builtin_access_owners_group_name, AppGroup.is_owner)
+        )
+    ).first()
     update_group_spy.reset_mock()
 
     data: dict[str, Any] = {
@@ -248,9 +259,11 @@ def test_put_group(
         "name": "Updated",
         "description": "new description",
     }
+    # Capture the id once before any requests — the failed PUT below rolls back
+    # the shared session and expires the fixture-loaded object.
     group_id = builtin_access_owners_group.id
     group_url = url_for("api-groups.group_by_id", group_id=group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 400
 
     # Updating tags is allowed, but nothing else
@@ -260,9 +273,7 @@ def test_put_group(
             "tags_to_add": [tag_id],
         }
     )
-    group_id = builtin_access_owners_group.id
-    group_url = url_for("api-groups.group_by_id", group_id=group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert update_group_spy.call_count == 0
 
@@ -271,7 +282,7 @@ def test_put_group(
     assert ret_data["name"] == builtin_access_owners_group_name
     assert ret_data["description"] != "new description"
     assert ret_data["id"] == group_id
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 1
 
     update_group_spy.reset_mock()
     data.update(
@@ -279,9 +290,7 @@ def test_put_group(
             "tags_to_remove": [tag_id],
         }
     )
-    group_id = builtin_access_owners_group.id
-    group_url = url_for("api-groups.group_by_id", group_id=group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert update_group_spy.call_count == 0
 
@@ -290,11 +299,11 @@ def test_put_group(
     assert ret_data["name"] == builtin_access_owners_group_name
     assert ret_data["description"] != "new description"
     assert ret_data["id"] == group_id
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 0
 
 
-def _update_group_type(
-    client: TestClient,
+async def _update_group_type(
+    client: AsyncClient,
     okta_group: OktaGroup,
     update_group_spy: Mock,
     group_type: str,
@@ -314,7 +323,7 @@ def _update_group_type(
     group_id = okta_group.id
     assert url_for is not None, "_update_group_type requires the url_for fixture"
     group_url = url_for("api-groups.group_by_id", group_id=group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert update_group_spy.call_count == 1
 
@@ -323,13 +332,16 @@ def _update_group_type(
     assert ret_data["name"] == data["name"]
     assert ret_data["description"] == f"new description {group_type}"
     assert ret_data["id"] == group_id
-    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 1
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == expected_tags_count
+    assert await db_count(db.session, select(AppTagMap).where(AppTagMap.ended_at.is_(None))) == 1
+    assert (
+        await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None)))
+        == expected_tags_count
+    )
 
 
-def test_put_app_group_rebind_authorization(
+async def test_put_app_group_rebind_authorization(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     app_group: AppGroup,
@@ -351,7 +363,7 @@ def test_put_app_group_rebind_authorization(
     )
     app_group.app_id = source_app.id
     db.session.add_all([source_app, target_app, source_app_owner_group, target_app_owner_group, app_group])
-    db.session.commit()
+    await db.session.commit()
 
     # Store IDs before requests — expunge_all() in ModifyGroupType can
     # detach fixture objects, causing DetachedInstanceError on access.
@@ -361,8 +373,10 @@ def test_put_app_group_rebind_authorization(
     target_app_name = target_app.name
     target_app_owner_group_id = target_app_owner_group.id
 
-    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
-    ModifyGroupUsers(group=app_group, owners_to_add=[access_owner.id], sync_to_okta=False).execute()
+    access_owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
+    await ModifyGroupUsers(group=app_group, owners_to_add=[access_owner.id], sync_to_okta=False).execute()
 
     mocker.patch.object(okta, "update_group")
     group_url = url_for("api-groups.group_by_id", group_id=app_group_id)
@@ -374,32 +388,34 @@ def test_put_app_group_rebind_authorization(
 
     # A group owner who does not own the target app cannot rebind the group
     mocker.patch.object(AuthorizationHelpers, "is_access_admin", return_value=False)
-    rep = client.put(group_url, json=rebind_data)
+    rep = await client.put(group_url, json=rebind_data)
     assert rep.status_code == 403
-    assert db.session.get(AppGroup, app_group_id).app_id == source_app_id
+    assert (await db.session.get(AppGroup, app_group_id)).app_id == source_app_id
 
     # An Access admin can rebind the group to a different app
     mocker.patch.object(AuthorizationHelpers, "is_access_admin", return_value=True)
-    rep = client.put(group_url, json=rebind_data)
+    rep = await client.put(group_url, json=rebind_data)
     assert rep.status_code == 200
     assert rep.json()["app_id"] == target_app_id
 
     # Reset group back to source app for the next case
-    group_obj = db.session.get(AppGroup, app_group_id)
+    group_obj = await db.session.get(AppGroup, app_group_id)
     group_obj.app_id = source_app_id
-    db.session.commit()
+    await db.session.commit()
 
     # An owner of the target app can also rebind the group
     mocker.patch.object(AuthorizationHelpers, "is_access_admin", return_value=False)
-    target_app_owner_group_obj = db.session.get(AppGroup, target_app_owner_group_id)
-    ModifyGroupUsers(group=target_app_owner_group_obj, owners_to_add=[access_owner.id], sync_to_okta=False).execute()
-    rep = client.put(group_url, json=rebind_data)
+    target_app_owner_group_obj = await db.session.get(AppGroup, target_app_owner_group_id)
+    await ModifyGroupUsers(
+        group=target_app_owner_group_obj, owners_to_add=[access_owner.id], sync_to_okta=False
+    ).execute()
+    rep = await client.put(group_url, json=rebind_data)
     assert rep.status_code == 200
     assert rep.json()["app_id"] == target_app_id
 
 
-def test_put_group_members(
-    client: TestClient,
+async def test_put_group_members(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     okta_group: OktaGroup,
@@ -411,19 +427,19 @@ def test_put_group_members(
 ) -> None:
     # test 404
     group_url = url_for("api-groups.group_members_by_id", group_id="randomid")
-    rep = client.put(group_url)
+    rep = await client.put(group_url)
     assert rep.status_code == 404
 
     db.session.add(access_app)
     db.session.add(okta_group)
     db.session.add(role_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyRoleGroups(
+    await ModifyRoleGroups(
         role_group=role_group,
         groups_to_add=[
             app_group.id,
@@ -434,13 +450,13 @@ def test_put_group_members(
         sync_to_okta=False,
     ).execute()
 
-    membership_access_request = CreateAccessRequest(
+    membership_access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=okta_group,
         request_ownership=False,
         request_reason="test reason",
     ).execute()
-    ownership_access_request = CreateAccessRequest(
+    ownership_access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=okta_group,
         request_ownership=True,
@@ -449,13 +465,13 @@ def test_put_group_members(
     assert membership_access_request is not None
     assert ownership_access_request is not None
 
-    role_associated_membership_access_request = CreateAccessRequest(
+    role_associated_membership_access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=app_group,
         request_ownership=False,
         request_reason="test reason",
     ).execute()
-    role_associated_ownership_access_request = CreateAccessRequest(
+    role_associated_ownership_access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=app_group,
         request_ownership=True,
@@ -465,10 +481,10 @@ def test_put_group_members(
     assert role_associated_ownership_access_request is not None
 
     # test put group members
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    remove_user_from_group_spy = mocker.patch.object(okta, "async_remove_user_from_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
-    remove_owner_from_group_spy = mocker.patch.object(okta, "async_remove_owner_from_group")
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    remove_user_from_group_spy = mocker.patch.object(okta, "remove_user_from_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
+    remove_owner_from_group_spy = mocker.patch.object(okta, "remove_owner_from_group")
 
     data: dict[str, Any] = {
         "members_to_add": [],
@@ -477,7 +493,7 @@ def test_put_group_members(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=okta_group.id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
@@ -503,7 +519,7 @@ def test_put_group_members(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=okta_group.id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -533,7 +549,7 @@ def test_put_group_members(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=okta_group.id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
@@ -562,7 +578,7 @@ def test_put_group_members(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=okta_group.id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 1
@@ -590,7 +606,7 @@ def test_put_group_members(
         "owners_to_remove": [user.id],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=okta_group.id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
@@ -617,7 +633,7 @@ def test_put_group_members(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=role_group.id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
@@ -645,7 +661,7 @@ def test_put_group_members(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=role_group.id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 2
     assert remove_user_from_group_spy.call_count == 0
@@ -664,8 +680,8 @@ def test_put_group_members(
     assert role_associated_ownership_access_request.approved_membership_id is not None
 
 
-def test_delete_group(
-    client: TestClient,
+async def test_delete_group(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     okta_group: OktaGroup,
@@ -677,65 +693,74 @@ def test_delete_group(
 ) -> None:
     # test 404
     group_url = url_for("api-groups.group_by_id", group_id="randomid")
-    rep = client.delete(group_url)
+    rep = await client.delete(group_url)
     assert rep.status_code == 404
 
     db.session.add(okta_group)
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    db.session.commit()
+    # Capture ids before requests — the expire_all() calls below expire all
+    # persistent fixture-loaded objects on the shared session.
+    tag_id = tag.id
+
+    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag_id))
+    await db.session.commit()
 
     # test delete group
-    delete_group_spy = mocker.patch.object(okta, "async_delete_group")
+    delete_group_spy = mocker.patch.object(okta, "delete_group")
 
     group_id = okta_group.id
     group_url = url_for("api-groups.group_by_id", group_id=group_id)
-    rep = client.delete(group_url)
+    rep = await client.delete(group_url)
     assert rep.status_code == 200
     assert delete_group_spy.call_count == 1
-    assert db.session.get(OktaGroup, group_id).deleted_at is not None
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
+    # The delete request's bulk update expired deleted_at on the identity-map
+    # instance; expire fully so the get() below reloads it.
+    db.session.expire_all()
+    assert (await db.session.get(OktaGroup, group_id)).deleted_at is not None
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 0
 
     db.session.add(user)
     db.session.add(access_app)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     app_group.is_owner = False
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
-    app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tag.id)
+    app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tag_id)
     db.session.add(app_tag_map)
-    db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag.id, app_tag_map_id=app_tag_map.id))
-    db.session.commit()
+    await db.session.commit()
+    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag_id, app_tag_map_id=app_tag_map.id))
+    await db.session.commit()
 
-    access_request = CreateAccessRequest(
+    access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=app_group,
         request_ownership=False,
         request_reason="test reason",
     ).execute()
+    assert access_request is not None
+    access_request_id = access_request.id
 
     # test delete app group with access request
     delete_group_spy.reset_mock()
 
     group_id = app_group.id
     group_url = url_for("api-groups.group_by_id", group_id=group_id)
-    rep = client.delete(group_url)
+    rep = await client.delete(group_url)
     assert rep.status_code == 200
     assert delete_group_spy.call_count == 1
-    assert db.session.get(OktaGroup, group_id).deleted_at is not None
-    assert access_request is not None
-    assert db.session.get(AccessRequest, access_request.id).status == AccessRequestStatus.REJECTED
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
-    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 1
+    db.session.expire_all()
+    assert (await db.session.get(OktaGroup, group_id)).deleted_at is not None
+    assert (await db.session.get(AccessRequest, access_request_id)).status == AccessRequestStatus.REJECTED
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 0
+    assert await db_count(db.session, select(AppTagMap).where(AppTagMap.ended_at.is_(None))) == 1
 
 
-def test_delete_group_as_app_group_deleter(
-    client: TestClient,
+async def test_delete_group_as_app_group_deleter(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     monkeypatch: pytest.MonkeyPatch,
@@ -747,30 +772,34 @@ def test_delete_group_as_app_group_deleter(
     mock_user: Any,
 ) -> None:
     db.session.add_all([user, access_app, okta_group])
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     app_group.is_owner = False
     db.session.add(app_group)
     unmanaged = AppGroupFactory.build(app_id=access_app.id, is_owner=False, is_managed=False)
     db.session.add(unmanaged)
-    db.session.commit()
+    await db.session.commit()
 
-    mocker.patch.object(okta, "async_delete_group")
+    mocker.patch.object(okta, "delete_group")
     mock_user(user.id)
     monkeypatch.setattr(settings, "APP_GROUP_DELETER_ID", f"someone-else,{user.id}")
 
     # Managed AppGroup: allowed.
-    rep = client.delete(url_for("api-groups.group_by_id", group_id=app_group.id))
+    app_group_id = app_group.id
+    okta_group_id = okta_group.id
+    unmanaged_id = unmanaged.id
+    rep = await client.delete(url_for("api-groups.group_by_id", group_id=app_group_id))
     assert rep.status_code == 200
-    assert db.session.get(OktaGroup, app_group.id).deleted_at is not None
+    db.session.expire_all()
+    assert (await db.session.get(OktaGroup, app_group_id)).deleted_at is not None
 
     # Plain OktaGroup and unmanaged AppGroup: still 403.
-    assert client.delete(url_for("api-groups.group_by_id", group_id=okta_group.id)).status_code == 403
-    assert client.delete(url_for("api-groups.group_by_id", group_id=unmanaged.id)).status_code == 403
+    assert (await client.delete(url_for("api-groups.group_by_id", group_id=okta_group_id))).status_code == 403
+    assert (await client.delete(url_for("api-groups.group_by_id", group_id=unmanaged_id))).status_code == 403
 
 
-def test_create_group(
-    client: TestClient,
+async def test_create_group(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -780,11 +809,11 @@ def test_create_group(
     # test bad data
     groups_url = url_for("api-groups.groups")
     data: dict[str, Any] = {}
-    rep = client.post(groups_url, json=data)
+    rep = await client.post(groups_url, json=data)
     assert rep.status_code == 400
 
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
     # Cast faker to our Protocol type that has the pystr method
     create_group_spy = mocker.patch.object(
@@ -792,20 +821,20 @@ def test_create_group(
     )
 
     data = {"type": "okta_group", "name": "Created", "description": "", "tags_to_add": [tag.id]}
-    rep = client.post(groups_url, json=data)
+    rep = await client.post(groups_url, json=data)
     assert rep.status_code == 201
     assert create_group_spy.call_count == 1
 
     data = rep.json()
-    assert db.session.get(OktaGroup, data["id"]) is not None
+    assert await db.session.get(OktaGroup, data["id"]) is not None
     assert data["name"] == "Created"
     assert data["description"] == ""
     assert data["active_group_tags"][0]["active_tag"]["id"] == tag.id
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 1
 
 
-def test_create_app_group(
-    client: TestClient,
+async def test_create_app_group(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -816,38 +845,38 @@ def test_create_app_group(
     # test bad data
     groups_url = url_for("api-groups.groups")
     data: dict[str, Any] = {}
-    rep = client.post(groups_url, json=data)
+    rep = await client.post(groups_url, json=data)
     assert rep.status_code == 400
 
     db.session.add(access_app)
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(AppTagMap(app_id=access_app.id, tag_id=tag.id))
-    db.session.commit()
+    await db.session.commit()
 
     create_group_spy = mocker.patch.object(
         okta, "create_group", return_value=Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
 
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 0
 
     app_group_name = f"{AppGroup.APP_GROUP_NAME_PREFIX}{access_app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}Created"
     data = {"type": "app_group", "app_id": access_app.id, "name": app_group_name, "description": ""}
-    rep = client.post(groups_url, json=data)
+    rep = await client.post(groups_url, json=data)
     assert rep.status_code == 201
     assert create_group_spy.call_count == 1
 
     data = rep.json()
-    assert db.session.get(OktaGroup, data["id"]) is not None
+    assert await db.session.get(OktaGroup, data["id"]) is not None
     assert data["name"] == app_group_name
     assert data["description"] == ""
     assert data["active_group_tags"][0]["active_tag"]["id"] == tag.id
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 1
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 1
 
 
-def test_create_app_group_cannot_set_is_owner_shadow_escalation(
+async def test_create_app_group_cannot_set_is_owner_shadow_escalation(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -868,20 +897,20 @@ def test_create_app_group_cannot_set_is_owner_shadow_escalation(
     )
     alice = OktaUserFactory.create()
     db.session.add_all([foo, owners_group, alice])
-    db.session.commit()
+    await db.session.commit()
     foo_id = foo.id
     foo_name = foo.name
 
-    ModifyGroupUsers(group=owners_group, owners_to_add=[alice.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=owners_group, owners_to_add=[alice.id], sync_to_okta=False).execute()
 
     mocker.patch.object(okta, "create_group", return_value=Group({"id": cast(FakerWithPyStr, faker).pystr()}))
 
     # act as Alice — a plain app owner, NOT an Access admin.
     app.state.current_user_email = alice.email
-    assert not AuthorizationHelpers.is_access_admin(db.session, alice.id)
+    assert not await AuthorizationHelpers.is_access_admin(db.session, alice.id)
 
     shadow_name = f"{AppGroup.APP_GROUP_NAME_PREFIX}{foo_name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}shadow"
-    rep = client.post(
+    rep = await client.post(
         url_for("api-groups.groups"),
         json={"type": "app_group", "app_id": foo_id, "name": shadow_name, "is_owner": True, "description": ""},
     )
@@ -889,21 +918,23 @@ def test_create_app_group_cannot_set_is_owner_shadow_escalation(
 
     # privilege flag should be ignored, so the new group is an
     # ordinary (non-owner) app group and Foo still has exactly one owner group.
-    created = db.session.get(AppGroup, rep.json()["id"])
+    created = await db.session.get(AppGroup, rep.json()["id"])
     assert not created.is_owner
     owner_groups = (
-        db.session.query(AppGroup)
-        .filter(AppGroup.app_id == foo_id, AppGroup.is_owner.is_(True), AppGroup.deleted_at.is_(None))
-        .all()
-    )
+        await db.session.scalars(
+            select(AppGroup).where(
+                AppGroup.app_id == foo_id, AppGroup.is_owner.is_(True), AppGroup.deleted_at.is_(None)
+            )
+        )
+    ).all()
     assert [g.id for g in owner_groups] == [owners_group.id]
 
 
-def test_get_all_group(client: TestClient, db: Db, access_app: App, url_for: Any) -> None:
+async def test_get_all_group(client: AsyncClient, db: Db, access_app: App, url_for: Any) -> None:
     groups_url = url_for("api-groups.groups")
 
     db.session.add(access_app)
-    db.session.commit()
+    await db.session.commit()
 
     groups = []
     groups.extend(OktaGroupFactory.create_batch(3))
@@ -911,16 +942,16 @@ def test_get_all_group(client: TestClient, db: Db, access_app: App, url_for: Any
     groups.extend(app_groups)
     groups.extend(RoleGroupFactory.create_batch(3))
     db.session.add_all(groups)
-    db.session.commit()
+    await db.session.commit()
 
-    rep = client.get(groups_url)
+    rep = await client.get(groups_url)
     assert rep.status_code == 200
 
     results = rep.json()
     for group in groups:
         assert any(u["id"] == group.id for u in results["items"])
 
-    rep = client.get(groups_url, params={"q": "App-"})
+    rep = await client.get(groups_url, params={"q": "App-"})
     assert rep.status_code == 200
 
     results = rep.json()
@@ -932,19 +963,19 @@ def test_get_all_group(client: TestClient, db: Db, access_app: App, url_for: Any
 # Do not renew functionality test
 # Since this field is only for expiring access, there are no checks for it anywhere in the API (only in the front end).
 # Test is just to make sure the field is set correctly
-def test_do_not_renew(
-    db: Db, client: TestClient, mocker: MockerFixture, user: OktaUser, okta_group: OktaGroup, url_for: Any
+async def test_do_not_renew(
+    db: Db, client: AsyncClient, mocker: MockerFixture, user: OktaUser, okta_group: OktaGroup, url_for: Any
 ) -> None:
     user2 = OktaUserFactory.create()
 
     db.session.add(okta_group)
     db.session.add(user)
     db.session.add(user2)
-    db.session.commit()
+    await db.session.commit()
 
     expiration_datetime = datetime.now() + timedelta(days=1)
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=okta_group,
         users_added_ended_at=expiration_datetime,
         members_to_add=[user.id, user2.id],
@@ -952,28 +983,37 @@ def test_do_not_renew(
     ).execute()
 
     # need the OktaUserGroupMember id to pass in later
-    membership_user2 = db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.user_id == user2.id).first()
+    membership_user2 = (
+        await db.session.scalars(select(OktaUserGroupMember).where(OktaUserGroupMember.user_id == user2.id))
+    ).first()
+
+    # Capture ids before any requests — the failed 403 PUT below rolls back the
+    # shared session and expires these fixture-loaded objects.
+    user_id = user.id
+    user2_id = user2.id
+    group_id = okta_group.id
+    membership_user2_id = membership_user2.id
 
     # test non-owner/admin perms
     mocker.patch.object(AuthorizationHelpers, "can_manage_group", return_value=False)
 
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    remove_user_from_group_spy = mocker.patch.object(okta, "async_remove_user_from_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
-    remove_owner_from_group_spy = mocker.patch.object(okta, "async_remove_owner_from_group")
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    remove_user_from_group_spy = mocker.patch.object(okta, "remove_user_from_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
+    remove_owner_from_group_spy = mocker.patch.object(okta, "remove_owner_from_group")
 
     data: dict[str, Any] = {
         "members_to_add": [],
         "owners_to_add": [],
-        "members_should_expire": [membership_user2.id],
+        "members_should_expire": [membership_user2_id],
         "owners_should_expire": [],
         "members_to_remove": [],
         "owners_to_remove": [],
     }
 
     # should fail
-    group_url = url_for("api-groups.group_members_by_id", group_id=okta_group.id)
-    rep = client.put(group_url, json=data)
+    group_url = url_for("api-groups.group_members_by_id", group_id=group_id)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 403
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
@@ -990,15 +1030,15 @@ def test_do_not_renew(
     remove_owner_from_group_spy.reset_mock()
 
     data = {
-        "members_to_add": [user.id],
+        "members_to_add": [user_id],
         "owners_to_add": [],
-        "members_should_expire": [membership_user2.id],
+        "members_should_expire": [membership_user2_id],
         "owners_should_expire": [],
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    group_url = url_for("api-groups.group_members_by_id", group_id=okta_group.id)
-    rep = client.put(group_url, json=data)
+    group_url = url_for("api-groups.group_members_by_id", group_id=group_id)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -1007,45 +1047,47 @@ def test_do_not_renew(
 
     data = rep.json()
     assert len(data["members"]) == 2
-    assert user.id in data["members"] and user2.id in data["members"]
+    assert user_id in data["members"] and user2_id in data["members"]
     assert len(data["owners"]) == 0
 
     # get OktaUserGroupMembers, check expiration dates and should_expire
     membership_user1 = (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            or_(
-                OktaUserGroupMember.ended_at.is_(None),
-                OktaUserGroupMember.ended_at > func.now(),
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(
+                or_(
+                    OktaUserGroupMember.ended_at.is_(None),
+                    OktaUserGroupMember.ended_at > func.now(),
+                )
             )
+            .where(OktaUserGroupMember.user_id == user_id)
         )
-        .filter(OktaUserGroupMember.user_id == user.id)
-        .all()
-    )
+    ).all()
 
     assert len(membership_user1) == 1
     assert membership_user1[0].ended_at is None
     assert membership_user1[0].should_expire is False
 
     memberships_user2 = (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            or_(
-                OktaUserGroupMember.ended_at.is_(None),
-                OktaUserGroupMember.ended_at > func.now(),
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(
+                or_(
+                    OktaUserGroupMember.ended_at.is_(None),
+                    OktaUserGroupMember.ended_at > func.now(),
+                )
             )
+            .where(OktaUserGroupMember.user_id == user2_id)
         )
-        .filter(OktaUserGroupMember.user_id == user2.id)
-        .all()
-    )
+    ).all()
 
     assert len(memberships_user2) == 1
     assert memberships_user2[0].ended_at == expiration_datetime
     assert memberships_user2[0].should_expire is True
 
 
-def test_do_not_renew_scoped_to_route_group(
-    db: Db, client: TestClient, mocker: MockerFixture, user: OktaUser, okta_group: OktaGroup, url_for: Any
+async def test_do_not_renew_scoped_to_route_group(
+    db: Db, client: AsyncClient, mocker: MockerFixture, user: OktaUser, okta_group: OktaGroup, url_for: Any
 ) -> None:
     victim_group = OktaGroup(id="victim-group-id", name="Victim-Group", type="okta_group")
     victim_user = OktaUserFactory.create()
@@ -1054,17 +1096,17 @@ def test_do_not_renew_scoped_to_route_group(
     db.session.add(victim_group)
     db.session.add(user)
     db.session.add(victim_user)
-    db.session.commit()
+    await db.session.commit()
 
     expiration_datetime = datetime.now() + timedelta(days=1)
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=okta_group,
         users_added_ended_at=expiration_datetime,
         members_to_add=[user.id],
         sync_to_okta=False,
     ).execute()
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=victim_group,
         users_added_ended_at=expiration_datetime,
         members_to_add=[victim_user.id],
@@ -1072,15 +1114,15 @@ def test_do_not_renew_scoped_to_route_group(
     ).execute()
 
     victim_membership = (
-        db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.user_id == victim_user.id).first()
-    )
+        await db.session.scalars(select(OktaUserGroupMember).where(OktaUserGroupMember.user_id == victim_user.id))
+    ).first()
     assert victim_membership is not None
 
     mocker.patch.object(AuthorizationHelpers, "can_manage_group", return_value=True)
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_remove_user_from_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
-    mocker.patch.object(okta, "async_remove_owner_from_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "remove_user_from_group")
+    mocker.patch.object(okta, "add_owner_to_group")
+    mocker.patch.object(okta, "remove_owner_from_group")
 
     data: dict[str, Any] = {
         "members_to_add": [],
@@ -1091,17 +1133,17 @@ def test_do_not_renew_scoped_to_route_group(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=okta_group.id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
 
-    db.session.refresh(victim_membership)
+    await db.session.refresh(victim_membership)
     assert victim_membership.should_expire is False
 
 
 @pytest.mark.parametrize("app", [False, True], indirect=True)
-def test_create_groups_with_and_without_description(
+async def test_create_groups_with_and_without_description(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -1112,7 +1154,7 @@ def test_create_groups_with_and_without_description(
     require_descriptions = settings.REQUIRE_DESCRIPTIONS
 
     db.session.add(access_app)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
@@ -1122,7 +1164,7 @@ def test_create_groups_with_and_without_description(
 
     # Test creating okta_group without description
     data: dict[str, Any] = {"type": "okta_group", "name": "TestGroupNoDesc"}
-    rep = client.post(groups_url, json=data)
+    rep = await client.post(groups_url, json=data)
     if require_descriptions:
         # Should fail when REQUIRE_DESCRIPTIONS=True
         assert rep.status_code == 400
@@ -1137,7 +1179,7 @@ def test_create_groups_with_and_without_description(
 
     # Test creating group with empty description
     data = {"type": "okta_group", "name": "TestGroupEmptyDesc", "description": ""}
-    rep = client.post(groups_url, json=data)
+    rep = await client.post(groups_url, json=data)
     if require_descriptions:
         # Should fail - empty description fails length validation
         assert rep.status_code == 400
@@ -1152,7 +1194,7 @@ def test_create_groups_with_and_without_description(
 
     # Test creating groups with descriptions should always succeed
     data = {"type": "role_group", "name": "Role-TestGroupWithDesc", "description": "This has a description"}
-    rep = client.post(groups_url, json=data)
+    rep = await client.post(groups_url, json=data)
     assert rep.status_code == 201
 
     result = rep.json()
@@ -1161,8 +1203,8 @@ def test_create_groups_with_and_without_description(
 
 
 @pytest.mark.parametrize("app", [False, True], indirect=True)
-def test_partial_group_update_preserves_description(
-    app: FastAPI, client: TestClient, db: Db, mocker: MockerFixture, okta_group: OktaGroup, url_for: Any
+async def test_partial_group_update_preserves_description(
+    app: FastAPI, client: AsyncClient, db: Db, mocker: MockerFixture, okta_group: OktaGroup, url_for: Any
 ) -> None:
     """Test that group updates handle descriptions correctly based on REQUIRE_DESCRIPTIONS setting"""
     require_descriptions = settings.REQUIRE_DESCRIPTIONS
@@ -1170,7 +1212,7 @@ def test_partial_group_update_preserves_description(
     # Set up the group with a description
     okta_group.description = "Original description"
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(okta, "update_group")
 
@@ -1178,7 +1220,7 @@ def test_partial_group_update_preserves_description(
 
     # Test updating with empty description
     data = {"type": "okta_group", "name": "UpdatedWithEmpty", "description": ""}
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     if require_descriptions:
         # Should fail - empty description fails length validation
         assert rep.status_code == 400
@@ -1195,12 +1237,12 @@ def test_partial_group_update_preserves_description(
     if not require_descriptions:
         # Need to reset since empty description succeeded above
         data = {"type": "okta_group", "name": "UpdatedWithEmpty", "description": "Original description"}
-        rep = client.put(group_url, json=data)
+        rep = await client.put(group_url, json=data)
         assert rep.status_code == 200
 
     # Test partial update without description should preserve existing description
     data = {"type": "okta_group", "name": "UpdatedName"}
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     result = rep.json()
     assert result["name"] == "UpdatedName"
@@ -1208,15 +1250,15 @@ def test_partial_group_update_preserves_description(
 
     # Test updating with valid description should succeed
     data = {"type": "okta_group", "name": "UpdatedName2", "description": "New description"}
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     result = rep.json()
     assert result["name"] == "UpdatedName2"
     assert result["description"] == "New description"
 
 
-def test_cannot_convert_app_prefixed_group_to_non_app_type(
-    client: TestClient,
+async def test_cannot_convert_app_prefixed_group_to_non_app_type(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     access_app: App,
@@ -1231,30 +1273,35 @@ def test_cannot_convert_app_prefixed_group_to_non_app_type(
     )
     db.session.add(access_app)
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
+
+    # Capture values before any requests — the failed 400 PUTs below roll back
+    # the shared session and expire these fixture-loaded objects.
+    group_name = app_group.name
+    app_id = access_app.id
 
     group_url = url_for("api-groups.group_by_id", group_id=app_group.id)
-    rep = client.put(group_url, json={"type": "okta_group", "name": app_group.name, "description": "desc"})
+    rep = await client.put(group_url, json={"type": "okta_group", "name": group_name, "description": "desc"})
     assert rep.status_code == 400
 
-    rep = client.put(group_url, json={"type": "role_group", "name": app_group.name, "description": "desc"})
+    rep = await client.put(group_url, json={"type": "role_group", "name": group_name, "description": "desc"})
     assert rep.status_code == 400
 
     # Changing to app_group (same type, different app) is still allowed
-    rep = client.put(
+    rep = await client.put(
         group_url,
         json={
             "type": "app_group",
-            "name": app_group.name,
+            "name": group_name,
             "description": "desc",
-            "app_id": access_app.id,
+            "app_id": app_id,
         },
     )
     assert rep.status_code == 200
 
 
-def test_cannot_create_group_with_reserved_app_prefix(
-    client: TestClient,
+async def test_cannot_create_group_with_reserved_app_prefix(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -1266,40 +1313,43 @@ def test_cannot_create_group_with_reserved_app_prefix(
     )
 
     db.session.add(access_app)
-    db.session.commit()
+    await db.session.commit()
+
+    # Capture values before any requests — the failed 400 POSTs below roll back
+    # the shared session and expire the fixture-loaded app.
+    app_name = access_app.name
+    app_id = access_app.id
 
     groups_url = url_for("api-groups.groups")
 
     # okta_group with App- prefix is blocked
-    rep = client.post(groups_url, json={"type": "okta_group", "name": "App-SomeName", "description": ""})
+    rep = await client.post(groups_url, json={"type": "okta_group", "name": "App-SomeName", "description": ""})
     assert rep.status_code == 400
 
     # role_group with App- prefix is blocked
-    rep = client.post(groups_url, json={"type": "role_group", "name": "App-SomeName", "description": ""})
+    rep = await client.post(groups_url, json={"type": "role_group", "name": "App-SomeName", "description": ""})
     assert rep.status_code == 400
 
     # app_group with App-*-Owners name is blocked
     owners_name = (
-        f"{AppGroup.APP_GROUP_NAME_PREFIX}{access_app.name}"
+        f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_name}"
         f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
     )
-    rep = client.post(
-        groups_url, json={"type": "app_group", "app_id": access_app.id, "name": owners_name, "description": ""}
+    rep = await client.post(
+        groups_url, json={"type": "app_group", "app_id": app_id, "name": owners_name, "description": ""}
     )
     assert rep.status_code == 400
 
     # app_group with App-*-NonOwners name is allowed
-    non_owners_name = (
-        f"{AppGroup.APP_GROUP_NAME_PREFIX}{access_app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}Members"
-    )
-    rep = client.post(
-        groups_url, json={"type": "app_group", "app_id": access_app.id, "name": non_owners_name, "description": ""}
+    non_owners_name = f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}Members"
+    rep = await client.post(
+        groups_url, json={"type": "app_group", "app_id": app_id, "name": non_owners_name, "description": ""}
     )
     assert rep.status_code == 201
 
 
-def test_cannot_rename_non_app_group_to_app_prefix(
-    client: TestClient,
+async def test_cannot_rename_non_app_group_to_app_prefix(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     access_app: App,
@@ -1310,29 +1360,36 @@ def test_cannot_rename_non_app_group_to_app_prefix(
     okta_group = OktaGroupFactory.create(name="Payments-Owners")
     db.session.add(access_app)
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
+
+    # Capture values before any requests — the failed 400 PUT below rolls back
+    # the shared session and expires the fixture-loaded app.
+    app_name = access_app.name
+    app_id = access_app.id
 
     group_url = url_for("api-groups.group_by_id", group_id=okta_group.id)
 
     # Renaming an okta_group to App- prefix without changing the type is blocked
-    rep = client.put(group_url, json={"type": "okta_group", "name": "App-Payments-Owners", "description": ""})
+    rep = await client.put(group_url, json={"type": "okta_group", "name": "App-Payments-Owners", "description": ""})
     assert rep.status_code == 400
 
     # Renaming to a non-App- prefix is still allowed
-    rep = client.put(group_url, json={"type": "okta_group", "name": "Legitimate-Payments-Owners", "description": ""})
+    rep = await client.put(
+        group_url, json={"type": "okta_group", "name": "Legitimate-Payments-Owners", "description": ""}
+    )
     assert rep.status_code == 200
 
     # Simultaneous conversion to app_group and rename to App- prefix is allowed
-    members_name = f"{AppGroup.APP_GROUP_NAME_PREFIX}{access_app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}Members"
-    rep = client.put(
+    members_name = f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}Members"
+    rep = await client.put(
         group_url,
-        json={"type": "app_group", "app_id": access_app.id, "name": members_name, "description": ""},
+        json={"type": "app_group", "app_id": app_id, "name": members_name, "description": ""},
     )
     assert rep.status_code == 200
 
 
-def test_cannot_create_group_with_reserved_role_prefix(
-    client: TestClient,
+async def test_cannot_create_group_with_reserved_role_prefix(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -1345,22 +1402,22 @@ def test_cannot_create_group_with_reserved_role_prefix(
     groups_url = url_for("api-groups.groups")
 
     # okta_group with Role- prefix is blocked
-    rep = client.post(groups_url, json={"type": "okta_group", "name": "Role-SomeName", "description": ""})
+    rep = await client.post(groups_url, json={"type": "okta_group", "name": "Role-SomeName", "description": ""})
     assert rep.status_code == 400
 
     # app_group with Role- prefix is blocked
-    rep = client.post(groups_url, json={"type": "app_group", "name": "Role-SomeName", "description": ""})
+    rep = await client.post(groups_url, json={"type": "app_group", "name": "Role-SomeName", "description": ""})
     assert rep.status_code == 400
 
     # role_group with Role- prefix is allowed
-    rep = client.post(
+    rep = await client.post(
         groups_url, json={"type": "role_group", "name": f"{RoleGroup.ROLE_GROUP_NAME_PREFIX}Admins", "description": ""}
     )
     assert rep.status_code == 201
 
 
-def test_cannot_rename_non_role_group_to_role_prefix(
-    client: TestClient,
+async def test_cannot_rename_non_role_group_to_role_prefix(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     url_for: Any,
@@ -1369,28 +1426,28 @@ def test_cannot_rename_non_role_group_to_role_prefix(
 
     okta_group = OktaGroupFactory.create(name="Some-Group")
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
 
     group_url = url_for("api-groups.group_by_id", group_id=okta_group.id)
 
     # Renaming an okta_group to Role- prefix without changing the type is blocked
-    rep = client.put(group_url, json={"type": "okta_group", "name": "Role-SomeName", "description": ""})
+    rep = await client.put(group_url, json={"type": "okta_group", "name": "Role-SomeName", "description": ""})
     assert rep.status_code == 400
 
     # Renaming to a non-Role- prefix is still allowed
-    rep = client.put(group_url, json={"type": "okta_group", "name": "Legitimate-SomeName", "description": ""})
+    rep = await client.put(group_url, json={"type": "okta_group", "name": "Legitimate-SomeName", "description": ""})
     assert rep.status_code == 200
 
     # Simultaneous conversion to role_group and rename to Role- prefix is allowed
-    rep = client.put(
+    rep = await client.put(
         group_url,
         json={"type": "role_group", "name": f"{RoleGroup.ROLE_GROUP_NAME_PREFIX}Admins", "description": ""},
     )
     assert rep.status_code == 200
 
 
-def test_cannot_convert_role_prefixed_group_to_non_role_type(
-    client: TestClient,
+async def test_cannot_convert_role_prefixed_group_to_non_role_type(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     url_for: Any,
@@ -1399,31 +1456,35 @@ def test_cannot_convert_role_prefixed_group_to_non_role_type(
 
     role_group = RoleGroupFactory.create(name=f"{RoleGroup.ROLE_GROUP_NAME_PREFIX}Admins")
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
+
+    # Capture values before any requests — the failed 400 PUTs below roll back
+    # the shared session and expire the fixture-loaded group.
+    group_name = role_group.name
 
     group_url = url_for("api-groups.group_by_id", group_id=role_group.id)
 
-    rep = client.put(group_url, json={"type": "okta_group", "name": role_group.name, "description": "desc"})
+    rep = await client.put(group_url, json={"type": "okta_group", "name": group_name, "description": "desc"})
     assert rep.status_code == 400
 
-    rep = client.put(group_url, json={"type": "app_group", "name": role_group.name, "description": "desc"})
+    rep = await client.put(group_url, json={"type": "app_group", "name": group_name, "description": "desc"})
     assert rep.status_code == 400
 
     # Keeping it as role_group is still allowed
-    rep = client.put(group_url, json={"type": "role_group", "name": role_group.name, "description": "desc"})
+    rep = await client.put(group_url, json={"type": "role_group", "name": group_name, "description": "desc"})
     assert rep.status_code == 200
 
 
-def test_put_group_members_rejects_short_user_id(
-    client: TestClient, db: Db, okta_group: OktaGroup, url_for: Any
+async def test_put_group_members_rejects_short_user_id(
+    client: AsyncClient, db: Db, okta_group: OktaGroup, url_for: Any
 ) -> None:
     """Each Okta user id must be exactly 20 characters wide. Pydantic
     enforces the constraint at the request boundary so malformed ids
     cannot leak into the operation layer."""
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
     group_url = url_for("api-groups.group_members_by_id_put", group_id=okta_group.id)
-    rep = client.put(
+    rep = await client.put(
         group_url,
         json={
             "members_to_add": ["short"],
@@ -1437,30 +1498,30 @@ def test_put_group_members_rejects_short_user_id(
     assert rep.status_code == 400
 
 
-def test_put_group_members_rejects_missing_required_lists(
-    client: TestClient, db: Db, okta_group: OktaGroup, url_for: Any
+async def test_put_group_members_rejects_missing_required_lists(
+    client: AsyncClient, db: Db, okta_group: OktaGroup, url_for: Any
 ) -> None:
     """`members_to_add`, `members_to_remove`, `owners_to_add`, and
     `owners_to_remove` are required fields on the request body. The Pydantic
     schema must reject a body that omits them entirely."""
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
     group_url = url_for("api-groups.group_members_by_id_put", group_id=okta_group.id)
-    rep = client.put(group_url, json={})
+    rep = await client.put(group_url, json={})
     # The project's exception handler maps Pydantic validation errors to 400
     # (not the FastAPI default 422) — see `api/exception_handlers.py`.
     assert rep.status_code == 400
 
 
-def test_put_group_members_accepts_well_formed_ids(
-    client: TestClient, db: Db, okta_group: OktaGroup, user: OktaUser, url_for: Any
+async def test_put_group_members_accepts_well_formed_ids(
+    client: AsyncClient, db: Db, okta_group: OktaGroup, user: OktaUser, url_for: Any
 ) -> None:
     """Sanity check: a 20-char id is accepted (regression guard for fix 1)."""
     db.session.add(okta_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
     group_url = url_for("api-groups.group_members_by_id_put", group_id=okta_group.id)
-    rep = client.put(
+    rep = await client.put(
         group_url,
         json={
             "members_to_add": [],
@@ -1472,8 +1533,8 @@ def test_put_group_members_accepts_well_formed_ids(
     assert rep.status_code == 200
 
 
-def test_app_group_app_ref_includes_lifecycle_plugin(
-    client: TestClient,
+async def test_app_group_app_ref_includes_lifecycle_plugin(
+    client: AsyncClient,
     db: Db,
     access_app: App,
     app_group: AppGroup,
@@ -1486,14 +1547,14 @@ def test_app_group_app_ref_includes_lifecycle_plugin(
     pages can dispatch on the plugin."""
     access_app.app_group_lifecycle_plugin = "noop"
     db.session.add(access_app)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
     # GET /api/groups/{app_group_id}
     group_url = url_for("api-groups.group_by_id", group_id=app_group.id)
-    rep = client.get(group_url)
+    rep = await client.get(group_url)
     assert rep.status_code == 200, rep.text
     data = rep.json()
     assert data["type"] == "app_group"
@@ -1501,7 +1562,7 @@ def test_app_group_app_ref_includes_lifecycle_plugin(
     assert data["app"].get("app_group_lifecycle_plugin") == "noop"
 
     # GET /api/groups (list) — same field must appear on app-group rows.
-    rep = client.get(url_for("api-groups.groups"))
+    rep = await client.get(url_for("api-groups.groups"))
     assert rep.status_code == 200, rep.text
     rows = rep.json()["items"]
     matched = next((r for r in rows if r["id"] == app_group.id), None)
@@ -1510,8 +1571,8 @@ def test_app_group_app_ref_includes_lifecycle_plugin(
     assert matched["app"].get("app_group_lifecycle_plugin") == "noop"
 
 
-def test_role_list_excludes_role_association_mappings(
-    client: TestClient,
+async def test_role_list_excludes_role_association_mappings(
+    client: AsyncClient,
     db: Db,
     role_group: RoleGroup,
     url_for: Any,
@@ -1521,9 +1582,9 @@ def test_role_list_excludes_role_association_mappings(
     not emit the bulky `active_role_associated_group_*_mappings` arrays
     (those belong on the role-detail endpoint, not the list)."""
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
 
-    rep = client.get(url_for("api-roles.roles"))
+    rep = await client.get(url_for("api-roles.roles"))
     assert rep.status_code == 200, rep.text
     rows = rep.json()["items"]
     matched = next((r for r in rows if r["id"] == role_group.id), None)

--- a/tests/test_group_membership_sync.py
+++ b/tests/test_group_membership_sync.py
@@ -3,7 +3,8 @@ from datetime import datetime, timedelta
 from typing import Callable, Tuple
 
 from pytest_mock import MockerFixture
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.models import OktaGroup, OktaUser, OktaUserGroupMember
 from api.extensions import Db
@@ -15,25 +16,25 @@ from tests.factories import GroupFactory, UserFactory
 MembershipDetails = namedtuple("MembershipDetails", ["expired_at", "db_pk"])
 
 
-def test_membership_sync(db: Db, mocker: MockerFixture) -> None:
+async def test_membership_sync(db: Db, mocker: MockerFixture) -> None:
     initial_okta_users = UserFactory.create_batch(3)
     initial_okta_groups = GroupFactory.create_batch(3)
-    initial_db_users, initial_db_groups = seed_db(db, initial_okta_users, initial_okta_groups)
+    initial_db_users, initial_db_groups = await seed_db(db, initial_okta_users, initial_okta_groups)
 
     def fake_list_users_for_group(group_id: str) -> list[User]:
         if group_id == initial_okta_groups[0].id:
             return initial_okta_users
         return []
 
-    memberships = run_sync(db, mocker, initial_okta_groups, fake_list_users_for_group, False)
+    memberships = await run_sync(db, mocker, initial_okta_groups, fake_list_users_for_group, False)
 
     assert memberships is not None
 
 
-def test_membership_in_okta_not_in_db_authoritative(db: Db, mocker: MockerFixture) -> None:
+async def test_membership_in_okta_not_in_db_authoritative(db: Db, mocker: MockerFixture) -> None:
     initial_okta_users = UserFactory.create_batch(3)
     initial_okta_groups = GroupFactory.create_batch(3)
-    initial_db_users, initial_db_groups = seed_db(db, initial_okta_users, initial_okta_groups)
+    initial_db_users, initial_db_groups = await seed_db(db, initial_okta_users, initial_okta_groups)
 
     def fake_list_users_for_group(group_id: str) -> list[User]:
         if group_id == initial_okta_groups[0].id:
@@ -42,44 +43,44 @@ def test_membership_in_okta_not_in_db_authoritative(db: Db, mocker: MockerFixtur
 
     delete_membership_spy = mocker.patch.object(okta, "remove_user_from_group")
 
-    _ = run_sync(db, mocker, initial_okta_groups, fake_list_users_for_group, True)
+    _ = await run_sync(db, mocker, initial_okta_groups, fake_list_users_for_group, True)
 
-    members = _get_group_members(db, initial_okta_groups[0].id)
+    members = await _get_group_members(db, initial_okta_groups[0].id)
 
     assert delete_membership_spy.call_count == 3
 
     assert len(members) == 0
 
 
-def test_membership_in_okta_not_in_db_not_authoritative(db: Db, mocker: MockerFixture) -> None:
+async def test_membership_in_okta_not_in_db_not_authoritative(db: Db, mocker: MockerFixture) -> None:
     initial_okta_users = UserFactory.create_batch(3)
     initial_okta_groups = GroupFactory.create_batch(3)
-    _, _ = seed_db(db, initial_okta_users, initial_okta_groups)
+    _, _ = await seed_db(db, initial_okta_users, initial_okta_groups)
 
     def fake_list_users_for_group(group_id: str) -> list[User]:
         if group_id == initial_okta_groups[0].id:
             return initial_okta_users
         return []
 
-    _ = run_sync(db, mocker, initial_okta_groups, fake_list_users_for_group, False)
+    _ = await run_sync(db, mocker, initial_okta_groups, fake_list_users_for_group, False)
 
-    members = _get_group_members(db, initial_okta_groups[0].id)
+    members = await _get_group_members(db, initial_okta_groups[0].id)
 
     assert members is not None
     assert len(members) == 3
 
 
-def test_membership_in_db_not_in_okta_not_authoritative(db: Db, mocker: MockerFixture) -> None:
+async def test_membership_in_db_not_in_okta_not_authoritative(db: Db, mocker: MockerFixture) -> None:
     initial_okta_users = UserFactory.create_batch(3)
     initial_okta_groups = GroupFactory.create_batch(3)
-    _, _ = seed_db(db, initial_okta_users, initial_okta_groups)
+    _, _ = await seed_db(db, initial_okta_users, initial_okta_groups)
 
     def fake_list_users_for_group(group_id: str) -> list[User]:
         return []
 
     # Add expired group membership
     expired_date = datetime.now() - timedelta(days=1)
-    _add_group_membership_record(
+    await _add_group_membership_record(
         db,
         initial_okta_users[0].id,
         initial_okta_groups[0].id,
@@ -88,7 +89,7 @@ def test_membership_in_db_not_in_okta_not_authoritative(db: Db, mocker: MockerFi
 
     # Add non-expired member
     non_expired_date = datetime.now() + timedelta(days=1)
-    _add_group_membership_record(
+    await _add_group_membership_record(
         db,
         initial_okta_users[1].id,
         initial_okta_groups[0].id,
@@ -96,28 +97,32 @@ def test_membership_in_db_not_in_okta_not_authoritative(db: Db, mocker: MockerFi
     )
 
     remove_membership_spy = mocker.patch.object(okta, "remove_user_from_group")
-    run_sync(db, mocker, initial_okta_groups, fake_list_users_for_group, False)
+    await run_sync(db, mocker, initial_okta_groups, fake_list_users_for_group, False)
 
-    members_rows = _get_group_members(db, initial_okta_groups[0].id)
+    members_rows = await _get_group_members(db, initial_okta_groups[0].id)
 
-    assert remove_membership_spy.call_count == 0
+    # The spy used to target only the syncer's direct (authoritative) removal
+    # path; ModifyGroupUsers' internal removal went through the separate
+    # `async_remove_user_from_group` name. With the names merged, the single
+    # ModifyGroupUsers removal of the non-expired member now hits the spy too.
+    assert remove_membership_spy.call_count == 1
     assert len(members_rows) == 2
     # Verify expired user is not updated
     assert members_rows[initial_okta_users[0].id].expired_at == expired_date
     assert members_rows[initial_okta_users[1].id].expired_at < non_expired_date
 
 
-def test_membership_in_db_not_in_okta_authoritative(db: Db, mocker: MockerFixture) -> None:
+async def test_membership_in_db_not_in_okta_authoritative(db: Db, mocker: MockerFixture) -> None:
     initial_okta_users = UserFactory.create_batch(3)
     initial_okta_groups = GroupFactory.create_batch(3)
-    _, _ = seed_db(db, initial_okta_users, initial_okta_groups)
+    _, _ = await seed_db(db, initial_okta_users, initial_okta_groups)
 
     def fake_list_users_for_group(group_id: str) -> list[User]:
         return []
 
     # Add expired group membership
     expired_date = datetime.now() - timedelta(days=1)
-    _add_group_membership_record(
+    await _add_group_membership_record(
         db,
         initial_okta_users[0].id,
         initial_okta_groups[0].id,
@@ -126,7 +131,7 @@ def test_membership_in_db_not_in_okta_authoritative(db: Db, mocker: MockerFixtur
 
     # Add non-expired member
     non_expired_date = datetime.now() + timedelta(days=1)
-    _add_group_membership_record(
+    await _add_group_membership_record(
         db,
         initial_okta_users[1].id,
         initial_okta_groups[0].id,
@@ -134,9 +139,9 @@ def test_membership_in_db_not_in_okta_authoritative(db: Db, mocker: MockerFixtur
     )
 
     add_membership_spy = mocker.patch.object(okta, "add_user_to_group")
-    run_sync(db, mocker, initial_okta_groups, fake_list_users_for_group, True)
+    await run_sync(db, mocker, initial_okta_groups, fake_list_users_for_group, True)
 
-    members_rows = _get_group_members(db, initial_okta_groups[0].id)
+    members_rows = await _get_group_members(db, initial_okta_groups[0].id)
 
     assert add_membership_spy.call_count == 1
     assert len(members_rows) == 2
@@ -145,10 +150,10 @@ def test_membership_in_db_not_in_okta_authoritative(db: Db, mocker: MockerFixtur
     assert members_rows[initial_okta_users[1].id].expired_at == non_expired_date
 
 
-def test_membership_in_both_authoritative(db: Db, mocker: MockerFixture) -> None:
+async def test_membership_in_both_authoritative(db: Db, mocker: MockerFixture) -> None:
     initial_okta_users = UserFactory.create_batch(3)
     initial_okta_groups = GroupFactory.create_batch(3)
-    _, _ = seed_db(db, initial_okta_users, initial_okta_groups)
+    _, _ = await seed_db(db, initial_okta_users, initial_okta_groups)
 
     def fake_list_users_for_group(group_id: str) -> list[User]:
         if group_id == initial_okta_groups[0].id:
@@ -157,7 +162,7 @@ def test_membership_in_both_authoritative(db: Db, mocker: MockerFixture) -> None
 
     # Add expired group membership
     expired_date = datetime.now() - timedelta(days=1)
-    _add_group_membership_record(
+    await _add_group_membership_record(
         db,
         initial_okta_users[0].id,
         initial_okta_groups[0].id,
@@ -166,7 +171,7 @@ def test_membership_in_both_authoritative(db: Db, mocker: MockerFixture) -> None
 
     # Add non-expired member
     non_expired_date = datetime.now() + timedelta(days=1)
-    _add_group_membership_record(
+    await _add_group_membership_record(
         db,
         initial_okta_users[1].id,
         initial_okta_groups[0].id,
@@ -174,9 +179,9 @@ def test_membership_in_both_authoritative(db: Db, mocker: MockerFixture) -> None
     )
 
     remove_membership_spy = mocker.patch.object(okta, "remove_user_from_group")
-    run_sync(db, mocker, initial_okta_groups, fake_list_users_for_group, True)
+    await run_sync(db, mocker, initial_okta_groups, fake_list_users_for_group, True)
 
-    members_rows = _get_group_members(db, initial_okta_groups[0].id)
+    members_rows = await _get_group_members(db, initial_okta_groups[0].id)
 
     assert remove_membership_spy.call_count == 1
     assert len(members_rows) == 2
@@ -188,10 +193,10 @@ def test_membership_in_both_authoritative(db: Db, mocker: MockerFixture) -> None
     return
 
 
-def test_membership_in_both_non_authoritative(db: Db, mocker: MockerFixture) -> None:
+async def test_membership_in_both_non_authoritative(db: Db, mocker: MockerFixture) -> None:
     initial_okta_users = UserFactory.create_batch(3)
     initial_okta_groups = GroupFactory.create_batch(3)
-    _, _ = seed_db(db, initial_okta_users, initial_okta_groups)
+    _, _ = await seed_db(db, initial_okta_users, initial_okta_groups)
 
     def fake_list_users_for_group(group_id: str) -> list[User]:
         if group_id == initial_okta_groups[0].id:
@@ -200,7 +205,7 @@ def test_membership_in_both_non_authoritative(db: Db, mocker: MockerFixture) -> 
 
     # Add expired group membership
     expired_date = datetime.now() - timedelta(days=1)
-    _add_group_membership_record(
+    await _add_group_membership_record(
         db,
         initial_okta_users[0].id,
         initial_okta_groups[0].id,
@@ -209,7 +214,7 @@ def test_membership_in_both_non_authoritative(db: Db, mocker: MockerFixture) -> 
 
     # Add non-expired member
     non_expired_date = datetime.now() + timedelta(days=1)
-    _add_group_membership_record(
+    await _add_group_membership_record(
         db,
         initial_okta_users[1].id,
         initial_okta_groups[0].id,
@@ -217,9 +222,9 @@ def test_membership_in_both_non_authoritative(db: Db, mocker: MockerFixture) -> 
     )
 
     remove_membership_spy = mocker.patch.object(okta, "remove_user_from_group")
-    run_sync(db, mocker, initial_okta_groups, fake_list_users_for_group, False)
+    await run_sync(db, mocker, initial_okta_groups, fake_list_users_for_group, False)
 
-    members_rows = _get_group_members(db, initial_okta_groups[0].id)
+    members_rows = await _get_group_members(db, initial_okta_groups[0].id)
 
     assert remove_membership_spy.call_count == 0
     assert len(members_rows) == 2
@@ -234,10 +239,10 @@ def test_membership_in_both_non_authoritative(db: Db, mocker: MockerFixture) -> 
     return
 
 
-def test_membership_unamanaged_group_in_okta_not_in_db_authoritative(db: Db, mocker: MockerFixture) -> None:
+async def test_membership_unamanaged_group_in_okta_not_in_db_authoritative(db: Db, mocker: MockerFixture) -> None:
     initial_okta_users = UserFactory.create_batch(3)
     initial_okta_groups = GroupFactory.create_batch(3)
-    initial_db_users, initial_db_groups = seed_db(db, initial_okta_users, initial_okta_groups)
+    initial_db_users, initial_db_groups = await seed_db(db, initial_okta_users, initial_okta_groups)
 
     def fake_list_users_for_group(group_id: str) -> list[User]:
         if group_id == initial_okta_groups[0].id:
@@ -246,7 +251,7 @@ def test_membership_unamanaged_group_in_okta_not_in_db_authoritative(db: Db, moc
 
     delete_membership_spy = mocker.patch.object(okta, "remove_user_from_group")
 
-    _ = run_sync(
+    _ = await run_sync(
         db,
         mocker,
         initial_okta_groups,
@@ -255,17 +260,17 @@ def test_membership_unamanaged_group_in_okta_not_in_db_authoritative(db: Db, moc
         groups_with_rules={initial_okta_groups[0].id},
     )
 
-    members = _get_group_members(db, initial_okta_groups[0].id)
+    members = await _get_group_members(db, initial_okta_groups[0].id)
 
     # Verify no deletes occurred because the group was listed as managed
     assert delete_membership_spy.call_count == 0
     assert len(members) == 3
 
 
-def test_membership_through_multiple_groups_non_authoritative(db: Db, mocker: MockerFixture) -> None:
+async def test_membership_through_multiple_groups_non_authoritative(db: Db, mocker: MockerFixture) -> None:
     initial_okta_users = UserFactory.create_batch(3)
     initial_okta_groups = GroupFactory.create_batch(3)
-    _, _ = seed_db(db, initial_okta_users, initial_okta_groups)
+    _, _ = await seed_db(db, initial_okta_users, initial_okta_groups)
 
     def fake_list_users_for_group(group_id: str) -> list[User]:
         if group_id == initial_okta_groups[0].id:
@@ -274,7 +279,7 @@ def test_membership_through_multiple_groups_non_authoritative(db: Db, mocker: Mo
 
     # Add group membership for user 0
     date_1 = datetime.now() + timedelta(days=2)
-    pk_1 = _add_group_membership_record(
+    pk_1 = await _add_group_membership_record(
         db,
         initial_okta_users[0].id,
         initial_okta_groups[0].id,
@@ -283,7 +288,7 @@ def test_membership_through_multiple_groups_non_authoritative(db: Db, mocker: Mo
 
     # Add another membership for user 0
     date_2 = datetime.now() + timedelta(days=1)
-    pk_2 = _add_group_membership_record(
+    pk_2 = await _add_group_membership_record(
         db,
         initial_okta_users[0].id,
         initial_okta_groups[0].id,
@@ -291,20 +296,20 @@ def test_membership_through_multiple_groups_non_authoritative(db: Db, mocker: Mo
     )
 
     remove_membership_spy = mocker.patch.object(okta, "remove_user_from_group")
-    run_sync(db, mocker, initial_okta_groups, fake_list_users_for_group, False)
+    await run_sync(db, mocker, initial_okta_groups, fake_list_users_for_group, False)
 
     assert remove_membership_spy.call_count == 0
 
     # Verify expired user is synced in. 'None' expiry date indicates
     # membership was synced in from okta
-    assert _get_group_membership(db, pk_1).expired_at == date_1
-    assert _get_group_membership(db, pk_2).expired_at == date_2
+    assert (await _get_group_membership(db, pk_1)).expired_at == date_1
+    assert (await _get_group_membership(db, pk_2)).expired_at == date_2
 
 
-def test_membership_sync_continues_after_group_failure(db: Db, mocker: MockerFixture) -> None:
+async def test_membership_sync_continues_after_group_failure(db: Db, mocker: MockerFixture) -> None:
     initial_okta_users = UserFactory.create_batch(3)
     initial_okta_groups = GroupFactory.create_batch(3)
-    _, _ = seed_db(db, initial_okta_users, initial_okta_groups)
+    _, _ = await seed_db(db, initial_okta_users, initial_okta_groups)
 
     def fake_list_users_for_group(group_id: str) -> list[User]:
         if group_id == initial_okta_groups[0].id:
@@ -313,27 +318,30 @@ def test_membership_sync_continues_after_group_failure(db: Db, mocker: MockerFix
             return initial_okta_users
         return []
 
-    _ = run_sync(db, mocker, initial_okta_groups, fake_list_users_for_group, False)
+    _ = await run_sync(db, mocker, initial_okta_groups, fake_list_users_for_group, False)
 
     # Verify the second group still got its members synced despite the first group failing
-    members = _get_group_members(db, initial_okta_groups[1].id)
+    members = await _get_group_members(db, initial_okta_groups[1].id)
     assert len(members) == 3
 
     # Verify the failing group has no members
-    failed_members = _get_group_members(db, initial_okta_groups[0].id)
+    failed_members = await _get_group_members(db, initial_okta_groups[0].id)
     assert len(failed_members) == 0
 
 
-def seed_db(db: Db, users: list[OktaUser], groups: list[OktaGroup]) -> Tuple[list[OktaUser], list[OktaGroup]]:
-    with Session(db.engine) as session:
+async def seed_db(db: Db, users: list[OktaUser], groups: list[OktaGroup]) -> Tuple[list[OktaUser], list[OktaGroup]]:
+    async with AsyncSession(db.engine) as session:
         session.add_all([Group(g).update_okta_group(OktaGroup(), {}) for g in groups])
         session.add_all([User(u).update_okta_user(OktaUser(), {}) for u in users])
-        session.commit()
+        await session.commit()
 
-        return (session.query(OktaUser).all(), session.query(OktaGroup).all())
+        return (
+            list((await session.scalars(select(OktaUser))).all()),
+            list((await session.scalars(select(OktaGroup))).all()),
+        )
 
 
-def run_sync(
+async def run_sync(
     db: Db,
     mocker: MockerFixture,
     okta_groups: list[OktaGroup],
@@ -341,45 +349,47 @@ def run_sync(
     act_as_authority: bool,
     groups_with_rules: set[str] = set(),
 ) -> list[OktaUserGroupMember]:
-    with Session(db.engine) as session:
+    async with AsyncSession(db.engine) as session:
         mocker.patch.object(okta, "list_groups", return_value=okta_groups)
 
         mocker.patch.object(okta, "list_users_for_group", side_effect=user_membership_func)
 
         mocker.patch.object(okta, "list_groups_with_active_rules", return_value=groups_with_rules)
 
-        sync_group_memberships(act_as_authority)
+        await sync_group_memberships(act_as_authority)
 
-        return session.query(OktaUserGroupMember).all()
+        return list((await session.scalars(select(OktaUserGroupMember))).all())
 
 
-def _get_group_members(db: Db, group_id: str) -> dict[str, MembershipDetails]:
+async def _get_group_members(db: Db, group_id: str) -> dict[str, MembershipDetails]:
     return {
         m.user_id: MembershipDetails(m.ended_at, m.id)
         for m in (
-            db.session.query(OktaUserGroupMember)
-            .filter(OktaUserGroupMember.group_id == group_id)
-            .filter(OktaUserGroupMember.is_owner.is_(False))
-            .all()
-        )
+            await db.session.scalars(
+                select(OktaUserGroupMember)
+                .where(OktaUserGroupMember.group_id == group_id)
+                .where(OktaUserGroupMember.is_owner.is_(False))
+            )
+        ).all()
     }
 
 
-def _get_group_membership(db: Db, membership_id: int) -> MembershipDetails:
+async def _get_group_membership(db: Db, membership_id: int) -> MembershipDetails:
     membership = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.id == membership_id)
-        .filter(OktaUserGroupMember.is_owner.is_(False))
-        .one()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.id == membership_id)
+            .where(OktaUserGroupMember.is_owner.is_(False))
+        )
+    ).one()
 
     return MembershipDetails(membership.ended_at, membership.id)
 
 
-def _add_group_membership_record(db: Db, user_id: str, group_id: str, ended_at: datetime) -> int:
+async def _add_group_membership_record(db: Db, user_id: str, group_id: str, ended_at: datetime) -> int:
     membership = OktaUserGroupMember(user_id=user_id, group_id=group_id, ended_at=ended_at, is_owner=False)
     db.session.add(membership)
-    db.session.commit()
+    await db.session.commit()
 
-    db.session.refresh(membership)
+    await db.session.refresh(membership)
     return membership.id

--- a/tests/test_group_ownership_sync.py
+++ b/tests/test_group_ownership_sync.py
@@ -3,7 +3,8 @@ from datetime import datetime, timedelta
 from typing import Callable, Tuple
 
 from pytest_mock import MockerFixture
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.models import AppGroup, OktaGroup, OktaUser, OktaUserGroupMember
 from api.extensions import Db
@@ -15,25 +16,25 @@ from tests.factories import AppFactory, AppGroupFactory, GroupFactory, UserFacto
 OwnershipDetails = namedtuple("OwnershipDetails", ["expired_at", "db_pk"])
 
 
-def test_ownership_sync(db: Db, mocker: MockerFixture) -> None:
+async def test_ownership_sync(db: Db, mocker: MockerFixture) -> None:
     initial_okta_users = UserFactory.create_batch(3)
     initial_okta_groups = GroupFactory.build_batch(3)
-    initial_db_users, initial_db_groups = seed_db(db, initial_okta_users, initial_okta_groups)
+    initial_db_users, initial_db_groups = await seed_db(db, initial_okta_users, initial_okta_groups)
 
     def fake_list_owners_for_group(group_id: str) -> list[User]:
         if group_id == initial_okta_groups[0].id:
             return initial_okta_users
         return []
 
-    ownerships = run_sync(db, mocker, initial_okta_groups, fake_list_owners_for_group, False)
+    ownerships = await run_sync(db, mocker, initial_okta_groups, fake_list_owners_for_group, False)
 
     assert ownerships is not None
 
 
-def test_ownership_in_okta_not_in_db_authoritative(db: Db, mocker: MockerFixture) -> None:
+async def test_ownership_in_okta_not_in_db_authoritative(db: Db, mocker: MockerFixture) -> None:
     initial_okta_users = UserFactory.create_batch(3)
     initial_okta_groups = GroupFactory.create_batch(3)
-    initial_db_users, initial_db_groups = seed_db(db, initial_okta_users, initial_okta_groups)
+    initial_db_users, initial_db_groups = await seed_db(db, initial_okta_users, initial_okta_groups)
 
     def fake_list_owners_for_group(group_id: str) -> list[User]:
         if group_id == initial_okta_groups[0].id:
@@ -42,44 +43,44 @@ def test_ownership_in_okta_not_in_db_authoritative(db: Db, mocker: MockerFixture
 
     delete_ownership_spy = mocker.patch.object(okta, "remove_owner_from_group")
 
-    _ = run_sync(db, mocker, initial_okta_groups, fake_list_owners_for_group, True)
+    _ = await run_sync(db, mocker, initial_okta_groups, fake_list_owners_for_group, True)
 
-    owners = _get_group_owners(db, initial_okta_groups[0].id)
+    owners = await _get_group_owners(db, initial_okta_groups[0].id)
 
     assert delete_ownership_spy.call_count == 3
 
     assert len(owners) == 0
 
 
-def test_ownership_in_okta_not_in_db_not_authoritative(db: Db, mocker: MockerFixture) -> None:
+async def test_ownership_in_okta_not_in_db_not_authoritative(db: Db, mocker: MockerFixture) -> None:
     initial_okta_users = UserFactory.create_batch(3)
     initial_okta_groups = GroupFactory.create_batch(3)
-    _, _ = seed_db(db, initial_okta_users, initial_okta_groups)
+    _, _ = await seed_db(db, initial_okta_users, initial_okta_groups)
 
     def fake_list_owners_for_group(group_id: str) -> list[User]:
         if group_id == initial_okta_groups[0].id:
             return initial_okta_users
         return []
 
-    _ = run_sync(db, mocker, initial_okta_groups, fake_list_owners_for_group, False)
+    _ = await run_sync(db, mocker, initial_okta_groups, fake_list_owners_for_group, False)
 
-    owners = _get_group_owners(db, initial_okta_groups[0].id)
+    owners = await _get_group_owners(db, initial_okta_groups[0].id)
 
     assert owners is not None
     assert len(owners) == 3
 
 
-def test_ownership_in_db_not_in_okta_not_authoritative(db: Db, mocker: MockerFixture) -> None:
+async def test_ownership_in_db_not_in_okta_not_authoritative(db: Db, mocker: MockerFixture) -> None:
     initial_okta_users = UserFactory.create_batch(3)
     initial_okta_groups = GroupFactory.create_batch(3)
-    _, _ = seed_db(db, initial_okta_users, initial_okta_groups)
+    _, _ = await seed_db(db, initial_okta_users, initial_okta_groups)
 
     def fake_list_owners_for_group(group_id: str) -> list[User]:
         return []
 
     # Add expired group ownership
     expired_date = datetime.now() - timedelta(days=1)
-    _add_group_ownership_record(
+    await _add_group_ownership_record(
         db,
         initial_okta_users[0].id,
         initial_okta_groups[0].id,
@@ -88,7 +89,7 @@ def test_ownership_in_db_not_in_okta_not_authoritative(db: Db, mocker: MockerFix
 
     # Add non-expired owner
     non_expired_date = datetime.now() + timedelta(days=1)
-    _add_group_ownership_record(
+    await _add_group_ownership_record(
         db,
         initial_okta_users[1].id,
         initial_okta_groups[0].id,
@@ -96,28 +97,32 @@ def test_ownership_in_db_not_in_okta_not_authoritative(db: Db, mocker: MockerFix
     )
 
     remove_ownership_spy = mocker.patch.object(okta, "remove_owner_from_group")
-    run_sync(db, mocker, initial_okta_groups, fake_list_owners_for_group, False)
+    await run_sync(db, mocker, initial_okta_groups, fake_list_owners_for_group, False)
 
-    owners_rows = _get_group_owners(db, initial_okta_groups[0].id)
+    owners_rows = await _get_group_owners(db, initial_okta_groups[0].id)
 
-    assert remove_ownership_spy.call_count == 0
+    # The spy used to target only the syncer's direct (authoritative) removal
+    # path; ModifyGroupUsers' internal removal went through the separate
+    # `async_remove_owner_from_group` name. With the names merged, the single
+    # ModifyGroupUsers removal of the non-expired owner now hits the spy too.
+    assert remove_ownership_spy.call_count == 1
     assert len(owners_rows) == 2
     # Verify expired user is not updated
     assert owners_rows[initial_okta_users[0].id].expired_at == expired_date
     assert owners_rows[initial_okta_users[1].id].expired_at < non_expired_date
 
 
-def test_ownership_in_db_not_in_okta_authoritative(db: Db, mocker: MockerFixture) -> None:
+async def test_ownership_in_db_not_in_okta_authoritative(db: Db, mocker: MockerFixture) -> None:
     initial_okta_users = UserFactory.create_batch(3)
     initial_okta_groups = GroupFactory.create_batch(3)
-    _, _ = seed_db(db, initial_okta_users, initial_okta_groups)
+    _, _ = await seed_db(db, initial_okta_users, initial_okta_groups)
 
     def fake_list_owners_for_group(group_id: str) -> list[User]:
         return []
 
     # Add expired group ownership
     expired_date = datetime.now() - timedelta(days=1)
-    _add_group_ownership_record(
+    await _add_group_ownership_record(
         db,
         initial_okta_users[0].id,
         initial_okta_groups[0].id,
@@ -126,7 +131,7 @@ def test_ownership_in_db_not_in_okta_authoritative(db: Db, mocker: MockerFixture
 
     # Add non-expired owner
     non_expired_date = datetime.now() + timedelta(days=1)
-    _add_group_ownership_record(
+    await _add_group_ownership_record(
         db,
         initial_okta_users[1].id,
         initial_okta_groups[0].id,
@@ -134,9 +139,9 @@ def test_ownership_in_db_not_in_okta_authoritative(db: Db, mocker: MockerFixture
     )
 
     add_ownership_spy = mocker.patch.object(okta, "add_owner_to_group")
-    run_sync(db, mocker, initial_okta_groups, fake_list_owners_for_group, True)
+    await run_sync(db, mocker, initial_okta_groups, fake_list_owners_for_group, True)
 
-    owners_rows = _get_group_owners(db, initial_okta_groups[0].id)
+    owners_rows = await _get_group_owners(db, initial_okta_groups[0].id)
 
     assert add_ownership_spy.call_count == 1
     assert len(owners_rows) == 2
@@ -145,7 +150,7 @@ def test_ownership_in_db_not_in_okta_authoritative(db: Db, mocker: MockerFixture
     assert owners_rows[initial_okta_users[1].id].expired_at == non_expired_date
 
 
-def test_app_ownership_in_db_not_in_okta_authoritative(db: Db, mocker: MockerFixture) -> None:
+async def test_app_ownership_in_db_not_in_okta_authoritative(db: Db, mocker: MockerFixture) -> None:
     initial_okta_users = UserFactory.create_batch(3)
     app = AppFactory.build()
     app_owner_group = AppGroupFactory.build(
@@ -161,16 +166,16 @@ def test_app_ownership_in_db_not_in_okta_authoritative(db: Db, mocker: MockerFix
     db.session.add(app)
     db.session.add(app_owner_group)
     db.session.add(app_non_owner_group)
-    db.session.commit()
+    await db.session.commit()
 
-    _, _ = seed_db(db, initial_okta_users, [])
+    _, _ = await seed_db(db, initial_okta_users, [])
 
     def fake_list_owners_for_group(group_id: str) -> list[User]:
         return []
 
     # Add expired group ownership
     expired_date = datetime.now() - timedelta(days=1)
-    _add_group_ownership_record(
+    await _add_group_ownership_record(
         db,
         initial_okta_users[0].id,
         app_non_owner_group.id,
@@ -179,7 +184,7 @@ def test_app_ownership_in_db_not_in_okta_authoritative(db: Db, mocker: MockerFix
 
     # Add non-expired owner
     non_expired_date = datetime.now() + timedelta(days=1)
-    _add_group_ownership_record(
+    await _add_group_ownership_record(
         db,
         initial_okta_users[1].id,
         app_owner_group.id,
@@ -188,7 +193,7 @@ def test_app_ownership_in_db_not_in_okta_authoritative(db: Db, mocker: MockerFix
 
     add_ownership_spy = mocker.patch.object(okta, "add_owner_to_group")
 
-    run_sync(
+    await run_sync(
         db,
         mocker,
         [
@@ -212,8 +217,8 @@ def test_app_ownership_in_db_not_in_okta_authoritative(db: Db, mocker: MockerFix
     )
 
     owners_rows = {}
-    owners_rows.update(_get_group_owners(db, app_owner_group.id))
-    owners_rows.update(_get_group_owners(db, app_non_owner_group.id))
+    owners_rows.update(await _get_group_owners(db, app_owner_group.id))
+    owners_rows.update(await _get_group_owners(db, app_non_owner_group.id))
 
     # Expect adding one owner to the app owner Okta group and one owner to the app non-owner Okta group
     assert add_ownership_spy.call_count == 2
@@ -223,10 +228,10 @@ def test_app_ownership_in_db_not_in_okta_authoritative(db: Db, mocker: MockerFix
     assert owners_rows[initial_okta_users[1].id].expired_at == non_expired_date
 
 
-def test_ownership_in_both_authoritative(db: Db, mocker: MockerFixture) -> None:
+async def test_ownership_in_both_authoritative(db: Db, mocker: MockerFixture) -> None:
     initial_okta_users = UserFactory.create_batch(3)
     initial_okta_groups = GroupFactory.create_batch(3)
-    _, _ = seed_db(db, initial_okta_users, initial_okta_groups)
+    _, _ = await seed_db(db, initial_okta_users, initial_okta_groups)
 
     def fake_list_owners_for_group(group_id: str) -> list[User]:
         if group_id == initial_okta_groups[0].id:
@@ -235,7 +240,7 @@ def test_ownership_in_both_authoritative(db: Db, mocker: MockerFixture) -> None:
 
     # Add expired group ownership
     expired_date = datetime.now() - timedelta(days=1)
-    _add_group_ownership_record(
+    await _add_group_ownership_record(
         db,
         initial_okta_users[0].id,
         initial_okta_groups[0].id,
@@ -244,7 +249,7 @@ def test_ownership_in_both_authoritative(db: Db, mocker: MockerFixture) -> None:
 
     # Add non-expired owner
     non_expired_date = datetime.now() + timedelta(days=1)
-    _add_group_ownership_record(
+    await _add_group_ownership_record(
         db,
         initial_okta_users[1].id,
         initial_okta_groups[0].id,
@@ -252,9 +257,9 @@ def test_ownership_in_both_authoritative(db: Db, mocker: MockerFixture) -> None:
     )
 
     remove_ownership_spy = mocker.patch.object(okta, "remove_owner_from_group")
-    run_sync(db, mocker, initial_okta_groups, fake_list_owners_for_group, True)
+    await run_sync(db, mocker, initial_okta_groups, fake_list_owners_for_group, True)
 
-    owners_rows = _get_group_owners(db, initial_okta_groups[0].id)
+    owners_rows = await _get_group_owners(db, initial_okta_groups[0].id)
 
     assert remove_ownership_spy.call_count == 1
     assert len(owners_rows) == 2
@@ -266,10 +271,10 @@ def test_ownership_in_both_authoritative(db: Db, mocker: MockerFixture) -> None:
     return
 
 
-def test_ownership_in_both_non_authoritative(db: Db, mocker: MockerFixture) -> None:
+async def test_ownership_in_both_non_authoritative(db: Db, mocker: MockerFixture) -> None:
     initial_okta_users = UserFactory.create_batch(3)
     initial_okta_groups = GroupFactory.create_batch(3)
-    _, _ = seed_db(db, initial_okta_users, initial_okta_groups)
+    _, _ = await seed_db(db, initial_okta_users, initial_okta_groups)
 
     def fake_list_owners_for_group(group_id: str) -> list[User]:
         if group_id == initial_okta_groups[0].id:
@@ -278,7 +283,7 @@ def test_ownership_in_both_non_authoritative(db: Db, mocker: MockerFixture) -> N
 
     # Add expired group ownership
     expired_date = datetime.now() - timedelta(days=1)
-    _add_group_ownership_record(
+    await _add_group_ownership_record(
         db,
         initial_okta_users[0].id,
         initial_okta_groups[0].id,
@@ -287,7 +292,7 @@ def test_ownership_in_both_non_authoritative(db: Db, mocker: MockerFixture) -> N
 
     # Add non-expired owner
     non_expired_date = datetime.now() + timedelta(days=1)
-    _add_group_ownership_record(
+    await _add_group_ownership_record(
         db,
         initial_okta_users[1].id,
         initial_okta_groups[0].id,
@@ -295,9 +300,9 @@ def test_ownership_in_both_non_authoritative(db: Db, mocker: MockerFixture) -> N
     )
 
     remove_ownership_spy = mocker.patch.object(okta, "remove_owner_from_group")
-    run_sync(db, mocker, initial_okta_groups, fake_list_owners_for_group, False)
+    await run_sync(db, mocker, initial_okta_groups, fake_list_owners_for_group, False)
 
-    owners_rows = _get_group_owners(db, initial_okta_groups[0].id)
+    owners_rows = await _get_group_owners(db, initial_okta_groups[0].id)
 
     assert remove_ownership_spy.call_count == 0
     assert len(owners_rows) == 2
@@ -312,10 +317,10 @@ def test_ownership_in_both_non_authoritative(db: Db, mocker: MockerFixture) -> N
     return
 
 
-def test_ownership_unamanaged_group_in_okta_not_in_db_authoritative(db: Db, mocker: MockerFixture) -> None:
+async def test_ownership_unamanaged_group_in_okta_not_in_db_authoritative(db: Db, mocker: MockerFixture) -> None:
     initial_okta_users = UserFactory.create_batch(3)
     initial_okta_groups = GroupFactory.create_batch(3)
-    initial_db_users, initial_db_groups = seed_db(db, initial_okta_users, initial_okta_groups)
+    initial_db_users, initial_db_groups = await seed_db(db, initial_okta_users, initial_okta_groups)
 
     def fake_list_owners_for_group(group_id: str) -> list[User]:
         if group_id == initial_okta_groups[0].id:
@@ -324,7 +329,7 @@ def test_ownership_unamanaged_group_in_okta_not_in_db_authoritative(db: Db, mock
 
     delete_ownership_spy = mocker.patch.object(okta, "remove_owner_from_group")
 
-    _ = run_sync(
+    _ = await run_sync(
         db,
         mocker,
         initial_okta_groups,
@@ -333,17 +338,17 @@ def test_ownership_unamanaged_group_in_okta_not_in_db_authoritative(db: Db, mock
         groups_with_rules={initial_okta_groups[0].id},
     )
 
-    owners = _get_group_owners(db, initial_okta_groups[0].id)
+    owners = await _get_group_owners(db, initial_okta_groups[0].id)
 
     # Verify no deletes occurred because the group was listed as managed
     assert delete_ownership_spy.call_count == 0
     assert len(owners) == 3
 
 
-def test_ownership_through_multiple_groups_non_authoritative(db: Db, mocker: MockerFixture) -> None:
+async def test_ownership_through_multiple_groups_non_authoritative(db: Db, mocker: MockerFixture) -> None:
     initial_okta_users = UserFactory.create_batch(3)
     initial_okta_groups = GroupFactory.create_batch(3)
-    _, _ = seed_db(db, initial_okta_users, initial_okta_groups)
+    _, _ = await seed_db(db, initial_okta_users, initial_okta_groups)
 
     def fake_list_owners_for_group(group_id: str) -> list[User]:
         if group_id == initial_okta_groups[0].id:
@@ -352,7 +357,7 @@ def test_ownership_through_multiple_groups_non_authoritative(db: Db, mocker: Moc
 
     # Add group ownership for user 0
     date_1 = datetime.now() + timedelta(days=2)
-    pk_1 = _add_group_ownership_record(
+    pk_1 = await _add_group_ownership_record(
         db,
         initial_okta_users[0].id,
         initial_okta_groups[0].id,
@@ -361,7 +366,7 @@ def test_ownership_through_multiple_groups_non_authoritative(db: Db, mocker: Moc
 
     # Add another ownership for user 0
     date_2 = datetime.now() + timedelta(days=1)
-    pk_2 = _add_group_ownership_record(
+    pk_2 = await _add_group_ownership_record(
         db,
         initial_okta_users[0].id,
         initial_okta_groups[0].id,
@@ -369,26 +374,29 @@ def test_ownership_through_multiple_groups_non_authoritative(db: Db, mocker: Moc
     )
 
     remove_ownership_spy = mocker.patch.object(okta, "remove_owner_from_group")
-    run_sync(db, mocker, initial_okta_groups, fake_list_owners_for_group, False)
+    await run_sync(db, mocker, initial_okta_groups, fake_list_owners_for_group, False)
 
     assert remove_ownership_spy.call_count == 0
 
     # Verify expired user is synced in. 'None' expiry date indicates
     # ownership was synced in from okta
-    assert _get_group_ownership(db, pk_1).expired_at == date_1
-    assert _get_group_ownership(db, pk_2).expired_at == date_2
+    assert (await _get_group_ownership(db, pk_1)).expired_at == date_1
+    assert (await _get_group_ownership(db, pk_2)).expired_at == date_2
 
 
-def seed_db(db: Db, users: list[OktaUser], groups: list[OktaGroup]) -> Tuple[list[OktaUser], list[OktaGroup]]:
-    with Session(db.engine) as session:
+async def seed_db(db: Db, users: list[OktaUser], groups: list[OktaGroup]) -> Tuple[list[OktaUser], list[OktaGroup]]:
+    async with AsyncSession(db.engine) as session:
         session.add_all([Group(g).update_okta_group(OktaGroup(), {}) for g in groups])
         session.add_all([User(u).update_okta_user(OktaUser(), {}) for u in users])
-        session.commit()
+        await session.commit()
 
-        return (session.query(OktaUser).all(), session.query(OktaGroup).all())
+        return (
+            list((await session.scalars(select(OktaUser))).all()),
+            list((await session.scalars(select(OktaGroup))).all()),
+        )
 
 
-def run_sync(
+async def run_sync(
     db: Db,
     mocker: MockerFixture,
     okta_groups: list[OktaGroup],
@@ -396,45 +404,47 @@ def run_sync(
     act_as_authority: bool,
     groups_with_rules: set[str] = set(),
 ) -> list[OktaUserGroupMember]:
-    with Session(db.engine) as session:
+    async with AsyncSession(db.engine) as session:
         mocker.patch.object(okta, "list_groups", return_value=okta_groups)
 
         mocker.patch.object(okta, "list_owners_for_group", side_effect=user_ownership_func)
 
         mocker.patch.object(okta, "list_groups_with_active_rules", return_value=groups_with_rules)
 
-        sync_group_ownerships(act_as_authority)
+        await sync_group_ownerships(act_as_authority)
 
-        return session.query(OktaUserGroupMember).all()
+        return list((await session.scalars(select(OktaUserGroupMember))).all())
 
 
-def _get_group_owners(db: Db, group_id: str) -> dict[str, OwnershipDetails]:
+async def _get_group_owners(db: Db, group_id: str) -> dict[str, OwnershipDetails]:
     return {
         m.user_id: OwnershipDetails(m.ended_at, m.id)
         for m in (
-            db.session.query(OktaUserGroupMember)
-            .filter(OktaUserGroupMember.group_id == group_id)
-            .filter(OktaUserGroupMember.is_owner.is_(True))
-            .all()
-        )
+            await db.session.scalars(
+                select(OktaUserGroupMember)
+                .where(OktaUserGroupMember.group_id == group_id)
+                .where(OktaUserGroupMember.is_owner.is_(True))
+            )
+        ).all()
     }
 
 
-def _get_group_ownership(db: Db, ownership_id: int) -> OwnershipDetails:
+async def _get_group_ownership(db: Db, ownership_id: int) -> OwnershipDetails:
     ownership = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.id == ownership_id)
-        .filter(OktaUserGroupMember.is_owner.is_(True))
-        .one()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.id == ownership_id)
+            .where(OktaUserGroupMember.is_owner.is_(True))
+        )
+    ).one()
 
     return OwnershipDetails(ownership.ended_at, ownership.id)
 
 
-def _add_group_ownership_record(db: Db, user_id: str, group_id: str, ended_at: datetime) -> int:
+async def _add_group_ownership_record(db: Db, user_id: str, group_id: str, ended_at: datetime) -> int:
     ownership = OktaUserGroupMember(user_id=user_id, group_id=group_id, ended_at=ended_at, is_owner=True)
     db.session.add(ownership)
-    db.session.commit()
+    await db.session.commit()
 
-    db.session.refresh(ownership)
+    await db.session.refresh(ownership)
     return ownership.id

--- a/tests/test_group_request.py
+++ b/tests/test_group_request.py
@@ -2,12 +2,12 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, cast, Protocol
 
 from factory import Faker
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
 from okta.models import Group
 from pytest_mock import MockerFixture
 from fastapi import FastAPI
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select
 from api.config import settings
 from api.extensions import Db
 from api.models import (
@@ -38,16 +38,16 @@ class FakerWithPyStr(Protocol):
     def pystr(self) -> str: ...
 
 
-def test_create_group_request(
+async def test_create_group_request(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     user: OktaUser,
 ) -> None:
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="Test Group",
         requested_group_description="Test Description",
@@ -63,20 +63,20 @@ def test_create_group_request(
     assert group_request.resolved_at is None
 
 
-def test_create_app_group_request(
+async def test_create_app_group_request(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     user: OktaUser,
 ) -> None:
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     app_obj = AppFactory.create()
     db.session.add(app_obj)
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name=f"App-{app_obj.name}-Admins",
         requested_group_description="Admin group for TestApp",
@@ -90,16 +90,16 @@ def test_create_app_group_request(
     assert group_request.requested_group_type == "app_group"
 
 
-def test_create_role_group_request(
+async def test_create_role_group_request(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     user: OktaUser,
 ) -> None:
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="Role-Engineering",
         requested_group_description="Engineering role",
@@ -111,18 +111,18 @@ def test_create_role_group_request(
     assert group_request.requested_group_type == "role_group"
 
 
-def test_create_group_request_with_tags(
+async def test_create_group_request_with_tags(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     user: OktaUser,
     tag: Tag,
 ) -> None:
     db.session.add(user)
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="Tagged Group",
         requested_group_description="Group with tags",
@@ -135,19 +135,19 @@ def test_create_group_request_with_tags(
     assert tag.id in group_request.requested_group_tags
 
 
-def test_create_group_request_with_ownership_ending_at(
+async def test_create_group_request_with_ownership_ending_at(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     user: OktaUser,
 ) -> None:
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     # Request ownership for 60 days
     requested_ending_at = datetime.now(timezone.utc) + timedelta(days=60)
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="Time Limited Group",
         requested_group_description="Group with time limit",
@@ -160,7 +160,7 @@ def test_create_group_request_with_ownership_ending_at(
     assert group_request.requested_ownership_ending_at is not None
 
     # Refresh to get the datetime with proper timezone info from DB
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
 
     # Should be close to the requested time (within a few seconds), make both timezone-aware
     stored_time = group_request.requested_ownership_ending_at
@@ -169,9 +169,9 @@ def test_create_group_request_with_ownership_ending_at(
     assert abs((stored_time - requested_ending_at).total_seconds()) < 5
 
 
-def test_create_group_request_tag_limits_ownership_time(
+async def test_create_group_request_tag_limits_ownership_time(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     user: OktaUser,
 ) -> None:
@@ -185,10 +185,10 @@ def test_create_group_request_tag_limits_ownership_time(
 
     db.session.add(user)
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
     # Request ownership with no ending time (should be limited to 90 days by tag)
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="Tag Limited Group",
         requested_group_description="Group with tag time limit",
@@ -202,7 +202,7 @@ def test_create_group_request_tag_limits_ownership_time(
     assert group_request.requested_ownership_ending_at is not None
 
     # Refresh to get proper timezone info
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     stored_time = group_request.requested_ownership_ending_at
     if stored_time.tzinfo is None:
         stored_time = stored_time.replace(tzinfo=timezone.utc)
@@ -213,9 +213,9 @@ def test_create_group_request_tag_limits_ownership_time(
     assert time_diff < 5  # Within 5 seconds of expected
 
 
-def test_create_group_request_tag_reduces_requested_ownership_time(
+async def test_create_group_request_tag_reduces_requested_ownership_time(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     user: OktaUser,
 ) -> None:
@@ -229,12 +229,12 @@ def test_create_group_request_tag_reduces_requested_ownership_time(
 
     db.session.add(user)
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
     # Request ownership for 90 days (should be reduced to 30 days)
     requested_ending_at = datetime.now(timezone.utc) + timedelta(days=90)
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="Tag Reduced Group",
         requested_group_description="Group with reduced time",
@@ -248,7 +248,7 @@ def test_create_group_request_tag_reduces_requested_ownership_time(
     assert group_request.requested_ownership_ending_at is not None
 
     # Refresh to get proper timezone info
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     stored_time = group_request.requested_ownership_ending_at
     if stored_time.tzinfo is None:
         stored_time = stored_time.replace(tzinfo=timezone.utc)
@@ -259,26 +259,28 @@ def test_create_group_request_tag_reduces_requested_ownership_time(
     assert time_diff < 5  # Within 5 seconds of expected
 
 
-def test_approve_group_request_creates_group(
+async def test_approve_group_request_creates_group(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    admin = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="New Group",
         requested_group_description="New group description",
@@ -288,57 +290,60 @@ def test_approve_group_request_creates_group(
 
     assert group_request is not None
 
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=admin,
         approval_reason="Approved",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert group_request.status == AccessRequestStatus.APPROVED
     assert group_request.resolved_at is not None
     assert group_request.resolver_user_id == admin.id
     assert group_request.approved_group_id is not None
 
-    created_group = db.session.get(OktaGroup, group_request.approved_group_id)
+    created_group = await db.session.get(OktaGroup, group_request.approved_group_id)
     assert created_group is not None
     assert created_group.name == "New Group"
     assert created_group.description == "New group description"
 
     ownerships = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == created_group.id)
-        .filter(OktaUserGroupMember.user_id == user.id)
-        .filter(OktaUserGroupMember.is_owner.is_(True))
-        .all()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == created_group.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+            .where(OktaUserGroupMember.is_owner.is_(True))
+        )
+    ).all()
     assert len(ownerships) == 1
     assert ownerships[0].created_reason == f"Group request approved: {group_request.request_reason}"
 
 
-def test_approve_group_request_sets_owner_with_ending_time(
+async def test_approve_group_request_sets_owner_with_ending_time(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    admin = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     # Request ownership for 60 days
     requested_ending_at = datetime.now(timezone.utc) + timedelta(days=60)
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="Time Limited Ownership Group",
         requested_group_description="Group with time-limited ownership",
@@ -349,24 +354,25 @@ def test_approve_group_request_sets_owner_with_ending_time(
 
     assert group_request is not None
 
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=admin,
         approval_reason="Approved",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert group_request.approved_group_id is not None
-    created_group = db.session.get(OktaGroup, group_request.approved_group_id)
+    created_group = await db.session.get(OktaGroup, group_request.approved_group_id)
 
     # Check that the requester is an owner with the correct ending time
     ownerships = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == created_group.id)
-        .filter(OktaUserGroupMember.user_id == user.id)
-        .filter(OktaUserGroupMember.is_owner.is_(True))
-        .all()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == created_group.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+            .where(OktaUserGroupMember.is_owner.is_(True))
+        )
+    ).all()
     assert len(ownerships) == 1
     assert ownerships[0].ended_at is not None
 
@@ -380,24 +386,26 @@ def test_approve_group_request_sets_owner_with_ending_time(
     assert time_diff < 5
 
 
-def test_approve_group_request_tag_limits_owner_ending_time(
+async def test_approve_group_request_tag_limits_owner_ending_time(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    admin = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     # Create a tag that limits ownership to 30 days
     tag = TagFactory.create(
@@ -407,10 +415,10 @@ def test_approve_group_request_tag_limits_owner_ending_time(
         },
     )
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
     # Request group with this tag, no ending time specified
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="Tag Constrained Group",
         requested_group_description="Group with tag constraint",
@@ -425,26 +433,27 @@ def test_approve_group_request_tag_limits_owner_ending_time(
     # Approver sets resolved ownership ending time to 90 days (should be reduced to 30 by tag)
     requested_90_days = datetime.now(timezone.utc) + timedelta(days=90)
     group_request.resolved_ownership_ending_at = requested_90_days
-    db.session.commit()
+    await db.session.commit()
 
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=admin,
         approval_reason="Approved with time limit",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert group_request.approved_group_id is not None
-    created_group = db.session.get(OktaGroup, group_request.approved_group_id)
+    created_group = await db.session.get(OktaGroup, group_request.approved_group_id)
 
     # Check that requester is an owner
     ownerships = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == created_group.id)
-        .filter(OktaUserGroupMember.user_id == user.id)
-        .filter(OktaUserGroupMember.is_owner.is_(True))
-        .all()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == created_group.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+            .where(OktaUserGroupMember.is_owner.is_(True))
+        )
+    ).all()
     assert len(ownerships) == 1
     assert ownerships[0].ended_at is not None
 
@@ -462,35 +471,37 @@ def test_approve_group_request_tag_limits_owner_ending_time(
     assert stored_time < requested_90_days
 
     # Check that resolved_ownership_ending_at was updated to the coalesced value
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     resolved_time = group_request.resolved_ownership_ending_at
     if resolved_time.tzinfo is None:
         resolved_time = resolved_time.replace(tzinfo=timezone.utc)
     assert resolved_time < requested_90_days
 
 
-def test_approve_group_request_applies_tags(
+async def test_approve_group_request_applies_tags(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
     tag: Tag,
 ) -> None:
-    admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    admin = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     db.session.add(user)
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="Tagged Group",
         requested_group_description="Group with tags",
@@ -503,54 +514,57 @@ def test_approve_group_request_applies_tags(
 
     # Set resolved tags (approver could modify these)
     group_request.resolved_group_tags = [tag.id]
-    db.session.commit()
+    await db.session.commit()
 
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=admin,
         approval_reason="Approved",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert group_request.approved_group_id is not None
-    created_group = db.session.get(OktaGroup, group_request.approved_group_id)
+    created_group = await db.session.get(OktaGroup, group_request.approved_group_id)
 
     # Check that the tag was applied
     tag_mappings = (
-        db.session.query(OktaGroupTagMap)
-        .filter(OktaGroupTagMap.group_id == created_group.id)
-        .filter(OktaGroupTagMap.tag_id == tag.id)
-        .filter(
-            or_(
-                OktaGroupTagMap.ended_at.is_(None),
-                OktaGroupTagMap.ended_at > func.now(),
+        await db.session.scalars(
+            select(OktaGroupTagMap)
+            .where(OktaGroupTagMap.group_id == created_group.id)
+            .where(OktaGroupTagMap.tag_id == tag.id)
+            .where(
+                or_(
+                    OktaGroupTagMap.ended_at.is_(None),
+                    OktaGroupTagMap.ended_at > func.now(),
+                )
             )
         )
-        .all()
-    )
+    ).all()
     assert len(tag_mappings) == 1
 
 
-def test_approve_group_request_sets_name(
+async def test_approve_group_request_sets_name(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    admin = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="Specific Name",
         requested_group_description="Specific description text",
@@ -560,42 +574,44 @@ def test_approve_group_request_sets_name(
 
     assert group_request is not None
 
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=admin,
         approval_reason="Approved",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert group_request.approved_group_id is not None
-    created_group = db.session.get(OktaGroup, group_request.approved_group_id)
+    created_group = await db.session.get(OktaGroup, group_request.approved_group_id)
     assert created_group.name == "Specific Name"
     assert created_group.description == "Specific description text"
 
 
-def test_approve_group_request_sets_type(
+async def test_approve_group_request_sets_type(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    admin = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
     app_obj = AppFactory.create()
 
     db.session.add(user)
     db.session.add(app_obj)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     # Test OktaGroup
-    group_request_okta = CreateGroupRequest(
+    group_request_okta = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="Regular Group",
         requested_group_description="Description",
@@ -605,22 +621,22 @@ def test_approve_group_request_sets_type(
 
     assert group_request_okta is not None
 
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request_okta,
         approver_user=admin,
         approval_reason="Approved",
     ).execute()
 
-    db.session.refresh(group_request_okta)
+    await db.session.refresh(group_request_okta)
     assert group_request_okta.status == AccessRequestStatus.APPROVED
     assert group_request_okta.resolver_user_id == admin.id
     assert group_request_okta.approved_group_id is not None
 
-    created_okta_group = db.session.get(OktaGroup, group_request_okta.approved_group_id)
+    created_okta_group = await db.session.get(OktaGroup, group_request_okta.approved_group_id)
     assert type(created_okta_group) is OktaGroup
 
     # Test AppGroup
-    group_request_app = CreateGroupRequest(
+    group_request_app = await CreateGroupRequest(
         requester_user=user,
         requested_group_name=f"App-{app_obj.name}-Users",
         requested_group_description="App group",
@@ -631,23 +647,25 @@ def test_approve_group_request_sets_type(
 
     assert group_request_app is not None
 
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request_app,
         approver_user=admin,
         approval_reason="Approved",
     ).execute()
 
-    db.session.refresh(group_request_app)
+    await db.session.refresh(group_request_app)
     assert group_request_app.status == AccessRequestStatus.APPROVED
     assert group_request_app.resolver_user_id == admin.id
     assert group_request_app.approved_group_id is not None
 
-    created_app_group = db.session.get(OktaGroup, group_request_app.approved_group_id)
+    created_app_group = await db.session.get(OktaGroup, group_request_app.approved_group_id)
     assert type(created_app_group) is AppGroup
+    # eager-load the joined-inheritance subclass column (lazy IO would raise in async)
+    await db.session.refresh(created_app_group, attribute_names=["app_id"])
     assert created_app_group.app_id == app_obj.id
 
     # Test RoleGroup
-    group_request_role = CreateGroupRequest(
+    group_request_role = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="Role-Marketing",
         requested_group_description="Role group",
@@ -657,24 +675,24 @@ def test_approve_group_request_sets_type(
 
     assert group_request_role is not None
 
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request_role,
         approver_user=admin,
         approval_reason="Approved",
     ).execute()
 
-    db.session.refresh(group_request_role)
+    await db.session.refresh(group_request_role)
     assert group_request_role.status == AccessRequestStatus.APPROVED
     assert group_request_role.resolver_user_id == admin.id
     assert group_request_role.approved_group_id is not None
 
-    created_role_group = db.session.get(OktaGroup, group_request_role.approved_group_id)
+    created_role_group = await db.session.get(OktaGroup, group_request_role.approved_group_id)
     assert type(created_role_group) is RoleGroup
 
 
-def test_app_owner_can_approve_request(
+async def test_app_owner_can_approve_request(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -686,13 +704,13 @@ def test_app_owner_can_approve_request(
     db.session.add(user)
     db.session.add(app_owner)
     db.session.add(app_obj)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     # Owner group for the app
     owner_group = AppGroupFactory.create(
@@ -702,7 +720,7 @@ def test_app_owner_can_approve_request(
     )
 
     db.session.add(owner_group)
-    db.session.commit()
+    await db.session.commit()
 
     # Add app_owner to owner group
     db.session.add(
@@ -712,9 +730,9 @@ def test_app_owner_can_approve_request(
             is_owner=True,
         )
     )
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name=f"App-{app_obj.name}-NewGroup",
         requested_group_description="New app group",
@@ -726,20 +744,20 @@ def test_app_owner_can_approve_request(
     assert group_request is not None
 
     # App owner should be able to approve
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=app_owner,
         approval_reason="Approved by app owner",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert group_request.status == AccessRequestStatus.APPROVED
     assert group_request.resolver_user_id == app_owner.id
 
 
-def test_app_owner_can_reject_request(
+async def test_app_owner_can_reject_request(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     user: OktaUser,
 ) -> None:
@@ -749,7 +767,7 @@ def test_app_owner_can_reject_request(
     db.session.add(user)
     db.session.add(app_owner)
     db.session.add(app_obj)
-    db.session.commit()
+    await db.session.commit()
 
     # Create owner group for the app
     owner_group = AppGroupFactory.create(
@@ -759,7 +777,7 @@ def test_app_owner_can_reject_request(
     )
 
     db.session.add(owner_group)
-    db.session.commit()
+    await db.session.commit()
 
     # Make app_owner an owner of the app via its owner group
     db.session.add(
@@ -769,9 +787,9 @@ def test_app_owner_can_reject_request(
             is_owner=True,
         )
     )
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name=f"App-{app_obj.name}-AnotherGroup",
         requested_group_description="Another app group",
@@ -783,21 +801,21 @@ def test_app_owner_can_reject_request(
     assert group_request is not None
 
     # App owner should be able to reject
-    RejectGroupRequest(
+    await RejectGroupRequest(
         group_request=group_request,
         rejection_reason="Rejected by app owner",
         notify_requester=True,
         current_user_id=app_owner.id,
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert group_request.status == AccessRequestStatus.REJECTED
     assert group_request.resolver_user_id == app_owner.id
 
 
-def test_wrong_app_owner_cannot_approve_request(
+async def test_wrong_app_owner_cannot_approve_request(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -811,13 +829,13 @@ def test_wrong_app_owner_cannot_approve_request(
     db.session.add(app_owner)
     db.session.add(app_obj)
     db.session.add(other_app)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     # Create owner groups for both apps
     owner_group = AppGroupFactory.create(
@@ -833,7 +851,7 @@ def test_wrong_app_owner_cannot_approve_request(
 
     db.session.add(owner_group)
     db.session.add(other_owner_group)
-    db.session.commit()
+    await db.session.commit()
 
     # Make app_owner an owner of 'app' but not 'other_app'
     db.session.add(
@@ -843,10 +861,10 @@ def test_wrong_app_owner_cannot_approve_request(
             is_owner=True,
         )
     )
-    db.session.commit()
+    await db.session.commit()
 
     # Create request for other_app
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name=f"App-{other_app.name}-NewGroup",
         requested_group_description="Group for other app",
@@ -859,34 +877,36 @@ def test_wrong_app_owner_cannot_approve_request(
 
     # Set resolved_app_id
     group_request.resolved_app_id = other_app.id
-    db.session.commit()
+    await db.session.commit()
 
     # App owner of 'app' should NOT be able to approve request for 'other_app'
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=app_owner,
         approval_reason="Should not be allowed",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     # Request should still be pending (not approved)
     assert group_request.status == AccessRequestStatus.PENDING
     assert group_request.resolved_at is None
 
 
-def test_admin_can_reject_request(
+async def test_admin_can_reject_request(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     user: OktaUser,
 ) -> None:
-    admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    admin = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     db.session.add(user)
     db.session.add(admin)
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="Admin Rejected Group",
         requested_group_description="Group rejected by admin",
@@ -896,21 +916,21 @@ def test_admin_can_reject_request(
 
     assert group_request is not None
 
-    RejectGroupRequest(
+    await RejectGroupRequest(
         group_request=group_request,
         rejection_reason="Rejected by admin",
         notify_requester=True,
         current_user_id=admin.id,
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert group_request.status == AccessRequestStatus.REJECTED
     assert group_request.resolver_user_id == admin.id
 
 
-def test_any_user_cannot_reject_request(
+async def test_any_user_cannot_reject_request(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     user: OktaUser,
 ) -> None:
@@ -918,9 +938,9 @@ def test_any_user_cannot_reject_request(
 
     db.session.add(user)
     db.session.add(other_user)
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="Other User Can't Reject Group",
         requested_group_description="Group can't be rejected by non-admin user",
@@ -930,28 +950,28 @@ def test_any_user_cannot_reject_request(
 
     assert group_request is not None
 
-    RejectGroupRequest(
+    await RejectGroupRequest(
         group_request=group_request,
         rejection_reason="Rejected by other_user",
         notify_requester=True,
         current_user_id=other_user.id,
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert group_request.status == AccessRequestStatus.PENDING
     assert group_request.resolved_at is None
 
 
-def test_user_can_reject_own_request(
+async def test_user_can_reject_own_request(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     user: OktaUser,
 ) -> None:
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="Self Rejected Group",
         requested_group_description="Group I don't want anymore",
@@ -961,28 +981,28 @@ def test_user_can_reject_own_request(
 
     assert group_request is not None
 
-    RejectGroupRequest(
+    await RejectGroupRequest(
         group_request=group_request,
         rejection_reason="I changed my mind",
         notify_requester=False,
         current_user_id=user.id,
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert group_request.status == AccessRequestStatus.REJECTED
     assert group_request.resolver_user_id == user.id
 
 
-def test_user_cannot_approve_own_request(
+async def test_user_cannot_approve_own_request(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     user: OktaUser,
 ) -> None:
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="Self Approval Attempt",
         requested_group_description="Trying to approve myself",
@@ -993,42 +1013,44 @@ def test_user_cannot_approve_own_request(
     assert group_request is not None
 
     # Attempt to self-approve should fail
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=user,
         approval_reason="Self approval",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     # Should still be pending
     assert group_request.status == AccessRequestStatus.PENDING
     assert group_request.resolved_at is None
 
 
-def test_approver_can_modify_group_details(
+async def test_approver_can_modify_group_details(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    admin = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
     tag = TagFactory.create(enabled=True)
     other_tag = TagFactory.create(enabled=True)
 
     db.session.add(user)
     db.session.add(tag)
     db.session.add(other_tag)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="Original Name",
         requested_group_description="Original description",
@@ -1043,17 +1065,17 @@ def test_approver_can_modify_group_details(
     group_request.resolved_group_name = "Modified Name"
     group_request.resolved_group_description = "Modified description"
     group_request.resolved_group_tags = [other_tag.id]
-    db.session.commit()
+    await db.session.commit()
 
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=admin,
         approval_reason="Approved with modifications",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert group_request.approved_group_id is not None
-    created_group = db.session.get(OktaGroup, group_request.approved_group_id)
+    created_group = await db.session.get(OktaGroup, group_request.approved_group_id)
 
     # Verify the modified values were used
     assert created_group.name == "Modified Name"
@@ -1061,24 +1083,25 @@ def test_approver_can_modify_group_details(
 
     # Check tags
     tag_mappings = (
-        db.session.query(OktaGroupTagMap)
-        .filter(OktaGroupTagMap.group_id == created_group.id)
-        .filter(
-            or_(
-                OktaGroupTagMap.ended_at.is_(None),
-                OktaGroupTagMap.ended_at > func.now(),
+        await db.session.scalars(
+            select(OktaGroupTagMap)
+            .where(OktaGroupTagMap.group_id == created_group.id)
+            .where(
+                or_(
+                    OktaGroupTagMap.ended_at.is_(None),
+                    OktaGroupTagMap.ended_at > func.now(),
+                )
             )
         )
-        .all()
-    )
+    ).all()
     tag_ids = [tm.tag_id for tm in tag_mappings]
     assert other_tag.id in tag_ids
     assert tag.id not in tag_ids
 
 
-def test_cannot_approve_already_resolved_request(
+async def test_cannot_approve_already_resolved_request(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -1088,15 +1111,15 @@ def test_cannot_approve_already_resolved_request(
 
     db.session.add(user)
     db.session.add(approver_user)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="Already Resolved",
         requested_group_description="Description",
@@ -1107,32 +1130,32 @@ def test_cannot_approve_already_resolved_request(
     assert group_request is not None
 
     # First approval
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=approver_user,
         approval_reason="First approval",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     first_approval_time = group_request.resolved_at
     first_group_id = group_request.approved_group_id
 
     # Try to approve again
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=approver_user,
         approval_reason="Second approval attempt",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     # Should still have the same resolution details
     assert group_request.resolved_at == first_approval_time
     assert group_request.approved_group_id == first_group_id
 
 
-def test_cannot_approve_deleted_requester(
+async def test_cannot_approve_deleted_requester(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -1142,15 +1165,15 @@ def test_cannot_approve_deleted_requester(
 
     db.session.add(user)
     db.session.add(approver_user)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="Deleted Requester Group",
         requested_group_description="Requester will be deleted",
@@ -1162,24 +1185,24 @@ def test_cannot_approve_deleted_requester(
 
     # Delete the requester
     user.deleted_at = func.now()
-    db.session.commit()
+    await db.session.commit()
 
     # Try to approve
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=approver_user,
         approval_reason="Should not work",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     # Should still be pending
     assert group_request.status == AccessRequestStatus.PENDING
     assert group_request.resolved_at is None
 
 
-def test_app_owner_auto_approves_own_app_group_request(
+async def test_app_owner_auto_approves_own_app_group_request(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -1189,13 +1212,13 @@ def test_app_owner_auto_approves_own_app_group_request(
 
     db.session.add(app_owner)
     db.session.add(app_obj)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     # Create owner group for the app
     owner_group = AppGroupFactory.create(
@@ -1205,7 +1228,7 @@ def test_app_owner_auto_approves_own_app_group_request(
     )
 
     db.session.add(owner_group)
-    db.session.commit()
+    await db.session.commit()
 
     # Make app_owner an owner of the app via its owner group
     db.session.add(
@@ -1215,10 +1238,10 @@ def test_app_owner_auto_approves_own_app_group_request(
             is_owner=True,
         )
     )
-    db.session.commit()
+    await db.session.commit()
 
     # App owner creates a group request for their own app
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=app_owner,
         requested_group_name=f"App-{app_obj.name}-NewTeam",
         requested_group_description="New team group for the app",
@@ -1230,35 +1253,38 @@ def test_app_owner_auto_approves_own_app_group_request(
     # Verify the request was automatically approved
     assert group_request is not None
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert group_request.status == AccessRequestStatus.APPROVED
     assert group_request.resolved_at is not None
     assert group_request.approved_group_id is not None
     assert group_request.resolution_reason == "Requester owns parent app and can create app groups"
 
     # Verify the group was created
-    created_group = db.session.get(OktaGroup, group_request.approved_group_id)
+    created_group = await db.session.get(OktaGroup, group_request.approved_group_id)
     assert created_group is not None
     assert type(created_group) is AppGroup
     assert created_group.name == f"App-{app_obj.name}-NewTeam"
     assert created_group.description == "New team group for the app"
+    # eager-load the joined-inheritance subclass column (lazy IO would raise in async)
+    await db.session.refresh(created_group, attribute_names=["app_id"])
     assert created_group.app_id == app_obj.id
 
     # Verify the requester (app owner) is set as the group owner
     ownerships = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == created_group.id)
-        .filter(OktaUserGroupMember.user_id == app_owner.id)
-        .filter(OktaUserGroupMember.is_owner.is_(True))
-        .all()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == created_group.id)
+            .where(OktaUserGroupMember.user_id == app_owner.id)
+            .where(OktaUserGroupMember.is_owner.is_(True))
+        )
+    ).all()
     assert len(ownerships) == 1
     assert ownerships[0].created_reason == f"Group request approved: {group_request.request_reason}"
 
 
-def test_app_owner_auto_approves_own_app_group_request_tagged(
+async def test_app_owner_auto_approves_own_app_group_request_tagged(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -1270,18 +1296,18 @@ def test_app_owner_auto_approves_own_app_group_request_tagged(
     db.session.add(app_owner)
     db.session.add(app_obj)
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
     # Apply tag to the app so it cascades to groups created for this app
     app_tag_map = AppTagMap(app_id=app_obj.id, tag_id=tag.id)
     db.session.add(app_tag_map)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     # Create owner group for the app
     owner_group = AppGroupFactory.create(
@@ -1291,7 +1317,7 @@ def test_app_owner_auto_approves_own_app_group_request_tagged(
     )
 
     db.session.add(owner_group)
-    db.session.commit()
+    await db.session.commit()
 
     # Make app_owner an owner of the app via its owner group
     db.session.add(
@@ -1301,11 +1327,11 @@ def test_app_owner_auto_approves_own_app_group_request_tagged(
             is_owner=True,
         )
     )
-    db.session.commit()
+    await db.session.commit()
 
     # App owner creates a group request for their own app
     # Include the tag in the request
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=app_owner,
         requested_group_name=f"App-{app_obj.name}-NewTeam",
         requested_group_description="New team group for the app",
@@ -1318,53 +1344,59 @@ def test_app_owner_auto_approves_own_app_group_request_tagged(
     # Verify the request was automatically approved
     assert group_request is not None
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert group_request.status == AccessRequestStatus.APPROVED
     assert group_request.resolved_at is not None
     assert group_request.approved_group_id is not None
     assert group_request.resolution_reason == "Requester owns parent app and can create app groups"
 
     # Verify the group was created
-    created_group = db.session.get(OktaGroup, group_request.approved_group_id)
+    created_group = await db.session.get(OktaGroup, group_request.approved_group_id)
     assert created_group is not None
     assert type(created_group) is AppGroup
     assert created_group.name == f"App-{app_obj.name}-NewTeam"
     assert created_group.description == "New team group for the app"
+    # eager-load the joined-inheritance subclass column (lazy IO would raise in async)
+    await db.session.refresh(created_group, attribute_names=["app_id"])
     assert created_group.app_id == app_obj.id
 
     # Verify the app owner is *not* set as the group owner due to tags (will own implicitly via app ownership)
     ownerships = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == created_group.id)
-        .filter(OktaUserGroupMember.user_id == app_owner.id)
-        .filter(OktaUserGroupMember.is_owner.is_(True))
-        .all()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == created_group.id)
+            .where(OktaUserGroupMember.user_id == app_owner.id)
+            .where(OktaUserGroupMember.is_owner.is_(True))
+        )
+    ).all()
     assert len(ownerships) == 0
 
     # Verify the tag was applied to the created group
     tag_mappings = {
         tag_map.tag_id
         for tag_map in (
-            db.session.query(OktaGroupTagMap)
-            .filter(OktaGroupTagMap.group_id == created_group.id)
-            .filter(OktaGroupTagMap.tag_id == tag.id)
-            .filter(
-                or_(
-                    OktaGroupTagMap.ended_at.is_(None),
-                    OktaGroupTagMap.ended_at > func.now(),
+            (
+                await db.session.scalars(
+                    select(OktaGroupTagMap)
+                    .where(OktaGroupTagMap.group_id == created_group.id)
+                    .where(OktaGroupTagMap.tag_id == tag.id)
+                    .where(
+                        or_(
+                            OktaGroupTagMap.ended_at.is_(None),
+                            OktaGroupTagMap.ended_at > func.now(),
+                        )
+                    )
                 )
-            )
-            .all()
+            ).all()
         )
     }
 
     assert len(tag_mappings) == 1
 
 
-def test_random_user_cannot_approve_group_request(
+async def test_random_user_cannot_approve_group_request(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     user: OktaUser,
     mocker: MockerFixture,
@@ -1374,15 +1406,15 @@ def test_random_user_cannot_approve_group_request(
 
     db.session.add(user)
     db.session.add(random_user)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="Random Approval Attempt",
         requested_group_description="Should not be approvable by random user",
@@ -1392,21 +1424,21 @@ def test_random_user_cannot_approve_group_request(
 
     assert group_request is not None
 
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=random_user,
         approval_reason="Should not work",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert group_request.status == AccessRequestStatus.PENDING
     assert group_request.resolved_at is None
     assert group_request.approved_group_id is None
 
 
-def test_app_owner_cannot_hijack_cross_app_group_via_resolved_name(
+async def test_app_owner_cannot_hijack_cross_app_group_via_resolved_name(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -1420,13 +1452,13 @@ def test_app_owner_cannot_hijack_cross_app_group_via_resolved_name(
     db.session.add(app_owner)
     db.session.add(app_a)
     db.session.add(app_b)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     owner_group = AppGroupFactory.create(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_a.name}"
@@ -1435,15 +1467,15 @@ def test_app_owner_cannot_hijack_cross_app_group_via_resolved_name(
         is_owner=True,
     )
     db.session.add(owner_group)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaUserGroupMember(user_id=app_owner.id, group_id=owner_group.id, is_owner=True))
-    db.session.commit()
+    await db.session.commit()
 
     sensitive_group = AppGroupFactory.create(name="App-Finance-Sensitive", app_id=app_b.id)
     db.session.add(sensitive_group)
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name=f"App-{app_a.name}-NewGroup",
         requested_group_description="New group for App A",
@@ -1455,34 +1487,35 @@ def test_app_owner_cannot_hijack_cross_app_group_via_resolved_name(
 
     # attacker overwrites resolved_group_name to target app b sensitive group
     group_request.resolved_group_name = sensitive_group.name
-    db.session.commit()
+    await db.session.commit()
 
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=app_owner,
         approval_reason="Approved",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert (
         group_request.status == AccessRequestStatus.PENDING
     ), "approval must be blocked when resolved_group_name collides with a pre-existing group"
     assert group_request.resolved_at is None
 
     hijacked_ownership = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == sensitive_group.id)
-        .filter(OktaUserGroupMember.user_id == user.id)
-        .filter(OktaUserGroupMember.is_owner.is_(True))
-        .filter(OktaUserGroupMember.ended_at.is_(None))
-        .first()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == sensitive_group.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+            .where(OktaUserGroupMember.is_owner.is_(True))
+            .where(OktaUserGroupMember.ended_at.is_(None))
+        )
+    ).first()
     assert hijacked_ownership is None
 
 
-def test_app_owner_cannot_hijack_okta_group_via_resolved_name(
+async def test_app_owner_cannot_hijack_okta_group_via_resolved_name(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -1494,13 +1527,13 @@ def test_app_owner_cannot_hijack_okta_group_via_resolved_name(
     db.session.add(user)
     db.session.add(app_owner)
     db.session.add(app_obj)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     owner_group = AppGroupFactory.create(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}"
@@ -1509,15 +1542,15 @@ def test_app_owner_cannot_hijack_okta_group_via_resolved_name(
         is_owner=True,
     )
     db.session.add(owner_group)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaUserGroupMember(user_id=app_owner.id, group_id=owner_group.id, is_owner=True))
-    db.session.commit()
+    await db.session.commit()
 
     existing_okta_group = OktaGroupFactory.create(name="Okta-Platform-Admins")
     db.session.add(existing_okta_group)
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name=f"App-{app_obj.name}-NewGroup",
         requested_group_description="New group",
@@ -1528,34 +1561,35 @@ def test_app_owner_cannot_hijack_okta_group_via_resolved_name(
     assert group_request is not None
 
     group_request.resolved_group_name = existing_okta_group.name
-    db.session.commit()
+    await db.session.commit()
 
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=app_owner,
         approval_reason="Approved",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert (
         group_request.status == AccessRequestStatus.PENDING
     ), "approval must be blocked when resolved_group_name collides with a pre-existing OktaGroup"
     assert group_request.resolved_at is None
 
     hijacked_ownership = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == existing_okta_group.id)
-        .filter(OktaUserGroupMember.user_id == user.id)
-        .filter(OktaUserGroupMember.is_owner.is_(True))
-        .filter(OktaUserGroupMember.ended_at.is_(None))
-        .first()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == existing_okta_group.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+            .where(OktaUserGroupMember.is_owner.is_(True))
+            .where(OktaUserGroupMember.ended_at.is_(None))
+        )
+    ).first()
     assert hijacked_ownership is None
 
 
-def test_app_owner_cannot_hijack_role_group_via_resolved_name(
+async def test_app_owner_cannot_hijack_role_group_via_resolved_name(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -1567,13 +1601,13 @@ def test_app_owner_cannot_hijack_role_group_via_resolved_name(
     db.session.add(user)
     db.session.add(app_owner)
     db.session.add(app_obj)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     owner_group = AppGroupFactory.create(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}"
@@ -1582,15 +1616,15 @@ def test_app_owner_cannot_hijack_role_group_via_resolved_name(
         is_owner=True,
     )
     db.session.add(owner_group)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaUserGroupMember(user_id=app_owner.id, group_id=owner_group.id, is_owner=True))
-    db.session.commit()
+    await db.session.commit()
 
     existing_role_group = RoleGroupFactory.create(name="Role-Security-Engineers")
     db.session.add(existing_role_group)
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name=f"App-{app_obj.name}-NewGroup",
         requested_group_description="New group",
@@ -1601,34 +1635,35 @@ def test_app_owner_cannot_hijack_role_group_via_resolved_name(
     assert group_request is not None
 
     group_request.resolved_group_name = existing_role_group.name
-    db.session.commit()
+    await db.session.commit()
 
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=app_owner,
         approval_reason="Approved",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert (
         group_request.status == AccessRequestStatus.PENDING
     ), "approval must be blocked when resolved_group_name collides with a pre-existing RoleGroup"
     assert group_request.resolved_at is None
 
     hijacked_ownership = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == existing_role_group.id)
-        .filter(OktaUserGroupMember.user_id == user.id)
-        .filter(OktaUserGroupMember.is_owner.is_(True))
-        .filter(OktaUserGroupMember.ended_at.is_(None))
-        .first()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == existing_role_group.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+            .where(OktaUserGroupMember.is_owner.is_(True))
+            .where(OktaUserGroupMember.ended_at.is_(None))
+        )
+    ).first()
     assert hijacked_ownership is None
 
 
-def test_app_owner_cannot_hijack_group_via_resolved_name_case_insensitive(
+async def test_app_owner_cannot_hijack_group_via_resolved_name_case_insensitive(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -1642,13 +1677,13 @@ def test_app_owner_cannot_hijack_group_via_resolved_name_case_insensitive(
     db.session.add(app_owner)
     db.session.add(app_a)
     db.session.add(app_b)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     owner_group = AppGroupFactory.create(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_a.name}"
@@ -1657,15 +1692,15 @@ def test_app_owner_cannot_hijack_group_via_resolved_name_case_insensitive(
         is_owner=True,
     )
     db.session.add(owner_group)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaUserGroupMember(user_id=app_owner.id, group_id=owner_group.id, is_owner=True))
-    db.session.commit()
+    await db.session.commit()
 
     sensitive_group = AppGroupFactory.create(name="App-Finance-Sensitive", app_id=app_b.id)
     db.session.add(sensitive_group)
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name=f"App-{app_a.name}-NewGroup",
         requested_group_description="New group for App A",
@@ -1677,32 +1712,33 @@ def test_app_owner_cannot_hijack_group_via_resolved_name_case_insensitive(
 
     # case-insensitive lookup should still collides
     group_request.resolved_group_name = sensitive_group.name.upper()
-    db.session.commit()
+    await db.session.commit()
 
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=app_owner,
         approval_reason="Approved",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert group_request.status == AccessRequestStatus.PENDING, "case-insensitive name collision must also be blocked"
     assert group_request.resolved_at is None
 
     hijacked_ownership = (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == sensitive_group.id)
-        .filter(OktaUserGroupMember.user_id == user.id)
-        .filter(OktaUserGroupMember.is_owner.is_(True))
-        .filter(OktaUserGroupMember.ended_at.is_(None))
-        .first()
-    )
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == sensitive_group.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+            .where(OktaUserGroupMember.is_owner.is_(True))
+            .where(OktaUserGroupMember.ended_at.is_(None))
+        )
+    ).first()
     assert hijacked_ownership is None
 
 
-def test_cannot_approve_okta_group_with_reserved_app_owners_name(
+async def test_cannot_approve_okta_group_with_reserved_app_owners_name(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -1714,13 +1750,13 @@ def test_cannot_approve_okta_group_with_reserved_app_owners_name(
     db.session.add(user)
     db.session.add(app_owner)
     db.session.add(app_obj)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     owner_group = AppGroupFactory.create(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}"
@@ -1729,11 +1765,11 @@ def test_cannot_approve_okta_group_with_reserved_app_owners_name(
         is_owner=True,
     )
     db.session.add(owner_group)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaUserGroupMember(user_id=app_owner.id, group_id=owner_group.id, is_owner=True))
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name=f"App-{app_obj.name}-NewGroup",
         requested_group_description="New group",
@@ -1745,32 +1781,30 @@ def test_cannot_approve_okta_group_with_reserved_app_owners_name(
 
     group_request.resolved_group_name = "App-Payments-Owners"
     group_request.resolved_group_type = "okta_group"
-    db.session.commit()
+    await db.session.commit()
 
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=app_owner,
         approval_reason="Approved",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert (
         group_request.status == AccessRequestStatus.PENDING
     ), "approval must be blocked when resolved_group_name uses the reserved App- prefix for a non-app_group type"
     assert group_request.resolved_at is None
 
     assert (
-        db.session.query(OktaGroup)
-        .filter(OktaGroup.name == "App-Payments-Owners")
-        .filter(OktaGroup.deleted_at.is_(None))
-        .first()
-        is None
-    )
+        await db.session.scalars(
+            select(OktaGroup).where(OktaGroup.name == "App-Payments-Owners").where(OktaGroup.deleted_at.is_(None))
+        )
+    ).first() is None
 
 
-def test_cannot_approve_role_group_with_reserved_app_owners_name(
+async def test_cannot_approve_role_group_with_reserved_app_owners_name(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -1782,13 +1816,13 @@ def test_cannot_approve_role_group_with_reserved_app_owners_name(
     db.session.add(user)
     db.session.add(app_owner)
     db.session.add(app_obj)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     owner_group = AppGroupFactory.create(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}"
@@ -1797,11 +1831,11 @@ def test_cannot_approve_role_group_with_reserved_app_owners_name(
         is_owner=True,
     )
     db.session.add(owner_group)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaUserGroupMember(user_id=app_owner.id, group_id=owner_group.id, is_owner=True))
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name=f"App-{app_obj.name}-NewGroup",
         requested_group_description="New group",
@@ -1813,32 +1847,30 @@ def test_cannot_approve_role_group_with_reserved_app_owners_name(
 
     group_request.resolved_group_name = "App-Payments-Owners"
     group_request.resolved_group_type = "role_group"
-    db.session.commit()
+    await db.session.commit()
 
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=app_owner,
         approval_reason="Approved",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert (
         group_request.status == AccessRequestStatus.PENDING
     ), "approval must be blocked when resolved_group_name uses the reserved App- prefix for a non-app_group type"
     assert group_request.resolved_at is None
 
     assert (
-        db.session.query(OktaGroup)
-        .filter(OktaGroup.name == "App-Payments-Owners")
-        .filter(OktaGroup.deleted_at.is_(None))
-        .first()
-        is None
-    )
+        await db.session.scalars(
+            select(OktaGroup).where(OktaGroup.name == "App-Payments-Owners").where(OktaGroup.deleted_at.is_(None))
+        )
+    ).first() is None
 
 
-def test_cannot_approve_okta_group_with_any_reserved_app_prefix(
+async def test_cannot_approve_okta_group_with_any_reserved_app_prefix(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -1850,13 +1882,13 @@ def test_cannot_approve_okta_group_with_any_reserved_app_prefix(
     db.session.add(user)
     db.session.add(app_owner)
     db.session.add(app_obj)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     owner_group = AppGroupFactory.create(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}"
@@ -1865,11 +1897,11 @@ def test_cannot_approve_okta_group_with_any_reserved_app_prefix(
         is_owner=True,
     )
     db.session.add(owner_group)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaUserGroupMember(user_id=app_owner.id, group_id=owner_group.id, is_owner=True))
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name=f"App-{app_obj.name}-NewGroup",
         requested_group_description="New group",
@@ -1882,32 +1914,30 @@ def test_cannot_approve_okta_group_with_any_reserved_app_prefix(
     # Non-Owners suffix: rule is broader than just App-*-Owners
     group_request.resolved_group_name = "App-Payments-Members"
     group_request.resolved_group_type = "okta_group"
-    db.session.commit()
+    await db.session.commit()
 
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=app_owner,
         approval_reason="Approved",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert (
         group_request.status == AccessRequestStatus.PENDING
     ), "approval must be blocked for any non-app_group resolved_group_name that starts with the App- prefix"
     assert group_request.resolved_at is None
 
     assert (
-        db.session.query(OktaGroup)
-        .filter(OktaGroup.name == "App-Payments-Members")
-        .filter(OktaGroup.deleted_at.is_(None))
-        .first()
-        is None
-    )
+        await db.session.scalars(
+            select(OktaGroup).where(OktaGroup.name == "App-Payments-Members").where(OktaGroup.deleted_at.is_(None))
+        )
+    ).first() is None
 
 
-def test_cannot_approve_app_group_request_with_owners_group_name(
+async def test_cannot_approve_app_group_request_with_owners_group_name(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -1919,13 +1949,13 @@ def test_cannot_approve_app_group_request_with_owners_group_name(
     db.session.add(user)
     db.session.add(app_owner)
     db.session.add(app_obj)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     owner_group = AppGroupFactory.create(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}"
@@ -1934,11 +1964,11 @@ def test_cannot_approve_app_group_request_with_owners_group_name(
         is_owner=True,
     )
     db.session.add(owner_group)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaUserGroupMember(user_id=app_owner.id, group_id=owner_group.id, is_owner=True))
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name=f"App-{app_obj.name}-NewGroup",
         requested_group_description="New group",
@@ -1954,33 +1984,33 @@ def test_cannot_approve_app_group_request_with_owners_group_name(
     )
     group_request.resolved_group_name = owners_group_name
     group_request.resolved_group_type = "app_group"
-    db.session.commit()
+    await db.session.commit()
 
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=app_owner,
         approval_reason="Approved",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert (
         group_request.status == AccessRequestStatus.PENDING
     ), "approval must be blocked when resolved_group_name matches the App-*-Owners pattern even for app_group type"
     assert group_request.resolved_at is None
 
     assert (
-        db.session.query(OktaGroup)
-        .filter(OktaGroup.name == owners_group_name)
-        .filter(OktaGroup.deleted_at.is_(None))
-        .filter(OktaGroup.id != owner_group.id)
-        .first()
-        is None
-    )
+        await db.session.scalars(
+            select(OktaGroup)
+            .where(OktaGroup.name == owners_group_name)
+            .where(OktaGroup.deleted_at.is_(None))
+            .where(OktaGroup.id != owner_group.id)
+        )
+    ).first() is None
 
 
-def test_cannot_approve_non_role_group_request_with_role_prefix(
+async def test_cannot_approve_non_role_group_request_with_role_prefix(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -1989,21 +2019,21 @@ def test_cannot_approve_non_role_group_request_with_role_prefix(
     admin = OktaUserFactory.create()
     db.session.add(user)
     db.session.add(admin)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     access_admin_group = RoleGroupFactory.create(name="App-Access-Owners")
     db.session.add(access_admin_group)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaUserGroupMember(user_id=admin.id, group_id=access_admin_group.id, is_owner=False))
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name=f"{RoleGroup.ROLE_GROUP_NAME_PREFIX}Admins",
         requested_group_description="A role group",
@@ -2015,22 +2045,22 @@ def test_cannot_approve_non_role_group_request_with_role_prefix(
     # Override the resolved name/type to use the Role- prefix with a non-role type
     group_request.resolved_group_name = f"{RoleGroup.ROLE_GROUP_NAME_PREFIX}Admins"
     group_request.resolved_group_type = "okta_group"
-    db.session.commit()
+    await db.session.commit()
 
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=admin,
         approval_reason="Approved",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert (
         group_request.status == AccessRequestStatus.PENDING
     ), "approval must be blocked for any non-role_group resolved_group_name that starts with the Role- prefix"
     assert group_request.resolved_at is None
 
 
-def test_group_request_list_filters_via_http(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_group_request_list_filters_via_http(client: AsyncClient, db: Db, url_for: Any) -> None:
     """`status`, `requester_user_id`, `requested_group_type`,
     `requested_app_id` and `q` each narrow /api/group-requests. Seed two
     requests of different types/requesters/apps so each filter must
@@ -2042,9 +2072,9 @@ def test_group_request_list_filters_via_http(client: TestClient, db: Db, url_for
     other_user = OktaUserFactory.create()
     target_app = AppFactory.create()
     db.session.add_all([target_user, other_user, target_app])
-    db.session.commit()
+    await db.session.commit()
 
-    target_gr = CreateGroupRequest(
+    target_gr = await CreateGroupRequest(
         requester_user=target_user,
         requested_group_name="ZelaTargetOktaGroup",
         requested_group_description="zela target desc",
@@ -2054,7 +2084,7 @@ def test_group_request_list_filters_via_http(client: TestClient, db: Db, url_for
         requested_ownership_ending_at=None,
         request_reason="please",
     ).execute()
-    other_gr = CreateGroupRequest(
+    other_gr = await CreateGroupRequest(
         requester_user=other_user,
         requested_group_name=f"App-{target_app.name}-OtherDistinctApp",
         requested_group_description="distinct app group desc",
@@ -2071,33 +2101,33 @@ def test_group_request_list_filters_via_http(client: TestClient, db: Db, url_for
     def ids(rep: Any) -> list[str]:
         return [r["id"] for r in rep.json()["items"]]
 
-    rep = client.get(list_url, params={"status": "PENDING"})
+    rep = await client.get(list_url, params={"status": "PENDING"})
     assert rep.status_code == 200
     assert {target_gr.id, other_gr.id}.issubset(set(ids(rep)))
 
-    rep = client.get(list_url, params={"requester_user_id": target_user.id})
+    rep = await client.get(list_url, params={"requester_user_id": target_user.id})
     assert rep.status_code == 200
     found = ids(rep)
     assert target_gr.id in found and other_gr.id not in found
 
-    rep = client.get(list_url, params={"requested_group_type": "okta_group"})
+    rep = await client.get(list_url, params={"requested_group_type": "okta_group"})
     assert rep.status_code == 200
     found = ids(rep)
     assert target_gr.id in found and other_gr.id not in found
 
-    rep = client.get(list_url, params={"requested_app_id": target_app.id})
+    rep = await client.get(list_url, params={"requested_app_id": target_app.id})
     assert rep.status_code == 200
     found = ids(rep)
     assert other_gr.id in found and target_gr.id not in found
 
-    rep = client.get(list_url, params={"q": "ZelaTargetOktaGroup"})
+    rep = await client.get(list_url, params={"q": "ZelaTargetOktaGroup"})
     assert rep.status_code == 200
     found = ids(rep)
     assert target_gr.id in found and other_gr.id not in found
 
 
-def test_post_group_request_validation_via_http(
-    client: TestClient, db: Db, user: OktaUser, mock_user: Any, url_for: Any
+async def test_post_group_request_validation_via_http(
+    client: AsyncClient, db: Db, user: OktaUser, mock_user: Any, url_for: Any
 ) -> None:
     """POST /api/group-requests pre-validates: deleted requester → 403,
     unknown tag → 400, and `app_group` without `requested_app_id` → 400
@@ -2109,9 +2139,9 @@ def test_post_group_request_validation_via_http(
     # (a) Deleted requester → 403
     deleted = OktaUserFactory.create(deleted_at=datetime.now(timezone.utc))
     db.session.add(deleted)
-    db.session.commit()
+    await db.session.commit()
     mock_user(deleted.id)
-    rep = client.post(
+    rep = await client.post(
         create_url,
         json={
             "requested_group_name": "Foo",
@@ -2125,9 +2155,9 @@ def test_post_group_request_validation_via_http(
 
     # (b) Unknown tag → 400
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
     mock_user(user.id)
-    rep = client.post(
+    rep = await client.post(
         create_url,
         json={
             "requested_group_name": "Foo",
@@ -2141,7 +2171,7 @@ def test_post_group_request_validation_via_http(
 
     # (c) app_group missing requested_app_id → 400 (Pydantic discriminator
     # rejects the missing required field on _AppGroupRequestBody).
-    rep = client.post(
+    rep = await client.post(
         create_url,
         json={
             "requested_group_name": "Foo",
@@ -2152,16 +2182,16 @@ def test_post_group_request_validation_via_http(
     assert rep.status_code == 400
 
 
-def test_post_group_request_app_id_must_exist_unknown(
-    client: TestClient, db: Db, user: OktaUser, mock_user: Any, url_for: Any
+async def test_post_group_request_app_id_must_exist_unknown(
+    client: AsyncClient, db: Db, user: OktaUser, mock_user: Any, url_for: Any
 ) -> None:
     """`requested_app_id` that does not match any App row → 404 "App not found".
     The router must verify the app exists before invoking
     `CreateGroupRequest`."""
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
     mock_user(user.id)
-    rep = client.post(
+    rep = await client.post(
         url_for("api-group-requests.group_requests_create"),
         json={
             "requested_group_name": "Foo",
@@ -2174,17 +2204,17 @@ def test_post_group_request_app_id_must_exist_unknown(
     assert "App not found" in rep.text
 
 
-def test_post_group_request_app_id_must_exist_deleted(
-    client: TestClient, db: Db, user: OktaUser, mock_user: Any, url_for: Any
+async def test_post_group_request_app_id_must_exist_deleted(
+    client: AsyncClient, db: Db, user: OktaUser, mock_user: Any, url_for: Any
 ) -> None:
     """`requested_app_id` pointing at a soft-deleted App → 404 (the resource
     queries `App.deleted_at.is_(None)` before accepting the request)."""
     db.session.add(user)
     deleted_app = AppFactory.create(name="DeletedApp", deleted_at=datetime.now(timezone.utc))
     db.session.add(deleted_app)
-    db.session.commit()
+    await db.session.commit()
     mock_user(user.id)
-    rep = client.post(
+    rep = await client.post(
         url_for("api-group-requests.group_requests_create"),
         json={
             "requested_group_name": "Foo",
@@ -2197,8 +2227,8 @@ def test_post_group_request_app_id_must_exist_deleted(
     assert "App not found" in rep.text
 
 
-def test_post_group_request_tag_ids_must_be_undeleted(
-    client: TestClient, db: Db, user: OktaUser, mock_user: Any, url_for: Any
+async def test_post_group_request_tag_ids_must_be_undeleted(
+    client: AsyncClient, db: Db, user: OktaUser, mock_user: Any, url_for: Any
 ) -> None:
     """A soft-deleted tag id must not be accepted — the router filters
     `Tag.deleted_at.is_(None)` before counting matches against the
@@ -2208,9 +2238,9 @@ def test_post_group_request_tag_ids_must_be_undeleted(
     db.session.add(user)
     deleted_tag = TagFactory.create(name="DeletedTag", deleted_at=datetime.now(timezone.utc))
     db.session.add(deleted_tag)
-    db.session.commit()
+    await db.session.commit()
     mock_user(user.id)
-    rep = client.post(
+    rep = await client.post(
         url_for("api-group-requests.group_requests_create"),
         json={
             "requested_group_name": "Foo",
@@ -2223,17 +2253,17 @@ def test_post_group_request_tag_ids_must_be_undeleted(
     assert "tags not found" in rep.text
 
 
-def test_put_group_request_ignores_legacy_resolution_reason_alias_via_http(
-    client: TestClient, db: Db, user: OktaUser, url_for: Any
+async def test_put_group_request_ignores_legacy_resolution_reason_alias_via_http(
+    client: AsyncClient, db: Db, user: OktaUser, url_for: Any
 ) -> None:
     """PUT /api/group-requests/{id} reads `reason` from the body (matching
     the access-request and role-request resolve endpoints). The legacy
     `resolution_reason` key is silently dropped, leaving the persisted
     resolution_reason empty."""
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="ResolveAliasOktaGroup",
         requested_group_description="alias drop test",
@@ -2243,22 +2273,24 @@ def test_put_group_request_ignores_legacy_resolution_reason_alias_via_http(
     assert group_request is not None
 
     resolve_url = url_for("api-group-requests.group_request_by_id_put", group_request_id=group_request.id)
-    rep = client.put(resolve_url, json={"approved": False, "resolution_reason": "should be dropped"})
+    rep = await client.put(resolve_url, json={"approved": False, "resolution_reason": "should be dropped"})
     assert rep.status_code == 200
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert group_request.status == AccessRequestStatus.REJECTED
     assert group_request.resolution_reason == ""
 
 
-def test_put_group_request_persists_reason_via_http(client: TestClient, db: Db, user: OktaUser, url_for: Any) -> None:
+async def test_put_group_request_persists_reason_via_http(
+    client: AsyncClient, db: Db, user: OktaUser, url_for: Any
+) -> None:
     """PUT /api/group-requests/{id} stores the body's `reason` verbatim on
     the resolved request's `resolution_reason` column (the DB column name
     is preserved; only the request-body key was renamed)."""
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name="ResolveResolutionReasonOktaGroup",
         requested_group_description="reason test",
@@ -2268,16 +2300,16 @@ def test_put_group_request_persists_reason_via_http(client: TestClient, db: Db, 
     assert group_request is not None
 
     resolve_url = url_for("api-group-requests.group_request_by_id_put", group_request_id=group_request.id)
-    rep = client.put(resolve_url, json={"approved": False, "reason": "duplicate work"})
+    rep = await client.put(resolve_url, json={"approved": False, "reason": "duplicate work"})
     assert rep.status_code == 200
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert group_request.status == AccessRequestStatus.REJECTED
     assert group_request.resolution_reason == "duplicate work"
 
 
-def test_put_group_request_app_owner_cannot_escalate_to_role_group(
-    client: TestClient,
+async def test_put_group_request_app_owner_cannot_escalate_to_role_group(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -2296,8 +2328,8 @@ def test_put_group_request_app_owner_cannot_escalate_to_role_group(
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     # Alice is the app owner of Foo. She is NOT an Access admin.
     alice = OktaUserFactory.create()
@@ -2305,7 +2337,7 @@ def test_put_group_request_app_owner_cannot_escalate_to_role_group(
     db.session.add(user)
     db.session.add(alice)
     db.session.add(foo_app)
-    db.session.commit()
+    await db.session.commit()
 
     owner_group = AppGroupFactory.create(
         name=(
@@ -2316,14 +2348,14 @@ def test_put_group_request_app_owner_cannot_escalate_to_role_group(
         is_owner=True,
     )
     db.session.add(owner_group)
-    db.session.commit()
+    await db.session.commit()
     # is_owner=True makes Alice a *manager* of app Foo
     db.session.add(OktaUserGroupMember(user_id=alice.id, group_id=owner_group.id, is_owner=True))
-    db.session.commit()
+    await db.session.commit()
 
     # Regular user files an app_group request against Foo. Alice is a valid
     # approver for this request because she owns Foo.
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name=f"App-{foo_app.name}-Members",
         requested_group_description="legit app group",
@@ -2339,7 +2371,7 @@ def test_put_group_request_app_owner_cannot_escalate_to_role_group(
     # resolved_app_id) still passes.
     mock_user(alice.id)
     resolve_url = url_for("api-group-requests.group_request_by_id_put", group_request_id=group_request.id)
-    rep = client.put(
+    rep = await client.put(
         resolve_url,
         json={
             "approved": True,
@@ -2352,8 +2384,10 @@ def test_put_group_request_app_owner_cannot_escalate_to_role_group(
     assert rep.status_code == 403
     # No RoleGroup should be created since Alice is only an
     # app owner but not an admin
-    db.session.refresh(group_request)
-    role_evil = db.session.query(RoleGroup).filter(func.lower(OktaGroup.name) == func.lower("Role-evil")).first()
+    await db.session.refresh(group_request)
+    role_evil = (
+        await db.session.scalars(select(RoleGroup).where(func.lower(OktaGroup.name) == func.lower("Role-evil")))
+    ).first()
     assert role_evil is None, (
         "App owner was able to escalate an app_group request into creating a RoleGroup "
         f"(PUT returned {rep.status_code}, request status={group_request.status})."
@@ -2362,8 +2396,8 @@ def test_put_group_request_app_owner_cannot_escalate_to_role_group(
     assert group_request.approved_group_id is None
 
 
-def test_put_group_request_app_owner_cannot_escalate_to_other_app(
-    client: TestClient,
+async def test_put_group_request_app_owner_cannot_escalate_to_other_app(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -2378,8 +2412,8 @@ def test_put_group_request_app_owner_cannot_escalate_to_other_app(
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     alice = OktaUserFactory.create()
     foo_app = AppFactory.create()
@@ -2388,7 +2422,7 @@ def test_put_group_request_app_owner_cannot_escalate_to_other_app(
     db.session.add(alice)
     db.session.add(foo_app)
     db.session.add(bar_app)
-    db.session.commit()
+    await db.session.commit()
 
     foo_owner_group = AppGroupFactory.create(
         name=(
@@ -2399,11 +2433,11 @@ def test_put_group_request_app_owner_cannot_escalate_to_other_app(
         is_owner=True,
     )
     db.session.add(foo_owner_group)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaUserGroupMember(user_id=alice.id, group_id=foo_owner_group.id, is_owner=True))
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name=f"App-{foo_app.name}-Members",
         requested_group_description="legit app group",
@@ -2415,7 +2449,7 @@ def test_put_group_request_app_owner_cannot_escalate_to_other_app(
 
     mock_user(alice.id)
     resolve_url = url_for("api-group-requests.group_request_by_id_put", group_request_id=group_request.id)
-    rep = client.put(
+    rep = await client.put(
         resolve_url,
         json={
             "approved": True,
@@ -2426,18 +2460,22 @@ def test_put_group_request_app_owner_cannot_escalate_to_other_app(
     )
 
     assert rep.status_code == 403
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
+    # the 403 request's rollback expired bar_app; reload it before reading .id
+    await db.session.refresh(bar_app)
     bar_group = (
-        db.session.query(AppGroup).filter(AppGroup.app_id == bar_app.id).filter(AppGroup.deleted_at.is_(None)).first()
-    )
+        await db.session.scalars(
+            select(AppGroup).where(AppGroup.app_id == bar_app.id).where(AppGroup.deleted_at.is_(None))
+        )
+    ).first()
     assert bar_group is None, "App owner of Foo escalated approval into creating a group attached to Bar."
     assert group_request.status == AccessRequestStatus.PENDING
     assert group_request.approved_group_id is None
 
 
-def test_approve_group_request_op_blocks_type_mismatch_for_non_admin(
+async def test_approve_group_request_op_blocks_type_mismatch_for_non_admin(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
@@ -2452,15 +2490,15 @@ def test_approve_group_request_op_blocks_type_mismatch_for_non_admin(
     mocker.patch.object(
         okta, "create_group", side_effect=lambda name, desc: Group({"id": cast(FakerWithPyStr, faker).pystr()})
     )
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
 
     alice = OktaUserFactory.create()
     foo_app = AppFactory.create()
     db.session.add(user)
     db.session.add(alice)
     db.session.add(foo_app)
-    db.session.commit()
+    await db.session.commit()
 
     foo_owner_group = AppGroupFactory.create(
         name=(
@@ -2471,11 +2509,11 @@ def test_approve_group_request_op_blocks_type_mismatch_for_non_admin(
         is_owner=True,
     )
     db.session.add(foo_owner_group)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaUserGroupMember(user_id=alice.id, group_id=foo_owner_group.id, is_owner=True))
-    db.session.commit()
+    await db.session.commit()
 
-    group_request = CreateGroupRequest(
+    group_request = await CreateGroupRequest(
         requester_user=user,
         requested_group_name=f"App-{foo_app.name}-Members",
         requested_group_description="legit app group",
@@ -2489,16 +2527,18 @@ def test_approve_group_request_op_blocks_type_mismatch_for_non_admin(
     # caller that bypasses the router (e.g. another internal operation).
     group_request.resolved_group_type = "role_group"
     group_request.resolved_group_name = "Role-evil"
-    db.session.commit()
+    await db.session.commit()
 
-    ApproveGroupRequest(
+    await ApproveGroupRequest(
         group_request=group_request,
         approver_user=alice,
         approval_reason="lgtm",
     ).execute()
 
-    db.session.refresh(group_request)
+    await db.session.refresh(group_request)
     assert group_request.status == AccessRequestStatus.PENDING
     assert group_request.approved_group_id is None
-    role_evil = db.session.query(RoleGroup).filter(func.lower(OktaGroup.name) == func.lower("Role-evil")).first()
+    role_evil = (
+        await db.session.scalars(select(RoleGroup).where(func.lower(OktaGroup.name) == func.lower("Role-evil")))
+    ).first()
     assert role_evil is None

--- a/tests/test_group_sync.py
+++ b/tests/test_group_sync.py
@@ -5,7 +5,8 @@ from okta.models.group_rule import GroupRule as OktaGroupRuleType
 from okta.models.group_rule_conditions import GroupRuleConditions as OktaGroupRuleConditionsType
 from okta.models.group_rule_expression import GroupRuleExpression as OktaGroupRuleExpressionType
 from pytest_mock import MockerFixture
-from sqlalchemy.orm import Session
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.models import OktaGroup
 from api.extensions import Db
@@ -15,14 +16,14 @@ from api.syncer import sync_groups
 from tests.factories import GroupFactory
 
 
-def test_group_sync_no_changes(db: Db, mocker: MockerFixture) -> None:
+async def test_group_sync_no_changes(db: Db, mocker: MockerFixture) -> None:
     initial_groups_in_okta = GroupFactory.create_batch(3)
 
-    initial_db_groups = seed_db(db, initial_groups_in_okta)
+    initial_db_groups = await seed_db(db, initial_groups_in_okta)
 
-    initial_groups_in_okta.insert(0, GroupFactory.create_access_owner_group())
+    initial_groups_in_okta.insert(0, await GroupFactory.create_access_owner_group())
 
-    new_db_groups = run_sync(db, mocker, initial_groups_in_okta, act_as_authority=True)
+    new_db_groups = await run_sync(db, mocker, initial_groups_in_okta, act_as_authority=True)
 
     for i in range(len(initial_groups_in_okta)):
         assert okta_groups_are_equal(
@@ -31,12 +32,12 @@ def test_group_sync_no_changes(db: Db, mocker: MockerFixture) -> None:
         )
 
 
-def test_group_sync_missing_group_in_okta(db: Db, mocker: MockerFixture) -> None:
+async def test_group_sync_missing_group_in_okta(db: Db, mocker: MockerFixture) -> None:
     groups_in_okta = GroupFactory.create_batch(3)
 
-    initial_db_groups = seed_db(db, groups_in_okta)
+    initial_db_groups = await seed_db(db, groups_in_okta)
 
-    groups_in_okta.insert(0, GroupFactory.create_access_owner_group())
+    groups_in_okta.insert(0, await GroupFactory.create_access_owner_group())
 
     removed_group = groups_in_okta.pop()
 
@@ -45,7 +46,7 @@ def test_group_sync_missing_group_in_okta(db: Db, mocker: MockerFixture) -> None
     assert removed_group_db_entry is not None
     assert removed_group_db_entry.deleted_at is None
 
-    new_db_groups = run_sync(db, mocker, groups_in_okta, act_as_authority=False)
+    new_db_groups = await run_sync(db, mocker, groups_in_okta, act_as_authority=False)
 
     # Verify that our chosen group was not removed from the db, but is deleted
     assert len(new_db_groups) == len(initial_db_groups)
@@ -54,7 +55,7 @@ def test_group_sync_missing_group_in_okta(db: Db, mocker: MockerFixture) -> None
     deleted_at = removed_group_db_entry.deleted_at
     assert deleted_at is not None
 
-    new_db_groups = run_sync(db, mocker, groups_in_okta, act_as_authority=True)
+    new_db_groups = await run_sync(db, mocker, groups_in_okta, act_as_authority=True)
 
     # Verify that being an authority does not change this
     # and that it also doesn't update the group deleted_at
@@ -64,40 +65,40 @@ def test_group_sync_missing_group_in_okta(db: Db, mocker: MockerFixture) -> None
     assert deleted_at == removed_group_db_entry.deleted_at
 
 
-def test_group_sync_missing_group_in_db(db: Db, mocker: MockerFixture) -> None:
+async def test_group_sync_missing_group_in_db(db: Db, mocker: MockerFixture) -> None:
     groups_in_okta = GroupFactory.create_batch(3)
 
-    initial_db_groups = seed_db(db, groups_in_okta)
+    initial_db_groups = await seed_db(db, groups_in_okta)
 
-    groups_in_okta.insert(0, GroupFactory.create_access_owner_group())
+    groups_in_okta.insert(0, await GroupFactory.create_access_owner_group())
 
     new_group_in_okta = GroupFactory.create()
     groups_in_okta.append(new_group_in_okta)
 
     delete_group_spy = mocker.patch.object(okta, "delete_group")
-    new_db_groups = run_sync(db, mocker, groups_in_okta, act_as_authority=True)
+    new_db_groups = await run_sync(db, mocker, groups_in_okta, act_as_authority=True)
 
     # Since we're authority, and the group isn't in the DB, then it shouldn't exist in okta.
     assert delete_group_spy.call_count == 1
     assert len(new_db_groups) == len(initial_db_groups)
     assert get_group_by_id(new_db_groups, new_group_in_okta.id) is None
 
-    new_db_groups = run_sync(db, mocker, groups_in_okta, act_as_authority=False)
+    new_db_groups = await run_sync(db, mocker, groups_in_okta, act_as_authority=False)
 
     assert len(new_db_groups) == len(initial_db_groups) + 1
     assert get_group_by_id(new_db_groups, new_group_in_okta.id) is not None
 
 
-def test_group_sync_deleted_in_db_exists_in_okta(db: Db, mocker: MockerFixture) -> None:
+async def test_group_sync_deleted_in_db_exists_in_okta(db: Db, mocker: MockerFixture) -> None:
     groups_in_okta = GroupFactory.create_batch(3)
 
-    seed_db(db, groups_in_okta)
+    await seed_db(db, groups_in_okta)
 
-    groups_in_okta.insert(0, GroupFactory.create_access_owner_group())
+    groups_in_okta.insert(0, await GroupFactory.create_access_owner_group())
 
     # Remove a group and then sync.
     removed_group = groups_in_okta.pop()
-    new_db_groups = run_sync(db, mocker, groups_in_okta, act_as_authority=True)
+    new_db_groups = await run_sync(db, mocker, groups_in_okta, act_as_authority=True)
 
     removed_group_entry = get_group_by_id(new_db_groups, removed_group.id)
     assert removed_group_entry is not None
@@ -110,8 +111,8 @@ def test_group_sync_deleted_in_db_exists_in_okta(db: Db, mocker: MockerFixture) 
     # Add the group back to okta to simulate a case where the value was updated in the DB
     # but somehow didn't get deleted from okta
     groups_in_okta.append(removed_group)
-    delete_group_spy = mocker.patch.object(okta, "async_delete_group")
-    new_db_groups = run_sync(db, mocker, groups_in_okta, act_as_authority=True)
+    delete_group_spy = mocker.patch.object(okta, "delete_group")
+    new_db_groups = await run_sync(db, mocker, groups_in_okta, act_as_authority=True)
 
     assert delete_group_spy.call_count == 1
     removed_group_entry = get_group_by_id(new_db_groups, removed_group.id)
@@ -120,26 +121,26 @@ def test_group_sync_deleted_in_db_exists_in_okta(db: Db, mocker: MockerFixture) 
     assert removed_group_entry.deleted_at != deleted_at
 
     # Run the sync again but not as an authority this time. The group should be resurrected
-    new_db_groups = run_sync(db, mocker, groups_in_okta, act_as_authority=False)
+    new_db_groups = await run_sync(db, mocker, groups_in_okta, act_as_authority=False)
 
     removed_group_entry = get_group_by_id(new_db_groups, removed_group.id)
     assert removed_group_entry is not None
     assert removed_group_entry.deleted_at is None
 
 
-def test_group_sync_externally_managed_group_in_okta(db: Db, mocker: MockerFixture) -> None:
+async def test_group_sync_externally_managed_group_in_okta(db: Db, mocker: MockerFixture) -> None:
     groups_in_okta = GroupFactory.create_batch(3)
 
-    seed_db(db, groups_in_okta)
+    await seed_db(db, groups_in_okta)
 
-    groups_in_okta.insert(0, GroupFactory.create_access_owner_group())
+    groups_in_okta.insert(0, await GroupFactory.create_access_owner_group())
 
     # Create an externally managed group and add it to Okta
     externally_managed_group = GroupFactory.create()
     externally_managed_group.is_managed = False
     groups_in_okta.append(externally_managed_group)
 
-    with Session(db.engine) as session:
+    async with AsyncSession(db.engine) as session:
         # Create a rule for the externally managed group
         test_rule_expression = OktaGroupRuleExpressionType()
         test_rule_expression.value = 'user.department equals "Test"'
@@ -152,8 +153,8 @@ def test_group_sync_externally_managed_group_in_okta(db: Db, mocker: MockerFixtu
             okta, "list_groups_with_active_rules", return_value={externally_managed_group.id: [test_rule]}
         )
         mocker.patch.object(okta, "list_groups", return_value=[Group(g) for g in groups_in_okta])
-        sync_groups(False)
-        new_db_groups = session.query(OktaGroup).all()
+        await sync_groups(False)
+        new_db_groups = list((await session.scalars(select(OktaGroup))).all())
 
     # Ensure that externally managed group and rule are added to db
     external_group_entry = get_group_by_id(new_db_groups, externally_managed_group.id)
@@ -162,19 +163,21 @@ def test_group_sync_externally_managed_group_in_okta(db: Db, mocker: MockerFixtu
     assert external_group_entry.externally_managed_data == {"Test": 'user.department equals "Test"'}
 
 
-def seed_db(db: Db, groups: list[OktaGroup]) -> list[OktaGroup]:
-    with Session(db.engine) as session:
+async def seed_db(db: Db, groups: list[OktaGroup]) -> list[OktaGroup]:
+    async with AsyncSession(db.engine) as session:
         session.add_all([Group(g).update_okta_group(OktaGroup(), {}) for g in groups])
-        session.commit()
-        return session.query(OktaGroup).all()
+        await session.commit()
+        return list((await session.scalars(select(OktaGroup))).all())
 
 
-def run_sync(db: Db, mocker: MockerFixture, okta_groups: list[OktaGroup], act_as_authority: bool) -> list[OktaGroup]:
-    with Session(db.engine) as session:
+async def run_sync(
+    db: Db, mocker: MockerFixture, okta_groups: list[OktaGroup], act_as_authority: bool
+) -> list[OktaGroup]:
+    async with AsyncSession(db.engine) as session:
         mocker.patch.object(okta, "list_groups_with_active_rules", return_value={})
         mocker.patch.object(okta, "list_groups", return_value=[Group(g) for g in okta_groups])
-        sync_groups(act_as_authority)
-        return session.query(OktaGroup).all()
+        await sync_groups(act_as_authority)
+        return list((await session.scalars(select(OktaGroup))).all())
 
 
 def get_group_by_id(group_list: list[OktaGroup], group_id: str) -> Optional[OktaGroup]:

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -1,24 +1,24 @@
 from typing import Any
 
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
 from pytest_mock import MockerFixture
 
 from api.extensions import Db
 
 
-def test_health_check(app: FastAPI, client: TestClient, db: Db, url_for: Any) -> None:
+async def test_health_check(app: FastAPI, client: AsyncClient, db: Db, url_for: Any) -> None:
     # test unauthenticated requests by setting the current user email to "Unauthenticated"
     app.state.current_user_email = "Unauthenticated"
 
     # test 200
     health_check_url = url_for("api-health-check.health_check")
-    rep = client.get(health_check_url)
+    rep = await client.get(health_check_url)
     assert rep.status_code == 200
 
 
-def test_health_check_does_not_leak_db_error(
-    app: FastAPI, client: TestClient, db: Db, mocker: MockerFixture, url_for: Any
+async def test_health_check_does_not_leak_db_error(
+    app: FastAPI, client: AsyncClient, db: Db, mocker: MockerFixture, url_for: Any
 ) -> None:
     # /api/healthz is unauthenticated (in AUTH_ALLOWLIST_PREFIXES), so its
     # error path must not expose driver/connection details to the caller.
@@ -27,7 +27,7 @@ def test_health_check_does_not_leak_db_error(
     secret = "could not connect: host=db.internal dbname=access user=access_admin password=hunter2"
     mocker.patch.object(db.session, "execute", side_effect=Exception(secret))
 
-    rep = client.get(url_for("api-health-check.health_check"))
+    rep = await client.get(url_for("api-health-check.health_check"))
     assert rep.status_code == 500
     # The raw exception text must not reach an unauthenticated client.
     assert secret not in rep.text

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -21,11 +21,13 @@ exact code path FastMCP would take, minus the JSON-RPC framing.
 from __future__ import annotations
 
 import json
-from typing import Any, Generator, Optional
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, Generator, Optional
 
+import httpx
 import pytest
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
+from sqlalchemy import select
 
 from api.config import settings
 from api.context import RequestContext, set_request_context
@@ -40,6 +42,22 @@ from api.mcp.auth import (
 from api.models import App, AppGroup, OktaGroup, OktaUser, RoleGroup
 from api.operations import ModifyGroupUsers
 from tests.factories import RoleGroupFactory
+
+
+@asynccontextmanager
+async def _mcp_client(a: FastAPI) -> AsyncIterator[httpx.AsyncClient]:
+    """In-process client for an MCP-enabled app with its lifespan running.
+
+    ``httpx.AsyncClient`` over ``ASGITransport`` does not run the app
+    lifespan, but the MCP ``StreamableHTTPSessionManager``'s task group only
+    exists while the lifespan is entered (the old sync ``TestClient`` context
+    manager did this implicitly) — so enter it manually around the request
+    phase.
+    """
+    async with a.router.lifespan_context(a):
+        transport = httpx.ASGITransport(app=a, raise_app_exceptions=False)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            yield client
 
 
 @pytest.fixture
@@ -66,7 +84,7 @@ def override_mcp_auth(with_mcp_enabled: None, monkeypatch: pytest.MonkeyPatch) -
     """
     holder: dict[str, Optional[MCPIdentity]] = {"identity": None}
 
-    def _stub(_scope: Any) -> Optional[MCPIdentity]:
+    async def _stub(_scope: Any) -> Optional[MCPIdentity]:
         return holder["identity"]
 
     # Patch all three providers as the middleware imports them. Any of
@@ -99,7 +117,7 @@ def test_mcp_route_present_when_enabled(with_mcp_enabled: None) -> None:
     assert "/mcp" in paths
 
 
-def test_unauthenticated_request_returns_401(
+async def test_unauthenticated_request_returns_401(
     override_mcp_auth: Any,
 ) -> None:
     """When every provider defers (returns None), the middleware emits a
@@ -108,13 +126,13 @@ def test_unauthenticated_request_returns_401(
     from api.app import create_app
 
     a = create_app(testing=True)
-    with TestClient(a, raise_server_exceptions=False) as client:
-        r = client.post("/mcp", json={})
+    async with _mcp_client(a) as client:
+        r = await client.post("/mcp", json={})
         assert r.status_code == 401
         assert r.headers.get("WWW-Authenticate", "").startswith("Bearer ")
 
 
-def test_authenticated_request_proceeds_past_middleware(
+async def test_authenticated_request_proceeds_past_middleware(
     db: Db,
     user: OktaUser,
     override_mcp_auth: Any,
@@ -124,31 +142,39 @@ def test_authenticated_request_proceeds_past_middleware(
     JSON-RPC framing isn't part of this contract; that's tested by the
     direct-call tool tests below."""
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
     override_mcp_auth(MCPIdentity(user_id=user.id, scopes=ALL_V1_SCOPES))
     from api.app import create_app
 
     a = create_app(testing=True)
-    with TestClient(a, raise_server_exceptions=False) as client:
-        r = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "initialize"})
+    async with _mcp_client(a) as client:
+        r = await client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "initialize"})
         # We accept any non-401 — FastMCP may 400/406 on a malformed
         # body, but it's past the auth gate, which is what we care about.
         assert r.status_code != 401, f"Auth gate rejected a valid identity: {r.status_code} {r.text}"
 
 
-def test_provider_chain_first_non_none_wins(
+async def test_provider_chain_first_non_none_wins(
     with_mcp_enabled: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The middleware walks dev → cloudflare → oidc in that order and
     takes the first non-None identity. Exercises the chain logic
-    directly against ``MCPAuthMiddleware`` rather than a TestClient so
+    directly against ``MCPAuthMiddleware`` rather than an HTTP client so
     each iteration is independent of FastMCP's session-manager lifecycle
     (which can only ``.run()`` once per instance).
     """
     dev_id = MCPIdentity(user_id="dev-user", scopes=ALL_V1_SCOPES)
     cf_id = MCPIdentity(user_id="cf-user", scopes=ALL_V1_SCOPES)
     oidc_id = MCPIdentity(user_id="oidc-user", scopes=ALL_V1_SCOPES)
+
+    def _resolves_to(identity: Optional[MCPIdentity]) -> Any:
+        # The middleware awaits each provider's resolve_identity, so the
+        # stubs must be coroutine functions.
+        async def _resolve(_scope: Any) -> Optional[MCPIdentity]:
+            return identity
+
+        return _resolve
 
     captured: dict[str, Any] = {}
 
@@ -175,38 +201,36 @@ def test_provider_chain_first_non_none_wins(
         await middleware({"type": "http", "path": "/mcp", "headers": []}, _async_receive, _async_send)
         return captured.get("identity")
 
-    import asyncio
-
     # Dev wins outright; CF and OIDC don't get called.
-    monkeypatch.setattr("api.mcp.auth.dev.resolve_identity", lambda _s: dev_id)
-    monkeypatch.setattr("api.mcp.auth.cloudflare.resolve_identity", lambda _s: cf_id)
-    monkeypatch.setattr("api.mcp.auth.oidc.resolve_identity", lambda _s: oidc_id)
-    assert asyncio.run(_run()) == dev_id
+    monkeypatch.setattr("api.mcp.auth.dev.resolve_identity", _resolves_to(dev_id))
+    monkeypatch.setattr("api.mcp.auth.cloudflare.resolve_identity", _resolves_to(cf_id))
+    monkeypatch.setattr("api.mcp.auth.oidc.resolve_identity", _resolves_to(oidc_id))
+    assert await _run() == dev_id
 
     # Dev defers → CF wins; OIDC doesn't get called.
-    monkeypatch.setattr("api.mcp.auth.dev.resolve_identity", lambda _s: None)
-    assert asyncio.run(_run()) == cf_id
+    monkeypatch.setattr("api.mcp.auth.dev.resolve_identity", _resolves_to(None))
+    assert await _run() == cf_id
 
     # Dev + CF defer → OIDC wins.
-    monkeypatch.setattr("api.mcp.auth.cloudflare.resolve_identity", lambda _s: None)
-    assert asyncio.run(_run()) == oidc_id
+    monkeypatch.setattr("api.mcp.auth.cloudflare.resolve_identity", _resolves_to(None))
+    assert await _run() == oidc_id
 
     # All defer → identity remains None (the middleware short-circuits
     # with 401 in that case; the inner app is not called, so 'identity'
     # is missing from captured rather than set to None).
-    monkeypatch.setattr("api.mcp.auth.oidc.resolve_identity", lambda _s: None)
-    assert asyncio.run(_run()) is None
+    monkeypatch.setattr("api.mcp.auth.oidc.resolve_identity", _resolves_to(None))
+    assert await _run() is None
 
 
-def _call_tool(mcp_server: Any, tool_name: str, **kwargs: Any) -> str:
+async def _call_tool(mcp_server: Any, tool_name: str, **kwargs: Any) -> str:
     """Invoke a registered tool's Python function directly, bypassing
     the JSON-RPC framing. The tool's authorization checks fire as they
     would in production because they consult the active ContextVar."""
     tool = mcp_server._tool_manager._tools[tool_name]
-    return tool.fn(**kwargs)
+    return await tool.fn(**kwargs)
 
 
-def test_read_tool_requires_read_all_scope(
+async def test_read_tool_requires_read_all_scope(
     with_mcp_enabled: None,
     db: Db,
     okta_group: OktaGroup,
@@ -215,7 +239,7 @@ def test_read_tool_requires_read_all_scope(
     """A token without read_all gets an error envelope from a read tool;
     a token with read_all gets data."""
     db.session.add_all([user, okta_group])
-    db.session.commit()
+    await db.session.commit()
     from api.mcp.server import create_mcp_server
 
     mcp = create_mcp_server()
@@ -223,7 +247,7 @@ def test_read_tool_requires_read_all_scope(
     # No scope → error envelope.
     token = set_mcp_identity(MCPIdentity(user_id=user.id, scopes=frozenset()))
     try:
-        result = _call_tool(mcp, "list_groups")
+        result = await _call_tool(mcp, "list_groups")
     finally:
         from api.mcp.auth import reset_mcp_identity
 
@@ -235,7 +259,7 @@ def test_read_tool_requires_read_all_scope(
     # With read_all → data.
     token = set_mcp_identity(MCPIdentity(user_id=user.id, scopes=frozenset({MCP_SCOPE_READ_ALL})))
     try:
-        result = _call_tool(mcp, "list_groups")
+        result = await _call_tool(mcp, "list_groups")
     finally:
         from api.mcp.auth import reset_mcp_identity
 
@@ -245,7 +269,7 @@ def test_read_tool_requires_read_all_scope(
     assert isinstance(payload["results"], list)
 
 
-def test_write_tool_requires_create_requests_scope(
+async def test_write_tool_requires_create_requests_scope(
     with_mcp_enabled: None,
     db: Db,
     okta_group: OktaGroup,
@@ -255,7 +279,7 @@ def test_write_tool_requires_create_requests_scope(
     read-only token gets an error envelope; granting the scope produces
     a request."""
     db.session.add_all([user, okta_group])
-    db.session.commit()
+    await db.session.commit()
     from api.mcp.auth import reset_mcp_identity
     from api.mcp.server import create_mcp_server
 
@@ -264,7 +288,7 @@ def test_write_tool_requires_create_requests_scope(
     # Read-only token — cannot create.
     token = set_mcp_identity(MCPIdentity(user_id=user.id, scopes=frozenset({MCP_SCOPE_READ_ALL})))
     try:
-        result = _call_tool(mcp, "create_access_request", group_id=okta_group.id, reason="testing")
+        result = await _call_tool(mcp, "create_access_request", group_id=okta_group.id, reason="testing")
     finally:
         reset_mcp_identity(token)
     payload = json.loads(result)
@@ -276,7 +300,7 @@ def test_write_tool_requires_create_requests_scope(
         MCPIdentity(user_id=user.id, scopes=frozenset({MCP_SCOPE_READ_ALL, MCP_SCOPE_CREATE_REQUESTS}))
     )
     try:
-        result = _call_tool(mcp, "create_access_request", group_id=okta_group.id, reason="legitimate ask")
+        result = await _call_tool(mcp, "create_access_request", group_id=okta_group.id, reason="legitimate ask")
     finally:
         reset_mcp_identity(token)
     payload = json.loads(result)
@@ -286,17 +310,19 @@ def test_write_tool_requires_create_requests_scope(
     assert payload["status"] == "PENDING"
 
 
-def _make_access_admin(db: Db) -> OktaUser:
+async def _make_access_admin(db: Db) -> OktaUser:
     """Return the bootstrap Access admin (seeded by the `db` fixture).
     Conftest's setup adds them as a *member* (not owner) of
     App-Access-Owners — that's the membership pattern is_access_admin
     checks for, so no additional wiring is needed."""
-    admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    admin = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
     assert admin is not None
     return admin
 
 
-def test_cloudflare_fallback_read_only_opt_in(
+async def test_cloudflare_fallback_read_only_opt_in(
     db: Db,
     user: OktaUser,
     monkeypatch: pytest.MonkeyPatch,
@@ -306,7 +332,7 @@ def test_cloudflare_fallback_read_only_opt_in(
     agents filing requests via MCP. Verifies the read-only configuration
     actually disables write capability."""
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     # CF provider gates on CLOUDFLARE_TEAM_DOMAIN being set.
     monkeypatch.setattr(settings, "CLOUDFLARE_TEAM_DOMAIN", "example.cloudflareaccess.com")
@@ -323,14 +349,14 @@ def test_cloudflare_fallback_read_only_opt_in(
     scope: dict[str, Any] = {
         "headers": [(b"cf-access-jwt-assertion", b"any-token")],
     }
-    identity = resolve_identity(scope=scope)
+    identity = await resolve_identity(scope=scope)
     assert identity is not None
     assert identity.scopes == frozenset({MCP_SCOPE_READ_ALL})
     # Critical: writes are NOT in this read-only fallback.
     assert MCP_SCOPE_CREATE_REQUESTS not in identity.scopes
 
 
-def test_cloudflare_fallback_honours_operator_config(
+async def test_cloudflare_fallback_honours_operator_config(
     db: Db,
     user: OktaUser,
     monkeypatch: pytest.MonkeyPatch,
@@ -339,7 +365,7 @@ def test_cloudflare_fallback_honours_operator_config(
     grants both scopes on CF-issued tokens that don't carry a scope
     claim, enabling read and write tools. Mirrors the shipped default."""
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     monkeypatch.setattr(settings, "CLOUDFLARE_TEAM_DOMAIN", "example.cloudflareaccess.com")
     monkeypatch.setattr(settings, "MCP_FALLBACK_SCOPES", "read_all,create_requests")
@@ -353,12 +379,12 @@ def test_cloudflare_fallback_honours_operator_config(
     scope: dict[str, Any] = {
         "headers": [(b"cf-access-jwt-assertion", b"any-token")],
     }
-    identity = resolve_identity(scope=scope)
+    identity = await resolve_identity(scope=scope)
     assert identity is not None
     assert identity.scopes == frozenset({MCP_SCOPE_READ_ALL, MCP_SCOPE_CREATE_REQUESTS})
 
 
-def test_cloudflare_fallback_empty_string_fails_closed(
+async def test_cloudflare_fallback_empty_string_fails_closed(
     db: Db,
     user: OktaUser,
     monkeypatch: pytest.MonkeyPatch,
@@ -368,7 +394,7 @@ def test_cloudflare_fallback_empty_string_fails_closed(
     require_scope check fails. Right answer once the provider starts
     emitting scope claims."""
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     monkeypatch.setattr(settings, "CLOUDFLARE_TEAM_DOMAIN", "example.cloudflareaccess.com")
     monkeypatch.setattr(settings, "MCP_FALLBACK_SCOPES", "")
@@ -382,12 +408,12 @@ def test_cloudflare_fallback_empty_string_fails_closed(
     scope: dict[str, Any] = {
         "headers": [(b"cf-access-jwt-assertion", b"any-token")],
     }
-    identity = resolve_identity(scope=scope)
+    identity = await resolve_identity(scope=scope)
     assert identity is not None
     assert identity.scopes == frozenset()
 
 
-def test_cloudflare_explicit_scope_claim_overrides_fallback(
+async def test_cloudflare_explicit_scope_claim_overrides_fallback(
     db: Db,
     user: OktaUser,
     monkeypatch: pytest.MonkeyPatch,
@@ -397,7 +423,7 @@ def test_cloudflare_explicit_scope_claim_overrides_fallback(
     OAuth ships scope claims; nothing in our code needs to change at
     that point, the fallback just stops firing."""
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     monkeypatch.setattr(settings, "CLOUDFLARE_TEAM_DOMAIN", "example.cloudflareaccess.com")
     # Permissive fallback — but the token's explicit scope should win.
@@ -412,33 +438,32 @@ def test_cloudflare_explicit_scope_claim_overrides_fallback(
     scope: dict[str, Any] = {
         "headers": [(b"cf-access-jwt-assertion", b"any-token")],
     }
-    identity = resolve_identity(scope=scope)
+    identity = await resolve_identity(scope=scope)
     assert identity is not None
     assert identity.scopes == frozenset({MCP_SCOPE_READ_ALL})
     assert MCP_SCOPE_CREATE_REQUESTS not in identity.scopes
 
 
-def test_dev_provider_resolves_in_development(
+async def test_dev_provider_resolves_in_development(
     db: Db,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """In ENV=development, the dev provider resolves CURRENT_OKTA_USER_EMAIL
     to an OktaUser and grants the full v1 scope set so local testing can
     exercise both read and write tools without a faked CF JWT."""
-    admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
-    assert admin is not None
+    admin = await _make_access_admin(db)
 
     monkeypatch.setattr(settings, "ENV", "development")
 
     from api.mcp.auth.dev import resolve_identity
 
-    identity = resolve_identity(scope={"headers": []})
+    identity = await resolve_identity(scope={"headers": []})
     assert identity is not None
     assert identity.user_id == admin.id
     assert identity.scopes == ALL_V1_SCOPES
 
 
-def test_dev_provider_defers_outside_dev_or_test(
+async def test_dev_provider_defers_outside_dev_or_test(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """In any production-style ENV, the dev provider returns None so the
@@ -448,10 +473,10 @@ def test_dev_provider_defers_outside_dev_or_test(
 
     from api.mcp.auth.dev import resolve_identity
 
-    assert resolve_identity(scope={"headers": []}) is None
+    assert await resolve_identity(scope={"headers": []}) is None
 
 
-def test_oidc_provider_defers_when_unconfigured(
+async def test_oidc_provider_defers_when_unconfigured(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Without OIDC_SERVER_METADATA_URL, the OIDC provider returns None
@@ -459,10 +484,10 @@ def test_oidc_provider_defers_when_unconfigured(
     monkeypatch.setattr(settings, "OIDC_SERVER_METADATA_URL", None)
     from api.mcp.auth.oidc import resolve_identity
 
-    assert resolve_identity(scope={"headers": []}) is None
+    assert await resolve_identity(scope={"headers": []}) is None
 
 
-def test_oidc_provider_defers_when_no_bearer_token(
+async def test_oidc_provider_defers_when_no_bearer_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """OIDC configured but no Authorization header → defer (None)."""
@@ -470,12 +495,12 @@ def test_oidc_provider_defers_when_no_bearer_token(
     monkeypatch.setattr(settings, "OIDC_MCP_AUDIENCE", "access-mcp")
     from api.mcp.auth.oidc import resolve_identity
 
-    assert resolve_identity(scope={"headers": []}) is None
+    assert await resolve_identity(scope={"headers": []}) is None
     # Also: a non-bearer Authorization header → still defer.
-    assert resolve_identity(scope={"headers": [(b"authorization", b"Basic abc")]}) is None
+    assert await resolve_identity(scope={"headers": [(b"authorization", b"Basic abc")]}) is None
 
 
-def test_oidc_provider_resolves_valid_token(
+async def test_oidc_provider_resolves_valid_token(
     db: Db,
     user: OktaUser,
     monkeypatch: pytest.MonkeyPatch,
@@ -483,7 +508,7 @@ def test_oidc_provider_resolves_valid_token(
     """Happy path: a verified token's email claim resolves to an
     OktaUser; the token's scope claim becomes the identity's scopes."""
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
     monkeypatch.setattr(settings, "OIDC_SERVER_METADATA_URL", "https://idp.example/.well-known/openid-configuration")
     monkeypatch.setattr(settings, "OIDC_MCP_AUDIENCE", "access-mcp")
 
@@ -528,13 +553,13 @@ def test_oidc_provider_resolves_valid_token(
     scope: dict[str, Any] = {
         "headers": [(b"authorization", b"Bearer any-token")],
     }
-    identity = oidc_provider.resolve_identity(scope=scope)
+    identity = await oidc_provider.resolve_identity(scope=scope)
     assert identity is not None
     assert identity.user_id == user.id
     assert identity.scopes == ALL_V1_SCOPES
 
 
-def test_oidc_provider_rejects_invalid_token(
+async def test_oidc_provider_rejects_invalid_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A token that fails verification → defer (None), no raise."""
@@ -569,7 +594,7 @@ def test_oidc_provider_rejects_invalid_token(
     scope: dict[str, Any] = {
         "headers": [(b"authorization", b"Bearer any-token")],
     }
-    assert oidc_provider.resolve_identity(scope=scope) is None
+    assert await oidc_provider.resolve_identity(scope=scope) is None
 
 
 def test_config_validation_rejects_both_cf_and_oidc(
@@ -623,7 +648,7 @@ def test_config_validation_no_op_when_mcp_disabled(
     _validate_mcp_auth_settings(s)
 
 
-def test_create_role_request_denies_non_owner(
+async def test_create_role_request_denies_non_owner(
     with_mcp_enabled: None,
     db: Db,
     role_group: RoleGroup,
@@ -635,7 +660,7 @@ def test_create_role_request_denies_non_owner(
     admin seeded by the test harness is intentionally not assigned as
     a role owner here, so the user has no path to authorization."""
     db.session.add_all([user, role_group, okta_group])
-    db.session.commit()
+    await db.session.commit()
     from api.mcp.auth import reset_mcp_identity
     from api.mcp.server import create_mcp_server
 
@@ -643,7 +668,7 @@ def test_create_role_request_denies_non_owner(
 
     token = set_mcp_identity(MCPIdentity(user_id=user.id, scopes=frozenset({MCP_SCOPE_CREATE_REQUESTS})))
     try:
-        result = _call_tool(
+        result = await _call_tool(
             mcp,
             "create_role_request",
             role_id=role_group.id,
@@ -657,7 +682,7 @@ def test_create_role_request_denies_non_owner(
     assert payload["error"] == "Current user is not allowed to perform this action"
 
 
-def test_create_role_request_allowed_for_role_owner(
+async def test_create_role_request_allowed_for_role_owner(
     with_mcp_enabled: None,
     db: Db,
     role_group: RoleGroup,
@@ -667,8 +692,8 @@ def test_create_role_request_allowed_for_role_owner(
     """A user who owns the role can submit a role request — same path
     POST /api/role-requests takes."""
     db.session.add_all([user, role_group, okta_group])
-    db.session.commit()
-    ModifyGroupUsers(
+    await db.session.commit()
+    await ModifyGroupUsers(
         group=role_group,
         members_to_add=[user.id],
         owners_to_add=[user.id],
@@ -681,7 +706,7 @@ def test_create_role_request_allowed_for_role_owner(
 
     token = set_mcp_identity(MCPIdentity(user_id=user.id, scopes=frozenset({MCP_SCOPE_CREATE_REQUESTS})))
     try:
-        result = _call_tool(
+        result = await _call_tool(
             mcp,
             "create_role_request",
             role_id=role_group.id,
@@ -698,7 +723,7 @@ def test_create_role_request_allowed_for_role_owner(
     assert payload["status"] == "PENDING"
 
 
-def test_create_role_request_allowed_for_access_admin(
+async def test_create_role_request_allowed_for_access_admin(
     with_mcp_enabled: None,
     db: Db,
     role_group: RoleGroup,
@@ -708,8 +733,8 @@ def test_create_role_request_allowed_for_access_admin(
     without being an owner of it — can_manage_group falls through to
     is_access_admin."""
     db.session.add_all([role_group, okta_group])
-    db.session.commit()
-    admin = _make_access_admin(db)
+    await db.session.commit()
+    admin = await _make_access_admin(db)
     from api.mcp.auth import reset_mcp_identity
     from api.mcp.server import create_mcp_server
 
@@ -717,7 +742,7 @@ def test_create_role_request_allowed_for_access_admin(
 
     token = set_mcp_identity(MCPIdentity(user_id=admin.id, scopes=frozenset({MCP_SCOPE_CREATE_REQUESTS})))
     try:
-        result = _call_tool(
+        result = await _call_tool(
             mcp,
             "create_role_request",
             role_id=role_group.id,
@@ -731,7 +756,7 @@ def test_create_role_request_allowed_for_access_admin(
     assert payload["requester_user_id"] == admin.id
 
 
-def test_create_role_request_rejects_role_as_target(
+async def test_create_role_request_rejects_role_as_target(
     with_mcp_enabled: None,
     db: Db,
     role_group: RoleGroup,
@@ -743,8 +768,8 @@ def test_create_role_request_rejects_role_as_target(
     authorization check passes and we reach the type guard."""
     other_role = RoleGroupFactory.build(name="Role-OtherRole", description="other role for testing")
     db.session.add_all([user, role_group, other_role])
-    db.session.commit()
-    ModifyGroupUsers(
+    await db.session.commit()
+    await ModifyGroupUsers(
         group=role_group,
         members_to_add=[user.id],
         owners_to_add=[user.id],
@@ -757,7 +782,7 @@ def test_create_role_request_rejects_role_as_target(
 
     token = set_mcp_identity(MCPIdentity(user_id=user.id, scopes=frozenset({MCP_SCOPE_CREATE_REQUESTS})))
     try:
-        result = _call_tool(
+        result = await _call_tool(
             mcp,
             "create_role_request",
             role_id=role_group.id,
@@ -771,7 +796,7 @@ def test_create_role_request_rejects_role_as_target(
     assert "role" in payload["error"].lower()
 
 
-def test_create_role_request_requires_create_requests_scope(
+async def test_create_role_request_requires_create_requests_scope(
     with_mcp_enabled: None,
     db: Db,
     role_group: RoleGroup,
@@ -781,8 +806,8 @@ def test_create_role_request_requires_create_requests_scope(
     """A read-only token cannot submit role requests even if the user
     is a role owner — scope check fires before authorization."""
     db.session.add_all([user, role_group, okta_group])
-    db.session.commit()
-    ModifyGroupUsers(
+    await db.session.commit()
+    await ModifyGroupUsers(
         group=role_group,
         members_to_add=[user.id],
         owners_to_add=[user.id],
@@ -795,7 +820,7 @@ def test_create_role_request_requires_create_requests_scope(
 
     token = set_mcp_identity(MCPIdentity(user_id=user.id, scopes=frozenset({MCP_SCOPE_READ_ALL})))
     try:
-        result = _call_tool(
+        result = await _call_tool(
             mcp,
             "create_role_request",
             role_id=role_group.id,
@@ -809,7 +834,7 @@ def test_create_role_request_requires_create_requests_scope(
     assert "create_requests" in payload["error"]
 
 
-def test_create_group_request_allowed_for_authenticated_user(
+async def test_create_group_request_allowed_for_authenticated_user(
     with_mcp_enabled: None,
     db: Db,
     user: OktaUser,
@@ -817,7 +842,7 @@ def test_create_group_request_allowed_for_authenticated_user(
     """Group requests are open to any authenticated, non-deleted user
     — same gate as POST /api/group-requests."""
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
     from api.mcp.auth import reset_mcp_identity
     from api.mcp.server import create_mcp_server
 
@@ -825,7 +850,7 @@ def test_create_group_request_allowed_for_authenticated_user(
 
     token = set_mcp_identity(MCPIdentity(user_id=user.id, scopes=frozenset({MCP_SCOPE_CREATE_REQUESTS})))
     try:
-        result = _call_tool(
+        result = await _call_tool(
             mcp,
             "create_group_request",
             group_name="SomeNewGroup",
@@ -841,7 +866,7 @@ def test_create_group_request_allowed_for_authenticated_user(
     assert payload["status"] == "PENDING"
 
 
-def test_create_group_request_requires_app_id_for_app_group(
+async def test_create_group_request_requires_app_id_for_app_group(
     with_mcp_enabled: None,
     db: Db,
     user: OktaUser,
@@ -850,7 +875,7 @@ def test_create_group_request_requires_app_id_for_app_group(
     raises 400 here, the MCP tool returns an error envelope with the
     same message."""
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
     from api.mcp.auth import reset_mcp_identity
     from api.mcp.server import create_mcp_server
 
@@ -860,7 +885,7 @@ def test_create_group_request_requires_app_id_for_app_group(
     try:
         # Missing app_id on app_group request — fails at body validation
         # because the discriminated union variant requires it.
-        result = _call_tool(
+        result = await _call_tool(
             mcp,
             "create_group_request",
             group_name="App-Foo-Newgrp",
@@ -873,7 +898,7 @@ def test_create_group_request_requires_app_id_for_app_group(
     assert "error" in payload, payload
 
 
-def test_create_group_request_rejects_unknown_app_id(
+async def test_create_group_request_rejects_unknown_app_id(
     with_mcp_enabled: None,
     db: Db,
     user: OktaUser,
@@ -881,7 +906,7 @@ def test_create_group_request_rejects_unknown_app_id(
     """A well-formed app_group request whose app_id doesn't resolve
     surfaces 'App not found' — mirrors POST /api/group-requests."""
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
     from api.mcp.auth import reset_mcp_identity
     from api.mcp.server import create_mcp_server
 
@@ -889,7 +914,7 @@ def test_create_group_request_rejects_unknown_app_id(
 
     token = set_mcp_identity(MCPIdentity(user_id=user.id, scopes=frozenset({MCP_SCOPE_CREATE_REQUESTS})))
     try:
-        result = _call_tool(
+        result = await _call_tool(
             mcp,
             "create_group_request",
             group_name="App-Foo-Newgrp",
@@ -903,7 +928,7 @@ def test_create_group_request_rejects_unknown_app_id(
     assert payload.get("error") == "App not found"
 
 
-def test_create_group_request_for_app_group(
+async def test_create_group_request_for_app_group(
     with_mcp_enabled: None,
     db: Db,
     user: OktaUser,
@@ -912,7 +937,8 @@ def test_create_group_request_for_app_group(
     """Happy-path for an app_group request: well-formed body, real
     app_id, returns a PENDING GroupRequest pointing at the app."""
     db.session.add_all([user, access_app])
-    db.session.commit()
+    await db.session.commit()
+    access_app_id = access_app.id
     from api.mcp.auth import reset_mcp_identity
     from api.mcp.server import create_mcp_server
 
@@ -922,12 +948,12 @@ def test_create_group_request_for_app_group(
     # Use the prefix matching this app so it passes the name pattern.
     target_name = f"{AppGroup.APP_GROUP_NAME_PREFIX}{access_app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}Newgrp"
     try:
-        result = _call_tool(
+        result = await _call_tool(
             mcp,
             "create_group_request",
             group_name=target_name,
             group_type="app_group",
-            app_id=access_app.id,
+            app_id=access_app_id,
             reason="want this app group",
         )
     finally:
@@ -935,10 +961,10 @@ def test_create_group_request_for_app_group(
     payload = json.loads(result)
     assert "error" not in payload, payload
     assert payload["requested_group_type"] == "app_group"
-    assert payload["requested_app_id"] == access_app.id
+    assert payload["requested_app_id"] == access_app_id
 
 
-def test_mcp_write_tags_audit_log_with_source_mcp(
+async def test_mcp_write_tags_audit_log_with_source_mcp(
     with_mcp_enabled: None,
     db: Db,
     okta_group: OktaGroup,
@@ -952,7 +978,7 @@ def test_mcp_write_tags_audit_log_with_source_mcp(
     import logging
 
     db.session.add_all([user, okta_group])
-    db.session.commit()
+    await db.session.commit()
     from api.mcp.auth import reset_mcp_identity
     from api.mcp.server import create_mcp_server
 
@@ -970,7 +996,7 @@ def test_mcp_write_tags_audit_log_with_source_mcp(
     )
     try:
         with caplog.at_level(logging.INFO, logger="access.audit"):
-            result = _call_tool(mcp, "create_access_request", group_id=okta_group.id, reason="audit-source-test")
+            result = await _call_tool(mcp, "create_access_request", group_id=okta_group.id, reason="audit-source-test")
     finally:
         reset_mcp_identity(id_token)
         from api.context import reset_request_context
@@ -997,7 +1023,7 @@ def test_prm_route_absent_when_disabled(app: FastAPI) -> None:
     assert "/.well-known/oauth-protected-resource/mcp" not in paths
 
 
-def test_prm_document_served_unauthenticated(
+async def test_prm_document_served_unauthenticated(
     override_mcp_auth: Any,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1012,12 +1038,12 @@ def test_prm_document_served_unauthenticated(
     from api.app import create_app
 
     a = create_app(testing=True)
-    with TestClient(a, raise_server_exceptions=False) as client:
+    async with _mcp_client(a) as client:
         # /mcp is gated...
-        assert client.post("/mcp", json={}).status_code == 401
+        assert (await client.post("/mcp", json={})).status_code == 401
         # ...the metadata document is not.
         for path in ("/.well-known/oauth-protected-resource", "/.well-known/oauth-protected-resource/mcp"):
-            r = client.get(path)
+            r = await client.get(path)
             assert r.status_code == 200, (path, r.text)
             body = r.json()
             assert body["resource"] == "http://testserver/mcp"
@@ -1027,7 +1053,7 @@ def test_prm_document_served_unauthenticated(
             assert body["bearer_methods_supported"] == ["header"]
 
 
-def test_prm_resource_url_honours_config_override(
+async def test_prm_resource_url_honours_config_override(
     with_mcp_enabled: None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1039,14 +1065,14 @@ def test_prm_resource_url_honours_config_override(
     from api.app import create_app
 
     a = create_app(testing=True)
-    with TestClient(a, raise_server_exceptions=False) as client:
-        body = client.get("/.well-known/oauth-protected-resource").json()
+    async with _mcp_client(a) as client:
+        body = (await client.get("/.well-known/oauth-protected-resource")).json()
         # Trailing slash trimmed; Host header ignored in favour of config.
         assert body["resource"] == "https://access.example.com/mcp"
         assert body["authorization_servers"] == ["https://team.cloudflareaccess.com"]
 
 
-def test_401_advertises_resource_metadata(
+async def test_401_advertises_resource_metadata(
     override_mcp_auth: Any,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1058,8 +1084,8 @@ def test_401_advertises_resource_metadata(
     from api.app import create_app
 
     a = create_app(testing=True)
-    with TestClient(a, raise_server_exceptions=False) as client:
-        r = client.post("/mcp", json={})
+    async with _mcp_client(a) as client:
+        r = await client.post("/mcp", json={})
         assert r.status_code == 401
         challenge = r.headers.get("WWW-Authenticate", "")
         assert challenge.startswith("Bearer ")

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -12,12 +12,12 @@ import base64
 import json
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Generator
+from typing import Any, AsyncGenerator, Generator
 
+import httpx
 import itsdangerous
 import pytest
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 from starlette.responses import RedirectResponse
 
@@ -82,10 +82,10 @@ def _build_oidc_mock(
 
 
 @pytest.fixture
-def seed_oidc_user(db: Db) -> OktaUser:
+async def seed_oidc_user(db: Db) -> OktaUser:
     user = OktaUserFactory.build(email=TEST_OIDC_USER_EMAIL)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
     return user
 
 
@@ -94,13 +94,13 @@ def _install_oidc_settings(env: str) -> None:
     settings.SECRET_KEY = TEST_SECRET_KEY
     settings.OIDC_CLIENT_SECRETS = STUB_OIDC_CLIENT_SECRETS
     settings.CLOUDFLARE_TEAM_DOMAIN = None
-    # The TestClient talks to host "testserver"; allow it so the
+    # The test client talks to host "testserver"; allow it so the
     # TrustedHostMiddleware guard (required for OIDC outside dev/test) is
     # satisfied and requests aren't rejected as spoofed-Host.
     settings.ALLOWED_HOSTS = "testserver"
     # Keep MCP out of these apps: they build their own app per test and the
-    # TestClient re-enters the lifespan, which the MCP session manager only
-    # tolerates once per process. MCP is covered by test_mcp.py.
+    # MCP session manager needs a running lifespan (and only tolerates one
+    # `.run()` per instance). MCP is covered by test_mcp.py.
     settings.ENABLE_MCP = False
     # Suppress create_app's `db.init_app(build_engine())` branch — the `db`
     # fixture has already bound an in-memory engine with the seeded schema,
@@ -186,13 +186,13 @@ def oidc_app(
 
 
 @pytest.fixture
-def oidc_client(oidc_app: FastAPI) -> Generator[TestClient, None, None]:
+async def oidc_client(oidc_app: FastAPI) -> AsyncGenerator[httpx.AsyncClient, None]:
     # Use https so the cookie jar will replay a Secure-flagged session cookie
     # back to the server on subsequent requests.
-    with TestClient(
-        oidc_app,
+    transport = httpx.ASGITransport(app=oidc_app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(
+        transport=transport,
         base_url="https://testserver",
-        raise_server_exceptions=False,
         follow_redirects=False,
     ) as c:
         yield c
@@ -239,12 +239,17 @@ def dev_oidc_app(
 
 
 @pytest.fixture
-def dev_oidc_client(dev_oidc_app: FastAPI) -> Generator[TestClient, None, None]:
-    with TestClient(dev_oidc_app, raise_server_exceptions=False, follow_redirects=False) as c:
+async def dev_oidc_client(dev_oidc_app: FastAPI) -> AsyncGenerator[httpx.AsyncClient, None]:
+    transport = httpx.ASGITransport(app=dev_oidc_app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+        follow_redirects=False,
+    ) as c:
         yield c
 
 
-def _set_session(client: TestClient, data: dict[str, Any]) -> None:
+def _set_session(client: httpx.AsyncClient, data: dict[str, Any]) -> None:
     client.cookies.set("session", _signed_session_cookie(TEST_SECRET_KEY, data))
 
 
@@ -262,42 +267,42 @@ def _read_session_from_set_cookie(set_cookie_header: str) -> dict[str, Any] | No
 # ---------------------------------------------------------------------------
 
 
-def test_unauthenticated_protected_endpoint_redirects_to_oidc_login(
-    oidc_client: TestClient,
+async def test_unauthenticated_protected_endpoint_redirects_to_oidc_login(
+    oidc_client: httpx.AsyncClient,
 ) -> None:
-    response = oidc_client.get("/api/users")
+    response = await oidc_client.get("/api/users")
     assert response.status_code == 307
     location = response.headers["location"]
     assert location.startswith("/oidc/login?next=")
     assert "next=%2Fapi%2Fusers" in location
 
 
-def test_oidc_login_is_in_allowlist(oidc_client: TestClient) -> None:
-    response = oidc_client.get("/oidc/login")
+async def test_oidc_login_is_in_allowlist(oidc_client: httpx.AsyncClient) -> None:
+    response = await oidc_client.get("/oidc/login")
     assert response.status_code == 302
     assert response.headers["location"].startswith("https://idp.test/authorize")
 
 
-def test_oidc_authorize_is_in_allowlist(oidc_client: TestClient) -> None:
-    response = oidc_client.get("/oidc/authorize")
+async def test_oidc_authorize_is_in_allowlist(oidc_client: httpx.AsyncClient) -> None:
+    response = await oidc_client.get("/oidc/authorize")
     assert response.status_code in (302, 307)
     assert not response.headers["location"].startswith("/oidc/login")
 
 
-def test_oidc_logout_is_in_allowlist(oidc_client: TestClient) -> None:
-    response = oidc_client.get("/oidc/logout")
+async def test_oidc_logout_is_in_allowlist(oidc_client: httpx.AsyncClient) -> None:
+    response = await oidc_client.get("/oidc/logout")
     assert response.status_code in (302, 307)
     assert not response.headers["location"].startswith("/oidc/login")
 
 
-def test_unmapped_api_path_redirects_through_auth_gate(oidc_client: TestClient) -> None:
-    response = oidc_client.get("/api/this-endpoint-does-not-exist")
+async def test_unmapped_api_path_redirects_through_auth_gate(oidc_client: httpx.AsyncClient) -> None:
+    response = await oidc_client.get("/api/this-endpoint-does-not-exist")
     assert response.status_code == 307
     assert response.headers["location"].startswith("/oidc/login?next=")
 
 
-def test_unauthenticated_spa_path_redirects_to_oidc_login(oidc_client: TestClient) -> None:
-    response = oidc_client.get("/groups/foo")
+async def test_unauthenticated_spa_path_redirects_to_oidc_login(oidc_client: httpx.AsyncClient) -> None:
+    response = await oidc_client.get("/groups/foo")
     assert response.status_code == 307
     location = response.headers["location"]
     assert location.startswith("/oidc/login?next=")
@@ -313,8 +318,8 @@ def test_unauthenticated_spa_path_redirects_to_oidc_login(oidc_client: TestClien
     "next_value",
     ["/dashboard", "/groups/foo", "/api/users/me", "/"],
 )
-def test_oidc_login_stores_safe_next(oidc_client: TestClient, next_value: str) -> None:
-    response = oidc_client.get(f"/oidc/login?next={next_value}")
+async def test_oidc_login_stores_safe_next(oidc_client: httpx.AsyncClient, next_value: str) -> None:
+    response = await oidc_client.get(f"/oidc/login?next={next_value}")
     assert response.status_code == 302
     session = _read_session_from_set_cookie(response.headers.get("set-cookie", ""))
     assert session is not None
@@ -336,17 +341,17 @@ def test_oidc_login_stores_safe_next(oidc_client: TestClient, next_value: str) -
         "relative/path",
     ],
 )
-def test_oidc_login_drops_unsafe_next(oidc_client: TestClient, next_value: str) -> None:
-    response = oidc_client.get("/oidc/login", params={"next": next_value})
+async def test_oidc_login_drops_unsafe_next(oidc_client: httpx.AsyncClient, next_value: str) -> None:
+    response = await oidc_client.get("/oidc/login", params={"next": next_value})
     assert response.status_code == 302
     session = _read_session_from_set_cookie(response.headers.get("set-cookie", ""))
     if session is not None:
         assert "oidc_next" not in session
 
 
-def test_oidc_authorize_uses_stored_next(oidc_client: TestClient) -> None:
+async def test_oidc_authorize_uses_stored_next(oidc_client: httpx.AsyncClient) -> None:
     _set_session(oidc_client, {"oidc_next": "/groups"})
-    response = oidc_client.get("/oidc/authorize")
+    response = await oidc_client.get("/oidc/authorize")
     assert response.status_code in (302, 307)
     assert response.headers["location"] == "/groups"
     session = _read_session_from_set_cookie(response.headers.get("set-cookie", ""))
@@ -355,8 +360,8 @@ def test_oidc_authorize_uses_stored_next(oidc_client: TestClient) -> None:
     assert session.get("userinfo", {}).get("email") == TEST_OIDC_USER_EMAIL
 
 
-def test_oidc_authorize_defaults_to_root_when_no_next(oidc_client: TestClient) -> None:
-    response = oidc_client.get("/oidc/authorize")
+async def test_oidc_authorize_defaults_to_root_when_no_next(oidc_client: httpx.AsyncClient) -> None:
+    response = await oidc_client.get("/oidc/authorize")
     assert response.status_code in (302, 307)
     assert response.headers["location"] == "/"
 
@@ -366,29 +371,29 @@ def test_oidc_authorize_defaults_to_root_when_no_next(oidc_client: TestClient) -
 # ---------------------------------------------------------------------------
 
 
-def test_full_login_flow(oidc_client: TestClient, seed_oidc_user: OktaUser) -> None:
-    initial = oidc_client.get("/api/users")
+async def test_full_login_flow(oidc_client: httpx.AsyncClient, seed_oidc_user: OktaUser) -> None:
+    initial = await oidc_client.get("/api/users")
     assert initial.status_code == 307
     redirect_target = initial.headers["location"]
     assert redirect_target.startswith("/oidc/login?next=")
 
-    login = oidc_client.get(redirect_target)
+    login = await oidc_client.get(redirect_target)
     assert login.status_code == 302
     assert login.headers["location"].startswith("https://idp.test/authorize")
 
-    callback = oidc_client.get("/oidc/authorize")
+    callback = await oidc_client.get("/oidc/authorize")
     assert callback.status_code in (302, 307)
     assert callback.headers["location"] == "/api/users"
 
-    final = oidc_client.get("/api/users")
+    final = await oidc_client.get("/api/users")
     assert final.status_code == 200
 
 
-def test_login_with_existing_session_still_bounces_through_idp(
-    oidc_client: TestClient,
+async def test_login_with_existing_session_still_bounces_through_idp(
+    oidc_client: httpx.AsyncClient,
 ) -> None:
     _set_session(oidc_client, {"userinfo": {"email": TEST_OIDC_USER_EMAIL}})
-    response = oidc_client.get("/oidc/login?next=/dashboard")
+    response = await oidc_client.get("/oidc/login?next=/dashboard")
     assert response.status_code == 302
     assert response.headers["location"].startswith("https://idp.test/authorize")
 
@@ -398,27 +403,29 @@ def test_login_with_existing_session_still_bounces_through_idp(
 # ---------------------------------------------------------------------------
 
 
-def test_authorize_token_exchange_failure_returns_403(oidc_client: TestClient, oidc_mock: SimpleNamespace) -> None:
+async def test_authorize_token_exchange_failure_returns_403(
+    oidc_client: httpx.AsyncClient, oidc_mock: SimpleNamespace
+) -> None:
     async def boom(request: Any) -> dict[str, Any]:
         raise RuntimeError("upstream IdP rejected the code")
 
     oidc_mock.authorize_access_token = boom
-    response = oidc_client.get("/oidc/authorize")
+    response = await oidc_client.get("/oidc/authorize")
     assert response.status_code == 403
     assert "OIDC authorization failed" in response.text
 
 
-def test_authorize_unknown_email_returns_404_on_next_request(
-    oidc_client: TestClient, oidc_mock: SimpleNamespace
+async def test_authorize_unknown_email_returns_404_on_next_request(
+    oidc_client: httpx.AsyncClient, oidc_mock: SimpleNamespace
 ) -> None:
     async def unknown_user(request: Any) -> dict[str, Any]:
         return {"userinfo": {"email": "stranger@example.com"}}
 
     oidc_mock.authorize_access_token = unknown_user
-    callback = oidc_client.get("/oidc/authorize")
+    callback = await oidc_client.get("/oidc/authorize")
     assert callback.status_code in (302, 307)
 
-    follow_up = oidc_client.get("/api/users")
+    follow_up = await oidc_client.get("/api/users")
     assert follow_up.status_code == 404
 
 
@@ -427,9 +434,9 @@ def test_authorize_unknown_email_returns_404_on_next_request(
 # ---------------------------------------------------------------------------
 
 
-def test_logout_clears_session_and_redirects_home(oidc_client: TestClient) -> None:
+async def test_logout_clears_session_and_redirects_home(oidc_client: httpx.AsyncClient) -> None:
     _set_session(oidc_client, {"userinfo": {"email": TEST_OIDC_USER_EMAIL}})
-    response = oidc_client.get("/oidc/logout")
+    response = await oidc_client.get("/oidc/logout")
     assert response.status_code in (302, 307)
     assert response.headers["location"] == "/"
     set_cookie = response.headers.get("set-cookie", "")
@@ -438,7 +445,7 @@ def test_logout_clears_session_and_redirects_home(oidc_client: TestClient) -> No
         assert session is None or "userinfo" not in session
 
 
-def test_logout_does_not_call_idp_end_session(oidc_client: TestClient, oidc_mock: SimpleNamespace) -> None:
+async def test_logout_does_not_call_idp_end_session(oidc_client: httpx.AsyncClient, oidc_mock: SimpleNamespace) -> None:
     # Even if the IdP advertises an `end_session_endpoint`, /oidc/logout only
     # clears the local session. Driving the IdP-side logout would require an
     # `id_token_hint` (Okta returns 400 without one) and a registered
@@ -452,18 +459,18 @@ def test_logout_does_not_call_idp_end_session(oidc_client: TestClient, oidc_mock
 
     oidc_mock.load_server_metadata = metadata_with_end_session
     _set_session(oidc_client, {"userinfo": {"email": TEST_OIDC_USER_EMAIL}})
-    response = oidc_client.get("/oidc/logout")
+    response = await oidc_client.get("/oidc/logout")
     assert response.headers["location"] == "/"
     assert metadata_calls == 0
 
 
-def test_post_logout_request_redirects_back_to_login(oidc_client: TestClient) -> None:
+async def test_post_logout_request_redirects_back_to_login(oidc_client: httpx.AsyncClient) -> None:
     _set_session(oidc_client, {"userinfo": {"email": TEST_OIDC_USER_EMAIL}})
-    logout = oidc_client.get("/oidc/logout")
+    logout = await oidc_client.get("/oidc/logout")
     assert logout.status_code in (302, 307)
 
     oidc_client.cookies.clear()
-    response = oidc_client.get("/api/users")
+    response = await oidc_client.get("/api/users")
     assert response.status_code == 307
     assert response.headers["location"].startswith("/oidc/login?next=")
 
@@ -473,18 +480,18 @@ def test_post_logout_request_redirects_back_to_login(oidc_client: TestClient) ->
 # ---------------------------------------------------------------------------
 
 
-def test_hsts_present_in_non_dev(oidc_client: TestClient) -> None:
-    response = oidc_client.get("/oidc/login")
+async def test_hsts_present_in_non_dev(oidc_client: httpx.AsyncClient) -> None:
+    response = await oidc_client.get("/oidc/login")
     assert response.headers.get("Strict-Transport-Security") == ("max-age=31536000; includeSubDomains")
 
 
-def test_hsts_absent_in_dev(dev_oidc_client: TestClient) -> None:
-    response = dev_oidc_client.get("/oidc/login")
+async def test_hsts_absent_in_dev(dev_oidc_client: httpx.AsyncClient) -> None:
+    response = await dev_oidc_client.get("/oidc/login")
     assert "Strict-Transport-Security" not in response.headers
 
 
-def test_other_security_headers_still_set(oidc_client: TestClient) -> None:
-    response = oidc_client.get("/oidc/login")
+async def test_other_security_headers_still_set(oidc_client: httpx.AsyncClient) -> None:
+    response = await oidc_client.get("/oidc/login")
     assert "Content-Security-Policy" in response.headers
     assert response.headers.get("X-Frame-Options") == "DENY"
     assert response.headers.get("Referrer-Policy") == "no-referrer"
@@ -496,8 +503,8 @@ def test_other_security_headers_still_set(oidc_client: TestClient) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_session_cookie_flags_in_non_dev(oidc_client: TestClient) -> None:
-    response = oidc_client.get("/oidc/login?next=/dashboard")
+async def test_session_cookie_flags_in_non_dev(oidc_client: httpx.AsyncClient) -> None:
+    response = await oidc_client.get("/oidc/login?next=/dashboard")
     set_cookie = response.headers.get("set-cookie", "").lower()
     assert "session=" in set_cookie
     assert "httponly" in set_cookie
@@ -505,9 +512,9 @@ def test_session_cookie_flags_in_non_dev(oidc_client: TestClient) -> None:
     assert "samesite=lax" in set_cookie
 
 
-def test_session_cookie_flags_in_dev_omit_secure(dev_oidc_client: TestClient) -> None:
+async def test_session_cookie_flags_in_dev_omit_secure(dev_oidc_client: httpx.AsyncClient) -> None:
     dev_oidc_client.cookies.set("session", _signed_session_cookie(TEST_SECRET_KEY, {"oidc_next": "/x"}))
-    response = dev_oidc_client.get("/oidc/logout")
+    response = await dev_oidc_client.get("/oidc/logout")
     set_cookie = response.headers.get("set-cookie", "").lower()
     assert "session=" in set_cookie
     assert "httponly" in set_cookie
@@ -560,46 +567,48 @@ def _has_trusted_host_middleware(app: FastAPI) -> bool:
     return any(m.cls.__name__ == TrustedHostMiddleware.__name__ for m in app.user_middleware)
 
 
-def test_request_with_allowed_host_passes(oidc_client: TestClient) -> None:
-    response = oidc_client.get("/oidc/login", headers={"host": "testserver"})
+async def test_request_with_allowed_host_passes(oidc_client: httpx.AsyncClient) -> None:
+    response = await oidc_client.get("/oidc/login", headers={"host": "testserver"})
     assert response.status_code == 302
 
 
-def test_request_with_spoofed_host_rejected(oidc_client: TestClient) -> None:
+async def test_request_with_spoofed_host_rejected(oidc_client: httpx.AsyncClient) -> None:
     # ALLOWED_HOSTS is "testserver" (set by the fixture); a spoofed Host is
     # rejected by TrustedHostMiddleware before any route runs.
-    response = oidc_client.get("/oidc/login", headers={"host": "evil.example.com"})
+    response = await oidc_client.get("/oidc/login", headers={"host": "evil.example.com"})
     assert response.status_code == 400
 
 
-def test_login_redirect_uri_derived_from_host(oidc_client: TestClient) -> None:
+async def test_login_redirect_uri_derived_from_host(oidc_client: httpx.AsyncClient) -> None:
     # The authorize_redirect mock echoes the redirect_uri into the IdP URL.
     # With no OIDC_OVERWRITE_REDIRECT_URI, it is built from the request host.
-    response = oidc_client.get("/oidc/login")
+    response = await oidc_client.get("/oidc/login")
     assert "https://testserver/oidc/authorize" in response.headers["location"]
 
 
-def test_overwrite_redirect_uri_pins_callback(oidc_client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_overwrite_redirect_uri_pins_callback(
+    oidc_client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr(settings, "OIDC_OVERWRITE_REDIRECT_URI", "https://pinned.example.com/oidc/authorize")
-    response = oidc_client.get("/oidc/login")
+    response = await oidc_client.get("/oidc/login")
     assert "https://pinned.example.com/oidc/authorize" in response.headers["location"]
 
 
-def test_create_app_requires_allowed_hosts_for_oidc_outside_dev(
+async def test_create_app_requires_allowed_hosts_for_oidc_outside_dev(
     monkeypatch: pytest.MonkeyPatch, db: Db, stub_build_dir: Path, installed_oidc_mock: None
 ) -> None:
     with pytest.raises(ValueError, match="ALLOWED_HOSTS"):
         _build_app_with(monkeypatch, env="staging", oidc=True, cf=False, allowed_hosts="")
 
 
-def test_create_app_oidc_dev_allowed_without_allowed_hosts(
+async def test_create_app_oidc_dev_allowed_without_allowed_hosts(
     monkeypatch: pytest.MonkeyPatch, db: Db, stub_build_dir: Path, installed_oidc_mock: None
 ) -> None:
     app = _build_app_with(monkeypatch, env="development", oidc=True, cf=False, allowed_hosts="")
     assert not _has_trusted_host_middleware(app)
 
 
-def test_create_app_cloudflare_outside_dev_not_required(
+async def test_create_app_cloudflare_outside_dev_not_required(
     monkeypatch: pytest.MonkeyPatch, db: Db, stub_build_dir: Path
 ) -> None:
     # Cloudflare deployment (no OIDC) doesn't hit the redirect_uri path, so the
@@ -608,7 +617,7 @@ def test_create_app_cloudflare_outside_dev_not_required(
     assert not _has_trusted_host_middleware(app)
 
 
-def test_create_app_adds_trusted_host_middleware_when_set(
+async def test_create_app_adds_trusted_host_middleware_when_set(
     monkeypatch: pytest.MonkeyPatch, db: Db, stub_build_dir: Path, installed_oidc_mock: None
 ) -> None:
     app = _build_app_with(monkeypatch, env="staging", oidc=True, cf=False, allowed_hosts="access.example.com")

--- a/tests/test_okta_retries.py
+++ b/tests/test_okta_retries.py
@@ -32,49 +32,71 @@ def mock_sleep(mocker: MockerFixture) -> Mock:
 
 
 @pytest.mark.parametrize("status_code", RETRIABLE_STATUS_CODES)
-def test_retry_logic_error_response_retriable(
+async def test_retry_logic_error_response_retriable(
     mocker: MockerFixture, mock_sleep: Mock, okta_service: OktaService, status_code: int
 ) -> None:
     mocked_request = mock_get_user(mocker, status_code)
 
     with pytest.raises(Exception):
-        okta_service.get_user("okta_id")
+        await okta_service.get_user("okta_id")
         assert mocked_request.call_count == 1 + REQUEST_MAX_RETRIES
         assert mock_sleep.call_count == REQUEST_MAX_RETRIES
 
 
-def test_retry_logic_error_response_non_retriable(
+async def test_retry_logic_error_response_non_retriable(
     mocker: MockerFixture, mock_sleep: Mock, okta_service: OktaService
 ) -> None:
     mocked_request = mock_get_user(mocker, 400)
 
     with pytest.raises(Exception):
-        okta_service.get_user("okta_id")
+        await okta_service.get_user("okta_id")
         assert mocked_request.call_count == 1
         assert mock_sleep.call_count == 0
 
 
-def test_retry_logic_no_error(mocker: MockerFixture, mock_sleep: Mock, okta_service: OktaService) -> None:
+async def test_retry_logic_no_error(mocker: MockerFixture, mock_sleep: Mock, okta_service: OktaService) -> None:
     mocked_request = mock_get_user(mocker, 200)
 
-    okta_service.get_user("okta_id")
+    await okta_service.get_user("okta_id")
     assert mocked_request.call_count == 1
     assert mock_sleep.call_count == 0
 
 
-def test_retry_logic_all_timeouts_raises(mocker: MockerFixture, mock_sleep: Mock, okta_service: OktaService) -> None:
-    mocker.patch("asyncio.wait_for", side_effect=asyncio.TimeoutError())
+def _fake_wait_for(outcomes: list[Any]) -> Any:
+    """side_effect for a patched asyncio.wait_for that closes the wrapped
+    coroutine (the real wait_for would consume it; leaving it unawaited
+    trips the `coroutine ... was never awaited` warning-as-error filter)."""
+
+    def fake_wait_for(coro: Any, timeout: float) -> Any:
+        coro.close()
+        outcome = outcomes.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    return fake_wait_for
+
+
+async def test_retry_logic_all_timeouts_raises(
+    mocker: MockerFixture, mock_sleep: Mock, okta_service: OktaService
+) -> None:
+    mocker.patch(
+        "asyncio.wait_for",
+        side_effect=_fake_wait_for([asyncio.TimeoutError() for _ in range(1 + REQUEST_MAX_RETRIES)]),
+    )
 
     with pytest.raises(OktaTimeout, match="timed out"):
-        okta_service.get_user("okta_id")
+        await okta_service.get_user("okta_id")
 
 
-def test_retry_logic_timeout_then_success(mocker: MockerFixture, mock_sleep: Mock, okta_service: OktaService) -> None:
+async def test_retry_logic_timeout_then_success(
+    mocker: MockerFixture, mock_sleep: Mock, okta_service: OktaService
+) -> None:
     success_response: Tuple[Any, Any, Optional[Exception]] = (UserFactory(), Mock(), None)
     mocker.patch(
         "asyncio.wait_for",
-        side_effect=[asyncio.TimeoutError(), success_response],
+        side_effect=_fake_wait_for([asyncio.TimeoutError(), success_response]),
     )
 
-    user = okta_service.get_user("okta_id")
+    user = await okta_service.get_user("okta_id")
     assert user is not None

--- a/tests/test_okta_service.py
+++ b/tests/test_okta_service.py
@@ -1,6 +1,4 @@
 import asyncio
-import threading
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -68,86 +66,74 @@ def test_is_managed_group_with_allow_discord_access_undefined() -> None:
         assert result is True
 
 
-def test_update_group_preserves_custom_attributes() -> None:
+async def test_update_group_preserves_custom_attributes() -> None:
     """Test that update_group preserves custom attributes when updating a group."""
-    # Create a new event loop for this test
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
+    service = OktaService()
 
-    # Mock asyncio.run to use our event loop
-    with patch("asyncio.run", side_effect=lambda x: loop.run_until_complete(x)):
-        # Create OktaService instance
-        service = OktaService()
+    # Set up the mocks for the existing group and the update call
+    group_id = "test-group-id"
 
-        # Set up the mocks for the existing group and the update call
-        group_id = "test-group-id"
+    # Create a mock group with a profile that has the custom attribute
+    existing_group = MagicMock()
+    # Instead of setting __dict__ directly, configure the mock properly
+    existing_group.profile = MagicMock()
+    existing_group.profile.name = "Old Name"
+    existing_group.profile.description = "Old Description"
+    existing_group.profile.allow_discord_access = True
 
-        # Create a mock group with a profile that has the custom attribute
-        existing_group = MagicMock()
-        # Instead of setting __dict__ directly, configure the mock properly
-        existing_group.profile = MagicMock()
-        existing_group.profile.name = "Old Name"
-        existing_group.profile.description = "Old Description"
-        existing_group.profile.allow_discord_access = True
+    # Mock the per-call Okta client's get_group and update_group methods
+    mock_client = MagicMock()
+    mock_client.get_group = AsyncMock(return_value=(existing_group, None, None))
+    mock_client.update_group = AsyncMock(return_value=(MagicMock(), None, None))
 
-        # Mock the per-call Okta client's get_group and update_group methods
-        mock_client = MagicMock()
-        mock_client.get_group = AsyncMock(return_value=(existing_group, None, None))
-        mock_client.update_group = AsyncMock(return_value=(MagicMock(), None, None))
+    # Mock the _okta_client async context manager to yield the mock client
+    class MockOktaClientContext:
+        """Async context manager that yields the mock Okta client"""
 
-        # Mock the _okta_client async context manager to yield the mock client
-        class MockOktaClientContext:
-            """Async context manager that yields the mock Okta client"""
+        async def __aenter__(self) -> MagicMock:
+            return mock_client
 
-            async def __aenter__(self) -> MagicMock:
-                return mock_client
+        async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+            return None
 
-            async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-                return None
+    # Use patch to mock the _okta_client method
+    # This avoids directly assigning to the method, which mypy doesn't like
+    with patch.object(service, "_okta_client", return_value=MockOktaClientContext()):
+        # Call update_group
+        await service.update_group(group_id, "New Name", "New Description")
 
-        # Use patch to mock the _okta_client method
-        # This avoids directly assigning to the method, which mypy doesn't like
-        with patch.object(service, "_okta_client", return_value=MockOktaClientContext()):
-            # Call update_group
-            service.update_group(group_id, "New Name", "New Description")
+        # Verify update_group was called with a payload that preserved the custom attribute
+        args, _ = mock_client.update_group.call_args
+        assert len(args) == 2
+        assert args[0] == group_id
 
-            # Verify update_group was called with a payload that preserved the custom attribute
-            args, _ = mock_client.update_group.call_args
-            assert len(args) == 2
-            assert args[0] == group_id
-
-            # Check that the payload contains both the updated fields and the preserved custom attribute
-            updated_payload = args[1]
-            assert updated_payload.profile.name == "New Name"
-            assert updated_payload.profile.description == "New Description"
-            assert updated_payload.profile.allow_discord_access is True
+        # Check that the payload contains both the updated fields and the preserved custom attribute
+        updated_payload = args[1]
+        assert updated_payload.profile.name == "New Name"
+        assert updated_payload.profile.description == "New Description"
+        assert updated_payload.profile.allow_discord_access is True
 
 
-def test_concurrent_calls_use_isolated_request_executors() -> None:
+async def test_concurrent_calls_use_isolated_request_executors() -> None:
     """Concurrent Okta calls must each get their own client, executor, and session.
 
-    Every public method runs its coroutine under its own ``asyncio.run`` event
-    loop, and the FastAPI/MCP threadpools drive those sync methods concurrently.
-    The previous design shared one ``self.okta_client`` (and its request executor)
-    across all calls, so concurrent ``set_session()`` calls clobbered each other and
-    a session bound to one loop was awaited on another ("Future attached to a
-    different loop"). With a fresh client per call, each call binds its session to
-    its own executor on its own loop, so nothing is shared to race on.
+    ``_okta_client()`` builds a fresh SDK client per call. A previous design
+    shared one ``self.okta_client`` (and its request executor) across all
+    calls, so concurrent ``set_session()`` calls clobbered each other and a
+    session created by one call could be torn down under another. With a
+    fresh client per call, each call binds its own pooled session to its own
+    executor, so concurrent calls on the service share nothing to race on.
     """
     service = OktaService()
     service.initialize("fake.domain", "fake.token")
 
     executors: list[Any] = []
-    loops: list[Any] = []
-    lock = threading.Lock()
 
     real_set_session = RequestExecutor.set_session
 
     def tracking_set_session(executor: Any, session: Any) -> None:
         real_set_session(executor, session)
-        with lock:
-            executors.append(executor)
-            loops.append(asyncio.get_running_loop())
+        executors.append(executor)
 
     call_count = 16
     success = (UserFactory(), MagicMock(), None)
@@ -156,12 +142,11 @@ def test_concurrent_calls_use_isolated_request_executors() -> None:
         patch.object(RequestExecutor, "set_session", tracking_set_session),
         patch("okta.client.Client.get_user", return_value=success),
     ):
-        with ThreadPoolExecutor(max_workers=8) as pool:
-            users = list(pool.map(lambda _: service.get_user("okta_id"), range(call_count)))
+        users = await asyncio.gather(*(service.get_user("okta_id") for _ in range(call_count)))
 
-    # No call raised (pool.map re-raises), and every call returned a user.
+    # No call raised (gather re-raises), and every call returned a user.
     assert len(users) == call_count
     assert all(user is not None for user in users)
-    # Each concurrent call got its own executor on its own event loop; nothing shared.
+    # Each concurrent call got its own client/request executor; nothing shared.
+    assert len(executors) == call_count
     assert len({id(executor) for executor in executors}) == call_count
-    assert len({id(loop) for loop in loops}) == call_count

--- a/tests/test_polymorphic_loader_coverage.py
+++ b/tests/test_polymorphic_loader_coverage.py
@@ -1,0 +1,272 @@
+"""Regression battery for the Flask-era lazy-load Sentry issues.
+
+ACCESS-FLASK-4N (`RoleGroup.active_role_associated_group_member_mappings`),
+ACCESS-FLASK-44 (`RoleGroupMap.active_group`), and ACCESS-FLASK-4E
+(`AppGroup.app`, `OktaGroup.active_group_tags`) were production
+`InvalidRequestError: ... lazy='raise_on_sql'` failures that never reproduced
+in tests. The reason: `raise_on_sql` raises identically in tests, so the only
+production-only ingredient was DATA SHAPE — the failing serializations needed
+polymorphic subtypes in nested positions (a role group whose associated groups
+are app groups, tagged groups inside request refs, app groups inside
+membership rows) that the suite never built. The five relationships involved
+were demoted to `lazy="select"` as a band-aid; the async migration flips them
+back to `raise_on_sql`, so this battery builds the production shape once and
+walks every read surface. Any eager-load gap fails deterministically here
+instead of as a paged 500.
+"""
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient
+
+from api.extensions import Db
+from api.models import (
+    OktaGroupTagMap,
+)
+from api.operations import (
+    CreateAccessRequest,
+    CreateRoleRequest,
+    ModifyGroupUsers,
+    ModifyRoleGroups,
+)
+from tests.factories import (
+    AppFactory,
+    AppGroupFactory,
+    OktaGroupFactory,
+    OktaUserFactory,
+    RoleGroupFactory,
+    TagFactory,
+)
+
+
+@pytest.fixture
+async def production_shape(db: Db) -> dict[str, Any]:
+    """Build the data shape from the ACCESS-FLASK Sentry reports.
+
+    A tagged role group with member+owner associations to a tagged app group
+    and a tagged plain group; a user holding direct and via-role access; a
+    pending access request targeting the ROLE group (the rich detail ref that
+    serializes the role's associated-group mappings); another targeting the
+    app group; and a role request from the role to the app group.
+    """
+    user = OktaUserFactory.build()
+    requester = OktaUserFactory.build()
+    app = AppFactory.build()
+    app_group = AppGroupFactory.build(app_id=app.id, name=f"App-{app.name}-Eng")
+    okta_group = OktaGroupFactory.build()
+    role_group = RoleGroupFactory.build()
+    tags = [TagFactory.build(constraints={}) for _ in range(3)]
+
+    db.session.add_all([user, requester, app, app_group, okta_group, role_group, *tags])
+    await db.session.commit()
+    db.session.add_all(
+        [
+            OktaGroupTagMap(tag_id=tags[0].id, group_id=app_group.id),
+            OktaGroupTagMap(tag_id=tags[1].id, group_id=okta_group.id),
+            OktaGroupTagMap(tag_id=tags[2].id, group_id=role_group.id),
+        ]
+    )
+    await db.session.commit()
+
+    # Role memberships first, then associate the role to both groups as
+    # member AND owner so `active_role_associated_group_*_mappings` rows
+    # exist with polymorphic `active_group` targets (AppGroup + OktaGroup).
+    await ModifyGroupUsers(
+        group=role_group.id, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(
+        group=okta_group.id, members_to_add=[requester.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyRoleGroups(
+        role_group=role_group.id,
+        groups_to_add=[app_group.id, okta_group.id],
+        owner_groups_to_add=[app_group.id],
+        sync_to_okta=False,
+    ).execute()
+
+    # Pending access request targeting the ROLE group: the detail ref
+    # serializes the role's associated-group mappings (ACCESS-FLASK-4N) and
+    # through them each mapping's active_group (44) and its app (4E).
+    request_role_target = await CreateAccessRequest(
+        requester_user=requester, requested_group=role_group, request_reason="role target"
+    ).execute()
+    request_app_target = await CreateAccessRequest(
+        requester_user=requester, requested_group=app_group, request_reason="app target"
+    ).execute()
+    role_request = await CreateRoleRequest(
+        requester_user=user,
+        requester_role=role_group,
+        requested_group=app_group,
+        request_ownership=False,
+        request_reason="role to app",
+    ).execute()
+
+    shape = {
+        "user": user.id,
+        "requester": requester.id,
+        "app": app.id,
+        "app_group": app_group.id,
+        "okta_group": okta_group.id,
+        "role_group": role_group.id,
+        "tag": tags[0].id,
+        "access_request_role_target": request_role_target.id,
+        "access_request_app_target": request_app_target.id,
+        "role_request": role_request.id,
+    }
+    # Drop identity-map state staled by the ops above (expire_on_commit=False)
+    # so the routes under test load everything through their own loaders.
+    db.session.expire_all()
+    return shape
+
+
+async def _get_ok(client: AsyncClient, url: str) -> Any:
+    rep = await client.get(url)
+    assert rep.status_code == 200, f"{url} -> {rep.status_code}: {rep.text[:500]}"
+    return rep.json()
+
+
+async def test_group_list_serializes_role_associations_and_apps(
+    app: FastAPI, client: AsyncClient, db: Db, production_shape: dict[str, Any], url_for: Any
+) -> None:
+    data = await _get_ok(client, url_for("api-groups.groups"))
+    by_id = {g["id"]: g for g in data["items"]}
+    role = by_id[production_shape["role_group"]]
+    # ACCESS-FLASK-4N: the role row exposes its associated-group mappings…
+    assert role["active_role_associated_group_member_mappings"]
+    # …44: each mapping exposes its active_group…
+    actives = [m["active_group"] for m in role["active_role_associated_group_member_mappings"]]
+    assert all(a is not None for a in actives)
+    # …4E: and the app-group one exposes its app.
+    app_refs = [a for a in actives if a["type"] == "app_group"]
+    assert app_refs and all(a["app"] is not None for a in app_refs)
+    # 4E-b: tags serialize on every row type.
+    assert by_id[production_shape["okta_group"]]["active_group_tags"]
+    assert by_id[production_shape["app_group"]]["active_group_tags"]
+    assert role["active_group_tags"]
+
+
+@pytest.mark.parametrize("key", ["role_group", "app_group", "okta_group"])
+async def test_group_detail_for_each_type(
+    app: FastAPI, client: AsyncClient, db: Db, production_shape: dict[str, Any], url_for: Any, key: str
+) -> None:
+    data = await _get_ok(client, url_for("api-groups.group_by_id", group_id=production_shape[key]))
+    assert data["active_group_tags"]
+    if key == "role_group":
+        mappings = data["active_role_associated_group_member_mappings"]
+        assert mappings
+        app_actives = [m["active_group"] for m in mappings if m["active_group"]["type"] == "app_group"]
+        assert app_actives and all(a["app"] is not None for a in app_actives)
+    if key == "app_group":
+        assert data["app"] is not None
+
+
+async def test_role_routes(
+    app: FastAPI, client: AsyncClient, db: Db, production_shape: dict[str, Any], url_for: Any
+) -> None:
+    await _get_ok(client, url_for("api-roles.roles"))
+    detail = await _get_ok(client, url_for("api-roles.role_by_id", role_id=production_shape["role_group"]))
+    mappings = detail["active_role_associated_group_member_mappings"]
+    assert mappings
+    assert any(m["active_group"]["type"] == "app_group" and m["active_group"]["app"] for m in mappings)
+    await _get_ok(client, url_for("api-roles.role_members_by_id", role_id=production_shape["role_group"]))
+
+
+async def test_user_routes_with_via_role_app_group_memberships(
+    app: FastAPI, client: AsyncClient, db: Db, production_shape: dict[str, Any], url_for: Any
+) -> None:
+    await _get_ok(client, url_for("api-users.users"))
+    data = await _get_ok(client, url_for("api-users.user_by_id", user_id=production_shape["user"]))
+    groups = [m["active_group"] for m in data["active_group_memberships"] if m.get("active_group")]
+    app_groups = [g for g in groups if g["type"] == "app_group"]
+    # via-role membership rows reach app groups; their `app` ref must be loaded
+    assert app_groups and all(g["app"] is not None for g in app_groups)
+
+
+async def test_access_request_detail_role_group_target(
+    app: FastAPI, client: AsyncClient, db: Db, production_shape: dict[str, Any], url_for: Any
+) -> None:
+    data = await _get_ok(
+        client,
+        url_for(
+            "api-access-requests.access_request_by_id", access_request_id=production_shape["access_request_role_target"]
+        ),
+    )
+    rg = data["requested_group"]
+    assert rg["type"] == "role_group"
+    assert rg["active_group_tags"]
+    mappings = rg["active_role_associated_group_member_mappings"]
+    assert mappings
+    app_actives = [
+        m["active_group"] for m in mappings if m["active_group"] and m["active_group"]["type"] == "app_group"
+    ]
+    assert app_actives and all(a["app"] is not None for a in app_actives)
+
+
+async def test_access_request_detail_app_group_target_and_lists(
+    app: FastAPI, client: AsyncClient, db: Db, production_shape: dict[str, Any], url_for: Any
+) -> None:
+    data = await _get_ok(
+        client,
+        url_for(
+            "api-access-requests.access_request_by_id", access_request_id=production_shape["access_request_app_target"]
+        ),
+    )
+    assert data["requested_group"]["type"] == "app_group"
+    assert data["requested_group"]["app"] is not None
+    assert data["requested_group"]["active_group_tags"]
+    await _get_ok(client, url_for("api-access-requests.access_requests"))
+
+
+async def test_role_request_routes(
+    app: FastAPI, client: AsyncClient, db: Db, production_shape: dict[str, Any], url_for: Any
+) -> None:
+    await _get_ok(client, url_for("api-role-requests.role_requests"))
+    data = await _get_ok(
+        client, url_for("api-role-requests.role_request_by_id", role_request_id=production_shape["role_request"])
+    )
+    assert data["requested_group"]["type"] == "app_group"
+    assert data["requested_group"]["app"] is not None
+
+
+async def test_tag_and_app_routes(
+    app: FastAPI, client: AsyncClient, db: Db, production_shape: dict[str, Any], url_for: Any
+) -> None:
+    await _get_ok(client, url_for("api-tags.tags"))
+    tag_detail = await _get_ok(client, url_for("api-tags.tag_by_id", tag_id=production_shape["tag"]))
+    # the tag is attached to the APP group: the nested active_group must carry its app
+    actives = [t["active_group"] for t in tag_detail["active_group_tags"] if t.get("active_group")]
+    assert any(g["type"] == "app_group" and g.get("app") for g in actives)
+    await _get_ok(client, url_for("api-apps.apps"))
+    await _get_ok(client, url_for("api-apps.app_by_id", app_id=production_shape["app"]))
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        "",  # unfiltered: emits role-associated mappings (the include_role_associations branch)
+        "user_id={user}",
+        "group_id={role_group}",
+        "group_id={app_group}",
+    ],
+)
+async def test_audit_users_with_polymorphic_rows(
+    app: FastAPI, client: AsyncClient, db: Db, production_shape: dict[str, Any], url_for: Any, params: str
+) -> None:
+    # The Flask-era comments singled out exactly this endpoint with user_id /
+    # group_id filters as the unloadable case that forced lazy="select".
+    url = url_for("api-audit.users_and_groups")
+    qs = params.format(**production_shape)
+    data = await _get_ok(client, f"{url}?{qs}" if qs else url)
+    assert data["items"]
+
+
+@pytest.mark.parametrize("params", ["", "role_id={role_group}", "group_id={app_group}"])
+async def test_audit_groups_with_polymorphic_rows(
+    app: FastAPI, client: AsyncClient, db: Db, production_shape: dict[str, Any], url_for: Any, params: str
+) -> None:
+    url = url_for("api-audit.groups_and_roles")
+    qs = params.format(**production_shape)
+    data = await _get_ok(client, f"{url}?{qs}" if qs else url)
+    assert data["items"]

--- a/tests/test_request_observability_middleware.py
+++ b/tests/test_request_observability_middleware.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from fastapi import FastAPI
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
 
 import api.middleware as middleware_module
 
@@ -18,10 +18,10 @@ def fake_hook(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     return fake
 
 
-def test_emits_counter_and_histogram_per_request(
-    app: FastAPI, client: TestClient, db: Any, fake_hook: MagicMock
+async def test_emits_counter_and_histogram_per_request(
+    app: FastAPI, client: AsyncClient, db: Any, fake_hook: MagicMock
 ) -> None:
-    rep = client.get("/api/healthz")
+    rep = await client.get("/api/healthz")
     assert rep.status_code == 200
 
     fake_hook.record_counter.assert_called_once()
@@ -35,27 +35,27 @@ def test_emits_counter_and_histogram_per_request(
     assert hist_kwargs["tags"] == {"method": "GET", "status": "200", "unit": "ms"}
 
 
-def test_tags_record_non_2xx_status(app: FastAPI, client: TestClient, db: Any, fake_hook: MagicMock) -> None:
-    rep = client.get("/api/this-route-does-not-exist")
+async def test_tags_record_non_2xx_status(app: FastAPI, client: AsyncClient, db: Any, fake_hook: MagicMock) -> None:
+    rep = await client.get("/api/this-route-does-not-exist")
     assert rep.status_code == 404
     assert fake_hook.record_counter.call_args.kwargs["tags"]["status"] == "404"
     assert fake_hook.record_histogram.call_args.kwargs["tags"]["status"] == "404"
 
 
-def test_does_not_emit_an_access_log_line(
-    app: FastAPI, client: TestClient, db: Any, fake_hook: MagicMock, caplog: pytest.LogCaptureFixture
+async def test_does_not_emit_an_access_log_line(
+    app: FastAPI, client: AsyncClient, db: Any, fake_hook: MagicMock, caplog: pytest.LogCaptureFixture
 ) -> None:
     caplog.set_level(logging.INFO)
-    client.get("/api/healthz")
+    await client.get("/api/healthz")
     assert [r for r in caplog.records if r.name.startswith("api.middleware")] == []
 
 
-def test_request_survives_plugin_hook_failure(
-    app: FastAPI, client: TestClient, db: Any, monkeypatch: pytest.MonkeyPatch
+async def test_request_survives_plugin_hook_failure(
+    app: FastAPI, client: AsyncClient, db: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     def boom() -> Any:
         raise RuntimeError("plugin manager not initialised")
 
     monkeypatch.setattr(middleware_module, "get_metrics_reporter_hook", boom)
-    rep = client.get("/api/healthz")
+    rep = await client.get("/api/healthz")
     assert rep.status_code == 200

--- a/tests/test_require_reason_constraint.py
+++ b/tests/test_require_reason_constraint.py
@@ -1,7 +1,8 @@
 from typing import Any
 
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
 from pytest_mock import MockerFixture
+from sqlalchemy import select
 
 from api.extensions import Db
 from api.models import (
@@ -19,10 +20,11 @@ from api.models import (
 from api.operations import CreateAccessRequest, ModifyGroupUsers, ModifyRoleGroups
 from api.services import okta
 from tests.factories import TagFactory
+from tests.helpers import db_count
 
 
-def test_require_reason_modify_group_users(
-    client: TestClient,
+async def test_require_reason_modify_group_users(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     access_app: App,
@@ -53,12 +55,12 @@ def test_require_reason_modify_group_users(
     db.session.add(access_app)
     db.session.add(role_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyRoleGroups(
+    await ModifyRoleGroups(
         role_group=role_group,
         groups_to_add=[
             okta_group.id,
@@ -78,27 +80,41 @@ def test_require_reason_modify_group_users(
     db.session.add(app_tag_map)
     app_tag_map2 = AppTagMap(app_id=access_app.id, tag_id=tags[2].id)
     db.session.add(app_tag_map2)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[1].id, app_tag_map_id=app_tag_map.id))
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id))
-    db.session.commit()
+    await db.session.commit()
 
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    remove_user_from_group_spy = mocker.patch.object(okta, "async_remove_user_from_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
-    remove_owner_from_group_spy = mocker.patch.object(okta, "async_remove_owner_from_group")
+    # Store IDs before requests — constraint-rejection (400) paths roll the
+    # shared session back, expiring instances; expired attributes cannot
+    # lazy-load under the async session.
+    user_id = user.id
+    okta_group_id = okta_group.id
+    app_group_id = app_group.id
+    role_group_id = role_group.id
+
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    remove_user_from_group_spy = mocker.patch.object(okta, "remove_user_from_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
+    remove_owner_from_group_spy = mocker.patch.object(okta, "remove_owner_from_group")
 
     # Establish a baseline of user memberships/ownerships with a created reason
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 0
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
 
@@ -107,36 +123,42 @@ def test_require_reason_modify_group_users(
 
     # Add the user to the okta group as member without a reason
     data: dict[str, Any] = {
-        "members_to_add": [user.id],
+        "members_to_add": [user_id],
         "owners_to_add": [],
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    group_url = url_for("api-groups.group_members_by_id", group_id=okta_group.id)
-    rep = client.put(group_url, json=data)
+    group_url = url_for("api-groups.group_members_by_id", group_id=okta_group_id)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 0
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
 
     # Add the user to the okta group as owner without a reason
     data = {
         "members_to_add": [],
-        "owners_to_add": [user.id],
+        "owners_to_add": [user_id],
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
@@ -148,15 +170,21 @@ def test_require_reason_modify_group_users(
     assert len(data["owners"]) == 1
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 0
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
 
@@ -167,36 +195,42 @@ def test_require_reason_modify_group_users(
 
     # Add the user to the okta group as member and owner without a reason
     data = {
-        "members_to_add": [user.id],
-        "owners_to_add": [user.id],
+        "members_to_add": [user_id],
+        "owners_to_add": [user_id],
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 0
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
 
     # Add the user to the okta group as member and owner with a reason
     data = {
-        "members_to_add": [user.id],
-        "owners_to_add": [user.id],
+        "members_to_add": [user_id],
+        "owners_to_add": [user_id],
         "members_to_remove": [],
         "owners_to_remove": [],
         "created_reason": "test reason",
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -208,15 +242,21 @@ def test_require_reason_modify_group_users(
     assert len(data["owners"]) == 1
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
 
@@ -227,13 +267,13 @@ def test_require_reason_modify_group_users(
 
     # Add the user to the app group as member without a reason
     data = {
-        "members_to_add": [user.id],
+        "members_to_add": [user_id],
         "owners_to_add": [],
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    group_url = url_for("api-groups.group_members_by_id", group_id=app_group.id)
-    rep = client.put(group_url, json=data)
+    group_url = url_for("api-groups.group_members_by_id", group_id=app_group_id)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -245,15 +285,21 @@ def test_require_reason_modify_group_users(
     assert len(data["owners"]) == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
 
@@ -265,58 +311,70 @@ def test_require_reason_modify_group_users(
     # Add the user to the app group as owner without a reason
     data = {
         "members_to_add": [],
-        "owners_to_add": [user.id],
+        "owners_to_add": [user_id],
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
 
     # Add the user to the app group as member and owner without a reason
     data = {
-        "members_to_add": [user.id],
-        "owners_to_add": [user.id],
+        "members_to_add": [user_id],
+        "owners_to_add": [user_id],
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
 
     # Add the user to the app group as member and owner with a reason
     data = {
-        "members_to_add": [user.id],
-        "owners_to_add": [user.id],
+        "members_to_add": [user_id],
+        "owners_to_add": [user_id],
         "members_to_remove": [],
         "owners_to_remove": [],
         "created_reason": "test reason",
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -328,15 +386,21 @@ def test_require_reason_modify_group_users(
     assert len(data["owners"]) == 1
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
 
@@ -347,36 +411,42 @@ def test_require_reason_modify_group_users(
 
     # Add the user to the role group as member without a reason
     data = {
-        "members_to_add": [user.id],
+        "members_to_add": [user_id],
         "owners_to_add": [],
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    group_url = url_for("api-groups.group_members_by_id", group_id=role_group.id)
-    rep = client.put(group_url, json=data)
+    group_url = url_for("api-groups.group_members_by_id", group_id=role_group_id)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
 
     # Add the user to the role group as owner without a reason
     data = {
         "members_to_add": [],
-        "owners_to_add": [user.id],
+        "owners_to_add": [user_id],
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
@@ -388,15 +458,21 @@ def test_require_reason_modify_group_users(
     assert len(data["owners"]) == 1
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
 
@@ -407,36 +483,42 @@ def test_require_reason_modify_group_users(
 
     # Add the user to the role group as member and owner without a reason
     data = {
-        "members_to_add": [user.id],
-        "owners_to_add": [user.id],
+        "members_to_add": [user_id],
+        "owners_to_add": [user_id],
         "members_to_remove": [],
         "owners_to_remove": [],
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
 
     # Add the user to the role group as member and owner with a reason
     data = {
-        "members_to_add": [user.id],
-        "owners_to_add": [user.id],
+        "members_to_add": [user_id],
+        "owners_to_add": [user_id],
         "members_to_remove": [],
         "owners_to_remove": [],
         "created_reason": "test reason",
     }
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 3
     assert remove_user_from_group_spy.call_count == 0
@@ -448,21 +530,27 @@ def test_require_reason_modify_group_users(
     assert len(data["owners"]) == 1
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 10
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
 
 
-def test_require_reason_modify_role_groups(
-    client: TestClient,
+async def test_require_reason_modify_role_groups(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     access_app: App,
@@ -493,12 +581,12 @@ def test_require_reason_modify_role_groups(
     db.session.add(access_app)
     db.session.add(role_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[], sync_to_okta=False).execute()
 
     db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tags[0].id))
     db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tags[2].id))
@@ -507,86 +595,105 @@ def test_require_reason_modify_role_groups(
     db.session.add(app_tag_map)
     app_tag_map2 = AppTagMap(app_id=access_app.id, tag_id=tags[2].id)
     db.session.add(app_tag_map2)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[1].id, app_tag_map_id=app_tag_map.id))
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id))
-    db.session.commit()
+    await db.session.commit()
 
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    remove_user_from_group_spy = mocker.patch.object(okta, "async_remove_user_from_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
-    remove_owner_from_group_spy = mocker.patch.object(okta, "async_remove_owner_from_group")
+    # Store IDs before requests — constraint-rejection (400) paths roll the
+    # shared session back, expiring instances; expired attributes cannot
+    # lazy-load under the async session.
+    okta_group_id = okta_group.id
+    app_group_id = app_group.id
+    role_group_id = role_group.id
+
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    remove_user_from_group_spy = mocker.patch.object(okta, "remove_user_from_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
+    remove_owner_from_group_spy = mocker.patch.object(okta, "remove_owner_from_group")
 
     # Establish a baseline of user memberships/ownerships with a created reason
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 0
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        )
         == 0
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        )
         == 0
     )
 
     # Add the role group as a member to the okta group without a reason
     data: dict[str, Any] = {
-        "groups_to_add": [okta_group.id],
+        "groups_to_add": [okta_group_id],
         "owner_groups_to_add": [],
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    role_url = url_for("api-roles.role_members_by_id", role_id=role_group.id)
-    rep = client.put(role_url, json=data)
+    role_url = url_for("api-roles.role_members_by_id", role_id=role_group_id)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 0
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        )
         == 0
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        )
         == 0
     )
 
     # Add the role group as a owner to the okta group without a reason
     data = {
         "groups_to_add": [],
-        "owner_groups_to_add": [okta_group.id],
+        "owner_groups_to_add": [okta_group_id],
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
 
     assert add_user_to_group_spy.call_count == 0
@@ -594,27 +701,33 @@ def test_require_reason_modify_role_groups(
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 0
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        )
         == 0
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        )
         == 1
     )
 
@@ -625,36 +738,42 @@ def test_require_reason_modify_role_groups(
 
     # Add the role group as a member and owner to the okta group without a reason
     data = {
-        "groups_to_add": [okta_group.id],
-        "owner_groups_to_add": [okta_group.id],
+        "groups_to_add": [okta_group_id],
+        "owner_groups_to_add": [okta_group_id],
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 0
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        )
         == 0
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        )
         == 1
     )
 
@@ -665,13 +784,13 @@ def test_require_reason_modify_role_groups(
 
     # Add the role group as a member to the okta group with a reason
     data = {
-        "groups_to_add": [okta_group.id],
+        "groups_to_add": [okta_group_id],
         "owner_groups_to_add": [],
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
         "created_reason": "test reason",
     }
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
 
     assert add_user_to_group_spy.call_count == 1
@@ -680,27 +799,33 @@ def test_require_reason_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        )
         == 1
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        )
         == 1
     )
 
@@ -712,12 +837,12 @@ def test_require_reason_modify_role_groups(
     # Add the role group as a owner to the okta group with a reason
     data = {
         "groups_to_add": [],
-        "owner_groups_to_add": [okta_group.id],
+        "owner_groups_to_add": [okta_group_id],
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
         "created_reason": "test reason",
     }
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
 
     assert add_user_to_group_spy.call_count == 0
@@ -726,27 +851,33 @@ def test_require_reason_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        )
         == 0
     )
 
@@ -757,13 +888,13 @@ def test_require_reason_modify_role_groups(
 
     # Add the role group as a member and owner to the okta group with a reason
     data = {
-        "groups_to_add": [okta_group.id],
-        "owner_groups_to_add": [okta_group.id],
+        "groups_to_add": [okta_group_id],
+        "owner_groups_to_add": [okta_group_id],
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
         "created_reason": "test reason",
     }
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
 
     assert add_user_to_group_spy.call_count == 1
@@ -772,27 +903,33 @@ def test_require_reason_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        )
         == 0
     )
 
@@ -803,12 +940,12 @@ def test_require_reason_modify_role_groups(
 
     # Add the role group as a member to the app group without a reason
     data = {
-        "groups_to_add": [app_group.id],
+        "groups_to_add": [app_group_id],
         "owner_groups_to_add": [],
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -816,27 +953,33 @@ def test_require_reason_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        )
         == 1
     )
 
@@ -848,82 +991,94 @@ def test_require_reason_modify_role_groups(
     # Add the role group as a owner to the app group without a reason
     data = {
         "groups_to_add": [],
-        "owner_groups_to_add": [app_group.id],
+        "owner_groups_to_add": [app_group_id],
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        )
         == 1
     )
 
     # Add the role group as a member and owner to the app group without a reason
     data = {
-        "groups_to_add": [app_group.id],
-        "owner_groups_to_add": [app_group.id],
+        "groups_to_add": [app_group_id],
+        "owner_groups_to_add": [app_group_id],
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
     }
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        )
         == 1
     )
 
     # Add the role group as a member to the app group with a reason
     data = {
-        "groups_to_add": [app_group.id],
+        "groups_to_add": [app_group_id],
         "owner_groups_to_add": [],
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
         "created_reason": "test reason",
     }
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
 
     assert add_user_to_group_spy.call_count == 1
@@ -932,27 +1087,33 @@ def test_require_reason_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        )
         == 3
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        )
         == 0
     )
 
@@ -964,12 +1125,12 @@ def test_require_reason_modify_role_groups(
     # Add the role group as a owner to the app group with a reason
     data = {
         "groups_to_add": [],
-        "owner_groups_to_add": [app_group.id],
+        "owner_groups_to_add": [app_group_id],
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
         "created_reason": "test reason",
     }
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
 
     assert add_user_to_group_spy.call_count == 0
@@ -978,27 +1139,33 @@ def test_require_reason_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        )
         == 4
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        )
         == 0
     )
 
@@ -1009,13 +1176,13 @@ def test_require_reason_modify_role_groups(
 
     # Add the role group as a member and owner to the app group with a reason
     data = {
-        "groups_to_add": [app_group.id],
-        "owner_groups_to_add": [app_group.id],
+        "groups_to_add": [app_group_id],
+        "owner_groups_to_add": [app_group_id],
         "groups_to_remove": [],
         "owner_groups_to_remove": [],
         "created_reason": "test reason",
     }
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
 
     assert add_user_to_group_spy.call_count == 1
@@ -1024,33 +1191,39 @@ def test_require_reason_modify_role_groups(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason != "", RoleGroupMap.ended_at.is_(None))
+        )
         == 4
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.created_reason == "", RoleGroupMap.ended_at.is_(None))
+        )
         == 0
     )
 
 
-def test_require_reason_approve_access_request(
-    client: TestClient,
+async def test_require_reason_approve_access_request(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     access_app: App,
@@ -1081,12 +1254,12 @@ def test_require_reason_approve_access_request(
     db.session.add(access_app)
     db.session.add(role_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyRoleGroups(
+    await ModifyRoleGroups(
         role_group=role_group,
         groups_to_add=[
             okta_group.id,
@@ -1106,32 +1279,38 @@ def test_require_reason_approve_access_request(
     db.session.add(app_tag_map)
     app_tag_map2 = AppTagMap(app_id=access_app.id, tag_id=tags[2].id)
     db.session.add(app_tag_map2)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[1].id, app_tag_map_id=app_tag_map.id))
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id))
-    db.session.commit()
+    await db.session.commit()
 
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    remove_user_from_group_spy = mocker.patch.object(okta, "async_remove_user_from_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
-    remove_owner_from_group_spy = mocker.patch.object(okta, "async_remove_owner_from_group")
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    remove_user_from_group_spy = mocker.patch.object(okta, "remove_user_from_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
+    remove_owner_from_group_spy = mocker.patch.object(okta, "remove_owner_from_group")
 
     # Establish a baseline of user memberships/ownerships with a created reason
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 0
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
 
     # Approve an access request to the okta group as member and approve without a reason
-    access_request = CreateAccessRequest(
+    access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=okta_group,
         request_ownership=False,
@@ -1139,29 +1318,42 @@ def test_require_reason_approve_access_request(
     ).execute()
 
     db.session.expire_all()
+    # reload async — sync attribute access cannot lazy-load the expired
+    # instance under the async session
+    assert access_request is not None
+    await db.session.refresh(access_request)
 
     data = {"approved": True, "reason": ""}
 
-    assert access_request is not None
     access_request_url = url_for("api-access-requests.access_request_by_id", access_request_id=access_request.id)
-    rep = client.put(access_request_url, json=data)
+    rep = await client.put(access_request_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 0
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
 
     # Approve an access request to the okta group as owner and approve without a reason
-    access_request = CreateAccessRequest(
+    # the PUT above expired the shared session (router db.expire_all());
+    # reload instances async before the operation reads their attributes
+    await db.session.refresh(user)
+    await db.session.refresh(okta_group)
+    access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=okta_group,
         request_ownership=True,
@@ -1170,7 +1362,7 @@ def test_require_reason_approve_access_request(
 
     assert access_request is not None
     access_request_url = url_for("api-access-requests.access_request_by_id", access_request_id=access_request.id)
-    rep = client.put(access_request_url, json=data)
+    rep = await client.put(access_request_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
@@ -1178,15 +1370,21 @@ def test_require_reason_approve_access_request(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 0
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
 
@@ -1196,7 +1394,11 @@ def test_require_reason_approve_access_request(
     remove_owner_from_group_spy.reset_mock()
 
     # Approve an access request to the okta group as member and approve with a reason
-    access_request = CreateAccessRequest(
+    # the PUT above expired the shared session (router db.expire_all());
+    # reload instances async before the operation reads their attributes
+    await db.session.refresh(user)
+    await db.session.refresh(okta_group)
+    access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=okta_group,
         request_ownership=False,
@@ -1207,7 +1409,7 @@ def test_require_reason_approve_access_request(
 
     assert access_request is not None
     access_request_url = url_for("api-access-requests.access_request_by_id", access_request_id=access_request.id)
-    rep = client.put(access_request_url, json=data)
+    rep = await client.put(access_request_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -1215,15 +1417,21 @@ def test_require_reason_approve_access_request(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
 
@@ -1233,7 +1441,11 @@ def test_require_reason_approve_access_request(
     remove_owner_from_group_spy.reset_mock()
 
     # Approve an access request to the okta group as owner and approve with a reason
-    access_request = CreateAccessRequest(
+    # the PUT above expired the shared session (router db.expire_all());
+    # reload instances async before the operation reads their attributes
+    await db.session.refresh(user)
+    await db.session.refresh(okta_group)
+    access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=okta_group,
         request_ownership=True,
@@ -1242,7 +1454,7 @@ def test_require_reason_approve_access_request(
 
     assert access_request is not None
     access_request_url = url_for("api-access-requests.access_request_by_id", access_request_id=access_request.id)
-    rep = client.put(access_request_url, json=data)
+    rep = await client.put(access_request_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
@@ -1250,15 +1462,21 @@ def test_require_reason_approve_access_request(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
 
@@ -1268,7 +1486,11 @@ def test_require_reason_approve_access_request(
     remove_owner_from_group_spy.reset_mock()
 
     # Approve an access request to the app group as member and approve without a reason
-    access_request = CreateAccessRequest(
+    # the PUT above expired the shared session (router db.expire_all());
+    # reload instances async before the operation reads their attributes
+    await db.session.refresh(user)
+    await db.session.refresh(app_group)
+    access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=app_group,
         request_ownership=False,
@@ -1279,7 +1501,7 @@ def test_require_reason_approve_access_request(
 
     assert access_request is not None
     access_request_url = url_for("api-access-requests.access_request_by_id", access_request_id=access_request.id)
-    rep = client.put(access_request_url, json=data)
+    rep = await client.put(access_request_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -1287,15 +1509,21 @@ def test_require_reason_approve_access_request(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
 
@@ -1305,7 +1533,11 @@ def test_require_reason_approve_access_request(
     remove_owner_from_group_spy.reset_mock()
 
     # Approve an access request to the app group as owner and approve without a reason
-    access_request = CreateAccessRequest(
+    # the PUT above expired the shared session (router db.expire_all());
+    # reload instances async before the operation reads their attributes
+    await db.session.refresh(user)
+    await db.session.refresh(app_group)
+    access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=app_group,
         request_ownership=True,
@@ -1314,24 +1546,34 @@ def test_require_reason_approve_access_request(
 
     assert access_request is not None
     access_request_url = url_for("api-access-requests.access_request_by_id", access_request_id=access_request.id)
-    rep = client.put(access_request_url, json=data)
+    rep = await client.put(access_request_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
 
     # Approve an access request to the app group as member and approve with a reason
-    access_request = CreateAccessRequest(
+    # the PUT above expired the shared session (router db.expire_all());
+    # reload instances async before the operation reads their attributes
+    await db.session.refresh(user)
+    await db.session.refresh(app_group)
+    access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=app_group,
         request_ownership=False,
@@ -1342,7 +1584,7 @@ def test_require_reason_approve_access_request(
 
     assert access_request is not None
     access_request_url = url_for("api-access-requests.access_request_by_id", access_request_id=access_request.id)
-    rep = client.put(access_request_url, json=data)
+    rep = await client.put(access_request_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -1350,15 +1592,21 @@ def test_require_reason_approve_access_request(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 3
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
 
@@ -1368,7 +1616,11 @@ def test_require_reason_approve_access_request(
     remove_owner_from_group_spy.reset_mock()
 
     # Approve an access request to the app group as owner and approve with a reason
-    access_request = CreateAccessRequest(
+    # the PUT above expired the shared session (router db.expire_all());
+    # reload instances async before the operation reads their attributes
+    await db.session.refresh(user)
+    await db.session.refresh(app_group)
+    access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=app_group,
         request_ownership=True,
@@ -1377,7 +1629,7 @@ def test_require_reason_approve_access_request(
 
     assert access_request is not None
     access_request_url = url_for("api-access-requests.access_request_by_id", access_request_id=access_request.id)
-    rep = client.put(access_request_url, json=data)
+    rep = await client.put(access_request_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
@@ -1385,15 +1637,21 @@ def test_require_reason_approve_access_request(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
 
@@ -1403,7 +1661,11 @@ def test_require_reason_approve_access_request(
     remove_owner_from_group_spy.reset_mock()
 
     # Approve an access request to the role group as member and approve without a reason
-    access_request = CreateAccessRequest(
+    # the PUT above expired the shared session (router db.expire_all());
+    # reload instances async before the operation reads their attributes
+    await db.session.refresh(user)
+    await db.session.refresh(role_group)
+    access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=role_group,
         request_ownership=False,
@@ -1414,24 +1676,34 @@ def test_require_reason_approve_access_request(
 
     assert access_request is not None
     access_request_url = url_for("api-access-requests.access_request_by_id", access_request_id=access_request.id)
-    rep = client.put(access_request_url, json=data)
+    rep = await client.put(access_request_url, json=data)
     assert rep.status_code == 400
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )
 
     # Approve an access request to the role group as owner and approve without a reason
-    access_request = CreateAccessRequest(
+    # the PUT above expired the shared session (router db.expire_all());
+    # reload instances async before the operation reads their attributes
+    await db.session.refresh(user)
+    await db.session.refresh(role_group)
+    access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=role_group,
         request_ownership=True,
@@ -1440,7 +1712,7 @@ def test_require_reason_approve_access_request(
 
     assert access_request is not None
     access_request_url = url_for("api-access-requests.access_request_by_id", access_request_id=access_request.id)
-    rep = client.put(access_request_url, json=data)
+    rep = await client.put(access_request_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
@@ -1448,15 +1720,21 @@ def test_require_reason_approve_access_request(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
 
@@ -1466,7 +1744,11 @@ def test_require_reason_approve_access_request(
     remove_owner_from_group_spy.reset_mock()
 
     # Approve an access request to the role group as member and approve with a reason
-    access_request = CreateAccessRequest(
+    # the PUT above expired the shared session (router db.expire_all());
+    # reload instances async before the operation reads their attributes
+    await db.session.refresh(user)
+    await db.session.refresh(role_group)
+    access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=role_group,
         request_ownership=False,
@@ -1477,7 +1759,7 @@ def test_require_reason_approve_access_request(
 
     assert access_request is not None
     access_request_url = url_for("api-access-requests.access_request_by_id", access_request_id=access_request.id)
-    rep = client.put(access_request_url, json=data)
+    rep = await client.put(access_request_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 3
     assert remove_user_from_group_spy.call_count == 0
@@ -1485,15 +1767,21 @@ def test_require_reason_approve_access_request(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 9
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 2
     )
 
@@ -1503,7 +1791,11 @@ def test_require_reason_approve_access_request(
     remove_owner_from_group_spy.reset_mock()
 
     # Approve an access request to the role group as owner and approve with a reason
-    access_request = CreateAccessRequest(
+    # the PUT above expired the shared session (router db.expire_all());
+    # reload instances async before the operation reads their attributes
+    await db.session.refresh(user)
+    await db.session.refresh(role_group)
+    access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=role_group,
         request_ownership=True,
@@ -1512,7 +1804,7 @@ def test_require_reason_approve_access_request(
 
     assert access_request is not None
     access_request_url = url_for("api-access-requests.access_request_by_id", access_request_id=access_request.id)
-    rep = client.put(access_request_url, json=data)
+    rep = await client.put(access_request_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
@@ -1520,14 +1812,20 @@ def test_require_reason_approve_access_request(
     assert remove_owner_from_group_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason != "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 10
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.created_reason == "", OktaUserGroupMember.ended_at.is_(None)
+            ),
+        )
         == 1
     )

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -1,10 +1,10 @@
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
 from pytest_mock import MockerFixture
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select
 from api.extensions import Db
 from api.models import (
     AccessRequestStatus,
@@ -20,10 +20,11 @@ from api.auth import permissions as AuthorizationHelpers
 from api.operations import CreateAccessRequest, ModifyGroupUsers, ModifyRoleGroups
 from api.services import okta
 from tests.factories import OktaUserFactory, RoleGroupFactory
+from tests.helpers import db_count
 
 
-def test_get_role(
-    client: TestClient,
+async def test_get_role(
+    client: AsyncClient,
     db: Db,
     role_group: RoleGroup,
     access_app: App,
@@ -34,22 +35,28 @@ def test_get_role(
 ) -> None:
     # test 404
     role_url = url_for("api-roles.role_by_id", role_id="randomid")
-    rep = client.get(role_url)
+    rep = await client.get(role_url)
     assert rep.status_code == 404
 
     db.session.add(access_app)
     db.session.add(okta_group)
     db.session.add(user)
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=app_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyRoleGroups(
+    await ModifyGroupUsers(
+        group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(
+        group=app_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyRoleGroups(
         role_group=role_group,
         groups_to_add=[
             okta_group.id,
@@ -71,75 +78,75 @@ def test_get_role(
 
     # test get role
     role_url = url_for("api-roles.role_by_id", role_id=role_group_id)
-    rep = client.get(role_url)
+    rep = await client.get(role_url)
     assert rep.status_code == 200
 
     data = rep.json()
     assert data["name"] == role_group_name
 
     app_url = url_for("api-roles.role_by_id", role_id=app_group_id)
-    rep = client.get(app_url)
+    rep = await client.get(app_url)
     assert rep.status_code == 404
 
     app_url = url_for("api-roles.role_by_id", role_id=okta_group_id)
-    rep = client.get(app_url)
+    rep = await client.get(app_url)
     assert rep.status_code == 404
 
 
-def test_get_role_prefers_active_after_name_reuse(
-    client: TestClient, db: Db, role_group: RoleGroup, url_for: Any
+async def test_get_role_prefers_active_after_name_reuse(
+    client: AsyncClient, db: Db, role_group: RoleGroup, url_for: Any
 ) -> None:
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
     role_name = role_group.name
     soft_deleted_id = role_group.id
 
     role_group.deleted_at = datetime.now(UTC).replace(tzinfo=None)
-    db.session.commit()
+    await db.session.commit()
 
     new_role = RoleGroupFactory.create(name=role_name)
     db.session.add(new_role)
-    db.session.commit()
+    await db.session.commit()
     active_id = new_role.id
     assert active_id != soft_deleted_id
 
-    rep = client.get(url_for("api-roles.role_by_id", role_id=role_name))
+    rep = await client.get(url_for("api-roles.role_by_id", role_id=role_name))
     assert rep.status_code == 200
     assert rep.json()["id"] == active_id
 
 
-def test_get_role_members_404_when_role_soft_deleted(
-    client: TestClient, db: Db, role_group: RoleGroup, okta_group: OktaGroup, url_for: Any
+async def test_get_role_members_404_when_role_soft_deleted(
+    client: AsyncClient, db: Db, role_group: RoleGroup, okta_group: OktaGroup, url_for: Any
 ) -> None:
     db.session.add(role_group)
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(RoleGroupMap(group_id=okta_group.id, role_group_id=role_group.id))
-    db.session.commit()
+    await db.session.commit()
     role_id = role_group.id
 
     role_group.deleted_at = datetime.now(UTC).replace(tzinfo=None)
-    db.session.commit()
+    await db.session.commit()
 
-    rep = client.get(url_for("api-roles.role_members_by_id", role_id=role_id))
+    rep = await client.get(url_for("api-roles.role_members_by_id", role_id=role_id))
     assert rep.status_code == 404
 
 
-def test_get_role_members(
-    client: TestClient, db: Db, role_group: RoleGroup, okta_group: OktaGroup, url_for: Any
+async def test_get_role_members(
+    client: AsyncClient, db: Db, role_group: RoleGroup, okta_group: OktaGroup, url_for: Any
 ) -> None:
     # test 404
     role_url = url_for("api-roles.role_members_by_id", role_id="randomid")
-    rep = client.get(role_url)
+    rep = await client.get(role_url)
     assert rep.status_code == 404
 
     db.session.add(role_group)
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
 
     # test get role group members
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group.id)
-    rep = client.get(role_url)
+    rep = await client.get(role_url)
     assert rep.status_code == 200
 
     data = rep.json()
@@ -147,10 +154,10 @@ def test_get_role_members(
     assert len(data["groups_owned_by_role"]) == 0
 
     db.session.add(RoleGroupMap(group_id=okta_group.id, role_group_id=role_group.id))
-    db.session.commit()
+    await db.session.commit()
 
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group.id)
-    rep = client.get(role_url)
+    rep = await client.get(role_url)
     assert rep.status_code == 200
 
     data = rep.json()
@@ -159,10 +166,10 @@ def test_get_role_members(
     assert len(data["groups_owned_by_role"]) == 0
 
     db.session.add(RoleGroupMap(group_id=okta_group.id, role_group_id=role_group.id, is_owner=True))
-    db.session.commit()
+    await db.session.commit()
 
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group.id)
-    rep = client.get(role_url)
+    rep = await client.get(role_url)
     assert rep.status_code == 200
 
     data = rep.json()
@@ -172,8 +179,8 @@ def test_get_role_members(
     assert data["groups_owned_by_role"][0] == okta_group.id
 
 
-def test_put_role_members(
-    client: TestClient,
+async def test_put_role_members(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     role_group: RoleGroup,
@@ -183,23 +190,23 @@ def test_put_role_members(
 ) -> None:
     # test 404
     role_url = url_for("api-roles.role_members_by_id", role_id="randomid")
-    rep = client.put(role_url)
+    rep = await client.put(role_url)
     assert rep.status_code == 404
 
     db.session.add(role_group)
     db.session.add(okta_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[], sync_to_okta=False).execute()
 
-    membership_access_request = CreateAccessRequest(
+    membership_access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=okta_group,
         request_ownership=False,
         request_reason="test reason",
     ).execute()
-    ownership_access_request = CreateAccessRequest(
+    ownership_access_request = await CreateAccessRequest(
         requester_user=user,
         requested_group=okta_group,
         request_ownership=True,
@@ -208,10 +215,10 @@ def test_put_role_members(
     assert membership_access_request is not None
     assert ownership_access_request is not None
 
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    remove_user_from_group_spy = mocker.patch.object(okta, "async_remove_user_from_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
-    remove_owner_from_group_spy = mocker.patch.object(okta, "async_remove_owner_from_group")
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    remove_user_from_group_spy = mocker.patch.object(okta, "remove_user_from_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
+    remove_owner_from_group_spy = mocker.patch.object(okta, "remove_owner_from_group")
 
     # test put role group members
     data: dict[str, Any] = {
@@ -221,7 +228,7 @@ def test_put_role_members(
         "owner_groups_to_remove": [],
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group.id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
@@ -247,7 +254,7 @@ def test_put_role_members(
         "owner_groups_to_remove": [],
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group.id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -276,7 +283,7 @@ def test_put_role_members(
         "owner_groups_to_remove": [],
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group.id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
@@ -304,7 +311,7 @@ def test_put_role_members(
         "owner_groups_to_remove": [],
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group.id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 1
@@ -331,7 +338,7 @@ def test_put_role_members(
         "owner_groups_to_remove": [okta_group.id],
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group.id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
@@ -347,21 +354,21 @@ def test_put_role_members(
     assert ownership_access_request.approved_membership_id is not None
 
 
-def test_get_all_role(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_get_all_role(client: AsyncClient, db: Db, url_for: Any) -> None:
     groups_url = url_for("api-roles.roles")
     groups = RoleGroupFactory.create_batch(10)
 
     db.session.add_all(groups)
-    db.session.commit()
+    await db.session.commit()
 
-    rep = client.get(groups_url)
+    rep = await client.get(groups_url)
     assert rep.status_code == 200
 
     results = rep.json()
     for group in groups:
         assert any(u["id"] == group.id for u in results["items"])
 
-    rep = client.get(groups_url, params={"q": "r"})
+    rep = await client.get(groups_url, params={"q": "r"})
     assert rep.status_code == 200
 
     results = rep.json()
@@ -369,8 +376,8 @@ def test_get_all_role(client: TestClient, db: Db, url_for: Any) -> None:
         assert any(u["id"] == group.id for u in results["items"])
 
 
-def test_complex_role_modifications(
-    client: TestClient,
+async def test_complex_role_modifications(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     okta_group: OktaGroup,
@@ -383,7 +390,7 @@ def test_complex_role_modifications(
     db.session.add(role_group)
     db.session.add(access_app)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     # Store IDs before requests — expunge_all() in ModifyGroupType can
     # detach fixture objects, causing DetachedInstanceError on access.
@@ -391,10 +398,10 @@ def test_complex_role_modifications(
     okta_group_id = okta_group.id
     role_group_id = role_group.id
 
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    remove_user_from_group_spy = mocker.patch.object(okta, "async_remove_user_from_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
-    remove_owner_from_group_spy = mocker.patch.object(okta, "async_remove_owner_from_group")
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    remove_user_from_group_spy = mocker.patch.object(okta, "remove_user_from_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
+    remove_owner_from_group_spy = mocker.patch.object(okta, "remove_owner_from_group")
 
     # Add user to okta group and role group
     data: dict[str, Any] = {
@@ -404,13 +411,13 @@ def test_complex_role_modifications(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=okta_group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 2
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 2
 
     data = rep.json()
     assert len(data["members"]) == 1
@@ -428,13 +435,13 @@ def test_complex_role_modifications(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=role_group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 3
 
     data = rep.json()
     assert len(data["members"]) == 1
@@ -453,13 +460,13 @@ def test_complex_role_modifications(
         "owner_groups_to_remove": [],
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group_id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 4
 
     data = rep.json()
     assert len(data["groups_in_role"]) == 1
@@ -478,14 +485,14 @@ def test_complex_role_modifications(
         "owner_groups_to_remove": [],
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group_id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     # The user is still in the okta group, so they shouldn't be removed
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 3
 
     data = rep.json()
     assert len(data["groups_in_role"]) == 0
@@ -503,13 +510,13 @@ def test_complex_role_modifications(
         "owner_groups_to_remove": [],
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group_id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 4
 
     data = rep.json()
     assert len(data["groups_in_role"]) == 1
@@ -528,7 +535,7 @@ def test_complex_role_modifications(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=role_group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     # The user is still in the okta group, so they shouldn't be removed
@@ -536,7 +543,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 1
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 2
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 2
 
     data = rep.json()
     assert len(data["members"]) == 0
@@ -554,13 +561,13 @@ def test_complex_role_modifications(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=role_group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 2
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 4
 
     data = rep.json()
     assert len(data["members"]) == 1
@@ -579,13 +586,13 @@ def test_complex_role_modifications(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=okta_group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 5
 
     data = rep.json()
     assert len(data["members"]) == 1
@@ -604,13 +611,13 @@ def test_complex_role_modifications(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=role_group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 6
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 6
 
     data = rep.json()
     assert len(data["members"]) == 1
@@ -630,13 +637,13 @@ def test_complex_role_modifications(
         "owner_groups_to_remove": [],
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group_id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 7
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 7
 
     data = rep.json()
     assert len(data["groups_in_role"]) == 1
@@ -657,13 +664,13 @@ def test_complex_role_modifications(
         "owner_groups_to_remove": [okta_group_id],
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group_id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 6
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 6
 
     data = rep.json()
     assert len(data["groups_in_role"]) == 1
@@ -682,13 +689,13 @@ def test_complex_role_modifications(
         "owner_groups_to_remove": [],
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group_id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 7
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 7
 
     data = rep.json()
     assert len(data["groups_in_role"]) == 1
@@ -708,13 +715,13 @@ def test_complex_role_modifications(
         "owners_to_remove": [user_id],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=role_group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 1
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 6
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 6
 
     data = rep.json()
     assert len(data["members"]) == 1
@@ -733,13 +740,13 @@ def test_complex_role_modifications(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=role_group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 7
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 7
 
     data = rep.json()
     assert len(data["members"]) == 1
@@ -759,7 +766,7 @@ def test_complex_role_modifications(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=role_group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     # The user is still in the okta group, so they shouldn't be removed
@@ -767,7 +774,7 @@ def test_complex_role_modifications(
     assert remove_user_from_group_spy.call_count == 1
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 4
 
     data = rep.json()
     assert len(data["members"]) == 0
@@ -786,13 +793,13 @@ def test_complex_role_modifications(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=role_group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 2
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 7
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 7
 
     data = rep.json()
     assert len(data["members"]) == 1
@@ -817,14 +824,14 @@ def test_complex_role_modifications(
 
     group_id = role_group_id
     group_url = url_for("api-groups.group_by_id", group_id=group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
     assert update_group_spy.call_count == 1
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 5
 
     data = rep.json()
     assert data["type"] == "app_group"
@@ -832,7 +839,7 @@ def test_complex_role_modifications(
     assert data["description"] == "new description app_group"
     assert data["id"] == group_id
 
-    app_group = db.session.get(AppGroup, group_id)
+    app_group = await db.session.get(AppGroup, group_id)
 
     # Modify group type back to role group
     add_user_to_group_spy.reset_mock()
@@ -851,14 +858,14 @@ def test_complex_role_modifications(
 
     group_id = app_group.id
     group_url = url_for("api-groups.group_by_id", group_id=group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
     assert update_group_spy.call_count == 1
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 5
 
     data = rep.json()
     assert data["type"] == "role_group"
@@ -866,8 +873,8 @@ def test_complex_role_modifications(
     assert data["description"] == "new description role_group"
     assert data["id"] == group_id
 
-    role_group = db.session.get(RoleGroup, group_id)
-    okta_group = db.session.get(OktaGroup, okta_group_id)
+    role_group = await db.session.get(RoleGroup, group_id)
+    okta_group = await db.session.get(OktaGroup, okta_group_id)
 
     # Add the role group back as a member and owner of the okta group, for a limited time
     add_user_to_group_spy.reset_mock()
@@ -882,14 +889,14 @@ def test_complex_role_modifications(
         "groups_added_ending_at": datetime.now(UTC) + timedelta(days=3),
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group_id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at > func.now()).count() == 2
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 5
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at > func.now())) == 2
 
     data = rep.json()
     assert len(data["groups_in_role"]) == 1
@@ -911,30 +918,32 @@ def test_complex_role_modifications(
         "users_added_ending_at": datetime.now(UTC) + timedelta(days=1),
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=role_group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 2
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 4
     # User should only be added for the length of their membership to the role group
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > func.now(),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=2)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > func.now(),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=2)),
+            ),
         )
-        .count()
         == 3
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 0
     )
 
@@ -952,31 +961,33 @@ def test_complex_role_modifications(
         "users_added_ending_at": datetime.now(UTC) + timedelta(days=7),
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=role_group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 2
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 4
     # User should be added for the length of the okta group membership to the role group
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 2
     )
     # User should only be added for the length of their membership to the role group
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+            ),
         )
-        .count()
         == 1
     )
 
@@ -998,21 +1009,22 @@ def test_complex_role_modifications(
         "owner_groups_to_remove": [],
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group_id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 4
     # User should only be in associated groups for the length of their membership to the role group
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+            ),
         )
-        .count()
         == 3
     )
 
@@ -1035,21 +1047,22 @@ def test_complex_role_modifications(
         "users_added_ending_at": datetime.now(UTC) + timedelta(days=5),
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=role_group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 2
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 4
     # User should only be in associated groups for the length of their membership to the role group
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=4)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=6)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=4)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=6)),
+            ),
         )
-        .count()
         == 3
     )
 
@@ -1073,21 +1086,22 @@ def test_complex_role_modifications(
         "groups_added_ending_at": datetime.now(UTC) + timedelta(days=14),
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group_id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 4
     # User should only be in associated groups for the length of their membership to the role group
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=4)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=6)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=4)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=6)),
+            ),
         )
-        .count()
         == 3
     )
 
@@ -1111,31 +1125,33 @@ def test_complex_role_modifications(
         "groups_added_ending_at": datetime.now(UTC) + timedelta(days=3),
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group_id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 4
     # User should only be in associated groups for the length of their membership to the role group
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=4)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=6)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=4)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=6)),
+            ),
         )
-        .count()
         == 1
     )
     # User should be added for the length of the okta group membership to the role group
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 2
     )
 
@@ -1157,21 +1173,22 @@ def test_complex_role_modifications(
         "owners_to_remove": [],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=role_group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 2
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 5
     # User should only be in associated groups for the length of their membership to the role group
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 2
     )
 
@@ -1193,13 +1210,13 @@ def test_complex_role_modifications(
         "owner_groups_to_remove": [],
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group_id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 7
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 7
 
     data = rep.json()
     assert len(data["groups_in_role"]) == 1
@@ -1219,13 +1236,13 @@ def test_complex_role_modifications(
         "owners_to_remove": [user_id],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=okta_group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 5
 
     data = rep.json()
     assert len(data["members"]) == 1
@@ -1248,14 +1265,14 @@ def test_complex_role_modifications(
     }
 
     group_url = url_for("api-groups.group_by_id", group_id=okta_group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
     assert update_group_spy.call_count == 1
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 5
 
     data = rep.json()
     assert data["type"] == "role_group"
@@ -1278,14 +1295,14 @@ def test_complex_role_modifications(
     }
 
     group_url = url_for("api-groups.group_by_id", group_id=okta_group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
     assert update_group_spy.call_count == 1
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 5
 
     data = rep.json()
     assert data["type"] == "okta_group"
@@ -1305,13 +1322,13 @@ def test_complex_role_modifications(
         "owner_groups_to_remove": [],
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group_id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 7
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 7
 
     data = rep.json()
     assert len(data["groups_in_role"]) == 1
@@ -1331,13 +1348,13 @@ def test_complex_role_modifications(
         "owners_to_remove": [user_id],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=okta_group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 5
 
     data = rep.json()
     assert len(data["members"]) == 1
@@ -1351,26 +1368,29 @@ def test_complex_role_modifications(
     remove_user_from_group_spy.reset_mock()
     add_owner_to_group_spy.reset_mock()
     remove_owner_from_group_spy.reset_mock()
-    delete_group_spy = mocker.patch.object(okta, "async_delete_group")
+    delete_group_spy = mocker.patch.object(okta, "delete_group")
 
     group_url = url_for("api-groups.group_by_id", group_id=role_group_id)
-    rep = client.delete(group_url)
+    rep = await client.delete(group_url)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 1
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 1
     assert delete_group_spy.call_count == 1
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
-    assert db.session.get(OktaGroup, group_id).deleted_at is not None
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 1
+    # The shared app/test session holds a stale identity-map entry for the
+    # deleted group; expire it so the awaited get() refreshes it async.
+    db.session.expire_all()
+    assert (await db.session.get(OktaGroup, group_id)).deleted_at is not None
 
 
 # Do not renew functionality test
 # Since this field is only for expiring access, there are no checks for it anywhere in the API (only in the front end).
 # Test is just to make sure the field is set correctly
-def test_do_not_renew(
+async def test_do_not_renew(
     db: Db,
-    client: TestClient,
+    client: AsyncClient,
     mocker: MockerFixture,
     role_group: RoleGroup,
     okta_group: OktaGroup,
@@ -1379,14 +1399,14 @@ def test_do_not_renew(
 ) -> None:
     db.session.add(okta_group)
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
 
     expiration_datetime = datetime.now() + timedelta(days=1)
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=role_group, users_added_ended_at=expiration_datetime, members_to_add=[user.id], sync_to_okta=False
     ).execute()
-    ModifyRoleGroups(
+    await ModifyRoleGroups(
         role_group=role_group,
         groups_added_ended_at=expiration_datetime,
         groups_to_add=[okta_group.id],
@@ -1394,13 +1414,15 @@ def test_do_not_renew(
     ).execute()
 
     # need the RoleGroupMap id to pass in later
-    role_group_map = db.session.query(RoleGroupMap).filter(RoleGroupMap.role_group_id == role_group.id).first()
+    role_group_map = (
+        await db.session.scalars(select(RoleGroupMap).where(RoleGroupMap.role_group_id == role_group.id))
+    ).first()
 
     # set one user to renew and one do not renew
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    remove_user_from_group_spy = mocker.patch.object(okta, "async_remove_user_from_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
-    remove_owner_from_group_spy = mocker.patch.object(okta, "async_remove_owner_from_group")
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    remove_user_from_group_spy = mocker.patch.object(okta, "remove_user_from_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
+    remove_owner_from_group_spy = mocker.patch.object(okta, "remove_owner_from_group")
 
     data: dict[str, Any] = {
         "groups_to_add": [],
@@ -1411,7 +1433,7 @@ def test_do_not_renew(
         "owner_groups_to_remove": [],
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group.id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
@@ -1425,24 +1447,25 @@ def test_do_not_renew(
 
     # get OktaUserGroupMembers, check expiration dates and should_expire
     membership_role = (
-        db.session.query(RoleGroupMap)
-        .filter(
-            or_(
-                RoleGroupMap.ended_at.is_(None),
-                RoleGroupMap.ended_at > func.now(),
+        await db.session.scalars(
+            select(RoleGroupMap)
+            .where(
+                or_(
+                    RoleGroupMap.ended_at.is_(None),
+                    RoleGroupMap.ended_at > func.now(),
+                )
             )
+            .where(RoleGroupMap.role_group_id == role_group.id)
         )
-        .filter(RoleGroupMap.role_group_id == role_group.id)
-        .all()
-    )
+    ).all()
 
     assert len(membership_role) == 1
     assert membership_role[0].ended_at == expiration_datetime
     assert membership_role[0].should_expire is True
 
 
-def test_do_not_renew_scoped_to_route_role(
-    db: Db, client: TestClient, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser, url_for: Any
+async def test_do_not_renew_scoped_to_route_role(
+    db: Db, client: AsyncClient, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser, url_for: Any
 ) -> None:
     victim_role = RoleGroupFactory.create()
     victim_okta_group = OktaGroup(
@@ -1456,27 +1479,29 @@ def test_do_not_renew_scoped_to_route_role(
     db.session.add(victim_role)
     db.session.add(victim_okta_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     expiration_datetime = datetime.now() + timedelta(days=1)
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=role_group, users_added_ended_at=expiration_datetime, members_to_add=[user.id], sync_to_okta=False
     ).execute()
-    ModifyRoleGroups(
+    await ModifyRoleGroups(
         role_group=role_group,
         groups_added_ended_at=expiration_datetime,
         groups_to_add=[okta_group.id],
         sync_to_okta=False,
     ).execute()
-    ModifyRoleGroups(
+    await ModifyRoleGroups(
         role_group=victim_role,
         groups_added_ended_at=expiration_datetime,
         groups_to_add=[victim_okta_group.id],
         sync_to_okta=False,
     ).execute()
 
-    victim_map = db.session.query(RoleGroupMap).filter(RoleGroupMap.role_group_id == victim_role.id).first()
+    victim_map = (
+        await db.session.scalars(select(RoleGroupMap).where(RoleGroupMap.role_group_id == victim_role.id))
+    ).first()
     assert victim_map is not None
 
     data: dict[str, Any] = {
@@ -1488,16 +1513,16 @@ def test_do_not_renew_scoped_to_route_role(
         "owner_groups_to_remove": [],
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group.id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
 
-    db.session.refresh(victim_map)
+    await db.session.refresh(victim_map)
     assert victim_map.should_expire is False
 
 
-def test_do_not_renew_requires_group_ownership(
+async def test_do_not_renew_requires_group_ownership(
     db: Db,
-    client: TestClient,
+    client: AsyncClient,
     mocker: MockerFixture,
     role_group: RoleGroup,
     okta_group: OktaGroup,
@@ -1507,21 +1532,23 @@ def test_do_not_renew_requires_group_ownership(
     db.session.add(role_group)
     db.session.add(okta_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     expiration_datetime = datetime.now() + timedelta(days=1)
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=role_group, users_added_ended_at=expiration_datetime, members_to_add=[user.id], sync_to_okta=False
     ).execute()
-    ModifyRoleGroups(
+    await ModifyRoleGroups(
         role_group=role_group,
         groups_added_ended_at=expiration_datetime,
         groups_to_add=[okta_group.id],
         sync_to_okta=False,
     ).execute()
 
-    role_group_map = db.session.query(RoleGroupMap).filter(RoleGroupMap.role_group_id == role_group.id).first()
+    role_group_map = (
+        await db.session.scalars(select(RoleGroupMap).where(RoleGroupMap.role_group_id == role_group.id))
+    ).first()
     assert role_group_map is not None
 
     # User is not an admin and not an owner of the group in the mapping
@@ -1537,14 +1564,14 @@ def test_do_not_renew_requires_group_ownership(
         "owner_groups_to_remove": [],
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group.id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 403
 
-    db.session.refresh(role_group_map)
+    await db.session.refresh(role_group_map)
     assert role_group_map.should_expire is False
 
 
-def test_role_list_owner_id_filter(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_role_list_owner_id_filter(client: AsyncClient, db: Db, url_for: Any) -> None:
     """`?owner_id=<user>` and `?owner_id=@me` filter /api/roles to the
     roles owned by that user. Flask had this; the FastAPI port previously
     only honored `q`."""
@@ -1557,22 +1584,22 @@ def test_role_list_owner_id_filter(client: TestClient, db: Db, url_for: Any) -> 
     role_a = RoleGroupFactory.create()
     role_b = RoleGroupFactory.create()
     db.session.add_all([owner, other, role_a, role_b])
-    db.session.commit()
+    await db.session.commit()
     end = datetime.now(timezone.utc) + timedelta(days=30)
     db.session.add(_OUGM(user_id=owner.id, group_id=role_a.id, is_owner=True, ended_at=end))
     db.session.add(_OUGM(user_id=other.id, group_id=role_b.id, is_owner=True, ended_at=end))
-    db.session.commit()
+    await db.session.commit()
 
     list_url = url_for("api-roles.roles")
-    rep = client.get(list_url, params={"owner_id": owner.id})
+    rep = await client.get(list_url, params={"owner_id": owner.id})
     assert rep.status_code == 200
     ids = [r["id"] for r in rep.json()["items"]]
     assert role_a.id in ids
     assert role_b.id not in ids
 
 
-def test_put_role_members_rejects_role_in_role(
-    client: TestClient,
+async def test_put_role_members_rejects_role_in_role(
+    client: AsyncClient,
     db: Db,
     role_group: RoleGroup,
     url_for: Any,
@@ -1581,15 +1608,19 @@ def test_put_role_members_rejects_role_in_role(
     inner_role = RoleGroupFactory.create()
     db.session.add(role_group)
     db.session.add(inner_role)
-    db.session.commit()
+    await db.session.commit()
+
+    # Store the ID before requests — the 400 response path rolls back the
+    # shared session, expiring inner_role and breaking sync attribute access.
+    inner_role_id = inner_role.id
 
     role_url = url_for("api-roles.role_members_by_id_put", role_id=role_group.id)
 
     # As member
-    rep = client.put(
+    rep = await client.put(
         role_url,
         json={
-            "groups_to_add": [inner_role.id],
+            "groups_to_add": [inner_role_id],
             "owner_groups_to_add": [],
             "groups_to_remove": [],
             "owner_groups_to_remove": [],
@@ -1599,11 +1630,11 @@ def test_put_role_members_rejects_role_in_role(
     assert "Roles cannot be added to other Roles" in rep.text
 
     # As owner
-    rep = client.put(
+    rep = await client.put(
         role_url,
         json={
             "groups_to_add": [],
-            "owner_groups_to_add": [inner_role.id],
+            "owner_groups_to_add": [inner_role_id],
             "groups_to_remove": [],
             "owner_groups_to_remove": [],
         },
@@ -1612,15 +1643,15 @@ def test_put_role_members_rejects_role_in_role(
     assert "Roles cannot be added to other Roles" in rep.text
 
 
-def test_put_role_members_rejects_short_group_id(
-    client: TestClient, db: Db, role_group: RoleGroup, url_for: Any
+async def test_put_role_members_rejects_short_group_id(
+    client: AsyncClient, db: Db, role_group: RoleGroup, url_for: Any
 ) -> None:
     """Each group id must be exactly 20 characters wide. Pydantic enforces
     the constraint at the request boundary."""
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
     role_url = url_for("api-roles.role_members_by_id_put", role_id=role_group.id)
-    rep = client.put(
+    rep = await client.put(
         role_url,
         json={
             "groups_to_add": ["short"],
@@ -1634,26 +1665,28 @@ def test_put_role_members_rejects_short_group_id(
     assert rep.status_code == 400
 
 
-def test_put_role_members_rejects_missing_required_lists(
-    client: TestClient, db: Db, role_group: RoleGroup, url_for: Any
+async def test_put_role_members_rejects_missing_required_lists(
+    client: AsyncClient, db: Db, role_group: RoleGroup, url_for: Any
 ) -> None:
     """`groups_to_add`, `groups_to_remove`, `owner_groups_to_add`, and
     `owner_groups_to_remove` are required fields on the request body. The
     Pydantic schema must reject a body that omits them entirely."""
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
     role_url = url_for("api-roles.role_members_by_id_put", role_id=role_group.id)
-    rep = client.put(role_url, json={})
+    rep = await client.put(role_url, json={})
     # The project's exception handler maps Pydantic validation errors to 400
     # (not the FastAPI default 422) — see `api/exception_handlers.py`.
     assert rep.status_code == 400
 
 
-def test_put_role_members_missing_body_400(client: TestClient, db: Db, role_group: RoleGroup, url_for: Any) -> None:
+async def test_put_role_members_missing_body_400(
+    client: AsyncClient, db: Db, role_group: RoleGroup, url_for: Any
+) -> None:
     """No body at all returns 400 (matches groups.py PUT members shape).
     Regression guard for the dropped `RoleMember()` substitution path."""
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
     role_url = url_for("api-roles.role_members_by_id_put", role_id=role_group.id)
-    rep = client.put(role_url)
+    rep = await client.put(role_url)
     assert rep.status_code == 400

--- a/tests/test_role_memberships_fix.py
+++ b/tests/test_role_memberships_fix.py
@@ -1,14 +1,16 @@
 from datetime import UTC, datetime, timedelta
 
 from pytest_mock import MockerFixture
+from sqlalchemy import select
 
 from api.integrity import verify_and_fix_role_memberships
 from api.extensions import Db
 from api.models import OktaGroup, OktaUser, OktaUserGroupMember, RoleGroup, RoleGroupMap
 from api.services import okta
+from tests.helpers import db_count
 
 
-def test_missing_user_from_group_membership(
+async def test_missing_user_from_group_membership(
     db: Db, mocker: MockerFixture, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser
 ) -> None:
     db.session.add(user)
@@ -19,33 +21,37 @@ def test_missing_user_from_group_membership(
     db.session.add(member_role_group_map)
     owner_role_group_map = RoleGroupMap(role_group_id=role_group.id, group_id=okta_group.id, is_owner=True)
     db.session.add(owner_role_group_map)
-    db.session.commit()
+    await db.session.commit()
 
     add_membership_spy = mocker.patch.object(okta, "add_user_to_group")
     add_ownership_spy = mocker.patch.object(okta, "add_owner_to_group")
 
-    verify_and_fix_role_memberships()
+    await verify_and_fix_role_memberships()
 
     assert add_membership_spy.call_count == 1
     assert add_ownership_spy.call_count == 1
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
-        .filter(OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
+            .where(OktaUserGroupMember.ended_at.is_(None)),
+        )
         == 1
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
-        .filter(OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
+            .where(OktaUserGroupMember.ended_at.is_(None)),
+        )
         == 1
     )
 
 
-def test_missing_user_from_group_membership_with_expiring_role_membership(
+async def test_missing_user_from_group_membership_with_expiring_role_membership(
     db: Db, mocker: MockerFixture, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser
 ) -> None:
     db.session.add(user)
@@ -58,53 +64,61 @@ def test_missing_user_from_group_membership_with_expiring_role_membership(
     db.session.add(member_role_group_map)
     owner_role_group_map = RoleGroupMap(role_group_id=role_group.id, group_id=okta_group.id, is_owner=True)
     db.session.add(owner_role_group_map)
-    db.session.commit()
+    await db.session.commit()
 
     add_membership_spy = mocker.patch.object(okta, "add_user_to_group")
     add_ownership_spy = mocker.patch.object(okta, "add_owner_to_group")
 
-    verify_and_fix_role_memberships()
+    await verify_and_fix_role_memberships()
 
     assert add_membership_spy.call_count == 1
     assert add_ownership_spy.call_count == 1
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=1)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=3)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
+            .where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=1)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=3)),
+            ),
         )
-        .count()
         == 1
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=1)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=3)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
+            .where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=1)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=3)),
+            ),
         )
-        .count()
         == 1
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
-        .filter(OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
+            .where(OktaUserGroupMember.ended_at.is_(None)),
+        )
         == 0
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
-        .filter(OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
+            .where(OktaUserGroupMember.ended_at.is_(None)),
+        )
         == 0
     )
 
 
-def test_missing_user_from_group_membership_with_expiring_role_assignment(
+async def test_missing_user_from_group_membership_with_expiring_role_assignment(
     db: Db, mocker: MockerFixture, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser
 ) -> None:
     db.session.add(user)
@@ -127,7 +141,7 @@ def test_missing_user_from_group_membership_with_expiring_role_assignment(
         ended_at=datetime.now(UTC) + timedelta(days=6),
     )
     db.session.add(owner_role_group_map)
-    db.session.commit()
+    await db.session.commit()
 
     # drop identity-map state staled by the ops above (expire_on_commit=False)
     db.session.expire_all()
@@ -135,48 +149,56 @@ def test_missing_user_from_group_membership_with_expiring_role_assignment(
     add_membership_spy = mocker.patch.object(okta, "add_user_to_group")
     add_ownership_spy = mocker.patch.object(okta, "add_owner_to_group")
 
-    verify_and_fix_role_memberships()
+    await verify_and_fix_role_memberships()
 
     assert add_membership_spy.call_count == 1
     assert add_ownership_spy.call_count == 1
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=1)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=3)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
+            .where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=1)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=3)),
+            ),
         )
-        .count()
         == 1
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=3)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=5)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
+            .where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=3)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=5)),
+            ),
         )
-        .count()
         == 1
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
-        .filter(OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
+            .where(OktaUserGroupMember.ended_at.is_(None)),
+        )
         == 0
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
-        .filter(OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
+            .where(OktaUserGroupMember.ended_at.is_(None)),
+        )
         == 0
     )
 
 
-def test_missing_user_from_group_membership_with_both_expiring(
+async def test_missing_user_from_group_membership_with_both_expiring(
     db: Db, mocker: MockerFixture, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser
 ) -> None:
     db.session.add(user)
@@ -197,53 +219,61 @@ def test_missing_user_from_group_membership_with_both_expiring(
         ended_at=datetime.now(UTC) + timedelta(days=4),
     )
     db.session.add(owner_role_group_map)
-    db.session.commit()
+    await db.session.commit()
 
     add_membership_spy = mocker.patch.object(okta, "add_user_to_group")
     add_ownership_spy = mocker.patch.object(okta, "add_owner_to_group")
 
-    verify_and_fix_role_memberships()
+    await verify_and_fix_role_memberships()
 
     assert add_membership_spy.call_count == 1
     assert add_ownership_spy.call_count == 1
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=1)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=3)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
+            .where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=1)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=3)),
+            ),
         )
-        .count()
         == 1
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=3)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=5)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
+            .where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=3)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=5)),
+            ),
         )
-        .count()
         == 1
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
-        .filter(OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
+            .where(OktaUserGroupMember.ended_at.is_(None)),
+        )
         == 0
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
-        .filter(OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
+            .where(OktaUserGroupMember.ended_at.is_(None)),
+        )
         == 0
     )
 
 
-def test_extra_user_from_role_membership(
+async def test_extra_user_from_role_membership(
     db: Db, mocker: MockerFixture, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser
 ) -> None:
     db.session.add(user)
@@ -254,7 +284,7 @@ def test_extra_user_from_role_membership(
     db.session.add(member_role_group_map)
     owner_role_group_map = RoleGroupMap(role_group_id=role_group.id, group_id=okta_group.id, is_owner=True)
     db.session.add(owner_role_group_map)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(
         OktaUserGroupMember(
             user_id=user.id,
@@ -270,40 +300,46 @@ def test_extra_user_from_role_membership(
             is_owner=True,
         )
     )
-    db.session.commit()
+    await db.session.commit()
 
     remove_membership_spy = mocker.patch.object(okta, "remove_user_from_group")
     remove_ownership_spy = mocker.patch.object(okta, "remove_owner_from_group")
 
-    verify_and_fix_role_memberships()
+    await verify_and_fix_role_memberships()
 
     assert remove_membership_spy.call_count == 1
     assert remove_ownership_spy.call_count == 1
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
-        .filter(OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
+            .where(OktaUserGroupMember.ended_at.is_(None)),
+        )
         == 0
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
-        .filter(OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
+            .where(OktaUserGroupMember.ended_at.is_(None)),
+        )
         == 0
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == okta_group.id)
-        .filter(OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == okta_group.id)
+            .where(OktaUserGroupMember.ended_at.is_(None)),
+        )
         == 0
     )
 
 
-def test_extra_user_from_role_membership_with_direct(
+async def test_extra_user_from_role_membership_with_direct(
     db: Db, mocker: MockerFixture, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser
 ) -> None:
     db.session.add(user)
@@ -314,7 +350,7 @@ def test_extra_user_from_role_membership_with_direct(
     db.session.add(member_role_group_map)
     owner_role_group_map = RoleGroupMap(role_group_id=role_group.id, group_id=okta_group.id, is_owner=True)
     db.session.add(owner_role_group_map)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(
         OktaUserGroupMember(
             user_id=user.id,
@@ -343,34 +379,40 @@ def test_extra_user_from_role_membership_with_direct(
             is_owner=True,
         )
     )
-    db.session.commit()
+    await db.session.commit()
 
     remove_membership_spy = mocker.patch.object(okta, "remove_user_from_group")
     remove_ownership_spy = mocker.patch.object(okta, "remove_owner_from_group")
 
-    verify_and_fix_role_memberships()
+    await verify_and_fix_role_memberships()
 
     assert remove_membership_spy.call_count == 0
     assert remove_ownership_spy.call_count == 0
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
-        .filter(OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.role_group_map_id == member_role_group_map.id)
+            .where(OktaUserGroupMember.ended_at.is_(None)),
+        )
         == 0
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
-        .filter(OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.role_group_map_id == owner_role_group_map.id)
+            .where(OktaUserGroupMember.ended_at.is_(None)),
+        )
         == 0
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.group_id == okta_group.id)
-        .filter(OktaUserGroupMember.ended_at.is_(None))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == okta_group.id)
+            .where(OktaUserGroupMember.ended_at.is_(None)),
+        )
         == 2
     )

--- a/tests/test_role_request.py
+++ b/tests/test_role_request.py
@@ -1,7 +1,8 @@
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
+from sqlalchemy import select
 from pytest_mock import MockerFixture
 from fastapi import FastAPI
 
@@ -31,15 +32,16 @@ from api.operations import (
 from api.plugins import ConditionalAccessResponse, get_conditional_access_hook, get_notification_hook
 from api.services import okta
 from tests.factories import AppGroupFactory, OktaGroupFactory, OktaUserFactory, RoleGroupFactory, RoleRequestFactory
+from tests.helpers import db_count
 
 SEVEN_DAYS_IN_SECONDS = 7 * 24 * 60 * 60
 THREE_DAYS_IN_SECONDS = 3 * 24 * 60 * 60
 ONE_DAY_IN_SECONDS = 24 * 60 * 60
 
 
-def test_get_role_request(
+async def test_get_role_request(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     okta_group: OktaGroup,
@@ -49,7 +51,7 @@ def test_get_role_request(
 ) -> None:
     # test 404
     role_request_url = url_for("api-role-requests.role_request_by_id", role_request_id="randomid")
-    rep = client.get(role_request_url)
+    rep = await client.get(role_request_url)
     assert rep.status_code == 404
 
     role_group2 = RoleGroupFactory.create()
@@ -58,12 +60,14 @@ def test_get_role_request(
     db.session.add(okta_group)
     db.session.add(role_group)
     db.session.add(role_group2)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
 
     # should be OK
-    okta_group_role_request = CreateRoleRequest(
+    okta_group_role_request = await CreateRoleRequest(
         requester_user=user,
         requester_role=role_group,
         requested_group=okta_group,
@@ -73,7 +77,7 @@ def test_get_role_request(
     assert okta_group_role_request is not None
 
     # should not be allowed
-    role_group_role_request = CreateRoleRequest(
+    role_group_role_request = await CreateRoleRequest(
         requester_user=user,
         requester_role=role_group,
         requested_group=role_group2,
@@ -84,7 +88,7 @@ def test_get_role_request(
 
     # test get okta group role_request
     role_request_url = url_for("api-role-requests.role_request_by_id", role_request_id=okta_group_role_request.id)
-    rep = client.get(role_request_url)
+    rep = await client.get(role_request_url)
     assert rep.status_code == 200
 
     data = rep.json()
@@ -96,26 +100,28 @@ def test_get_role_request(
     assert data["request_ownership"] == okta_group_role_request.request_ownership
 
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group.id)
-    rep = client.get(role_url)
+    rep = await client.get(role_url)
     assert rep.status_code == 200
 
     data = rep.json()
     assert len(data["groups_in_role"]) == 0
     assert len(data["groups_owned_by_role"]) == 0
 
-    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
 
-    okta_group_role_request = ApproveRoleRequest(
+    okta_group_role_request = await ApproveRoleRequest(
         role_request=okta_group_role_request, approver_user=access_owner
     ).execute()
 
     assert add_user_to_group_spy.call_count == 1
     assert add_owner_to_group_spy.call_count == 0
 
-    rep = client.get(role_request_url)
+    rep = await client.get(role_request_url)
     assert rep.status_code == 200
 
     data = rep.json()
@@ -126,7 +132,7 @@ def test_get_role_request(
     assert data["request_ownership"] == okta_group_role_request.request_ownership
 
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group.id)
-    rep = client.get(role_url)
+    rep = await client.get(role_url)
     assert rep.status_code == 200
 
     data = rep.json()
@@ -135,8 +141,8 @@ def test_get_role_request(
     assert len(data["groups_owned_by_role"]) == 0
 
 
-def test_get_role_request_includes_nested_role_and_group_data(
-    client: TestClient,
+async def test_get_role_request_includes_nested_role_and_group_data(
+    client: AsyncClient,
     db: Db,
     okta_group: OktaGroup,
     role_group: RoleGroup,
@@ -151,9 +157,9 @@ def test_get_role_request_includes_nested_role_and_group_data(
     db.session.add(okta_group)
     db.session.add(role_group)
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=role_group,
         members_to_add=[role_member.id],
         owners_to_add=[user.id],
@@ -161,9 +167,9 @@ def test_get_role_request_includes_nested_role_and_group_data(
     ).execute()
 
     db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    db.session.commit()
+    await db.session.commit()
 
-    role_request = CreateRoleRequest(
+    role_request = await CreateRoleRequest(
         requester_user=user,
         requester_role=role_group,
         requested_group=okta_group,
@@ -172,7 +178,7 @@ def test_get_role_request_includes_nested_role_and_group_data(
     ).execute()
     assert role_request is not None
 
-    rep = client.get(url_for("api-role-requests.role_request_by_id", role_request_id=role_request.id))
+    rep = await client.get(url_for("api-role-requests.role_request_by_id", role_request_id=role_request.id))
     assert rep.status_code == 200, rep.text
     data = rep.json()
 
@@ -187,9 +193,9 @@ def test_get_role_request_includes_nested_role_and_group_data(
     assert tag.id in tag_ids
 
 
-def test_put_role_request(
+async def test_put_role_request(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     role_request: RoleRequest,
@@ -202,44 +208,48 @@ def test_put_role_request(
     # body shape returns 404. (PUT with no body returns 400 because the
     # ResolveRoleRequestBody schema rejects the missing `approved` field.)
     role_request_url = url_for("api-role-requests.role_request_by_id", role_request_id="randomid")
-    rep = client.put(role_request_url, json={"approved": True})
+    rep = await client.put(role_request_url, json={"approved": True})
     assert rep.status_code == 404
 
     db.session.add(user)
     db.session.add(okta_group)
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
 
     role_request.requested_group_id = okta_group.id
     role_request.requester_role_id = role_group.id
     role_request.requester_user_id = user.id
     db.session.add(role_request)
-    db.session.commit()
+    await db.session.commit()
 
     # test missing data
     data: dict[str, Any] = {}
     role_request_url = url_for("api-role-requests.role_request_by_id", role_request_id=role_request.id)
-    rep = client.put(role_request_url, json=data)
+    rep = await client.put(role_request_url, json=data)
     assert rep.status_code == 400
 
     # test update role_request
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
 
-    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 0
+    assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at.is_(None))) == 0
     # The Access owner plus the role membership and ownership added above
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 3
 
     data = {"approved": True, "reason": "test reason"}
 
-    rep = client.put(role_request_url, json=data)
+    rep = await client.put(role_request_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert add_owner_to_group_spy.call_count == 0
 
-    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     data = rep.json()
     assert data["requester"]["email"] == user.email
@@ -252,10 +262,10 @@ def test_put_role_request(
     assert data["resolver"]["email"] == access_owner.email
     assert data["resolution_reason"] == role_request.resolution_reason
 
-    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 1
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at.is_(None))) == 1
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 4
 
-    role_request2 = CreateRoleRequest(
+    role_request2 = await CreateRoleRequest(
         requester_user=user,
         requester_role=role_group,
         requested_group=okta_group,
@@ -270,12 +280,14 @@ def test_put_role_request(
     data = {"approved": False, "reason": "test reason"}
 
     role_request_url = url_for("api-role-requests.role_request_by_id", role_request_id=role_request.id)
-    rep = client.put(role_request_url, json=data)
+    rep = await client.put(role_request_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
 
-    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     data = rep.json()
     assert data["requester"]["email"] == user.email
@@ -288,12 +300,12 @@ def test_put_role_request(
     assert data["resolver"]["email"] == access_owner.email
     assert data["resolution_reason"] == role_request.resolution_reason
 
-    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 1
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at.is_(None))) == 1
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 4
 
 
-def test_put_role_request_by_non_owner(
-    client: TestClient,
+async def test_put_role_request_by_non_owner(
+    client: AsyncClient,
     app: FastAPI,
     db: Db,
     role_group: RoleGroup,
@@ -301,21 +313,23 @@ def test_put_role_request_by_non_owner(
     user: OktaUser,
     url_for: Any,
 ) -> None:
-    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     db.session.add(user)
     db.session.add(role_group)
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=role_group,
         members_to_add=[user.id],
         owners_to_add=[access_owner.id, user.id],
         sync_to_okta=False,
     ).execute()
 
-    role_request_by_owner = CreateRoleRequest(
+    role_request_by_owner = await CreateRoleRequest(
         requester_user=access_owner,
         requester_role=role_group,
         requested_group=okta_group,
@@ -323,7 +337,7 @@ def test_put_role_request_by_non_owner(
         request_reason="test reason",
     ).execute()
 
-    role_request_by_non_owner = CreateRoleRequest(
+    role_request_by_non_owner = await CreateRoleRequest(
         requester_user=user,
         requester_role=role_group,
         requested_group=okta_group,
@@ -331,9 +345,9 @@ def test_put_role_request_by_non_owner(
         request_reason="test reason",
     ).execute()
 
-    db.session.commit()
+    await db.session.commit()
 
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 4
 
     assert role_request_by_owner is not None
     assert role_request_by_owner.status == AccessRequestStatus.PENDING
@@ -345,41 +359,47 @@ def test_put_role_request_by_non_owner(
 
     role_request_url = url_for("api-role-requests.role_request_by_id", role_request_id=role_request_by_owner.id)
     data = {"approved": True, "reason": "test approval"}
-    rep = client.put(role_request_url, json=data)
+    rep = await client.put(role_request_url, json=data)
     assert rep.status_code == 403
 
+    # The failed request's rollback on the shared session expired the
+    # identity map; reload before reading ORM attributes.
+    await db.session.refresh(role_request_by_owner)
     assert role_request_by_owner.status == AccessRequestStatus.PENDING
     assert role_request_by_owner.resolved_at is None
     assert role_request_by_owner.resolver_user_id is None
 
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 4
 
     data = {"approved": False, "reason": "test rejection"}
 
-    rep = client.put(role_request_url, json=data)
+    rep = await client.put(role_request_url, json=data)
     assert rep.status_code == 403
 
+    await db.session.refresh(role_request_by_owner)
+    await db.session.refresh(role_request_by_non_owner)
     assert role_request_by_owner.status == AccessRequestStatus.PENDING
     assert role_request_by_owner.resolved_at is None
     assert role_request_by_owner.resolver_user_id is None
 
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 4
 
     role_request_url = url_for("api-role-requests.role_request_by_id", role_request_id=role_request_by_non_owner.id)
 
     data = {"approved": True, "reason": "test approval"}
-    rep = client.put(role_request_url, json=data)
+    rep = await client.put(role_request_url, json=data)
     assert rep.status_code == 403
 
+    await db.session.refresh(role_request_by_non_owner)
     assert role_request_by_non_owner.status == AccessRequestStatus.PENDING
     assert role_request_by_non_owner.resolved_at is None
     assert role_request_by_non_owner.resolver_user_id is None
 
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 4
 
     data = {"approved": False, "reason": "test rejection"}
 
-    rep = client.put(role_request_url, json=data)
+    rep = await client.put(role_request_url, json=data)
     assert rep.status_code == 200
 
     data = rep.json()
@@ -395,21 +415,21 @@ def test_put_role_request_by_non_owner(
     assert role_request_by_non_owner.resolved_at is not None
     assert role_request_by_non_owner.resolver_user_id == user.id
 
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 4
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 4
 
 
-def test_create_role_request(
-    app: FastAPI, client: TestClient, db: Db, role_group: RoleGroup, okta_group: OktaGroup, url_for: Any
+async def test_create_role_request(
+    app: FastAPI, client: AsyncClient, db: Db, role_group: RoleGroup, okta_group: OktaGroup, url_for: Any
 ) -> None:
     # test bad data
     role_requests_url = url_for("api-role-requests.role_requests")
     data: dict[str, Any] = {}
-    rep = client.post(role_requests_url, json=data)
+    rep = await client.post(role_requests_url, json=data)
     assert rep.status_code == 400
 
     db.session.add(okta_group)
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
 
     data = {
         "role_id": role_group.id,
@@ -418,12 +438,14 @@ def test_create_role_request(
         "reason": "test reason",
     }
 
-    rep = client.post(role_requests_url, json=data)
+    rep = await client.post(role_requests_url, json=data)
     assert rep.status_code == 201
 
     data = rep.json()
-    role_request = db.session.get(RoleRequest, data["id"])
-    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    role_request = await db.session.get(RoleRequest, data["id"])
+    access_owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     assert data["requester"]["email"] == access_owner.email
     assert data["requester_role"]["name"] == role_group.name
@@ -435,9 +457,9 @@ def test_create_role_request(
 
 
 # Try to create an role request when not the role owner or Access admin, then become owner and try again
-def test_create_role_request_not_role_owner(
+async def test_create_role_request_not_role_owner(
     app: FastAPI,
-    client: TestClient,
+    client: AsyncClient,
     db: Db,
     role_group: RoleGroup,
     okta_group: OktaGroup,
@@ -447,7 +469,7 @@ def test_create_role_request_not_role_owner(
     db.session.add(user)
     db.session.add(okta_group)
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
 
     app.state.current_user_email = user.email
 
@@ -459,10 +481,16 @@ def test_create_role_request_not_role_owner(
     }
 
     role_requests_url = url_for("api-role-requests.role_requests")
-    rep = client.post(role_requests_url, json=data)
+    rep = await client.post(role_requests_url, json=data)
     assert rep.status_code == 403
 
-    ModifyGroupUsers(
+    # The failed request's rollback on the shared session expired the
+    # identity map; reload before reading ORM attributes.
+    await db.session.refresh(user)
+    await db.session.refresh(role_group)
+    await db.session.refresh(okta_group)
+
+    await ModifyGroupUsers(
         group=role_group,
         members_to_add=[],
         owners_to_add=[user.id],
@@ -476,11 +504,11 @@ def test_create_role_request_not_role_owner(
         "reason": "test reason",
     }
 
-    rep = client.post(role_requests_url, json=data)
+    rep = await client.post(role_requests_url, json=data)
     assert rep.status_code == 201
 
     out = rep.json()
-    role_request = db.session.get(RoleRequest, out["id"])
+    role_request = await db.session.get(RoleRequest, out["id"])
 
     assert out["requester"]["email"] == user.email
     assert out["requester_role"]["name"] == role_group.name
@@ -491,29 +519,29 @@ def test_create_role_request_not_role_owner(
     assert out["request_ownership"] == role_request.request_ownership
 
 
-def test_get_all_role_request(
-    client: TestClient, db: Db, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser, url_for: Any
+async def test_get_all_role_request(
+    client: AsyncClient, db: Db, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser, url_for: Any
 ) -> None:
     role_requests_url = url_for("api-role-requests.role_requests")
     db.session.add(user)
     db.session.add(role_group)
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
 
     role_requests = RoleRequestFactory.create_batch(
         10, requester_user_id=user.id, requester_role_id=role_group.id, requested_group_id=okta_group.id
     )
     db.session.add_all(role_requests)
-    db.session.commit()
+    await db.session.commit()
 
-    rep = client.get(role_requests_url)
+    rep = await client.get(role_requests_url)
     assert rep.status_code == 200
 
     results = rep.json()
     for request in role_requests:
         assert any(u["id"] == request.id for u in results["items"])
 
-    rep = client.get(role_requests_url, params={"q": "pend"})
+    rep = await client.get(role_requests_url, params={"q": "pend"})
     assert rep.status_code == 200
 
     results = rep.json()
@@ -521,35 +549,37 @@ def test_get_all_role_request(
         assert any(u["id"] == request.id for u in results["items"])
 
     # Should be able to query by requester role and requested group
-    rep = client.get(role_requests_url, params={"q": role_requests[0].requester_role.name})
+    rep = await client.get(role_requests_url, params={"q": role_requests[0].requester_role.name})
     assert rep.status_code == 200
 
     results = rep.json()
     assert any(u["id"] == role_requests[0].id for u in results["items"])
 
-    rep = client.get(role_requests_url, params={"q": role_requests[0].requested_group.name})
+    rep = await client.get(role_requests_url, params={"q": role_requests[0].requested_group.name})
     assert rep.status_code == 200
 
     results = rep.json()
     assert any(u["id"] == role_requests[0].id for u in results["items"])
 
 
-def test_create_role_request_notification(
+async def test_create_role_request_notification(
     app: FastAPI, db: Db, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser, mocker: MockerFixture
 ) -> None:
     db.session.add(user)
     db.session.add(role_group)
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
 
     hook = get_notification_hook()
     request_created_notification_spy = mocker.patch.object(hook, "access_role_request_created")
     request_completed_notification_spy = mocker.patch.object(hook, "access_role_request_completed")
-    add_membership_spy = mocker.patch.object(okta, "async_add_user_to_group")
+    add_membership_spy = mocker.patch.object(okta, "add_user_to_group")
 
-    role_request = CreateRoleRequest(
+    role_request = await CreateRoleRequest(
         requester_user=user,
         requester_role=role_group,
         requested_group=okta_group,
@@ -560,27 +590,29 @@ def test_create_role_request_notification(
     assert role_request is not None
     assert request_created_notification_spy.call_count == 1
 
-    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
-    ApproveRoleRequest(role_request=role_request, approver_user=access_owner).execute()
+    await ApproveRoleRequest(role_request=role_request, approver_user=access_owner).execute()
 
     assert add_membership_spy.call_count == 1
     assert request_completed_notification_spy.call_count == 1
 
     role_request.status = AccessRequestStatus.PENDING
     role_request.resolved_at = None
-    db.session.commit()
+    await db.session.commit()
 
     add_membership_spy.reset_mock()
     request_completed_notification_spy.reset_mock()
 
-    RejectRoleRequest(role_request=role_request, current_user_id=access_owner).execute()
+    await RejectRoleRequest(role_request=role_request, current_user_id=access_owner).execute()
 
     assert add_membership_spy.call_count == 0
     assert request_completed_notification_spy.call_count == 1
 
 
-def test_create_app_role_request_notification(
+async def test_create_app_role_request_notification(
     app: FastAPI,
     db: Db,
     access_app: App,
@@ -600,7 +632,7 @@ def test_create_app_role_request_notification(
     db.session.add(app_owner_user)
     db.session.add(user)
 
-    db.session.commit()
+    await db.session.commit()
 
     # Add app group that no one owns
     app_group.app_id = access_app.id
@@ -612,25 +644,27 @@ def test_create_app_role_request_notification(
     app_owner_group.is_owner = True
     db.session.add(app_owner_group)
 
-    db.session.commit()
+    await db.session.commit()
 
     # Add role group that user owns
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
 
     # Add app_owner_user to the owner group
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=app_owner_group, members_to_add=[], owners_to_add=[app_owner_user.id], sync_to_okta=False
     ).execute()
 
     hook = get_notification_hook()
     request_created_notification_spy = mocker.patch.object(hook, "access_role_request_created")
     request_completed_notification_spy = mocker.patch.object(hook, "access_role_request_completed")
-    add_membership_spy = mocker.patch.object(okta, "async_add_user_to_group")
+    add_membership_spy = mocker.patch.object(okta, "add_user_to_group")
 
-    role_request = CreateRoleRequest(
+    role_request = await CreateRoleRequest(
         requester_user=user,
         requester_role=role_group,
         requested_group=app_group,
@@ -646,9 +680,11 @@ def test_create_app_role_request_notification(
     assert kwargs["group"] == app_group
     assert kwargs["requester"] == user
 
-    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
-    ApproveRoleRequest(role_request=role_request, approver_user=access_owner).execute()
+    await ApproveRoleRequest(role_request=role_request, approver_user=access_owner).execute()
 
     assert add_membership_spy.call_count == 1
     assert request_completed_notification_spy.call_count == 1
@@ -660,12 +696,12 @@ def test_create_app_role_request_notification(
 
     role_request.status = AccessRequestStatus.PENDING
     role_request.resolved_at = None
-    db.session.commit()
+    await db.session.commit()
 
     add_membership_spy.reset_mock()
     request_completed_notification_spy.reset_mock()
 
-    RejectRoleRequest(role_request=role_request, current_user_id=access_owner).execute()
+    await RejectRoleRequest(role_request=role_request, current_user_id=access_owner).execute()
 
     assert add_membership_spy.call_count == 0
     assert request_completed_notification_spy.call_count == 1
@@ -676,12 +712,14 @@ def test_create_app_role_request_notification(
     assert kwargs["requester"] == user
 
 
-def test_get_all_possible_role_request_approvers(app: FastAPI, mocker: MockerFixture, db: Db) -> None:
-    access_admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+async def test_get_all_possible_role_request_approvers(app: FastAPI, mocker: MockerFixture, db: Db) -> None:
+    access_admin = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     users = OktaUserFactory.build_batch(3)
     db.session.add_all(users)
-    db.session.commit()
+    await db.session.commit()
 
     mocker.patch(
         "api.models.access_request.get_group_managers",
@@ -696,7 +734,7 @@ def test_get_all_possible_role_request_approvers(app: FastAPI, mocker: MockerFix
     req = RoleRequest()
     req.requested_group = AppGroupFactory.create()
 
-    approvers = get_all_possible_request_approvers(req)
+    approvers = await get_all_possible_request_approvers(req)
 
     # Assert that the access admin and 3 users are returned with no duplicates
     assert len(approvers) == 4
@@ -706,7 +744,7 @@ def test_get_all_possible_role_request_approvers(app: FastAPI, mocker: MockerFix
     assert users[2] in approvers
 
 
-def test_role_request_approvers_tagged(
+async def test_role_request_approvers_tagged(
     app: FastAPI,
     db: Db,
     role_group: RoleGroup,
@@ -721,32 +759,38 @@ def test_role_request_approvers_tagged(
     db.session.add(user2)
     db.session.add(user3)
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
 
     # Add role group that user owns
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=role_group, members_to_add=[user2.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=okta_group, owners_to_add=[user2.id, user3.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user2.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(group=okta_group, owners_to_add=[user2.id, user3.id], sync_to_okta=False).execute()
 
     # Add tag
     tag.constraints = {
         Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY: True,
     }
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
     db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    db.session.commit()
+    await db.session.commit()
 
     # drop identity-map state staled by the ops above (expire_on_commit=False)
     db.session.expire_all()
+    # ... then reload the objects the operation reads in this task context.
+    await db.session.refresh(user)
+    await db.session.refresh(role_group)
+    await db.session.refresh(okta_group)
 
     hook = get_notification_hook()
     request_created_notification_spy = mocker.patch.object(hook, "access_role_request_created")
 
-    role_request = CreateRoleRequest(
+    role_request = await CreateRoleRequest(
         requester_user=user,
         requester_role=role_group,
         requested_group=okta_group,
@@ -764,7 +808,7 @@ def test_role_request_approvers_tagged(
     assert user3 in kwargs["approvers"]
 
 
-def test_resolve_app_role_request_notification(
+async def test_resolve_app_role_request_notification(
     app: FastAPI,
     db: Db,
     access_app: App,
@@ -773,7 +817,9 @@ def test_resolve_app_role_request_notification(
     user: OktaUser,
     mocker: MockerFixture,
 ) -> None:
-    access_admin = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_admin = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     app_owner_user1 = OktaUserFactory.build()
     app_owner_user2 = OktaUserFactory.build()
@@ -787,7 +833,7 @@ def test_resolve_app_role_request_notification(
     db.session.add(app_owner_user2)
     db.session.add(user)  # Future group owner
 
-    db.session.commit()
+    await db.session.commit()
 
     # Add app group that no one owns
     app_group.app_id = access_app.id
@@ -799,16 +845,18 @@ def test_resolve_app_role_request_notification(
     app_owner_group.is_owner = True
     db.session.add(app_owner_group)
 
-    db.session.commit()
+    await db.session.commit()
 
     # Add role group that user owns
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
 
     # Add app_owner_user to the owner group
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=app_owner_group,
         members_to_add=[],
         owners_to_add=[app_owner_user1.id, app_owner_user2.id],
@@ -818,9 +866,9 @@ def test_resolve_app_role_request_notification(
     hook = get_notification_hook()
     request_created_notification_spy = mocker.patch.object(hook, "access_role_request_created")
     request_completed_notification_spy = mocker.patch.object(hook, "access_role_request_completed")
-    add_ownership_spy = mocker.patch.object(okta, "async_add_owner_to_group")
+    add_ownership_spy = mocker.patch.object(okta, "add_owner_to_group")
 
-    role_request = CreateRoleRequest(
+    role_request = await CreateRoleRequest(
         requester_user=user,
         requester_role=role_group,
         requested_group=app_group,
@@ -839,7 +887,7 @@ def test_resolve_app_role_request_notification(
     assert app_owner_user1 in kwargs["approvers"]
     assert app_owner_user2 in kwargs["approvers"]
 
-    ApproveRoleRequest(role_request=role_request, approver_user=app_owner_user1).execute()
+    await ApproveRoleRequest(role_request=role_request, approver_user=app_owner_user1).execute()
 
     assert add_ownership_spy.call_count == 1
     assert request_completed_notification_spy.call_count == 1
@@ -857,12 +905,12 @@ def test_resolve_app_role_request_notification(
     # Reset the access request so we can test the reject path
     role_request.status = AccessRequestStatus.PENDING
     role_request.resolved_at = None
-    db.session.commit()
+    await db.session.commit()
 
     add_ownership_spy.reset_mock()
     request_completed_notification_spy.reset_mock()
 
-    RejectRoleRequest(role_request=role_request, current_user_id=app_owner_user1).execute()
+    await RejectRoleRequest(role_request=role_request, current_user_id=app_owner_user1).execute()
 
     assert add_ownership_spy.call_count == 0
     assert request_completed_notification_spy.call_count == 1
@@ -878,7 +926,7 @@ def test_resolve_app_role_request_notification(
     assert user in kwargs["approvers"]
 
 
-def test_auto_resolve_create_role_request(
+async def test_auto_resolve_create_role_request(
     app: FastAPI,
     db: Db,
     okta_group: OktaGroup,
@@ -891,12 +939,14 @@ def test_auto_resolve_create_role_request(
     db.session.add(role_group)
     db.session.add(okta_group)
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
     db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
 
     notification_hook = get_notification_hook()
     request_created_notification_spy = mocker.patch.object(notification_hook, "access_role_request_created")
@@ -907,9 +957,9 @@ def test_auto_resolve_create_role_request(
         "role_request_created",
         return_value=[ConditionalAccessResponse(approved=True, reason="Auto-Approved")],
     )
-    add_membership_spy = mocker.patch.object(okta, "async_add_user_to_group")
+    add_membership_spy = mocker.patch.object(okta, "add_user_to_group")
 
-    role_request = CreateRoleRequest(
+    role_request = await CreateRoleRequest(
         requester_user=user,
         requester_role=role_group,
         requested_group=okta_group,
@@ -918,6 +968,8 @@ def test_auto_resolve_create_role_request(
     ).execute()
 
     assert role_request is not None
+    # The auto-approval's bulk update expired the resolution columns; reload.
+    await db.session.refresh(role_request)
     assert role_request.status == AccessRequestStatus.APPROVED
     assert role_request.resolved_at is not None
     assert role_request.resolver_user_id is None
@@ -946,7 +998,7 @@ def test_auto_resolve_create_role_request(
         return_value=[ConditionalAccessResponse(approved=False, reason="Auto-Rejected")],
     )
 
-    role_request = CreateRoleRequest(
+    role_request = await CreateRoleRequest(
         requester_user=user,
         requester_role=role_group,
         requested_group=okta_group,
@@ -955,6 +1007,7 @@ def test_auto_resolve_create_role_request(
     ).execute()
 
     assert role_request is not None
+    await db.session.refresh(role_request)
     assert role_request.status == AccessRequestStatus.REJECTED
     assert role_request.resolved_at is not None
     assert role_request.resolver_user_id is None
@@ -981,7 +1034,7 @@ def test_auto_resolve_create_role_request(
         request_hook, "role_request_created", return_value=[None]
     )
 
-    role_request = CreateRoleRequest(
+    role_request = await CreateRoleRequest(
         requester_user=user,
         requester_role=role_group,
         requested_group=okta_group,
@@ -1007,7 +1060,7 @@ def test_auto_resolve_create_role_request(
     assert tag in kwargs["group_tags"]
 
 
-def test_auto_resolve_create_role_request_with_time_limit_constraint_tag(
+async def test_auto_resolve_create_role_request_with_time_limit_constraint_tag(
     app: FastAPI,
     db: Db,
     role_group: RoleGroup,
@@ -1024,12 +1077,14 @@ def test_auto_resolve_create_role_request_with_time_limit_constraint_tag(
         Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: THREE_DAYS_IN_SECONDS,
     }
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
     db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
 
     notification_hook = get_notification_hook()
     request_created_notification_spy = mocker.patch.object(notification_hook, "access_role_request_created")
@@ -1046,9 +1101,9 @@ def test_auto_resolve_create_role_request_with_time_limit_constraint_tag(
             ),
         ],
     )
-    add_membership_spy = mocker.patch.object(okta, "async_add_user_to_group")
+    add_membership_spy = mocker.patch.object(okta, "add_user_to_group")
 
-    role_request = CreateRoleRequest(
+    role_request = await CreateRoleRequest(
         requester_user=user,
         requester_role=role_group,
         requested_group=okta_group,
@@ -1057,6 +1112,8 @@ def test_auto_resolve_create_role_request_with_time_limit_constraint_tag(
     ).execute()
 
     assert role_request is not None
+    # The auto-approval's bulk update expired the resolution columns; reload.
+    await db.session.refresh(role_request)
     assert role_request.status == AccessRequestStatus.APPROVED
     assert role_request.resolved_at is not None
     assert role_request.resolver_user_id is None
@@ -1075,7 +1132,7 @@ def test_auto_resolve_create_role_request_with_time_limit_constraint_tag(
     assert tag in kwargs["group_tags"]
 
 
-def test_time_limit_constraint_tag(
+async def test_time_limit_constraint_tag(
     app: FastAPI,
     db: Db,
     access_app: App,
@@ -1085,43 +1142,47 @@ def test_time_limit_constraint_tag(
     tag: Tag,
     mocker: MockerFixture,
 ) -> None:
-    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     # Add App
     db.session.add(access_app)
 
     # Add User
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     # Add app group that no one owns
     app_group.app_id = access_app.id
     app_group.is_owner = False
     db.session.add(app_group)
 
-    db.session.commit()
+    await db.session.commit()
 
     # Add role group that user owns
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
 
     # Add tag
     tag.constraints = {
         Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: THREE_DAYS_IN_SECONDS,
     }
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag.id))
-    db.session.commit()
+    await db.session.commit()
 
     hook = get_notification_hook()
     request_created_notification_spy = mocker.patch.object(hook, "access_role_request_created")
 
     # Make request for more than time limit
-    role_request = CreateRoleRequest(
+    role_request = await CreateRoleRequest(
         requester_user=user,
         requester_role=role_group,
         requested_group=app_group,
@@ -1139,14 +1200,14 @@ def test_time_limit_constraint_tag(
     assert kwargs["requester"] == user
 
     # Try to approve for more than time limit
-    ApproveRoleRequest(
+    await ApproveRoleRequest(
         role_request=role_request,
         approver_user=access_owner,
         ending_at=datetime.now() + timedelta(seconds=SEVEN_DAYS_IN_SECONDS),
     ).execute()
 
     # Should only be approved for time limit if approved time is higher
-    approval = db.session.query(RoleGroupMap).filter(RoleGroupMap.role_group == role_group).first()
+    approval = (await db.session.scalars(select(RoleGroupMap).where(RoleGroupMap.role_group == role_group))).first()
     # Make sure approval time is correct (could be a couple milliseconds off from calculated which is okay)
     approval_time = approval.ended_at.replace(tzinfo=timezone.utc)
     expected_approval_time = datetime.now(timezone.utc) + timedelta(seconds=THREE_DAYS_IN_SECONDS)
@@ -1154,7 +1215,7 @@ def test_time_limit_constraint_tag(
     assert expected_approval_time - approval_time < timedelta(minutes=1)
 
 
-def test_owner_cant_add_self_constraint_tag(
+async def test_owner_cant_add_self_constraint_tag(
     app: FastAPI,
     db: Db,
     access_app: App,
@@ -1164,7 +1225,9 @@ def test_owner_cant_add_self_constraint_tag(
     tag: Tag,
     mocker: MockerFixture,
 ) -> None:
-    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
     # Add App
     db.session.add(access_app)
@@ -1173,42 +1236,48 @@ def test_owner_cant_add_self_constraint_tag(
     user2 = OktaUserFactory.create()
     db.session.add(user)
     db.session.add(user2)
-    db.session.commit()
+    await db.session.commit()
 
     # Add app group that no one owns
     app_group.app_id = access_app.id
     app_group.is_owner = False
     db.session.add(app_group)
 
-    db.session.commit()
+    await db.session.commit()
 
     # Add role group that user owns
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=role_group, members_to_add=[user.id, user2.id], owners_to_add=[user.id], sync_to_okta=False
     ).execute()
-    ModifyGroupUsers(group=app_group, owners_to_add=[user2.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(group=app_group, owners_to_add=[user2.id], sync_to_okta=False).execute()
 
     # Add tag
     tag.constraints = {
         Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY: True,
     }
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag.id))
-    db.session.commit()
+    await db.session.commit()
 
     db.session.expire_all()
+    # ... then reload the objects the operations below read in this task context.
+    await db.session.refresh(user)
+    await db.session.refresh(user2)
+    await db.session.refresh(access_owner)
+    await db.session.refresh(role_group)
+    await db.session.refresh(app_group)
 
     hook = get_notification_hook()
     request_created_notification_spy = mocker.patch.object(hook, "access_role_request_created")
     request_completed_notification_spy = mocker.patch.object(hook, "access_role_request_completed")
-    add_membership_spy = mocker.patch.object(okta, "async_add_user_to_group")
+    add_membership_spy = mocker.patch.object(okta, "add_user_to_group")
 
-    role_request = CreateRoleRequest(
+    role_request = await CreateRoleRequest(
         requester_user=user,
         requester_role=role_group,
         requested_group=app_group,
@@ -1227,13 +1296,13 @@ def test_owner_cant_add_self_constraint_tag(
     assert kwargs["approvers"][0] == access_owner
 
     # user2 owns the group and is a member of the requester role, should fail
-    should_fail = ApproveRoleRequest(
+    should_fail = await ApproveRoleRequest(
         role_request=role_request,
         approver_user=user2,
     ).execute()
     assert should_fail.status == AccessRequestStatus.PENDING
 
-    should_pass = ApproveRoleRequest(
+    should_pass = await ApproveRoleRequest(
         role_request=role_request,
         approver_user=access_owner,
     ).execute()
@@ -1248,8 +1317,8 @@ def test_owner_cant_add_self_constraint_tag(
     assert kwargs["requester"] == user
 
 
-def test_role_request_approval_via_direct_add(
-    client: TestClient,
+async def test_role_request_approval_via_direct_add(
+    client: AsyncClient,
     app: FastAPI,
     db: Db,
     role_group: RoleGroup,
@@ -1264,15 +1333,17 @@ def test_role_request_approval_via_direct_add(
     db.session.add(role_group)
     db.session.add(okta_group)
     db.session.add(okta_group2)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
 
     hook = get_notification_hook()
     request_created_notification_spy = mocker.patch.object(hook, "access_role_request_created")
     request_completed_notification_spy = mocker.patch.object(hook, "access_role_request_completed")
 
-    role_request = CreateRoleRequest(
+    role_request = await CreateRoleRequest(
         requester_user=user,
         requester_role=role_group,
         requested_group=okta_group,
@@ -1283,9 +1354,11 @@ def test_role_request_approval_via_direct_add(
     assert role_request is not None
     assert request_created_notification_spy.call_count == 1
 
-    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
-    ModifyRoleGroups(
+    await ModifyRoleGroups(
         role_group=role_group, groups_to_add=[okta_group.id], sync_to_okta=False, created_reason="test"
     ).execute()
 
@@ -1299,7 +1372,7 @@ def test_role_request_approval_via_direct_add(
     assert access_owner in kwargs["approvers"]
 
     group_url = url_for("api-groups.group_members_by_id", group_id=okta_group.id)
-    rep = client.get(group_url)
+    rep = await client.get(group_url)
     assert rep.status_code == 200
     data = rep.json()
     assert len(data["members"]) == 1
@@ -1309,7 +1382,7 @@ def test_role_request_approval_via_direct_add(
     request_created_notification_spy.reset_mock()
     request_completed_notification_spy.reset_mock()
 
-    role_request = CreateRoleRequest(
+    role_request = await CreateRoleRequest(
         requester_user=user,
         requester_role=role_group,
         requested_group=okta_group2,
@@ -1320,9 +1393,11 @@ def test_role_request_approval_via_direct_add(
     assert role_request is not None
     assert request_created_notification_spy.call_count == 1
 
-    access_owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    access_owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
 
-    ModifyRoleGroups(
+    await ModifyRoleGroups(
         role_group=role_group, owner_groups_to_add=[okta_group2.id], sync_to_okta=False, created_reason="test"
     ).execute()
 
@@ -1336,7 +1411,7 @@ def test_role_request_approval_via_direct_add(
     assert access_owner in kwargs["approvers"]
 
     group_url = url_for("api-groups.group_members_by_id", group_id=okta_group2.id)
-    rep = client.get(group_url)
+    rep = await client.get(group_url)
     assert rep.status_code == 200
     data = rep.json()
     assert len(data["owners"]) == 1
@@ -1344,7 +1419,7 @@ def test_role_request_approval_via_direct_add(
     assert data["owners"][0] == user.id
 
 
-def test_role_request_list_filters_via_http(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_role_request_list_filters_via_http(client: AsyncClient, db: Db, url_for: Any) -> None:
     """`status`, `requester_user_id`, `requested_group_id` and
     `requester_role_id` each narrow the role_requests list. Seed two
     requests across two users / two roles / two target groups so each
@@ -1357,22 +1432,22 @@ def test_role_request_list_filters_via_http(client: TestClient, db: Db, url_for:
     target_group = OktaGroupFactory.create()
     other_group = OktaGroupFactory.create()
     db.session.add_all([target_user, other_user, target_role, other_role, target_group, other_group])
-    db.session.commit()
-    ModifyGroupUsers(
+    await db.session.commit()
+    await ModifyGroupUsers(
         group=target_role, members_to_add=[target_user.id], owners_to_add=[target_user.id], sync_to_okta=False
     ).execute()
-    ModifyGroupUsers(
+    await ModifyGroupUsers(
         group=other_role, members_to_add=[other_user.id], owners_to_add=[other_user.id], sync_to_okta=False
     ).execute()
 
-    target_rr = CreateRoleRequest(
+    target_rr = await CreateRoleRequest(
         requester_user=target_user,
         requester_role=target_role,
         requested_group=target_group,
         request_ownership=False,
         request_reason="please",
     ).execute()
-    other_rr = CreateRoleRequest(
+    other_rr = await CreateRoleRequest(
         requester_user=other_user,
         requester_role=other_role,
         requested_group=other_group,
@@ -1386,33 +1461,33 @@ def test_role_request_list_filters_via_http(client: TestClient, db: Db, url_for:
     def ids(rep: Any) -> list[str]:
         return [r["id"] for r in rep.json()["items"]]
 
-    rep = client.get(list_url, params={"status": "PENDING"})
+    rep = await client.get(list_url, params={"status": "PENDING"})
     assert rep.status_code == 200
     assert {target_rr.id, other_rr.id}.issubset(set(ids(rep)))
 
-    rep = client.get(list_url, params={"status": "APPROVED"})
+    rep = await client.get(list_url, params={"status": "APPROVED"})
     assert rep.status_code == 200
     assert target_rr.id not in ids(rep)
     assert other_rr.id not in ids(rep)
 
-    rep = client.get(list_url, params={"requester_user_id": target_user.id})
+    rep = await client.get(list_url, params={"requester_user_id": target_user.id})
     assert rep.status_code == 200
     found = ids(rep)
     assert target_rr.id in found and other_rr.id not in found
 
-    rep = client.get(list_url, params={"requested_group_id": target_group.id})
+    rep = await client.get(list_url, params={"requested_group_id": target_group.id})
     assert rep.status_code == 200
     found = ids(rep)
     assert target_rr.id in found and other_rr.id not in found
 
-    rep = client.get(list_url, params={"requester_role_id": target_role.id})
+    rep = await client.get(list_url, params={"requester_role_id": target_role.id})
     assert rep.status_code == 200
     found = ids(rep)
     assert target_rr.id in found and other_rr.id not in found
 
 
-def test_get_role_request_detail_requested_group_for_app_group(
-    client: TestClient,
+async def test_get_role_request_detail_requested_group_for_app_group(
+    client: AsyncClient,
     db: Db,
     access_app: App,
     app_group: AppGroup,
@@ -1429,22 +1504,22 @@ def test_get_role_request_detail_requested_group_for_app_group(
     db.session.add(user)
     db.session.add(access_app)
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     app_group.is_owner = False
     db.session.add(app_group)
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag.id))
-    db.session.commit()
-    ModifyGroupUsers(
+    await db.session.commit()
+    await ModifyGroupUsers(
         group=role_group,
         members_to_add=[user.id],
         owners_to_add=[user.id],
         sync_to_okta=False,
     ).execute()
 
-    rr = CreateRoleRequest(
+    rr = await CreateRoleRequest(
         requester_user=user,
         requester_role=role_group,
         requested_group=app_group,
@@ -1453,7 +1528,7 @@ def test_get_role_request_detail_requested_group_for_app_group(
     ).execute()
     assert rr is not None
 
-    rep = client.get(url_for("api-role-requests.role_request_by_id", role_request_id=rr.id))
+    rep = await client.get(url_for("api-role-requests.role_request_by_id", role_request_id=rr.id))
     assert rep.status_code == 200, rep.text
     data = rep.json()
     rg = data["requested_group"]
@@ -1467,8 +1542,8 @@ def test_get_role_request_detail_requested_group_for_app_group(
     assert tag.id in tag_ids
 
 
-def test_put_role_request_pending_check_includes_resolved_at(
-    client: TestClient, db: Db, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser, url_for: Any
+async def test_put_role_request_pending_check_includes_resolved_at(
+    client: AsyncClient, db: Db, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser, url_for: Any
 ) -> None:
     """Flask gates resolve on `status == PENDING AND resolved_at is None`.
     The previous FastAPI version dropped the resolved_at half and drifted
@@ -1476,9 +1551,11 @@ def test_put_role_request_pending_check_includes_resolved_at(
     db.session.add(user)
     db.session.add(role_group)
     db.session.add(okta_group)
-    db.session.commit()
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    rr = CreateRoleRequest(
+    await db.session.commit()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    rr = await CreateRoleRequest(
         requester_user=user,
         requester_role=role_group,
         requested_group=okta_group,
@@ -1488,9 +1565,9 @@ def test_put_role_request_pending_check_includes_resolved_at(
     assert rr is not None
     # Force `resolved_at` to a non-null timestamp while leaving status PENDING.
     rr.resolved_at = datetime.now(timezone.utc)
-    db.session.commit()
+    await db.session.commit()
 
     put_url = url_for("api-role-requests.role_request_by_id_put", role_request_id=rr.id)
-    rep = client.put(put_url, json={"approved": False, "reason": "no"})
+    rep = await client.put(put_url, json={"approved": False, "reason": "no"})
     assert rep.status_code == 409
     assert "is not pending" in rep.text

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 import pytest
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
 from pytest_mock import MockerFixture
 from fastapi import FastAPI
 
@@ -14,61 +14,61 @@ from api.models import App, AppGroup, AppTagMap, OktaGroup, OktaGroupTagMap, Tag
 from tests.factories import TagFactory
 
 
-def test_get_tag(
-    client: TestClient, db: Db, tag: Tag, access_app: App, app_group: AppGroup, okta_group: OktaGroup, url_for: Any
+async def test_get_tag(
+    client: AsyncClient, db: Db, tag: Tag, access_app: App, app_group: AppGroup, okta_group: OktaGroup, url_for: Any
 ) -> None:
     # test 404
     tag_url = url_for("api-tags.tag_by_id", tag_id="randomid")
-    rep = client.get(tag_url)
+    rep = await client.get(tag_url)
     assert rep.status_code == 404
 
     db.session.add(tag)
     db.session.add(access_app)
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
     db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
     app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tag.id)
     db.session.add(app_tag_map)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag.id, app_tag_map_id=app_tag_map.id))
-    db.session.commit()
+    await db.session.commit()
 
     # test get tag
     tag_url = url_for("api-tags.tag_by_id", tag_id=tag.id)
-    rep = client.get(tag_url)
+    rep = await client.get(tag_url)
     assert rep.status_code == 200
 
     data = rep.json()
     assert data["name"] == tag.name
 
 
-def test_put_tag(
-    client: TestClient, db: Db, tag: Tag, access_app: App, app_group: AppGroup, okta_group: OktaGroup, url_for: Any
+async def test_put_tag(
+    client: AsyncClient, db: Db, tag: Tag, access_app: App, app_group: AppGroup, okta_group: OktaGroup, url_for: Any
 ) -> None:
     # test 404 — with a valid (empty) body shape so the path resolution
     # runs ahead of body-validation rejection.
     tag_url = url_for("api-tags.tag_by_id", tag_id="randomid")
-    rep = client.put(tag_url, json={})
+    rep = await client.put(tag_url, json={})
     assert rep.status_code == 404
 
     db.session.add(tag)
     db.session.add(access_app)
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
     db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
     app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tag.id)
     db.session.add(app_tag_map)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag.id, app_tag_map_id=app_tag_map.id))
-    db.session.commit()
+    await db.session.commit()
 
     data = {
         "name": "Updated",
@@ -77,7 +77,7 @@ def test_put_tag(
         "constraints": {Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 9999},
     }
     tag_url = url_for("api-tags.tag_by_id", tag_id=tag.id)
-    rep = client.put(tag_url, json=data)
+    rep = await client.put(tag_url, json=data)
     assert rep.status_code == 200
 
     data = rep.json()
@@ -94,7 +94,7 @@ def test_put_tag(
         "constraints": {},
     }
     tag_url = url_for("api-tags.tag_by_id", tag_id=tag.id)
-    rep = client.put(tag_url, json=data)
+    rep = await client.put(tag_url, json=data)
     assert rep.status_code == 200
 
     data = rep.json()
@@ -107,60 +107,63 @@ def test_put_tag(
     data = {
         "constraints": {"invalid_constraint": "asdfas"},
     }
-    rep = client.put(tag_url, json=data)
+    rep = await client.put(tag_url, json=data)
     assert rep.status_code == 400
 
     data = {
         "constraints": {"time_limit": "asdfas"},
     }
-    rep = client.put(tag_url, json=data)
+    rep = await client.put(tag_url, json=data)
     assert rep.status_code == 400
 
 
-def test_delete_tag(
-    client: TestClient, db: Db, tag: Tag, access_app: App, app_group: AppGroup, okta_group: OktaGroup, url_for: Any
+async def test_delete_tag(
+    client: AsyncClient, db: Db, tag: Tag, access_app: App, app_group: AppGroup, okta_group: OktaGroup, url_for: Any
 ) -> None:
     # test 404
     tag_url = url_for("api-tags.tag_by_id", tag_id="randomid")
-    rep = client.delete(tag_url)
+    rep = await client.delete(tag_url)
     assert rep.status_code == 404
 
     db.session.add(tag)
     db.session.add(access_app)
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
     db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
     app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tag.id)
     db.session.add(app_tag_map)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag.id, app_tag_map_id=app_tag_map.id))
-    db.session.commit()
+    await db.session.commit()
 
     tag_id = tag.id
     tag_url = url_for("api-tags.tag_by_id", tag_id=tag_id)
-    rep = client.delete(tag_url)
+    rep = await client.delete(tag_url)
     assert rep.status_code == 200
-    assert db.session.get(Tag, tag_id).deleted_at is not None
+    # The delete request's bulk update expired deleted_at on the identity-map
+    # instance; refresh before reading it.
+    await db.session.refresh(tag)
+    assert tag.deleted_at is not None
 
 
-def test_create_tag(client: TestClient, db: Db, mocker: MockerFixture, url_for: Any) -> None:
+async def test_create_tag(client: AsyncClient, db: Db, mocker: MockerFixture, url_for: Any) -> None:
     # test bad data
     tags_url = url_for("api-tags.tags")
     data: dict[str, Any] = {}
-    rep = client.post(tags_url, json=data)
+    rep = await client.post(tags_url, json=data)
     assert rep.status_code == 400
 
     data = {"name": "Created", "description": ""}
 
-    rep = client.post(tags_url, json=data)
+    rep = await client.post(tags_url, json=data)
     assert rep.status_code == 201
 
     data = rep.json()
-    tag = db.session.get(Tag, data["id"])
+    tag = await db.session.get(Tag, data["id"])
 
     assert tag.name == "Created"
     assert tag.description == ""
@@ -169,11 +172,11 @@ def test_create_tag(client: TestClient, db: Db, mocker: MockerFixture, url_for: 
 
     data = {"name": "Created2", "description": "", "enabled": False, "constraints": {}}
 
-    rep = client.post(tags_url, json=data)
+    rep = await client.post(tags_url, json=data)
     assert rep.status_code == 201
 
     data = rep.json()
-    tag = db.session.get(Tag, data["id"])
+    tag = await db.session.get(Tag, data["id"])
 
     assert tag.name == "Created2"
     assert tag.description == ""
@@ -181,21 +184,21 @@ def test_create_tag(client: TestClient, db: Db, mocker: MockerFixture, url_for: 
     assert tag.constraints == {}
 
 
-def test_get_all_tag(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_get_all_tag(client: AsyncClient, db: Db, url_for: Any) -> None:
     tags_url = url_for("api-tags.tags")
 
     tags = TagFactory.create_batch(3)
     db.session.add_all(tags)
-    db.session.commit()
+    await db.session.commit()
 
-    rep = client.get(tags_url)
+    rep = await client.get(tags_url)
     assert rep.status_code == 200
 
     results = rep.json()
     for tag in tags:
         assert any(u["id"] == tag.id for u in results["items"])
 
-    rep = client.get(tags_url, params={"q": "Tag-"})
+    rep = await client.get(tags_url, params={"q": "Tag-"})
     assert rep.status_code == 200
 
     results = rep.json()
@@ -205,8 +208,8 @@ def test_get_all_tag(client: TestClient, db: Db, url_for: Any) -> None:
 
 
 @pytest.mark.parametrize("app", [False, True], indirect=True)
-def test_create_tag_with_and_without_description(
-    app: FastAPI, client: TestClient, db: Db, mocker: MockerFixture, url_for: Any
+async def test_create_tag_with_and_without_description(
+    app: FastAPI, client: AsyncClient, db: Db, mocker: MockerFixture, url_for: Any
 ) -> None:
     """Test that tags work with or without descriptions based on REQUIRE_DESCRIPTIONS setting"""
     require_descriptions = settings.REQUIRE_DESCRIPTIONS
@@ -215,7 +218,7 @@ def test_create_tag_with_and_without_description(
 
     # Test creating tag without description
     data: dict[str, Any] = {"name": "TestTag"}
-    rep = client.post(tags_url, json=data)
+    rep = await client.post(tags_url, json=data)
     if require_descriptions:
         # Should fail when REQUIRE_DESCRIPTIONS=True
         assert rep.status_code == 400
@@ -225,13 +228,13 @@ def test_create_tag_with_and_without_description(
         # Should succeed with backwards compatibility
         assert rep.status_code == 201
         result = rep.json()
-        tag = db.session.get(Tag, result["id"])
+        tag = await db.session.get(Tag, result["id"])
         assert tag.name == "TestTag"
         assert tag.description == ""
 
     # Test creating tag with empty description
     data = {"name": "TestTag2", "description": ""}
-    rep = client.post(tags_url, json=data)
+    rep = await client.post(tags_url, json=data)
     if require_descriptions:
         # Should fail - empty description fails length validation
         assert rep.status_code == 400
@@ -241,24 +244,24 @@ def test_create_tag_with_and_without_description(
         # Should succeed with empty description
         assert rep.status_code == 201
         result = rep.json()
-        tag = db.session.get(Tag, result["id"])
+        tag = await db.session.get(Tag, result["id"])
         assert tag.name == "TestTag2"
         assert tag.description == ""
 
     # Test creating tag with a description should always succeed
     data = {"name": "TestTag3", "description": "This has a description"}
-    rep = client.post(tags_url, json=data)
+    rep = await client.post(tags_url, json=data)
     assert rep.status_code == 201
 
     result = rep.json()
-    tag = db.session.get(Tag, result["id"])
+    tag = await db.session.get(Tag, result["id"])
     assert tag.name == "TestTag3"
     assert tag.description == "This has a description"
 
 
 @pytest.mark.parametrize("app", [False, True], indirect=True)
-def test_partial_tag_update_preserves_description(
-    app: FastAPI, client: TestClient, db: Db, mocker: MockerFixture, tag: Tag, url_for: Any
+async def test_partial_tag_update_preserves_description(
+    app: FastAPI, client: AsyncClient, db: Db, mocker: MockerFixture, tag: Tag, url_for: Any
 ) -> None:
     """Test that tag updates handle descriptions correctly based on REQUIRE_DESCRIPTIONS setting"""
     require_descriptions = settings.REQUIRE_DESCRIPTIONS
@@ -266,13 +269,13 @@ def test_partial_tag_update_preserves_description(
     # Set up the tag with a description
     tag.description = "Original description"
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
     tag_url = url_for("api-tags.tag_by_id", tag_id=tag.id)
 
     # Test updating with empty description
     data = {"name": "UpdatedWithEmpty", "description": ""}
-    rep = client.put(tag_url, json=data)
+    rep = await client.put(tag_url, json=data)
     if require_descriptions:
         # Should fail - empty description fails length validation
         assert rep.status_code == 400
@@ -289,12 +292,12 @@ def test_partial_tag_update_preserves_description(
     if not require_descriptions:
         # Need to reset since empty description succeeded above
         data = {"name": "UpdatedWithEmpty", "description": "Original description"}
-        rep = client.put(tag_url, json=data)
+        rep = await client.put(tag_url, json=data)
         assert rep.status_code == 200
 
     # Test partial update without description should preserve existing description
     data = {"name": "UpdatedTag"}
-    rep = client.put(tag_url, json=data)
+    rep = await client.put(tag_url, json=data)
     assert rep.status_code == 200
     result = rep.json()
     assert result["name"] == "UpdatedTag"
@@ -302,101 +305,101 @@ def test_partial_tag_update_preserves_description(
 
     # Test updating with valid description should succeed
     data = {"name": "UpdatedTag2", "description": "Updated description"}
-    rep = client.put(tag_url, json=data)
+    rep = await client.put(tag_url, json=data)
     assert rep.status_code == 200
     result = rep.json()
     assert result["name"] == "UpdatedTag2"
     assert result["description"] == "Updated description"
 
 
-def test_post_tag_validation_via_http(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_post_tag_validation_via_http(client: AsyncClient, db: Db, url_for: Any) -> None:
     """Empty name, overlong description, unknown constraint key and bad
     constraint value all rejected at the HTTP layer."""
     tags_url = url_for("api-tags.tags")
 
-    rep = client.post(tags_url, json={"name": ""})
+    rep = await client.post(tags_url, json={"name": ""})
     assert rep.status_code == 400
 
-    rep = client.post(tags_url, json={"name": "good", "description": "x" * 1025})
+    rep = await client.post(tags_url, json={"name": "good", "description": "x" * 1025})
     assert rep.status_code == 400
 
-    rep = client.post(tags_url, json={"name": "good", "constraints": {"not_a_real_constraint": True}})
+    rep = await client.post(tags_url, json={"name": "good", "constraints": {"not_a_real_constraint": True}})
     assert rep.status_code == 400
 
-    rep = client.post(tags_url, json={"name": "good", "constraints": {"disallow_self_add_ownership": "not-bool"}})
+    rep = await client.post(tags_url, json={"name": "good", "constraints": {"disallow_self_add_ownership": "not-bool"}})
     assert rep.status_code == 400
 
 
-def test_post_tag_require_descriptions_via_http(
-    client: TestClient, db: Db, url_for: Any, monkeypatch: pytest.MonkeyPatch
+async def test_post_tag_require_descriptions_via_http(
+    client: AsyncClient, db: Db, url_for: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """REQUIRE_DESCRIPTIONS gates POST at the HTTP boundary."""
     monkeypatch.setattr(settings, "REQUIRE_DESCRIPTIONS", True)
     tags_url = url_for("api-tags.tags")
-    rep = client.post(tags_url, json={"name": "needs-desc"})
+    rep = await client.post(tags_url, json={"name": "needs-desc"})
     assert rep.status_code == 400
 
 
-def test_post_tag_duplicate_name_blocked(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_post_tag_duplicate_name_blocked(client: AsyncClient, db: Db, url_for: Any) -> None:
     """Duplicate tag name on POST returns 400 (not silent 201)."""
     tags_url = url_for("api-tags.tags")
-    rep = client.post(tags_url, json={"name": "DupTag"})
+    rep = await client.post(tags_url, json={"name": "DupTag"})
     assert rep.status_code == 201
 
-    rep = client.post(tags_url, json={"name": "duptag"})  # case-insensitive
+    rep = await client.post(tags_url, json={"name": "duptag"})  # case-insensitive
     assert rep.status_code == 400
     assert "already exists" in rep.text
 
 
-def test_put_tag_rename_collision_blocked(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_put_tag_rename_collision_blocked(client: AsyncClient, db: Db, url_for: Any) -> None:
     """Renaming a tag onto another tag's name is rejected with 400."""
     tag_a = TagFactory.create(name="OneTag")
     tag_b = TagFactory.create(name="OtherTag")
     db.session.add_all([tag_a, tag_b])
-    db.session.commit()
+    await db.session.commit()
 
     put_url = url_for("api-tags.tag_by_id_put", tag_id=tag_b.id)
-    rep = client.put(put_url, json={"name": "onetag"})  # case-insensitive
+    rep = await client.put(put_url, json={"name": "onetag"})  # case-insensitive
     assert rep.status_code == 400
     assert "already exists" in rep.text
 
 
-def test_get_tags_q_via_http(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_get_tags_q_via_http(client: AsyncClient, db: Db, url_for: Any) -> None:
     """Q — `q` query param honored on /api/tags."""
     db.session.add_all([TagFactory.create(name="ZelaTagOne"), TagFactory.create(name="OtherTag")])
-    db.session.commit()
+    await db.session.commit()
     tags_url = url_for("api-tags.tags")
-    rep = client.get(tags_url, params={"q": "ZelaTag"})
+    rep = await client.get(tags_url, params={"q": "ZelaTag"})
     assert rep.status_code == 200
     names = [t["name"] for t in rep.json()["items"]]
     assert "ZelaTagOne" in names
     assert "OtherTag" not in names
 
 
-def test_put_tag_404_for_soft_deleted(client: TestClient, db: Db, tag: Tag, url_for: Any) -> None:
+async def test_put_tag_404_for_soft_deleted(client: AsyncClient, db: Db, tag: Tag, url_for: Any) -> None:
     """PUT on a soft-deleted tag returns 404."""
     tag.deleted_at = datetime.now(timezone.utc)
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
     tag_url = url_for("api-tags.tag_by_id_put", tag_id=tag.id)
-    rep = client.put(tag_url, json={"name": "RenamedAfterDelete"})
+    rep = await client.put(tag_url, json={"name": "RenamedAfterDelete"})
     assert rep.status_code == 404
 
 
-def test_delete_tag_404_for_soft_deleted(client: TestClient, db: Db, tag: Tag, url_for: Any) -> None:
+async def test_delete_tag_404_for_soft_deleted(client: AsyncClient, db: Db, tag: Tag, url_for: Any) -> None:
     """DELETE on an already-soft-deleted tag returns 404."""
     tag.deleted_at = datetime.now(timezone.utc)
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
     tag_url = url_for("api-tags.tag_by_id_delete", tag_id=tag.id)
-    rep = client.delete(tag_url)
+    rep = await client.delete(tag_url)
     assert rep.status_code == 404
 
 
-def test_put_tag_emits_tag_modify_audit_log(
-    client: TestClient,
+async def test_put_tag_emits_tag_modify_audit_log(
+    client: AsyncClient,
     db: Db,
     tag: Tag,
     url_for: Any,
@@ -405,11 +408,11 @@ def test_put_tag_emits_tag_modify_audit_log(
     """PUT /api/tags/{id} emits a `tag_modify` audit log carrying old/new state."""
     original_name = tag.name
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
 
     tag_url = url_for("api-tags.tag_by_id_put", tag_id=tag.id)
     with caplog.at_level(logging.INFO, logger="access.audit"):
-        rep = client.put(tag_url, json={"name": "RenamedTag"})
+        rep = await client.put(tag_url, json={"name": "RenamedTag"})
         assert rep.status_code == 200
 
     audit_records = [r for r in caplog.records if r.name == "access.audit"]
@@ -429,23 +432,23 @@ def test_put_tag_emits_tag_modify_audit_log(
     assert payload["old_tag"]["name"] == original_name
 
 
-def test_list_tags_search_matches_description(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_list_tags_search_matches_description(client: AsyncClient, db: Db, url_for: Any) -> None:
     """`q` matches against Tag.description as well as Tag.name."""
     name_only = TagFactory.create(name="HaystackTag", description="generic")
     desc_only = TagFactory.create(name="OtherName", description="contains needle here")
     db.session.add_all([name_only, desc_only])
-    db.session.commit()
+    await db.session.commit()
 
     tags_url = url_for("api-tags.tags")
-    rep = client.get(tags_url, params={"q": "needle"})
+    rep = await client.get(tags_url, params={"q": "needle"})
     assert rep.status_code == 200
     ids = [t["id"] for t in rep.json()["items"]]
     assert desc_only.id in ids
     assert name_only.id not in ids
 
 
-def test_list_tags_response_is_summary_shape(
-    client: TestClient,
+async def test_list_tags_response_is_summary_shape(
+    client: AsyncClient,
     db: Db,
     tag: Tag,
     okta_group: OktaGroup,
@@ -454,12 +457,12 @@ def test_list_tags_response_is_summary_shape(
     """List response uses `TagListItem` — no `active_group_tags`, no `deleted_at`."""
     db.session.add(tag)
     db.session.add(okta_group)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    db.session.commit()
+    await db.session.commit()
 
     tags_url = url_for("api-tags.tags")
-    rep = client.get(tags_url)
+    rep = await client.get(tags_url)
     assert rep.status_code == 200
     items = rep.json()["items"]
     matched = [item for item in items if item["id"] == tag.id]
@@ -471,7 +474,7 @@ def test_list_tags_response_is_summary_shape(
     assert set(item.keys()) == expected_keys
 
 
-def test_get_tag_prefers_active_over_deleted_with_same_name(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_get_tag_prefers_active_over_deleted_with_same_name(client: AsyncClient, db: Db, url_for: Any) -> None:
     """When two tags share the same name (one soft-deleted, one active),
     GET /api/tags/{name} must return the active one. The router uses
     `nullsfirst(deleted_at.desc())` to enforce that ordering."""
@@ -480,33 +483,33 @@ def test_get_tag_prefers_active_over_deleted_with_same_name(client: TestClient, 
     db.session.add(deleted)
     active = TagFactory.create(name="DupName", description="new")
     db.session.add(active)
-    db.session.commit()
+    await db.session.commit()
 
     tag_url = url_for("api-tags.tag_by_id", tag_id="DupName")
-    rep = client.get(tag_url)
+    rep = await client.get(tag_url)
     assert rep.status_code == 200
     body = rep.json()
     assert body["id"] == active.id
     assert body["deleted_at"] is None
 
 
-def test_get_tag_returns_deleted_when_no_active_match(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_get_tag_returns_deleted_when_no_active_match(client: AsyncClient, db: Db, url_for: Any) -> None:
     """If only a soft-deleted tag with that name exists, GET still returns
     it (the `nullsfirst(deleted_at.desc())` ordering falls through to the
     deleted row when no active row exists)."""
     deleted = TagFactory.create(name="OnlyDeleted")
     deleted.deleted_at = datetime.now(timezone.utc)
     db.session.add(deleted)
-    db.session.commit()
+    await db.session.commit()
 
     tag_url = url_for("api-tags.tag_by_id", tag_id="OnlyDeleted")
-    rep = client.get(tag_url)
+    rep = await client.get(tag_url)
     assert rep.status_code == 200
     assert rep.json()["id"] == deleted.id
 
 
-def test_get_tag_detail_includes_active_app_tags(
-    client: TestClient,
+async def test_get_tag_detail_includes_active_app_tags(
+    client: AsyncClient,
     db: Db,
     tag: Tag,
     access_app: App,
@@ -517,13 +520,13 @@ def test_get_tag_detail_includes_active_app_tags(
     is attached to. The FastAPI `TagDetail` must include `active_app_tags`."""
     db.session.add(tag)
     db.session.add(access_app)
-    db.session.commit()
+    await db.session.commit()
     app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tag.id)
     db.session.add(app_tag_map)
-    db.session.commit()
+    await db.session.commit()
 
     tag_url = url_for("api-tags.tag_by_id", tag_id=tag.id)
-    rep = client.get(tag_url)
+    rep = await client.get(tag_url)
     assert rep.status_code == 200, rep.text
     data = rep.json()
     assert "active_app_tags" in data
@@ -532,8 +535,8 @@ def test_get_tag_detail_includes_active_app_tags(
     assert access_app.id in app_ids
 
 
-def test_get_tag_detail_active_group_tags_carries_group_description(
-    client: TestClient,
+async def test_get_tag_detail_active_group_tags_carries_group_description(
+    client: AsyncClient,
     db: Db,
     tag: Tag,
     okta_group: OktaGroup,
@@ -543,12 +546,12 @@ def test_get_tag_detail_active_group_tags_carries_group_description(
     okta_group.description = "tag-detail-description-fixture"
     db.session.add(okta_group)
     db.session.add(tag)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    db.session.commit()
+    await db.session.commit()
 
     tag_url = url_for("api-tags.tag_by_id", tag_id=tag.id)
-    rep = client.get(tag_url)
+    rep = await client.get(tag_url)
     assert rep.status_code == 200, rep.text
     data = rep.json()
     descriptions = [

--- a/tests/test_time_limit_constraint.py
+++ b/tests/test_time_limit_constraint.py
@@ -1,10 +1,10 @@
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
 from pytest_mock import MockerFixture
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, select
 from api.extensions import Db
 from api.models import (
     App,
@@ -21,14 +21,15 @@ from api.models import (
 from api.operations import ModifyGroupUsers, ModifyRoleGroups
 from api.services import okta
 from tests.factories import TagFactory
+from tests.helpers import db_count
 
 SEVEN_DAYS_IN_SECONDS = 7 * 24 * 60 * 60
 THREE_DAYS_IN_SECONDS = 3 * 24 * 60 * 60
 ONE_DAY_IN_SECONDS = 24 * 60 * 60
 
 
-def test_time_limit_modify_group_users(
-    client: TestClient,
+async def test_time_limit_modify_group_users(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     access_app: App,
@@ -60,10 +61,10 @@ def test_time_limit_modify_group_users(
     db.session.add(access_app)
     db.session.add(role_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
     db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[0].id))
     db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[1].id))
@@ -71,24 +72,25 @@ def test_time_limit_modify_group_users(
     db.session.add(app_tag_map)
     app_tag_map2 = AppTagMap(app_id=access_app.id, tag_id=tags[2].id)
     db.session.add(app_tag_map2)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[0].id, app_tag_map_id=app_tag_map.id))
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id))
-    db.session.commit()
+    await db.session.commit()
 
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    remove_user_from_group_spy = mocker.patch.object(okta, "async_remove_user_from_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
-    remove_owner_from_group_spy = mocker.patch.object(okta, "async_remove_owner_from_group")
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    remove_user_from_group_spy = mocker.patch.object(okta, "remove_user_from_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
+    remove_owner_from_group_spy = mocker.patch.object(okta, "remove_owner_from_group")
 
     # Establish a baseline where a user shouldn't be expiring in the next 8 days
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > func.now(),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > func.now(),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+            ),
         )
-        .count()
         == 0
     )
 
@@ -101,7 +103,7 @@ def test_time_limit_modify_group_users(
         "users_added_ending_at": datetime.now(UTC) + timedelta(days=7),
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=app_group.id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -114,21 +116,23 @@ def test_time_limit_modify_group_users(
 
     # user should only be added to the app group for 3 days (time limit constraint)
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 2
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+            ),
         )
-        .count()
         == 0
     )
 
@@ -145,7 +149,7 @@ def test_time_limit_modify_group_users(
         "users_added_ending_at": datetime.now(UTC) + timedelta(days=1),
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=app_group.id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
@@ -158,21 +162,23 @@ def test_time_limit_modify_group_users(
 
     # user should only be added to the app group group for 1 days (less than time limit constraint)
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > func.now(),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=2)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > func.now(),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=2)),
+            ),
         )
-        .count()
         == 2
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 0
     )
 
@@ -188,7 +194,7 @@ def test_time_limit_modify_group_users(
         "owners_to_remove": [user.id],
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=app_group.id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 1
@@ -211,13 +217,13 @@ def test_time_limit_modify_group_users(
         "owner_groups_to_remove": [],
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group.id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 0
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 0
     assert remove_owner_from_group_spy.call_count == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 1
 
     data = rep.json()
     assert len(data["groups_in_role"]) == 1
@@ -234,7 +240,7 @@ def test_time_limit_modify_group_users(
         "users_added_ending_at": datetime.now(UTC) + timedelta(days=7),
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=role_group.id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 2
     assert remove_user_from_group_spy.call_count == 0
@@ -247,21 +253,23 @@ def test_time_limit_modify_group_users(
 
     # user should only be added to the role and okta group for 3 days (time limit constraint)
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+            ),
         )
-        .count()
         == 0
     )
 
@@ -278,7 +286,7 @@ def test_time_limit_modify_group_users(
         "users_added_ending_at": datetime.now(UTC) + timedelta(days=1),
     }
     group_url = url_for("api-groups.group_members_by_id", group_id=role_group.id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 2
     assert remove_user_from_group_spy.call_count == 0
@@ -291,27 +299,29 @@ def test_time_limit_modify_group_users(
 
     # user should only be added to the role and okta group for 1 days (less than time limit constraint)
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > func.now(),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=2)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > func.now(),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=2)),
+            ),
         )
-        .count()
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 0
     )
 
 
-def test_time_limit_modify_role_groups(
-    client: TestClient,
+async def test_time_limit_modify_role_groups(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     access_app: App,
@@ -343,10 +353,10 @@ def test_time_limit_modify_role_groups(
     db.session.add(access_app)
     db.session.add(role_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
     db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[0].id))
     db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[1].id))
@@ -354,34 +364,40 @@ def test_time_limit_modify_role_groups(
     db.session.add(app_tag_map)
     app_tag_map2 = AppTagMap(app_id=access_app.id, tag_id=tags[2].id)
     db.session.add(app_tag_map2)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[0].id, app_tag_map_id=app_tag_map.id))
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id))
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(
+        group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
 
-    add_user_to_group_spy = mocker.patch.object(okta, "async_add_user_to_group")
-    remove_user_from_group_spy = mocker.patch.object(okta, "async_remove_user_from_group")
-    add_owner_to_group_spy = mocker.patch.object(okta, "async_add_owner_to_group")
-    remove_owner_from_group_spy = mocker.patch.object(okta, "async_remove_owner_from_group")
+    add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
+    remove_user_from_group_spy = mocker.patch.object(okta, "remove_user_from_group")
+    add_owner_to_group_spy = mocker.patch.object(okta, "add_owner_to_group")
+    remove_owner_from_group_spy = mocker.patch.object(okta, "remove_owner_from_group")
 
     # Establish a base line of tag, user, and role mappings
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 2
     )
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 3
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
-        .count()
+        await db_count(
+            db.session,
+            select(RoleGroupMap).where(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now())),
+        )
         == 0
     )
 
@@ -393,32 +409,34 @@ def test_time_limit_modify_role_groups(
         "owner_groups_to_remove": [],
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group.id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 4
     )
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 3
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(
-            RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(RoleGroupMap).where(
+                RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 0
     )
-    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at.is_(None))) == 2
 
     # Add the role group as a member and owner of the app group, for an unlimited time
     add_user_to_group_spy.reset_mock()
@@ -432,36 +450,38 @@ def test_time_limit_modify_role_groups(
         "owner_groups_to_remove": [],
     }
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group.id)
-    rep = client.put(role_url, json=data)
+    rep = await client.put(role_url, json=data)
     assert rep.status_code == 200
     assert add_user_to_group_spy.call_count == 1
     assert remove_user_from_group_spy.call_count == 0
     assert add_owner_to_group_spy.call_count == 1
     assert remove_owner_from_group_spy.call_count == 0
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 6
     )
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 3
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(
-            RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(RoleGroupMap).where(
+                RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 2
     )
-    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at.is_(None))) == 2
 
 
-def test_time_limit_modify_group_type(
-    client: TestClient,
+async def test_time_limit_modify_group_type(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     access_app: App,
@@ -492,16 +512,20 @@ def test_time_limit_modify_group_type(
     db.session.add(access_app)
     db.session.add(role_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[0].id))
     db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[2].id))
     db.session.add_all([AppTagMap(app_id=access_app.id, tag_id=tag.id) for tag in tags])
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyRoleGroups(
+    await ModifyGroupUsers(
+        group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyRoleGroups(
         role_group=role_group,
         groups_to_add=[
             okta_group.id,
@@ -515,19 +539,20 @@ def test_time_limit_modify_group_type(
     role_group_id = role_group.id
 
     # Establish a base line of tag, user, and role mappings
-    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 3
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 2
+    assert await db_count(db.session, select(AppTagMap).where(AppTagMap.ended_at.is_(None))) == 3
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 2
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 4
     )
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
-    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 3
+    assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at.is_(None))) == 2
 
     update_group_spy = mocker.patch.object(okta, "update_group")
 
@@ -540,7 +565,7 @@ def test_time_limit_modify_group_type(
     }
 
     group_url = url_for("api-groups.group_by_id", group_id=okta_group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert update_group_spy.call_count == 1
 
@@ -549,35 +574,37 @@ def test_time_limit_modify_group_type(
     assert ret_data["name"] == data["name"]
     assert ret_data["description"] == data["description"]
     assert ret_data["id"] == okta_group_id
-    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 3
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 5
+    assert await db_count(db.session, select(AppTagMap).where(AppTagMap.ended_at.is_(None))) == 3
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 5
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 6
     )
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 1
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(
-            RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(RoleGroupMap).where(
+                RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 2
     )
-    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 0
+    assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at.is_(None))) == 0
 
     # Update the role group to be an app group which should affect and also limit it's role group mapping
     update_group_spy.reset_mock()
     data["name"] = data["name"].replace("Updated-Okta", "Updated-Role")
 
     group_url = url_for("api-groups.group_by_id", group_id=role_group_id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert update_group_spy.call_count == 1
 
@@ -586,28 +613,30 @@ def test_time_limit_modify_group_type(
     assert ret_data["name"] == data["name"]
     assert ret_data["description"] == data["description"]
     assert ret_data["id"] == role_group_id
-    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 3
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 8
+    assert await db_count(db.session, select(AppTagMap).where(AppTagMap.ended_at.is_(None))) == 3
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 8
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 4
     )
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 1
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now()))
-        .count()
+        await db_count(
+            db.session,
+            select(RoleGroupMap).where(or_(RoleGroupMap.ended_at.is_(None), RoleGroupMap.ended_at > func.now())),
+        )
         == 0
     )
 
 
-def test_time_limit_modify_group_tags(
-    client: TestClient,
+async def test_time_limit_modify_group_tags(
+    client: AsyncClient,
     db: Db,
     access_app: App,
     app_group: AppGroup,
@@ -634,10 +663,10 @@ def test_time_limit_modify_group_tags(
     db.session.add(access_app)
     db.session.add(role_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
     db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[0].id))
     db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[1].id))
@@ -646,14 +675,18 @@ def test_time_limit_modify_group_tags(
     db.session.add(app_tag_map)
     app_tag_map2 = AppTagMap(app_id=access_app.id, tag_id=tags[2].id)
     db.session.add(app_tag_map2)
-    db.session.commit()
+    await db.session.commit()
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[0].id, app_tag_map_id=app_tag_map.id))
     db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id))
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyRoleGroups(
+    await ModifyGroupUsers(
+        group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyRoleGroups(
         role_group=role_group,
         groups_to_add=[
             okta_group.id,
@@ -666,201 +699,226 @@ def test_time_limit_modify_group_tags(
         sync_to_okta=False,
     ).execute()
 
+    # Capture tag values before any requests — the tag PUTs below expire the
+    # fixture-loaded objects on the shared session.
+    tag0_id, tag0_name, tag0_description = tags[0].id, tags[0].name, tags[0].description
+    tag2_id, tag2_name, tag2_description = tags[2].id, tags[2].name, tags[2].description
+
     # Establish a baseline of user and role mappings
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 3
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+            ),
         )
-        .count()
         == 6
     )
-    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at.is_(None))) == 2
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(
-            RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=6)),
-            RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+        await db_count(
+            db.session,
+            select(RoleGroupMap).where(
+                RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=6)),
+                RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+            ),
         )
-        .count()
         == 2
     )
 
     # Update the primary tag constraint time limit to 3 days
     data = {
-        "name": tags[0].name,
-        "description": tags[0].description,
+        "name": tag0_name,
+        "description": tag0_description,
         "enabled": True,
         "constraints": {
             Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: THREE_DAYS_IN_SECONDS,
             Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: THREE_DAYS_IN_SECONDS,
         },
     }
-    tag_url = url_for("api-tags.tag_by_id", tag_id=tags[0].id)
-    rep = client.put(tag_url, json=data)
+    tag_url = url_for("api-tags.tag_by_id", tag_id=tag0_id)
+    rep = await client.put(tag_url, json=data)
     assert rep.status_code == 200
 
     data = rep.json()
-    assert data["name"] == tags[0].name
-    assert data["description"] == tags[0].description
+    assert data["name"] == tag0_name
+    assert data["description"] == tag0_description
     assert data["enabled"] is True
     assert data["constraints"] == {
         Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: THREE_DAYS_IN_SECONDS,
         Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: THREE_DAYS_IN_SECONDS,
     }
-    assert data["id"] == tags[0].id
+    assert data["id"] == tag0_id
 
     # The primary tag should reduce the user and role mappings to three days
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 3
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 6
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+            ),
         )
-        .count()
         == 0
     )
-    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at.is_(None))) == 2
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(
-            RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(RoleGroupMap).where(
+                RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(
-            RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=6)),
-            RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+        await db_count(
+            db.session,
+            select(RoleGroupMap).where(
+                RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=6)),
+                RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+            ),
         )
-        .count()
         == 0
     )
 
     # Update the disabled tag to enabled
     data = {
-        "name": tags[2].name,
-        "description": tags[2].description,
+        "name": tag2_name,
+        "description": tag2_description,
         "enabled": True,
         "constraints": {
             Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: ONE_DAY_IN_SECONDS,
             Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: ONE_DAY_IN_SECONDS,
         },
     }
-    tag_url = url_for("api-tags.tag_by_id", tag_id=tags[2].id)
-    rep = client.put(tag_url, json=data)
+    tag_url = url_for("api-tags.tag_by_id", tag_id=tag2_id)
+    rep = await client.put(tag_url, json=data)
     assert rep.status_code == 200
 
     data = rep.json()
-    assert data["name"] == tags[2].name
-    assert data["description"] == tags[2].description
+    assert data["name"] == tag2_name
+    assert data["description"] == tag2_description
     assert data["enabled"] is True
     assert data["constraints"] == {
         Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: ONE_DAY_IN_SECONDS,
         Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: ONE_DAY_IN_SECONDS,
     }
-    assert data["id"] == tags[2].id
+    assert data["id"] == tag2_id
 
     # The enabled tag should reduce the user and role mappings to one day
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 3
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > func.now(),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=2)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > func.now(),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=2)),
+            ),
         )
-        .count()
         == 6
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2))),
+        )
         == 0
     )
-    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at.is_(None))) == 2
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.ended_at > func.now(), RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=2)))
-        .count()
+        await db_count(
+            db.session,
+            select(RoleGroupMap).where(
+                RoleGroupMap.ended_at > func.now(), RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=2))
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2))).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)))
+        )
         == 0
     )
 
     # Update the last tag to be disabled
     data = {
-        "name": tags[2].name,
-        "description": tags[2].description,
+        "name": tag2_name,
+        "description": tag2_description,
         "enabled": False,
         "constraints": {
             Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: ONE_DAY_IN_SECONDS,
             Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: ONE_DAY_IN_SECONDS,
         },
     }
-    tag_url = url_for("api-tags.tag_by_id", tag_id=tags[2].id)
-    rep = client.put(tag_url, json=data)
+    tag_url = url_for("api-tags.tag_by_id", tag_id=tag2_id)
+    rep = await client.put(tag_url, json=data)
     assert rep.status_code == 200
 
     data = rep.json()
-    assert data["name"] == tags[2].name
-    assert data["description"] == tags[2].description
+    assert data["name"] == tag2_name
+    assert data["description"] == tag2_description
     assert data["enabled"] is False
     assert data["constraints"] == {
         Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: ONE_DAY_IN_SECONDS,
         Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: ONE_DAY_IN_SECONDS,
     }
-    assert data["id"] == tags[2].id
+    assert data["id"] == tag2_id
 
     # The disabled tag should have no effect on the user and role mappings
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 3
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > func.now(),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=2)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > func.now(),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=2)),
+            ),
         )
-        .count()
         == 6
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)))
-        .count()
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2))),
+        )
         == 0
     )
-    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at.is_(None))) == 2
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(RoleGroupMap.ended_at > func.now(), RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=2)))
-        .count()
+        await db_count(
+            db.session,
+            select(RoleGroupMap).where(
+                RoleGroupMap.ended_at > func.now(), RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=2))
+            ),
+        )
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2))).count()
+        await db_count(
+            db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)))
+        )
         == 0
     )
 
 
-def test_time_limit_add_group_tags(
-    client: TestClient,
+async def test_time_limit_add_group_tags(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     access_app: App,
@@ -892,14 +950,18 @@ def test_time_limit_add_group_tags(
     db.session.add(access_app)
     db.session.add(role_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyRoleGroups(
+    await ModifyGroupUsers(
+        group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyRoleGroups(
         role_group=role_group,
         groups_to_add=[okta_group.id, app_group.id],
         owner_groups_to_add=[okta_group.id, app_group.id],
@@ -907,14 +969,22 @@ def test_time_limit_add_group_tags(
     ).execute()
 
     # Establish a base line of tag, user, and role mappings
-    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 0
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at > func.now()).count() == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 9
-    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at > func.now()).count() == 0
-    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 4
+    assert await db_count(db.session, select(AppTagMap).where(AppTagMap.ended_at.is_(None))) == 0
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 0
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at > func.now())) == 0
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 9
+    assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at > func.now())) == 0
+    assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at.is_(None))) == 4
 
     update_group_spy = mocker.patch.object(okta, "update_group")
+
+    # Capture values before any requests — the group PUTs below expire the
+    # fixture-loaded objects on the shared session.
+    tag1_id, tag2_id = tags[1].id, tags[2].id
+    role_group_id = role_group.id
+    role_group_data = {"type": role_group.type, "name": role_group.name, "description": role_group.description}
+    app_group_id, app_group_type, app_group_description = app_group.id, app_group.type, app_group.description
+    app_id, app_name = access_app.id, access_app.name
 
     # Add the primary and disabled tag to the okta group
     data: dict[str, Any] = {
@@ -924,150 +994,158 @@ def test_time_limit_add_group_tags(
         "tags_to_add": [tags[0].id, tags[2].id],
     }
     group_url = url_for("api-groups.group_by_id", group_id=okta_group.id)
-    rep = client.put(group_url, json=data)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert update_group_spy.call_count == 1
 
-    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 0
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 2
+    assert await db_count(db.session, select(AppTagMap).where(AppTagMap.ended_at.is_(None))) == 0
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 2
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 4
     )
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 5
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 5
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(
-            RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(RoleGroupMap).where(
+                RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 2
     )
-    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at.is_(None))) == 2
 
     update_group_spy.reset_mock()
 
     # Add the secondary and disabled tag to the role group
     data = {
-        "type": role_group.type,
-        "name": role_group.name,
-        "description": role_group.description,
-        "tags_to_add": [tags[1].id, tags[2].id],
+        **role_group_data,
+        "tags_to_add": [tag1_id, tag2_id],
     }
-    group_url = url_for("api-groups.group_by_id", group_id=role_group.id)
-    rep = client.put(group_url, json=data)
+    group_url = url_for("api-groups.group_by_id", group_id=role_group_id)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert update_group_spy.call_count == 1
 
-    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 0
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 4
+    assert await db_count(db.session, select(AppTagMap).where(AppTagMap.ended_at.is_(None))) == 0
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 4
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+            ),
         )
-        .count()
         == 4
     )
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 1
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(
-            RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(RoleGroupMap).where(
+                RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(
-            RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=6)),
-            RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+        await db_count(
+            db.session,
+            select(RoleGroupMap).where(
+                RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=6)),
+                RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+            ),
         )
-        .count()
         == 0
     )
-    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at.is_(None))) == 2
 
     update_group_spy.reset_mock()
 
     # Add the secondary and disabled tag to the app group
     data = {
-        "type": app_group.type,
-        "name": f"{AppGroup.APP_GROUP_NAME_PREFIX}{access_app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}Updated",
-        "description": app_group.description,
-        "tags_to_add": [tags[1].id, tags[2].id],
-        "app_id": access_app.id,
+        "type": app_group_type,
+        "name": f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}Updated",
+        "description": app_group_description,
+        "tags_to_add": [tag1_id, tag2_id],
+        "app_id": app_id,
     }
-    group_url = url_for("api-groups.group_by_id", group_id=app_group.id)
-    rep = client.put(group_url, json=data)
+    group_url = url_for("api-groups.group_by_id", group_id=app_group_id)
+    rep = await client.put(group_url, json=data)
     assert rep.status_code == 200
     assert update_group_spy.call_count == 1
 
-    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 0
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 6
+    assert await db_count(db.session, select(AppTagMap).where(AppTagMap.ended_at.is_(None))) == 0
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 6
 
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 4
     )
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+            ),
         )
-        .count()
         == 4
     )
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 1
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 1
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(
-            RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(RoleGroupMap).where(
+                RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 2
     )
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(
-            RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=6)),
-            RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+        await db_count(
+            db.session,
+            select(RoleGroupMap).where(
+                RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=6)),
+                RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+            ),
         )
-        .count()
         == 2
     )
-    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 0
+    assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at.is_(None))) == 0
 
 
-def test_time_limit_add_app_tags(
-    client: TestClient,
+async def test_time_limit_add_app_tags(
+    client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
     access_app: App,
@@ -1097,57 +1175,68 @@ def test_time_limit_add_app_tags(
     db.session.add(access_app)
     db.session.add(role_group)
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=app_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyRoleGroups(
+    await ModifyGroupUsers(
+        group=app_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyRoleGroups(
         role_group=role_group, groups_to_add=[app_group.id], owner_groups_to_add=[app_group.id], sync_to_okta=False
     ).execute()
 
     # Establish a base line of tag, user, and role mappings
-    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 0
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at > func.now()).count() == 0
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 7
-    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at > func.now()).count() == 0
-    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 2
+    assert await db_count(db.session, select(AppTagMap).where(AppTagMap.ended_at.is_(None))) == 0
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 0
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at > func.now())) == 0
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 7
+    assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at > func.now())) == 0
+    assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at.is_(None))) == 2
 
     update_group_spy = mocker.patch.object(okta, "update_group")
 
-    # Add the primary and disabled tag to the app
-    data = {"name": "Updated", "description": "new description", "tags_to_add": [tags[0].id, tags[2].id]}
+    # Capture ids before any requests — the app PUTs below expire the
+    # fixture-loaded objects on the shared session.
+    tag0_id, tag1_id, tag2_id = tags[0].id, tags[1].id, tags[2].id
+    app_id = access_app.id
 
-    app_url = url_for("api-apps.app_by_id", app_id=access_app.id)
-    rep = client.put(app_url, json=data)
+    # Add the primary and disabled tag to the app
+    data = {"name": "Updated", "description": "new description", "tags_to_add": [tag0_id, tag2_id]}
+
+    app_url = url_for("api-apps.app_by_id", app_id=app_id)
+    rep = await client.put(app_url, json=data)
     assert rep.status_code == 200
     assert update_group_spy.call_count == 1
 
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 2
-    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 2
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 2
+    assert await db_count(db.session, select(AppTagMap).where(AppTagMap.ended_at.is_(None))) == 2
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 4
     )
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 3
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(
-            RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(RoleGroupMap).where(
+                RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 2
     )
-    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 0
+    assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at.is_(None))) == 0
 
     update_group_spy.reset_mock()
 
@@ -1155,34 +1244,36 @@ def test_time_limit_add_app_tags(
     data = {
         "name": "Updated",
         "description": "new description",
-        "tags_to_remove": [tags[0].id],
-        "tags_to_add": [tags[1].id, tags[2].id],
+        "tags_to_remove": [tag0_id],
+        "tags_to_add": [tag1_id, tag2_id],
     }
 
-    app_url = url_for("api-apps.app_by_id", app_id=access_app.id)
-    rep = client.put(app_url, json=data)
+    app_url = url_for("api-apps.app_by_id", app_id=app_id)
+    rep = await client.put(app_url, json=data)
     assert rep.status_code == 200
     assert update_group_spy.call_count == 0
 
-    assert db.session.query(OktaGroupTagMap).filter(OktaGroupTagMap.ended_at.is_(None)).count() == 2
-    assert db.session.query(AppTagMap).filter(AppTagMap.ended_at.is_(None)).count() == 2
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 2
+    assert await db_count(db.session, select(AppTagMap).where(AppTagMap.ended_at.is_(None))) == 2
     assert (
-        db.session.query(OktaUserGroupMember)
-        .filter(
-            OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 4
     )
-    assert db.session.query(OktaUserGroupMember).filter(OktaUserGroupMember.ended_at.is_(None)).count() == 3
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 3
     assert (
-        db.session.query(RoleGroupMap)
-        .filter(
-            RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-            RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+        await db_count(
+            db.session,
+            select(RoleGroupMap).where(
+                RoleGroupMap.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                RoleGroupMap.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
         )
-        .count()
         == 2
     )
-    assert db.session.query(RoleGroupMap).filter(RoleGroupMap.ended_at.is_(None)).count() == 0
+    assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at.is_(None))) == 0

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 
-from fastapi.testclient import TestClient
+from httpx import AsyncClient
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
 from api.config import settings
@@ -12,8 +13,8 @@ from tests.factories import OktaUserFactory
 from typing import Any
 
 
-def test_get_user_at_me_includes_group_memberships(
-    client: TestClient,
+async def test_get_user_at_me_includes_group_memberships(
+    client: AsyncClient,
     db: Db,
     okta_group: OktaGroup,
     url_for: Any,
@@ -22,16 +23,18 @@ def test_get_user_at_me_includes_group_memberships(
     active_group_ownerships to render the user's groups. The migrated
     OktaUserDetail originally dropped these lists."""
     db.session.add(okta_group)
-    db.session.commit()
-    access_user = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
-    ModifyGroupUsers(
+    await db.session.commit()
+    access_user = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
+    await ModifyGroupUsers(
         group=okta_group,
         members_to_add=[access_user.id],
         owners_to_add=[access_user.id],
         sync_to_okta=False,
     ).execute()
 
-    rep = client.get(url_for("api-users.user_by_id", user_id="@me"))
+    rep = await client.get(url_for("api-users.user_by_id", user_id="@me"))
     assert rep.status_code == 200, rep.text
     data = rep.json()
     assert "active_group_memberships" in data
@@ -42,8 +45,8 @@ def test_get_user_at_me_includes_group_memberships(
     assert okta_group.id in owner_group_ids
 
 
-def test_get_user_profile_filtered_by_allowlist(
-    client: TestClient,
+async def test_get_user_profile_filtered_by_allowlist(
+    client: AsyncClient,
     db: Db,
     user: OktaUser,
     url_for: Any,
@@ -52,9 +55,9 @@ def test_get_user_profile_filtered_by_allowlist(
     `USER_DISPLAY_CUSTOM_ATTRIBUTES`. Anything else must be stripped."""
     user.profile = {"Title": "Engineer", "Manager": "boss@example.com", "Secret": "shh"}
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
-    rep = client.get(url_for("api-users.user_by_id", user_id=user.id))
+    rep = await client.get(url_for("api-users.user_by_id", user_id=user.id))
     assert rep.status_code == 200, rep.text
     profile = rep.json()["profile"]
     # Defaults are "Title,Manager"
@@ -63,8 +66,8 @@ def test_get_user_profile_filtered_by_allowlist(
     assert "Secret" not in profile
 
 
-def test_get_user(
-    client: TestClient,
+async def test_get_user(
+    client: AsyncClient,
     db: Db,
     user: OktaUser,
     access_app: App,
@@ -75,22 +78,28 @@ def test_get_user(
 ) -> None:
     # test 404
     user_url = url_for("api-users.user_by_id", user_id="randomid")
-    rep = client.get(user_url)
+    rep = await client.get(user_url)
     assert rep.status_code == 404
 
     db.session.add(access_app)
     db.session.add(okta_group)
     db.session.add(user)
     db.session.add(role_group)
-    db.session.commit()
+    await db.session.commit()
     app_group.app_id = access_app.id
     db.session.add(app_group)
-    db.session.commit()
+    await db.session.commit()
 
-    ModifyGroupUsers(group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyGroupUsers(group=app_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False).execute()
-    ModifyRoleGroups(
+    await ModifyGroupUsers(
+        group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(
+        group=app_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyRoleGroups(
         role_group=role_group,
         groups_to_add=[okta_group.id, app_group.id],
         owner_groups_to_add=[okta_group.id, app_group.id],
@@ -105,7 +114,7 @@ def test_get_user(
 
     # test get user
     user_url = url_for("api-users.user_by_id", user_id=user_id)
-    rep = client.get(user_url)
+    rep = await client.get(user_url)
     assert rep.status_code == 200
 
     data = rep.json()
@@ -113,48 +122,48 @@ def test_get_user(
     assert data["email"] == user_email
 
 
-def test_put_user(client: TestClient, db: Db, user: OktaUser, url_for: Any) -> None:
+async def test_put_user(client: AsyncClient, db: Db, user: OktaUser, url_for: Any) -> None:
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     # test 405
     user_url = url_for("api-users.user_by_id", user_id=user.id)
-    rep = client.put(user_url)
+    rep = await client.put(user_url)
     assert rep.status_code == 405
 
 
-def test_delete_user(client: TestClient, db: Db, user: OktaUser, url_for: Any) -> None:
+async def test_delete_user(client: AsyncClient, db: Db, user: OktaUser, url_for: Any) -> None:
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
     # test 405
     user_url = url_for("api-users.user_by_id", user_id=user.id)
-    rep = client.delete(user_url)
+    rep = await client.delete(user_url)
     assert rep.status_code == 405
 
 
-def test_create_user(client: TestClient, db: Db, user: OktaUser, url_for: Any) -> None:
+async def test_create_user(client: AsyncClient, db: Db, user: OktaUser, url_for: Any) -> None:
     # test 405 (POST not allowed on /api/users)
     users_url = url_for("api-users.users")
-    rep = client.post(users_url, json={"id": user.id, "email": user.email})
+    rep = await client.post(users_url, json={"id": user.id, "email": user.email})
     assert rep.status_code == 405
 
 
-def test_get_all_user(client: TestClient, db: Db, url_for: Any) -> None:
+async def test_get_all_user(client: AsyncClient, db: Db, url_for: Any) -> None:
     users_url = url_for("api-users.users")
     users = OktaUserFactory.create_batch(10)
 
     db.session.add_all(users)
-    db.session.commit()
+    await db.session.commit()
 
-    rep = client.get(users_url)
+    rep = await client.get(users_url)
     assert rep.status_code == 200
 
     results = rep.json()
     for user in users:
         assert any(u["id"] == user.id for u in results["items"])
 
-    rep = client.get(users_url, params={"q": "a"})
+    rep = await client.get(users_url, params={"q": "a"})
     assert rep.status_code == 200
 
     results = rep.json()
@@ -162,7 +171,7 @@ def test_get_all_user(client: TestClient, db: Db, url_for: Any) -> None:
         assert any(u["id"] == user.id for u in results["items"])
 
 
-def test_user_email_uniqueness(client: TestClient, db: Db) -> None:
+async def test_user_email_uniqueness(client: AsyncClient, db: Db) -> None:
     known_email = "test@email.com"
 
     # Create a user with a unique email
@@ -171,34 +180,34 @@ def test_user_email_uniqueness(client: TestClient, db: Db) -> None:
     user1.email = known_email
 
     db.session.add(user1)
-    db.session.commit()
+    await db.session.commit()
 
     # Trying to insert a user with the same email should fail
     user2 = OktaUserFactory.create()
     user2.email = known_email
     try:
         db.session.add(user2)
-        db.session.commit()
+        await db.session.commit()
         assert False
     except IntegrityError as e:
         assert "constraint" in str(e)
-        db.session.rollback()
+        await db.session.rollback()
 
     # Verify another user with the same email can be inserted if its state is deleted
     user2.deleted_at = datetime.now(timezone.utc)
     db.session.add(user2)
-    db.session.commit()  # This should not raise an exception
+    await db.session.commit()  # This should not raise an exception
 
 
-def test_user_summary_includes_timestamps(client: TestClient, db: Db, user: OktaUser, url_for: Any) -> None:
+async def test_user_summary_includes_timestamps(client: AsyncClient, db: Db, user: OktaUser, url_for: Any) -> None:
     """`OktaUserSummary` exposes `created_at` and `updated_at` so the
     React user list can sort by creation time. Flask's Marshmallow
     UserList included these in `only=(...)`; the FastAPI summary
     schema must keep parity."""
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
-    rep = client.get(url_for("api-users.users"))
+    rep = await client.get(url_for("api-users.users"))
     assert rep.status_code == 200
     results = rep.json()["items"]
     assert results, "expected at least one user in the list"
@@ -208,7 +217,7 @@ def test_user_summary_includes_timestamps(client: TestClient, db: Db, user: Okta
     assert sample["created_at"] is not None
 
 
-def test_get_user_manager_includes_profile(client: TestClient, db: Db, user: OktaUser, url_for: Any) -> None:
+async def test_get_user_manager_includes_profile(client: AsyncClient, db: Db, user: OktaUser, url_for: Any) -> None:
     """Flask's nested manager schema retained `profile` (filtered to
     `USER_DISPLAY_CUSTOM_ATTRIBUTES`). The FastAPI `OktaUserDetail.manager`
     must expose the same dict so the React user-detail page can render the
@@ -216,13 +225,13 @@ def test_get_user_manager_includes_profile(client: TestClient, db: Db, user: Okt
     manager = OktaUserFactory.create()
     manager.profile = {"Title": "Director", "Manager": "ceo@example.com"}
     db.session.add(manager)
-    db.session.commit()
+    await db.session.commit()
 
     user.manager_id = manager.id
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
-    rep = client.get(url_for("api-users.user_by_id", user_id=user.id))
+    rep = await client.get(url_for("api-users.user_by_id", user_id=user.id))
     assert rep.status_code == 200, rep.text
     data = rep.json()
     assert data["manager"] is not None
@@ -234,8 +243,8 @@ def test_get_user_manager_includes_profile(client: TestClient, db: Db, user: Okt
     assert profile.get("Manager") == "ceo@example.com"
 
 
-def test_get_user_excludes_aggregated_membership_lists(
-    client: TestClient, db: Db, user: OktaUser, url_for: Any
+async def test_get_user_excludes_aggregated_membership_lists(
+    client: AsyncClient, db: Db, user: OktaUser, url_for: Any
 ) -> None:
     """Flask's `UserResource.get()` excluded `all_group_memberships_and_ownerships`
     and `active_group_memberships_and_ownerships`. The FastAPI `OktaUserDetail`
@@ -243,9 +252,9 @@ def test_get_user_excludes_aggregated_membership_lists(
     duplicate the data already in `active_group_memberships` /
     `active_group_ownerships`."""
     db.session.add(user)
-    db.session.commit()
+    await db.session.commit()
 
-    rep = client.get(url_for("api-users.user_by_id", user_id=user.id))
+    rep = await client.get(url_for("api-users.user_by_id", user_id=user.id))
     assert rep.status_code == 200, rep.text
     data = rep.json()
     assert "all_group_memberships_and_ownerships" not in data

--- a/tests/test_user_sync.py
+++ b/tests/test_user_sync.py
@@ -1,11 +1,11 @@
 from typing import List
 
 from pytest_mock import MockerFixture
-from sqlalchemy.orm import Session
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from sqlalchemy import func
-from api.models import AccessRequest, AccessRequestStatus, OktaGroup, OktaUser, OktaUserGroupMember, RoleGroup
 from api.extensions import Db
+from api.models import AccessRequest, AccessRequestStatus, OktaGroup, OktaUser, OktaUserGroupMember, RoleGroup
 from api.operations import CreateAccessRequest
 from api.services import okta
 from api.services.okta_service import User, UserSchema
@@ -13,12 +13,12 @@ from api.syncer import sync_users
 from tests.factories import UserFactory, UserSchemaFactory
 
 
-def test_user_sync_no_changes(db: Db, mocker: MockerFixture) -> None:
+async def test_user_sync_no_changes(db: Db, mocker: MockerFixture) -> None:
     initial_users_in_okta = UserFactory.create_batch(3)
 
-    initial_db_users = seed_db(db, initial_users_in_okta)
+    initial_db_users = await seed_db(db, initial_users_in_okta)
 
-    new_db_users = run_sync(db, mocker, initial_users_in_okta)
+    new_db_users = await run_sync(db, mocker, initial_users_in_okta)
 
     for i in range(len(initial_users_in_okta)):
         assert okta_users_are_equal(
@@ -27,29 +27,29 @@ def test_user_sync_no_changes(db: Db, mocker: MockerFixture) -> None:
         )
 
 
-def test_user_sync_updates_fields(db: Db, mocker: MockerFixture) -> None:
+async def test_user_sync_updates_fields(db: Db, mocker: MockerFixture) -> None:
     initial_users_in_okta = UserFactory.create_batch(1)
 
-    _ = seed_db(db, initial_users_in_okta)
+    _ = await seed_db(db, initial_users_in_okta)
 
     initial_users_in_okta[0].profile.login = "changed"
 
-    new_db_users = run_sync(db, mocker, initial_users_in_okta)
+    new_db_users = await run_sync(db, mocker, initial_users_in_okta)
 
     assert get_user_by_id(new_db_users, initial_users_in_okta[0].id).email == "changed"
 
 
-def test_user_sync_updates_deleted_user(
+async def test_user_sync_updates_deleted_user(
     db: Db, mocker: MockerFixture, okta_group: OktaGroup, role_group: RoleGroup
 ) -> None:
     initial_users_in_okta = UserFactory.create_batch(1)
 
-    initial_db_users = seed_db(db, initial_users_in_okta)
+    initial_db_users = await seed_db(db, initial_users_in_okta)
 
     # Add a managed group membership and ownership to the user to be deleted
     db.session.add(okta_group)
-    db.session.commit()
-    db.session.commit()
+    await db.session.commit()
+    await db.session.commit()
     managed_membership = OktaUserGroupMember(
         user_id=initial_users_in_okta[0].id, group_id=okta_group.id, ended_at=None, is_owner=False
     )
@@ -58,13 +58,13 @@ def test_user_sync_updates_deleted_user(
         user_id=initial_users_in_okta[0].id, group_id=okta_group.id, ended_at=None, is_owner=True
     )
     db.session.add(managed_ownership)
-    db.session.commit()
+    await db.session.commit()
 
     # Add a unmanaged group membership and ownership to the user to be deleted
     role_group.is_managed = False
     db.session.add(role_group)
-    db.session.commit()
-    db.session.commit()
+    await db.session.commit()
+    await db.session.commit()
     unmanaged_membership = OktaUserGroupMember(
         user_id=initial_users_in_okta[0].id, group_id=role_group.id, ended_at=None, is_owner=False
     )
@@ -73,10 +73,10 @@ def test_user_sync_updates_deleted_user(
         user_id=initial_users_in_okta[0].id, group_id=role_group.id, ended_at=None, is_owner=True
     )
     db.session.add(unmanaged_ownership)
-    db.session.commit()
+    await db.session.commit()
 
     # Create AccessRequest to test it gets rejected
-    access_request = CreateAccessRequest(
+    access_request = await CreateAccessRequest(
         requester_user=initial_db_users[0],
         requested_group=okta_group,
         request_ownership=False,
@@ -86,36 +86,40 @@ def test_user_sync_updates_deleted_user(
     initial_users_in_okta[0].status = "DEPROVISIONED"
     initial_users_in_okta[0].status_changed = "2022-06-02 11:54:51.724560"
 
-    delete_membership_spy = mocker.patch.object(okta, "async_remove_user_from_group")
-    delete_ownership_spy = mocker.patch.object(okta, "async_remove_owner_from_group")
+    delete_membership_spy = mocker.patch.object(okta, "remove_user_from_group")
+    delete_ownership_spy = mocker.patch.object(okta, "remove_owner_from_group")
 
-    new_db_users = run_sync(db, mocker, initial_users_in_okta)
+    new_db_users = await run_sync(db, mocker, initial_users_in_okta)
 
     deleted_user = get_user_by_id(new_db_users, initial_users_in_okta[0].id)
     assert str(deleted_user.deleted_at) == initial_users_in_okta[0].status_changed
-    assert db.session.get(OktaUser, initial_users_in_okta[0].id).deleted_at is not None
+    # synchronize_session="fetch" expired these rows during the sync; refresh
+    # them on the async session before reading their attributes.
+    for membership in (managed_membership, managed_ownership, unmanaged_membership, unmanaged_ownership):
+        await db.session.refresh(membership)
+    assert (await db.session.get(OktaUser, initial_users_in_okta[0].id)).deleted_at is not None
     assert access_request is not None
-    assert db.session.get(AccessRequest, access_request.id).status == AccessRequestStatus.REJECTED
-    assert db.session.get(OktaUserGroupMember, managed_membership.id).ended_at is not None
-    assert db.session.get(OktaUserGroupMember, managed_ownership.id).ended_at is not None
-    assert db.session.get(OktaUserGroupMember, unmanaged_membership.id).ended_at is not None
-    assert db.session.get(OktaUserGroupMember, unmanaged_ownership.id).ended_at is not None
+    assert (await db.session.get(AccessRequest, access_request.id)).status == AccessRequestStatus.REJECTED
+    assert (await db.session.get(OktaUserGroupMember, managed_membership.id)).ended_at is not None
+    assert (await db.session.get(OktaUserGroupMember, managed_ownership.id)).ended_at is not None
+    assert (await db.session.get(OktaUserGroupMember, unmanaged_membership.id)).ended_at is not None
+    assert (await db.session.get(OktaUserGroupMember, unmanaged_ownership.id)).ended_at is not None
     # Should only be called once each for the managed group
     assert delete_membership_spy.call_count == 1
     assert delete_ownership_spy.call_count == 1
 
 
-def test_user_sync_deletes_disappearing_user(
+async def test_user_sync_deletes_disappearing_user(
     db: Db, mocker: MockerFixture, okta_group: OktaGroup, role_group: RoleGroup
 ) -> None:
     initial_users_in_okta = UserFactory.create_batch(1)
 
-    initial_db_users = seed_db(db, initial_users_in_okta)
+    initial_db_users = await seed_db(db, initial_users_in_okta)
 
     # Add a managed group membership and ownership to the user to be deleted
     db.session.add(okta_group)
-    db.session.commit()
-    db.session.commit()
+    await db.session.commit()
+    await db.session.commit()
     managed_membership = OktaUserGroupMember(
         user_id=initial_users_in_okta[0].id, group_id=okta_group.id, ended_at=None, is_owner=False
     )
@@ -124,13 +128,13 @@ def test_user_sync_deletes_disappearing_user(
         user_id=initial_users_in_okta[0].id, group_id=okta_group.id, ended_at=None, is_owner=True
     )
     db.session.add(managed_ownership)
-    db.session.commit()
+    await db.session.commit()
 
     # Add a unmanaged group membership and ownership to the user to be deleted
     role_group.is_managed = False
     db.session.add(role_group)
-    db.session.commit()
-    db.session.commit()
+    await db.session.commit()
+    await db.session.commit()
     unmanaged_membership = OktaUserGroupMember(
         user_id=initial_users_in_okta[0].id, group_id=role_group.id, ended_at=None, is_owner=False
     )
@@ -139,51 +143,55 @@ def test_user_sync_deletes_disappearing_user(
         user_id=initial_users_in_okta[0].id, group_id=role_group.id, ended_at=None, is_owner=True
     )
     db.session.add(unmanaged_ownership)
-    db.session.commit()
+    await db.session.commit()
 
     # Create AccessRequest to test it gets rejected
-    access_request = CreateAccessRequest(
+    access_request = await CreateAccessRequest(
         requester_user=initial_db_users[0],
         requested_group=okta_group,
         request_ownership=False,
         request_reason="test reason",
     ).execute()
 
-    delete_membership_spy = mocker.patch.object(okta, "async_remove_user_from_group")
-    delete_ownership_spy = mocker.patch.object(okta, "async_remove_owner_from_group")
+    delete_membership_spy = mocker.patch.object(okta, "remove_user_from_group")
+    delete_ownership_spy = mocker.patch.object(okta, "remove_owner_from_group")
 
     assert get_user_by_id(initial_db_users, initial_users_in_okta[0].id).deleted_at is None
 
-    new_db_users = run_sync(db, mocker, [])
+    new_db_users = await run_sync(db, mocker, [])
 
     assert len(initial_db_users) == len(new_db_users)
     assert get_user_by_id(new_db_users, initial_users_in_okta[0].id).deleted_at is not None
-    assert db.session.get(OktaUser, initial_users_in_okta[0].id).deleted_at is not None
+    # synchronize_session="fetch" expired these rows during the sync; refresh
+    # them on the async session before reading their attributes.
+    for membership in (managed_membership, managed_ownership, unmanaged_membership, unmanaged_ownership):
+        await db.session.refresh(membership)
+    assert (await db.session.get(OktaUser, initial_users_in_okta[0].id)).deleted_at is not None
     assert access_request is not None
-    assert db.session.get(AccessRequest, access_request.id).status == AccessRequestStatus.REJECTED
-    assert db.session.get(OktaUserGroupMember, managed_membership.id).ended_at is not None
-    assert db.session.get(OktaUserGroupMember, managed_ownership.id).ended_at is not None
-    assert db.session.get(OktaUserGroupMember, unmanaged_membership.id).ended_at is not None
-    assert db.session.get(OktaUserGroupMember, unmanaged_ownership.id).ended_at is not None
+    assert (await db.session.get(AccessRequest, access_request.id)).status == AccessRequestStatus.REJECTED
+    assert (await db.session.get(OktaUserGroupMember, managed_membership.id)).ended_at is not None
+    assert (await db.session.get(OktaUserGroupMember, managed_ownership.id)).ended_at is not None
+    assert (await db.session.get(OktaUserGroupMember, unmanaged_membership.id)).ended_at is not None
+    assert (await db.session.get(OktaUserGroupMember, unmanaged_ownership.id)).ended_at is not None
     # Should never be called as the user no longer exists in Okta
     assert delete_membership_spy.call_count == 0
     assert delete_ownership_spy.call_count == 0
 
 
-def test_user_sync_ends_memberships_for_previously_deleted_user(
+async def test_user_sync_ends_memberships_for_previously_deleted_user(
     db: Db, mocker: MockerFixture, okta_group: OktaGroup, role_group: RoleGroup
 ) -> None:
     initial_users_in_okta = UserFactory.create_batch(1)
 
-    seed_db(db, initial_users_in_okta)
+    await seed_db(db, initial_users_in_okta)
 
     # Mark the user as deleted in Access
-    db.session.get(OktaUser, initial_users_in_okta[0].id).deleted_at = func.now()
+    (await db.session.get(OktaUser, initial_users_in_okta[0].id)).deleted_at = func.now()
 
     # Add a managed group membership and ownership to the user to be deleted
     db.session.add(okta_group)
-    db.session.commit()
-    db.session.commit()
+    await db.session.commit()
+    await db.session.commit()
     managed_membership = OktaUserGroupMember(
         user_id=initial_users_in_okta[0].id, group_id=okta_group.id, ended_at=None, is_owner=False
     )
@@ -192,13 +200,13 @@ def test_user_sync_ends_memberships_for_previously_deleted_user(
         user_id=initial_users_in_okta[0].id, group_id=okta_group.id, ended_at=None, is_owner=True
     )
     db.session.add(managed_ownership)
-    db.session.commit()
+    await db.session.commit()
 
     # Add a unmanaged group membership and ownership to the user to be deleted
     role_group.is_managed = False
     db.session.add(role_group)
-    db.session.commit()
-    db.session.commit()
+    await db.session.commit()
+    await db.session.commit()
     unmanaged_membership = OktaUserGroupMember(
         user_id=initial_users_in_okta[0].id, group_id=role_group.id, ended_at=None, is_owner=False
     )
@@ -207,42 +215,46 @@ def test_user_sync_ends_memberships_for_previously_deleted_user(
         user_id=initial_users_in_okta[0].id, group_id=role_group.id, ended_at=None, is_owner=True
     )
     db.session.add(unmanaged_ownership)
-    db.session.commit()
+    await db.session.commit()
 
     initial_users_in_okta[0].status = "DEPROVISIONED"
     initial_users_in_okta[0].status_changed = "2022-06-02 11:54:51.724560"
 
-    delete_membership_spy = mocker.patch.object(okta, "async_remove_user_from_group")
-    delete_ownership_spy = mocker.patch.object(okta, "async_remove_owner_from_group")
+    delete_membership_spy = mocker.patch.object(okta, "remove_user_from_group")
+    delete_ownership_spy = mocker.patch.object(okta, "remove_owner_from_group")
 
-    new_db_users = run_sync(db, mocker, initial_users_in_okta)
+    new_db_users = await run_sync(db, mocker, initial_users_in_okta)
 
     deleted_user = get_user_by_id(new_db_users, initial_users_in_okta[0].id)
     assert str(deleted_user.deleted_at) == initial_users_in_okta[0].status_changed
-    assert db.session.get(OktaUser, initial_users_in_okta[0].id).deleted_at is not None
-    assert db.session.get(OktaUserGroupMember, managed_membership.id).ended_at is not None
-    assert db.session.get(OktaUserGroupMember, managed_ownership.id).ended_at is not None
-    assert db.session.get(OktaUserGroupMember, unmanaged_membership.id).ended_at is not None
-    assert db.session.get(OktaUserGroupMember, unmanaged_ownership.id).ended_at is not None
+    # synchronize_session="fetch" expired these rows during the sync; refresh
+    # them on the async session before reading their attributes.
+    for membership in (managed_membership, managed_ownership, unmanaged_membership, unmanaged_ownership):
+        await db.session.refresh(membership)
+    assert (await db.session.get(OktaUser, initial_users_in_okta[0].id)).deleted_at is not None
+    assert (await db.session.get(OktaUserGroupMember, managed_membership.id)).ended_at is not None
+    assert (await db.session.get(OktaUserGroupMember, managed_ownership.id)).ended_at is not None
+    assert (await db.session.get(OktaUserGroupMember, unmanaged_membership.id)).ended_at is not None
+    assert (await db.session.get(OktaUserGroupMember, unmanaged_ownership.id)).ended_at is not None
     # Should only be called once each for the managed group
     assert delete_membership_spy.call_count == 1
     assert delete_ownership_spy.call_count == 1
 
 
-def seed_db(db: Db, users: List[User]) -> List[OktaUser]:
-    with Session(db.engine) as session:
+async def seed_db(db: Db, users: List[User]) -> List[OktaUser]:
+    async with AsyncSession(db.engine) as session:
         session.add_all([User(u).update_okta_user(OktaUser(), {}) for u in users])
-        session.commit()
-        return session.query(OktaUser).all()
+        await session.commit()
+        return list((await session.scalars(select(OktaUser))).all())
 
 
-def run_sync(db: Db, mocker: MockerFixture, okta_users: List[User]) -> List[OktaUser]:
+async def run_sync(db: Db, mocker: MockerFixture, okta_users: List[User]) -> List[OktaUser]:
     schema = UserSchemaFactory.create()
-    with Session(db.engine) as session:
+    async with AsyncSession(db.engine) as session:
         mocker.patch.object(okta, "list_users", return_value=[User(u) for u in okta_users])
         mocker.patch.object(okta, "get_user_schema", return_value=UserSchema(schema))
-        sync_users()
-        return session.query(OktaUser).all()
+        await sync_users()
+        return list((await session.scalars(select(OktaUser))).all())
 
 
 def get_user_by_id(user_list: List[OktaUser], user_id: str) -> OktaUser:

--- a/tests/test_zombie_role_requests.py
+++ b/tests/test_zombie_role_requests.py
@@ -13,6 +13,7 @@ group is a role) where it is the requester role.
 
 import pytest
 from pytest_mock import MockerFixture
+from sqlalchemy import select
 
 from api.config import settings
 from api.extensions import Db
@@ -25,23 +26,27 @@ from api.services import okta
 def _mock_okta(mocker: MockerFixture) -> None:
     # Keep the operations off the network. patch.object auto-detects the async
     # functions and substitutes AsyncMocks.
-    mocker.patch.object(okta, "async_add_user_to_group")
-    mocker.patch.object(okta, "async_add_owner_to_group")
-    mocker.patch.object(okta, "async_remove_user_from_group")
-    mocker.patch.object(okta, "async_remove_owner_from_group")
-    mocker.patch.object(okta, "async_delete_group")
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
+    mocker.patch.object(okta, "remove_user_from_group")
+    mocker.patch.object(okta, "remove_owner_from_group")
+    mocker.patch.object(okta, "delete_group")
 
 
-def _access_owner(db: Db) -> OktaUser:
-    owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+async def _access_owner(db: Db) -> OktaUser:
+    owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
     assert owner is not None
     return owner
 
 
-def _pending_role_request(db: Db, *, requester_role: RoleGroup, requested_group: OktaGroup, requester_user: OktaUser):
+async def _pending_role_request(
+    db: Db, *, requester_role: RoleGroup, requested_group: OktaGroup, requester_user: OktaUser
+):
     # Requester must own the role to file a role request for it.
-    ModifyGroupUsers(group=requester_role, owners_to_add=[requester_user.id], sync_to_okta=False).execute()
-    role_request = CreateRoleRequest(
+    await ModifyGroupUsers(group=requester_role, owners_to_add=[requester_user.id], sync_to_okta=False).execute()
+    role_request = await CreateRoleRequest(
         requester_user=requester_user,
         requester_role=requester_role,
         requested_group=requested_group,
@@ -57,34 +62,38 @@ def _pending_role_request(db: Db, *, requester_role: RoleGroup, requested_group:
 # ---------------------------------------------------------------------------
 
 
-def test_unmanage_group_rejects_pending_role_request_for_group(
+async def test_unmanage_group_rejects_pending_role_request_for_group(
     db: Db, user: OktaUser, role_group: RoleGroup, okta_group: OktaGroup
 ) -> None:
     db.session.add_all([user, role_group, okta_group])
-    db.session.commit()
-    role_request = _pending_role_request(db, requester_role=role_group, requested_group=okta_group, requester_user=user)
+    await db.session.commit()
+    role_request = await _pending_role_request(
+        db, requester_role=role_group, requested_group=okta_group, requester_user=user
+    )
 
     # Group transitions to unmanaged (as the syncer does before UnmanageGroup).
     okta_group.is_managed = False
-    db.session.commit()
+    await db.session.commit()
 
-    UnmanageGroup(group=okta_group, current_user_id=_access_owner(db).id).execute()
+    await UnmanageGroup(group=okta_group, current_user_id=(await _access_owner(db)).id).execute()
 
-    db.session.refresh(role_request)
+    await db.session.refresh(role_request)
     assert role_request.status == AccessRequestStatus.REJECTED
     assert role_request.resolved_at is not None
 
 
-def test_delete_group_rejects_pending_role_request_for_group(
+async def test_delete_group_rejects_pending_role_request_for_group(
     db: Db, user: OktaUser, role_group: RoleGroup, okta_group: OktaGroup
 ) -> None:
     db.session.add_all([user, role_group, okta_group])
-    db.session.commit()
-    role_request = _pending_role_request(db, requester_role=role_group, requested_group=okta_group, requester_user=user)
+    await db.session.commit()
+    role_request = await _pending_role_request(
+        db, requester_role=role_group, requested_group=okta_group, requester_user=user
+    )
 
-    DeleteGroup(group=okta_group, sync_to_okta=False, current_user_id=_access_owner(db).id).execute()
+    await DeleteGroup(group=okta_group, sync_to_okta=False, current_user_id=(await _access_owner(db)).id).execute()
 
-    db.session.refresh(role_request)
+    await db.session.refresh(role_request)
     assert role_request.status == AccessRequestStatus.REJECTED
     assert role_request.resolved_at is not None
 
@@ -94,33 +103,37 @@ def test_delete_group_rejects_pending_role_request_for_group(
 # ---------------------------------------------------------------------------
 
 
-def test_unmanage_group_rejects_pending_role_request_where_group_is_requester_role(
+async def test_unmanage_group_rejects_pending_role_request_where_group_is_requester_role(
     db: Db, user: OktaUser, role_group: RoleGroup, okta_group: OktaGroup
 ) -> None:
     db.session.add_all([user, role_group, okta_group])
-    db.session.commit()
+    await db.session.commit()
     # role_group is the requester; okta_group is the requested target.
-    role_request = _pending_role_request(db, requester_role=role_group, requested_group=okta_group, requester_user=user)
+    role_request = await _pending_role_request(
+        db, requester_role=role_group, requested_group=okta_group, requester_user=user
+    )
 
     role_group.is_managed = False
-    db.session.commit()
+    await db.session.commit()
 
-    UnmanageGroup(group=role_group, current_user_id=_access_owner(db).id).execute()
+    await UnmanageGroup(group=role_group, current_user_id=(await _access_owner(db)).id).execute()
 
-    db.session.refresh(role_request)
+    await db.session.refresh(role_request)
     assert role_request.status == AccessRequestStatus.REJECTED
     assert role_request.resolved_at is not None
 
 
-def test_delete_group_rejects_pending_role_request_where_group_is_requester_role(
+async def test_delete_group_rejects_pending_role_request_where_group_is_requester_role(
     db: Db, user: OktaUser, role_group: RoleGroup, okta_group: OktaGroup
 ) -> None:
     db.session.add_all([user, role_group, okta_group])
-    db.session.commit()
-    role_request = _pending_role_request(db, requester_role=role_group, requested_group=okta_group, requester_user=user)
+    await db.session.commit()
+    role_request = await _pending_role_request(
+        db, requester_role=role_group, requested_group=okta_group, requester_user=user
+    )
 
-    DeleteGroup(group=role_group, sync_to_okta=False, current_user_id=_access_owner(db).id).execute()
+    await DeleteGroup(group=role_group, sync_to_okta=False, current_user_id=(await _access_owner(db)).id).execute()
 
-    db.session.refresh(role_request)
+    await db.session.refresh(role_request)
     assert role_request.status == AccessRequestStatus.REJECTED
     assert role_request.resolved_at is not None

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ commands=
 commands=
   pytest -s tests {posargs}
 setenv =
-       TEST_DATABASE_URI = postgresql+pg8000://postgres:postgres@localhost:5432
+       TEST_DATABASE_URI = postgresql+asyncpg://postgres:postgres@localhost:5432
 
 
 [testenv:ruff]
@@ -39,3 +39,10 @@ commands =
 [testenv:mypy]
 commands =
   mypy .
+
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+asyncio_default_test_loop_scope = function
+filterwarnings =
+    error:coroutine .* was never awaited:RuntimeWarning


### PR DESCRIPTION
Regression battery for the four Flask-era Sentry issues (`ACCESS-FLASK-4N`, `ACCESS-FLASK-44`, `ACCESS-FLASK-4E`) — the `InvalidRequestError: ... lazy='raise_on_sql'` production failures that motivated demoting five relationships to `lazy="select"`, which #477 flips back to `raise_on_sql`.

**Why they never reproduced locally:** `raise_on_sql` raises identically under test, so the only production-only ingredient was *data shape*. The failing serializations required polymorphic subtypes in nested positions — a role group whose associated groups are **app groups**, tagged groups inside request refs, app groups inside membership rows — which the suite never built. The error chain in the reports maps exactly onto the schema nesting: `RoleGroup.active_role_associated_group_member_mappings` (4N) → each mapping's `active_group` (44) → that group's `app` when it's an AppGroup (4E), plus `active_group_tags` (4E) on every rich group ref.

This battery builds that shape once (tagged role group with member+owner associations to a tagged app group and a tagged plain group, via-role memberships, pending access/role requests targeting both group types) and walks every read surface: groups list + detail per type, roles, users, access-request detail with role-group and app-group targets, role requests, tags, apps, and `/api/audit/users` + `/api/audit/groups` both unfiltered and with the `user_id`/`group_id` filters the old model comments singled out. Assertions verify the nested payloads are **populated**, not just 200 — so both failure modes are covered: a missing eager load fails loudly instead of paging on-call, and a silently-empty collection fails instead of shipping wrong data.

**Result: all 17 scenarios pass against the current loaders** — the eager-load topology from the FastAPI migration plus #477's fixes closes every gap behind the four Sentry issues. Full suite: 536 passed.

## PR stack

Merge bottom-up; each PR is based on the branch of the one before it (retarget to `main` as predecessors merge).

1. #475 — async dependency prep (SQLAlchemy[asyncio] 2.0.50, asyncpg, aiosqlite)
2. #476 — legacy Query API -> 2.0-style statements (~350 sites)
3. #477 — eliminate lazy loading and commit-expiration from the ORM layer
4. #478 — operation DB resolution out of `__init__` into `_resolve()`
5. #479 — keep `db.session` access out of spawned notification tasks
6. #480 — **the async flip** (production + tests + docs)
7. #481 — surface failed Okta/notification fan-out tasks
8. #482 — regression battery for the Flask-era lazy-load Sentry issues ⬅️ **this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

