### PR TITLE
Add @swc/core to npm allowScripts allowlist (fix node-lint)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "allowScripts": {
     "@sentry/cli": true,
+    "@swc/core": true,
     "esbuild": true,
     "fsevents": true
   },


### PR DESCRIPTION
## What

Add `@swc/core` to the `allowScripts` allowlist in `package.json`.

## Why

[#473](https://github.com/discord/access/pull/473) enabled `strict-allow-scripts=true` (npm v12 secure install defaults), but its allowlist only covered `@sentry/cli`, `esbuild`, and `fsevents`. It missed **`@swc/core`** — a transitive dependency of `@openapi-codegen/cli` (the `npm run codegen` tool, added in [#470](https://github.com/discord/access/pull/470)) that ships a `postinstall` install script (`hasInstallScript: true`).

As a result `npm ci` fails with `ESTRICTALLOWSCRIPTS` on **every** PR and on `main` itself:

```
npm error code ESTRICTALLOWSCRIPTS
npm error --strict-allow-scripts: 1 package(s) have install scripts not covered by allowScripts:
npm error   @swc/core@1.15.41 (install: (install scripts present))
```

`node-lint` passed at the commit before #473 (`ed88f03`) and has failed on every commit since (`a4702b3`, `786612b`, …). This is why the otherwise-innocent pyjwt bump in [#486](https://github.com/discord/access/pull/486) shows a red `node-lint`.

`@swc/core`'s `postinstall` is the standard [NAPI-RS](https://napi.rs/) native-binary validator/fallback — it checks that the platform-specific optional dependency loaded correctly and falls back to wasm otherwise — the same category as the already-allowlisted `esbuild` and `fsevents`. It is a trusted, build-time-only devDependency, so it is allowlisted rather than denied.

`@swc/core` is the only install-script package not previously covered. With this change all four install-script packages (`@sentry/cli`, `@swc/core`, `esbuild`, `fsevents`) are allowlisted.

## Verification

Reproduced the CI environment locally with the pinned `npm@11.16.0`:

- **Fixed** — `npm ci --dry-run` passes the `strict-allow-scripts` check with `@swc/core` listed (no `ESTRICTALLOWSCRIPTS`).
- **Negative control** — removing `@swc/core` reproduces the exact CI error: `ESTRICTALLOWSCRIPTS ... @swc/core@1.15.41`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
