### PR TITLE
feat: added a generic way to directly link to IdP for Access users and groups

### DIFF
--- a/config/config.default.json
+++ b/config/config.default.json
@@ -11,7 +11,10 @@
     },
     "DEFAULT_ACCESS_TIME": "1209600",
     "NAME_VALIDATION_PATTERN": "^[A-Z][A-Za-z0-9\\-]*$",
-    "NAME_VALIDATION_ERROR": "Name must start capitalized and contain only alphanumeric characters or hyphens."
+    "NAME_VALIDATION_ERROR": "Name must start capitalized and contain only alphanumeric characters or hyphens.",
+    "IDP_NAME": "",
+    "IDP_USER_URL_TEMPLATE": "",
+    "IDP_GROUP_URL_TEMPLATE": ""
   },
   "BACKEND": {
     "NAME_VALIDATION_PATTERN": "[A-Z][A-Za-z0-9-]*",

--- a/src/components/IdpLinkButton.tsx
+++ b/src/components/IdpLinkButton.tsx
@@ -1,0 +1,37 @@
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+
+import {idpName} from '../config/idpLink';
+
+const moveTooltip = {modifiers: [{name: 'offset', options: {offset: [0, -10]}}]};
+
+interface IdpLinkButtonProps {
+  url: string | null;
+}
+
+export default function IdpLinkButton({url}: IdpLinkButtonProps) {
+  if (url == null) {
+    return null;
+  }
+
+  const button = (
+    <IconButton
+      aria-label={idpName ? `Open in ${idpName}` : 'Open in identity provider'}
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer">
+      <OpenInNewIcon />
+    </IconButton>
+  );
+
+  if (!idpName) {
+    return button;
+  }
+
+  return (
+    <Tooltip title={`Open in ${idpName}`} placement="top" PopperProps={moveTooltip}>
+      {button}
+    </Tooltip>
+  );
+}

--- a/src/config/accessConfig.ts
+++ b/src/config/accessConfig.ts
@@ -3,6 +3,9 @@ export interface AccessConfig {
   DEFAULT_ACCESS_TIME: string;
   NAME_VALIDATION_PATTERN: string;
   NAME_VALIDATION_ERROR: string;
+  IDP_NAME: string;
+  IDP_USER_URL_TEMPLATE: string;
+  IDP_GROUP_URL_TEMPLATE: string;
 }
 
 // use the globally-injected ACCESS_CONFIG from src/globals.d.ts, typed to AccessConfig interface

--- a/src/config/idpLink.ts
+++ b/src/config/idpLink.ts
@@ -1,0 +1,18 @@
+import accessConfig from './accessConfig';
+
+export const idpName = accessConfig.IDP_NAME;
+
+function buildUrl(template: string, id: string): string | null {
+  if (!template || !id) {
+    return null;
+  }
+  return template.replaceAll('{id}', encodeURIComponent(id));
+}
+
+export function idpUserUrl(id: string): string | null {
+  return buildUrl(accessConfig.IDP_USER_URL_TEMPLATE, id);
+}
+
+export function idpGroupUrl(id: string): string | null {
+  return buildUrl(accessConfig.IDP_GROUP_URL_TEMPLATE, id);
+}

--- a/src/pages/groups/Read.tsx
+++ b/src/pages/groups/Read.tsx
@@ -22,6 +22,8 @@ import Typography from '@mui/material/Typography';
 
 import AuditGroupIcon from '@mui/icons-material/History';
 import AuditRoleIcon from '@mui/icons-material/Diversity2';
+import IdpLinkButton from '../../components/IdpLinkButton';
+import {idpGroupUrl} from '../../config/idpLink';
 import DeleteIcon from '@mui/icons-material/Close';
 import GroupIcon from '@mui/icons-material/People';
 import TagIcon from '@mui/icons-material/LocalOffer';
@@ -299,6 +301,7 @@ export default function ReadGroup() {
                       </IconButton>
                     </Tooltip>
                   ) : null}
