### PR TITLE
Deleted users does't close requests

### DIFF
--- a/api/operations/delete_user.py
+++ b/api/operations/delete_user.py
@@ -7,8 +7,16 @@ from sqlalchemy.orm import (
 
 from sqlalchemy import func, or_
 from api.extensions import db
-from api.models import AccessRequest, AccessRequestStatus, OktaGroup, OktaUser, OktaUserGroupMember
-from api.operations import RejectAccessRequest
+from api.models import (
+    AccessRequest,
+    AccessRequestStatus,
+    GroupRequest,
+    OktaGroup,
+    OktaUser,
+    OktaUserGroupMember,
+    RoleRequest,
+)
+from api.operations import RejectAccessRequest, RejectGroupRequest, RejectRoleRequest
 from api.services import okta
 
 
@@ -90,6 +98,38 @@ class DeleteUser:
         for obsolete_access_request in obsolete_access_requests:
             RejectAccessRequest(
                 access_request=obsolete_access_request,
+                rejection_reason="Closed because the requestor was deleted",
+                current_user_id=self.current_user_id,
+            ).execute()
+
+        # Reject pending role requests by the deleted user. ApproveRoleRequest
+        # doesn't guard on a deleted requester, so a surviving one would still
+        # grant the role access to the group after the requester is gone.
+        obsolete_role_requests = (
+            db.session.query(RoleRequest)
+            .filter(RoleRequest.requester_user_id == self.user.id)
+            .filter(RoleRequest.status == AccessRequestStatus.PENDING)
+            .filter(RoleRequest.resolved_at.is_(None))
+            .all()
+        )
+        for obsolete_role_request in obsolete_role_requests:
+            RejectRoleRequest(
+                role_request=obsolete_role_request,
+                rejection_reason="Closed because the requestor was deleted",
+                current_user_id=self.current_user_id,
+            ).execute()
+
+        # Reject pending group requests by the deleted user, mirroring above.
+        obsolete_group_requests = (
+            db.session.query(GroupRequest)
+            .filter(GroupRequest.requester_user_id == self.user.id)
+            .filter(GroupRequest.status == AccessRequestStatus.PENDING)
+            .filter(GroupRequest.resolved_at.is_(None))
+            .all()
+        )
+        for obsolete_group_request in obsolete_group_requests:
+            RejectGroupRequest(
+                group_request=obsolete_group_request,
                 rejection_reason="Closed because the requestor was deleted",
                 current_user_id=self.current_user_id,
             ).execute()

--- a/tests/test_delete_user_rejects_pending_requests.py
+++ b/tests/test_delete_user_rejects_pending_requests.py
@@ -1,0 +1,107 @@
+"""DeleteUser rejects the deleted user's pending requests.
+
+AccessRequests were already rejected on delete; these assert RoleRequests and
+GroupRequests are handled the same way (the AccessRequest test is the baseline).
+"""
+
+import pytest
+from pytest_mock import MockerFixture
+
+from api.config import settings
+from api.extensions import Db
+from api.models import AccessRequestStatus, OktaGroup, OktaUser, RoleGroup
+from api.operations import (
+    CreateAccessRequest,
+    CreateGroupRequest,
+    CreateRoleRequest,
+    DeleteUser,
+    ModifyGroupUsers,
+)
+from api.services import okta
+
+DELETION_REASON = "Closed because the requestor was deleted"
+
+
+@pytest.fixture(autouse=True)
+def _mock_okta(mocker: MockerFixture) -> None:
+    # Keep operations off the network.
+    mocker.patch.object(okta, "async_remove_user_from_group")
+    mocker.patch.object(okta, "async_remove_owner_from_group")
+
+
+def _access_owner(db: Db) -> OktaUser:
+    owner = db.session.query(OktaUser).filter(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL).first()
+    assert owner is not None
+    return owner
+
+
+def test_delete_user_rejects_pending_access_request(db: Db, user: OktaUser, okta_group: OktaGroup) -> None:
+    db.session.add_all([user, okta_group])
+    db.session.commit()
+
+    access_request = CreateAccessRequest(
+        requester_user=user,
+        requested_group=okta_group,
+        request_reason="need this group",
+    ).execute()
+    assert access_request is not None
+    # Widened local so the precondition check doesn't narrow the attribute type
+    # and make the post-refresh REJECTED assertion look non-overlapping to mypy.
+    created_status: AccessRequestStatus = access_request.status
+    assert created_status == AccessRequestStatus.PENDING
+
+    DeleteUser(user=user, sync_to_okta=False, current_user_id=_access_owner(db).id).execute()
+
+    db.session.refresh(access_request)
+    assert access_request.status == AccessRequestStatus.REJECTED
+    assert access_request.resolved_at is not None
+    assert access_request.resolution_reason == DELETION_REASON
+
+
+def test_delete_user_rejects_pending_role_request(
+    db: Db, user: OktaUser, role_group: RoleGroup, okta_group: OktaGroup
+) -> None:
+    db.session.add_all([user, role_group, okta_group])
+    db.session.commit()
+
+    # Requester must own the role to file a role request for it.
+    ModifyGroupUsers(group=role_group, owners_to_add=[user.id], sync_to_okta=False).execute()
+    role_request = CreateRoleRequest(
+        requester_user=user,
+        requester_role=role_group,
+        requested_group=okta_group,
+        request_reason="role needs this group",
+    ).execute()
+    assert role_request is not None
+    created_status: AccessRequestStatus = role_request.status
+    assert created_status == AccessRequestStatus.PENDING
+
+    DeleteUser(user=user, sync_to_okta=False, current_user_id=_access_owner(db).id).execute()
+
+    db.session.refresh(role_request)
+    assert role_request.status == AccessRequestStatus.REJECTED
+    assert role_request.resolved_at is not None
+    assert role_request.resolution_reason == DELETION_REASON
+
+
+def test_delete_user_rejects_pending_group_request(db: Db, user: OktaUser) -> None:
+    db.session.add(user)
+    db.session.commit()
+
+    group_request = CreateGroupRequest(
+        requester_user=user,
+        requested_group_name="Test Group",
+        requested_group_description="Test Description",
+        requested_group_type="okta_group",
+        request_reason="need this group",
+    ).execute()
+    assert group_request is not None
+    created_status: AccessRequestStatus = group_request.status
+    assert created_status == AccessRequestStatus.PENDING
+
+    DeleteUser(user=user, sync_to_okta=False, current_user_id=_access_owner(db).id).execute()
+
+    db.session.refresh(group_request)
+    assert group_request.status == AccessRequestStatus.REJECTED
+    assert group_request.resolved_at is not None
+    assert group_request.resolution_reason == DELETION_REASON


### PR DESCRIPTION
delete_user didn't reject the user's pending role requests or group requests 

updated code to match access request logic and close out pending requests from deleted users