### PR TITLE
fix: eager-load OktaGroupTagMap.active_tag in role-request assignee filter

### DIFF
--- a/.github/workflows/openapi-client-drift.yml
+++ b/.github/workflows/openapi-client-drift.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: 24
 
       - name: Install frontend deps
         run: npm ci

--- a/api/routers/role_requests.py
+++ b/api/routers/role_requests.py
@@ -17,6 +17,7 @@ from api.models import (
     App,
     AppGroup,
     OktaGroup,
+    OktaGroupTagMap,
     OktaUser,
     OktaUserGroupMember,
     RoleGroup,
@@ -174,7 +175,13 @@ def list_role_requests(
                                 selectinload(OktaGroup.active_user_memberships)
                             ),
                             joinedload(RoleRequest.requested_group).options(
-                                selectinload(OktaGroup.active_group_tags),
+                                # `active_tag` is read per tag below in the
+                                # disallow-self-add constraint check, so nest its
+                                # loader — selectinload of the collection alone
+                                # leaves OktaGroupTagMap.active_tag on raise_on_sql.
+                                selectinload(OktaGroup.active_group_tags).options(
+                                    joinedload(OktaGroupTagMap.active_tag)
+                                ),
                                 selectinload(OktaGroup.active_user_ownerships),
                             ),
                         )
@@ -195,7 +202,13 @@ def list_role_requests(
                                 selectinload(OktaGroup.active_user_memberships)
                             ),
                             joinedload(RoleRequest.requested_group).options(
-                                selectinload(OktaGroup.active_group_tags),
+                                # `active_tag` is read per tag below in the
+                                # disallow-self-add constraint check, so nest its
+                                # loader — selectinload of the collection alone
+                                # leaves OktaGroupTagMap.active_tag on raise_on_sql.
+                                selectinload(OktaGroup.active_group_tags).options(
+                                    joinedload(OktaGroupTagMap.active_tag)
+                                ),
                                 selectinload(OktaGroup.active_user_ownerships),
                             ),
                         )
@@ -232,7 +245,11 @@ def list_role_requests(
                 owned_groups = (
                     db.scalars(
                         select(OktaGroup)
-                        .options(joinedload(OktaGroup.active_group_tags))
+                        # `active_tag` is read per tag below; nest its loader so
+                        # OktaGroupTagMap.active_tag isn't left on raise_on_sql.
+                        .options(
+                            selectinload(OktaGroup.active_group_tags).options(joinedload(OktaGroupTagMap.active_tag))
+                        )
                         .where(
                             or_(
                                 OktaGroup.id.in_(groups_owned_subquery),

--- a/src/pages/roles/List.tsx
+++ b/src/pages/roles/List.tsx
@@ -27,7 +27,6 @@ import {useRoles} from '../../api/apiComponents';
 import {RoleGroupListItem} from '../../api/apiSchemas';
 import TablePaginationActions from '../../components/actions/TablePaginationActions';
 import TableTopBar, {TableTopBarAutocomplete} from '../../components/TableTopBar';
-import {EmptyListEntry} from '../../components/EmptyListEntry';
 import LinkTableRow from '../../components/LinkTableRow';
 import MarkdownDescription from '../../components/MarkdownDescription';
 
@@ -142,12 +141,10 @@ export default function ListRoles() {
                 </TableCell>
               </LinkTableRow>
             ))}
-            {emptyRows > 0 ? (
+            {emptyRows > 0 && (
               <TableRow style={{height: 33 * emptyRows}}>
                 <TableCell colSpan={2} />
               </TableRow>
-            ) : (
-              <EmptyListEntry cellProps={{colSpan: 2}} />
             )}
           </TableBody>
           <TableFooter>

--- a/tests/test_polymorphic_loader_coverage.py
+++ b/tests/test_polymorphic_loader_coverage.py
@@ -258,6 +258,13 @@ def test_role_request_routes(
     app: FastAPI, client: TestClient, db: Db, production_shape: dict[str, Any], url_for: Any
 ) -> None:
     _get_ok(client, url_for("api-role-requests.role_requests"))
+    # The assignee ("requests I can resolve") filter runs an admin-only branch
+    # that reads `tm.active_tag` for each tag on every pending request's target
+    # group — a code path, not serialization, so it needs its own nested
+    # active_tag loader. The bootstrap user is an Access admin and there's a
+    # pending role request targeting the tagged app group, so this exercises it.
+    base = url_for("api-role-requests.role_requests")
+    _get_ok(client, f"{base}?assignee_user_id=@me")
     data = _get_ok(
         client, url_for("api-role-requests.role_request_by_id", role_request_id=production_shape["role_request"])
     )


### PR DESCRIPTION
## Staging error

```
InvalidRequestError: 'OktaGroupTagMap.active_tag' is not available due to lazy='raise_on_sql'
  at api/routers/role_requests.py:207, in list_role_requests
```

`GET /api/role-requests?assignee_user_id=…` 500s whenever a pending request targets a tagged group. Surfaced in staging right after #477 deployed.

## Cause

The assignee ("requests I can resolve") branch of `list_role_requests` reads `tm.active_tag` for every tag on each pending request's target group to evaluate the `disallow_self_add_*` constraints. The three queries feeding those reads eager-loaded only the `active_group_tags` **collection**, not the nested `OktaGroupTagMap.active_tag` on each element. #477 flipped `active_tag` to `lazy="raise_on_sql"`, so the per-element read now raises instead of lazy-loading.

This is a **code-path** read (constraint evaluation), not serialization — which is why loading the collection looked sufficient. Fix nests `joinedload(OktaGroupTagMap.active_tag)` under the `active_group_tags` loaders in all three queries (the admin owner/member branches and the non-admin owned-groups query).

## Why the audit + battery missed it

The post-#477 audit verified the `active_group_tags` collection was loaded at each read site but didn't check that the per-element `active_tag` was nested — loading a `*_tags` collection does not load each row's `active_tag`; both are needed wherever `tm.active_tag for tm in group.active_group_tags` is read. And the polymorphic battery called the role-requests list **without** the assignee filter, so the admin branch never ran.

## Test

Added an `assignee_user_id=@me` call to the battery's `test_role_request_routes` (the bootstrap user is an Access admin and there's a pending role request targeting the tagged app group). On the battery's cold session it reproduces the **exact** staging `InvalidRequestError` without the fix and passes with it — verified both directions.

Full gate green: ruff (format + check), mypy, 541 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also on this branch (small, unrelated fixes)

- **Roles list "None" row** — `ListRoles` rendered `EmptyListEntry` ("None") in the else-branch of `emptyRows > 0 ? <spacer> : <EmptyListEntry>`. `emptyTableRows` returns `0` on page 0 regardless of row count, so the else-branch fired on the first page whenever rows were present, drawing a phantom "None" row beneath the real roles. Now matches the sibling list pages (groups/users/apps) — only the `emptyRows > 0` spacer, no `EmptyListEntry`. Verified in the running preview (row gone, `tsc`/prettier clean).
- **`openapi-client-drift.yml`** — bumped Node from 20 → 24 to match the lint job.