+                  <IdpLinkButton url={idpGroupUrl(group.id)} />
                 </Stack>
               </Stack>
             </Paper>

--- a/src/pages/groups/Read.tsx
+++ b/src/pages/groups/Read.tsx
@@ -57,7 +57,7 @@ import {
   RoleGroupDetail,
   GroupMember,
 } from '../../api/apiSchemas';
-import {canManageGroup} from '../../authorization';
+import {canManageGroup, isAccessAdmin} from '../../authorization';
 import {EmptyListEntry} from '../../components/EmptyListEntry';
 import {Diversity3 as RoleIcon} from '@mui/icons-material';
 import AppLinkButton from './AppLinkButton';
@@ -301,7 +301,7 @@ export default function ReadGroup() {
                       </IconButton>
                     </Tooltip>
                   ) : null}
-                  <IdpLinkButton url={idpGroupUrl(group.id)} />
+                  {isAccessAdmin(currentUser) && <IdpLinkButton url={idpGroupUrl(group.id)} />}
                 </Stack>
               </Stack>
             </Paper>

--- a/src/pages/users/Read.tsx
+++ b/src/pages/users/Read.tsx
@@ -55,7 +55,7 @@ import Loading from '../../components/Loading';
 import RemoveGroupsDialog, {RemoveGroupsDialogParameters} from '../roles/RemoveGroups';
 import RemoveOwnDirectAccessDialog, {RemoveOwnDirectAccessDialogParameters} from '../groups/RemoveOwnDirectAccess';
 import {groupBy, displayUserName} from '../../helpers';
-import {canManageGroup, isGroupOwner} from '../../authorization';
+import {canManageGroup, isGroupOwner, isAccessAdmin} from '../../authorization';
 import {EmptyListEntry} from '../../components/EmptyListEntry';
 import MembershipChip from '../../components/MembershipChip';
 
@@ -644,7 +644,7 @@ export default function ReadUser() {
                       <AuditIcon />
                     </IconButton>
                   </Tooltip>
-                  <IdpLinkButton url={idpUserUrl(user.id)} />
+                  {isAccessAdmin(currentUser) && <IdpLinkButton url={idpUserUrl(user.id)} />}
                 </Box>
               </Stack>
             </Paper>

--- a/src/pages/users/Read.tsx
+++ b/src/pages/users/Read.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import {Link as RouterLink, useParams, useNavigate} from 'react-router-dom';
 
 import AuditIcon from '@mui/icons-material/History';
+import IdpLinkButton from '../../components/IdpLinkButton';
+import {idpUserUrl} from '../../config/idpLink';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
 import UnfoldMoreIcon from '@mui/icons-material/UnfoldMore';
@@ -642,6 +644,7 @@ export default function ReadUser() {
                       <AuditIcon />
                     </IconButton>
                   </Tooltip>
+                  <IdpLinkButton url={idpUserUrl(user.id)} />
                 </Box>
               </Stack>
             </Paper>


### PR DESCRIPTION
Adds an "Open in IdP" button to the group and user detail pages that deep-links out to the configured identity provider's console for that resource, using the underlying Okta ID. The link target is driven by configurable URL templates (IDP_NAME, IDP_USER_URL_TEMPLATE, IDP_GROUP_URL_TEMPLATE) so it works for any IdP backend, and the button is hidden entirely when no template is configured. No backend changes; config defaults to empty so existing deployments are unaffected until they opt in.

Users verification:

<img width="1259" height="427" alt="Screenshot 2026-06-17 at 2 46 22 PM" src="https://github.com/user-attachments/assets/06a8def7-1bba-4267-bcea-d81155595757" />


Groups verification:

<img width="1390" height="421" alt="Screenshot 2026-06-17 at 2 43 44 PM" src="https://github.com/user-attachments/assets/4e3cd54a-a876-426d-8316-33e54e16fc90" />
