### PR TITLE
feat: serve IdP deep-link config from /api/config at runtime

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -322,6 +322,7 @@ def create_app(testing: Optional[bool] = False) -> FastAPI:
         apps,
         audit,
         bugs,
+        config,
         group_requests,
         groups,
         health,
@@ -337,6 +338,7 @@ def create_app(testing: Optional[bool] = False) -> FastAPI:
     app.include_router(apps.router, responses=DEFAULT_ERROR_RESPONSES)
     app.include_router(audit.router, responses=DEFAULT_ERROR_RESPONSES)
     app.include_router(bugs.router, responses=DEFAULT_ERROR_RESPONSES)
+    app.include_router(config.router, responses=DEFAULT_ERROR_RESPONSES)
     app.include_router(group_requests.router, responses=DEFAULT_ERROR_RESPONSES)
     app.include_router(groups.router, responses=DEFAULT_ERROR_RESPONSES)
     app.include_router(plugins.router, responses=DEFAULT_ERROR_RESPONSES)

--- a/api/config.py
+++ b/api/config.py
@@ -126,6 +126,16 @@ class Settings(BaseSettings):
     APP_VERSION: str = "Not Defined"
     APP_NAME: str = "Access"
 
+    # IdP deep-linking. Surfaced to the frontend at runtime via GET /api/config
+    # and rendered as the "Open in IdP" button on user/group pages. Empty
+    # (default) hides the button, so existing deployments are unaffected until
+    # they opt in. `{id}` in the templates is replaced with the resource's
+    # underlying Okta id. Read at runtime (not baked into the build) so one
+    # bundle can target different IdP consoles per env.
+    IDP_NAME: str = ""
+    IDP_USER_URL_TEMPLATE: str = ""
+    IDP_GROUP_URL_TEMPLATE: str = ""
+
     # Sentry
     FASTAPI_SENTRY_DSN: Optional[str] = None
     REACT_SENTRY_DSN: Optional[str] = None

--- a/api/routers/config.py
+++ b/api/routers/config.py
@@ -1,0 +1,30 @@
+"""Runtime app-config router.
+
+Surfaces deploy-time configuration the frontend reads at runtime — currently
+the IdP deep-link templates rendered as the "Open in IdP" button on user and
+group pages. Reading these at runtime (rather than baking them into the Vite
+build) lets one built bundle target different IdP consoles per deployment env.
+
+Auth-gated by the global `require_authenticated` dependency in
+`api.app.create_app`; the response carries no secrets (URL templates only).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from api.config import settings
+from api.schemas import AppConfig, IdpConfig
+
+router = APIRouter(prefix="/api/config", tags=["config"])
+
+
+@router.get("", name="app_config")
+def get_app_config() -> AppConfig:
+    return AppConfig(
+        idp=IdpConfig(
+            name=settings.IDP_NAME,
+            user_url_template=settings.IDP_USER_URL_TEMPLATE,
+            group_url_template=settings.IDP_GROUP_URL_TEMPLATE,
+        )
+    )

--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -11,6 +11,7 @@ field.
 
 from api.schemas.audit_logs import AuditLogSchema, EventType  # noqa: F401
 from api.schemas.audit_rows import AuditGroupRoleRow, AuditUserGroupRow  # noqa: F401
+from api.schemas.config_schemas import AppConfig, IdpConfig  # noqa: F401
 from api.schemas.core_schemas import (  # noqa: F401
     AppDetail,
     AppGroupDetail,

--- a/api/schemas/config_schemas.py
+++ b/api/schemas/config_schemas.py
@@ -1,0 +1,23 @@
+"""Pydantic response schemas for the runtime app-config router.
+
+`api/routers/config.py` surfaces deploy-time configuration the frontend
+needs at runtime (currently the IdP deep-link templates), read from
+`settings` so a single built bundle can target different IdP consoles
+per deployment env.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class IdpConfig(BaseModel):
+    """IdP deep-link configuration. Empty strings disable the feature."""
+
+    name: str
+    user_url_template: str
+    group_url_template: str
+
+
+class AppConfig(BaseModel):
+    idp: IdpConfig

--- a/config/config.default.json
+++ b/config/config.default.json
@@ -11,10 +11,7 @@
     },
     "DEFAULT_ACCESS_TIME": "1209600",
     "NAME_VALIDATION_PATTERN": "^[A-Z][A-Za-z0-9\\-]*$",
-    "NAME_VALIDATION_ERROR": "Name must start capitalized and contain only alphanumeric characters or hyphens.",
-    "IDP_NAME": "",
-    "IDP_USER_URL_TEMPLATE": "",
-    "IDP_GROUP_URL_TEMPLATE": ""
+    "NAME_VALIDATION_ERROR": "Name must start capitalized and contain only alphanumeric characters or hyphens."
   },
   "BACKEND": {
     "NAME_VALIDATION_PATTERN": "[A-Z][A-Za-z0-9-]*",

--- a/src/api/apiComponents.ts
+++ b/src/api/apiComponents.ts
@@ -855,6 +855,75 @@ export const useSentryBug = (
   });
 };
 
+export type AppConfigError = Fetcher.ErrorWrapper<{
+  status: Exclude<ClientErrorStatus | ServerErrorStatus, 200>;
+  payload: Schemas.ProblemDetail;
+}>;
+
+export type AppConfigVariables = ApiContext['fetcherOptions'];
+
+export const fetchAppConfig = (variables: AppConfigVariables, signal?: AbortSignal) =>
+  apiFetch<Schemas.AppConfig, AppConfigError, undefined, {}, {}, {}>({
+    url: '/api/config',
+    method: 'get',
+    ...variables,
+    signal,
+  });
+
+export function appConfigQuery(variables: AppConfigVariables): {
+  queryKey: reactQuery.QueryKey;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.AppConfig>;
+};
+
+export function appConfigQuery(variables: AppConfigVariables | reactQuery.SkipToken): {
+  queryKey: reactQuery.QueryKey;
+  queryFn: ((options: QueryFnOptions) => Promise<Schemas.AppConfig>) | reactQuery.SkipToken;
+};
+
+export function appConfigQuery(variables: AppConfigVariables | reactQuery.SkipToken) {
+  return {
+    queryKey: queryKeyFn({
+      path: '/api/config',
+      operationId: 'appConfig',
+      variables,
+    }),
+    queryFn:
+      variables === reactQuery.skipToken
+        ? reactQuery.skipToken
+        : ({signal}: QueryFnOptions) => fetchAppConfig(variables, signal),
+  };
+}
+
+export const useSuspenseAppConfig = <TData = Schemas.AppConfig>(
+  variables: AppConfigVariables,
+  options?: Omit<
+    reactQuery.UseQueryOptions<Schemas.AppConfig, AppConfigError, TData>,
+    'queryKey' | 'queryFn' | 'initialData'
+  >,
+) => {
+  const {queryOptions, fetcherOptions} = useApiContext(options);
+  return reactQuery.useSuspenseQuery<Schemas.AppConfig, AppConfigError, TData>({
+    ...appConfigQuery(deepMerge(fetcherOptions, variables)),
+    ...options,
+    ...queryOptions,
+  });
+};
+
+export const useAppConfig = <TData = Schemas.AppConfig>(
+  variables: AppConfigVariables | reactQuery.SkipToken,
+  options?: Omit<
+    reactQuery.UseQueryOptions<Schemas.AppConfig, AppConfigError, TData>,
+    'queryKey' | 'queryFn' | 'initialData'
+  >,
+) => {
+  const {queryOptions, fetcherOptions} = useApiContext(options);
+  return reactQuery.useQuery<Schemas.AppConfig, AppConfigError, TData>({
+    ...appConfigQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
+    ...options,
+    ...queryOptions,
+  });
+};
+
 export type GroupRequestsQueryParams = {
   q?: string | null;
   status?: string | null;
@@ -3234,6 +3303,11 @@ export type QueryOperation =
       path: '/api/audit/groups';
       operationId: 'groupsAndRoles';
       variables: GroupsAndRolesVariables | reactQuery.SkipToken;
+    }
+  | {
+      path: '/api/config';
+      operationId: 'appConfig';
+      variables: AppConfigVariables | reactQuery.SkipToken;
     }
   | {
       path: '/api/group-requests';

--- a/src/api/apiSchemas.ts
+++ b/src/api/apiSchemas.ts
@@ -94,6 +94,10 @@ export type AccessRequestSummary = {
   active_resolver?: OktaUserSummary | null;
 };
 
+export type AppConfig = {
+  idp: IdpConfig;
+};
+
 /**
  * Full App detail.
  */
@@ -524,6 +528,15 @@ export type GroupSummary =
   | (Omit<AppGroupSummary, 'type'> & {
       type: 'app_group';
     });
+
+/**
+ * IdP deep-link configuration. Empty strings disable the feature.
+ */
+export type IdpConfig = {
+  name: string;
+  user_url_template: string;
+  group_url_template: string;
+};
 
 export type OktaGroupDetail = {
   id: string;

--- a/src/components/IdpLinkButton.tsx
+++ b/src/components/IdpLinkButton.tsx
@@ -2,15 +2,14 @@ import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 
-import {idpName} from '../config/idpLink';
-
 const moveTooltip = {modifiers: [{name: 'offset', options: {offset: [0, -10]}}]};
 
 interface IdpLinkButtonProps {
   url: string | null;
+  idpName: string;
 }
 
-export default function IdpLinkButton({url}: IdpLinkButtonProps) {
+export default function IdpLinkButton({url, idpName}: IdpLinkButtonProps) {
   if (url == null) {
     return null;
   }

--- a/src/config/accessConfig.ts
+++ b/src/config/accessConfig.ts
@@ -3,9 +3,6 @@ export interface AccessConfig {
   DEFAULT_ACCESS_TIME: string;
   NAME_VALIDATION_PATTERN: string;
   NAME_VALIDATION_ERROR: string;
-  IDP_NAME: string;
-  IDP_USER_URL_TEMPLATE: string;
-  IDP_GROUP_URL_TEMPLATE: string;
 }
 
 // use the globally-injected ACCESS_CONFIG from src/globals.d.ts, typed to AccessConfig interface

--- a/src/config/idpLink.ts
+++ b/src/config/idpLink.ts
@@ -1,6 +1,4 @@
-import accessConfig from './accessConfig';
-
-export const idpName = accessConfig.IDP_NAME;
+import {useAppConfig} from '../api/apiComponents';
 
 function buildUrl(template: string, id: string): string | null {
   if (!template || !id) {
@@ -9,10 +7,27 @@ function buildUrl(template: string, id: string): string | null {
   return template.replaceAll('{id}', encodeURIComponent(id));
 }
 
-export function idpUserUrl(id: string): string | null {
-  return buildUrl(accessConfig.IDP_USER_URL_TEMPLATE, id);
+export interface IdpLinks {
+  // Display name of the IdP (e.g. "Okta"); empty string when unconfigured.
+  idpName: string;
+  // Build a deep link to the user / group in the IdP console, or null when
+  // the corresponding template is unconfigured (which hides the button).
+  idpUserUrl: (id: string) => string | null;
+  idpGroupUrl: (id: string) => string | null;
 }
 
-export function idpGroupUrl(id: string): string | null {
-  return buildUrl(accessConfig.IDP_GROUP_URL_TEMPLATE, id);
+/**
+ * IdP deep-link config, fetched at runtime from `GET /api/config` rather than
+ * baked into the build, so one bundle can target different IdP consoles per
+ * deployment env. Until the request resolves (or if it fails) everything is
+ * empty/null, so the "Open in IdP" button stays hidden.
+ */
+export function useIdpLinks(): IdpLinks {
+  const {data} = useAppConfig({});
+  const idp = data?.idp;
+  return {
+    idpName: idp?.name ?? '',
+    idpUserUrl: (id: string) => buildUrl(idp?.user_url_template ?? '', id),
+    idpGroupUrl: (id: string) => buildUrl(idp?.group_url_template ?? '', id),
+  };
 }

--- a/src/pages/groups/Read.tsx
+++ b/src/pages/groups/Read.tsx
@@ -23,7 +23,7 @@ import Typography from '@mui/material/Typography';
 import AuditGroupIcon from '@mui/icons-material/History';
 import AuditRoleIcon from '@mui/icons-material/Diversity2';
 import IdpLinkButton from '../../components/IdpLinkButton';
-import {idpGroupUrl} from '../../config/idpLink';
+import {useIdpLinks} from '../../config/idpLink';
 import DeleteIcon from '@mui/icons-material/Close';
 import GroupIcon from '@mui/icons-material/People';
 import TagIcon from '@mui/icons-material/LocalOffer';
@@ -93,6 +93,7 @@ function sortRoleGroups(
 
 export default function ReadGroup() {
   const currentUser = useCurrentUser();
+  const {idpName, idpGroupUrl} = useIdpLinks();
 
   const {id} = useParams();
   const navigate = useNavigate();
@@ -301,7 +302,7 @@ export default function ReadGroup() {
                       </IconButton>
                     </Tooltip>
                   ) : null}
-                  {isAccessAdmin(currentUser) && <IdpLinkButton url={idpGroupUrl(group.id)} />}
+                  {isAccessAdmin(currentUser) && <IdpLinkButton url={idpGroupUrl(group.id)} idpName={idpName} />}
                 </Stack>
               </Stack>
             </Paper>

--- a/src/pages/users/Read.tsx
+++ b/src/pages/users/Read.tsx
@@ -3,7 +3,7 @@ import {Link as RouterLink, useParams, useNavigate} from 'react-router-dom';
 
 import AuditIcon from '@mui/icons-material/History';
 import IdpLinkButton from '../../components/IdpLinkButton';
-import {idpUserUrl} from '../../config/idpLink';
+import {useIdpLinks} from '../../config/idpLink';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
 import UnfoldMoreIcon from '@mui/icons-material/UnfoldMore';
@@ -454,6 +454,7 @@ function collectGroupNames(ownerPartitions: PartitionedGroups, memberPartitions:
 
 export default function ReadUser() {
   const currentUser = useCurrentUser();
+  const {idpName, idpUserUrl} = useIdpLinks();
 
   const {id} = useParams();
 
@@ -644,7 +645,7 @@ export default function ReadUser() {
                       <AuditIcon />
                     </IconButton>
                   </Tooltip>
-                  {isAccessAdmin(currentUser) && <IdpLinkButton url={idpUserUrl(user.id)} />}
+                  {isAccessAdmin(currentUser) && <IdpLinkButton url={idpUserUrl(user.id)} idpName={idpName} />}
                 </Box>
               </Stack>
             </Paper>

--- a/tests/test_config_endpoint.py
+++ b/tests/test_config_endpoint.py
@@ -1,0 +1,37 @@
+"""Tests for the runtime app-config endpoint (GET /api/config).
+
+The endpoint surfaces the IdP deep-link templates to the frontend at
+runtime (read from `settings`), so the same built bundle can point at
+different IdP consoles per deployment env.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.config import settings
+
+
+def test_config_endpoint_returns_idp_settings(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "IDP_NAME", "Okta")
+    monkeypatch.setattr(settings, "IDP_USER_URL_TEMPLATE", "https://example-admin.okta.com/admin/user/profile/view/{id}")
+    monkeypatch.setattr(settings, "IDP_GROUP_URL_TEMPLATE", "https://example-admin.okta.com/admin/group/{id}")
+
+    rep = client.get("/api/config")
+
+    assert rep.status_code == 200, rep.text
+    idp = rep.json()["idp"]
+    assert idp["name"] == "Okta"
+    assert idp["user_url_template"] == "https://example-admin.okta.com/admin/user/profile/view/{id}"
+    assert idp["group_url_template"] == "https://example-admin.okta.com/admin/group/{id}"
+
+
+def test_config_endpoint_defaults_to_empty(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "IDP_NAME", "")
+    monkeypatch.setattr(settings, "IDP_USER_URL_TEMPLATE", "")
+    monkeypatch.setattr(settings, "IDP_GROUP_URL_TEMPLATE", "")
+
+    rep = client.get("/api/config")
+
+    assert rep.status_code == 200, rep.text
+    idp = rep.json()["idp"]
+    assert idp == {"name": "", "user_url_template": "", "group_url_template": ""}

--- a/tests/test_config_endpoint.py
+++ b/tests/test_config_endpoint.py
@@ -13,7 +13,9 @@ from api.config import settings
 
 def test_config_endpoint_returns_idp_settings(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings, "IDP_NAME", "Okta")
-    monkeypatch.setattr(settings, "IDP_USER_URL_TEMPLATE", "https://example-admin.okta.com/admin/user/profile/view/{id}")
+    monkeypatch.setattr(
+        settings, "IDP_USER_URL_TEMPLATE", "https://example-admin.okta.com/admin/user/profile/view/{id}"
+    )
     monkeypatch.setattr(settings, "IDP_GROUP_URL_TEMPLATE", "https://example-admin.okta.com/admin/group/{id}")
 
     rep = client.get("/api/config")


### PR DESCRIPTION
## Summary
Adds a runtime `GET /api/config` endpoint and switches the "Open in IdP" button (#491) to read its `IDP_*` config from it, instead of the build-time-baked frontend `ACCESS_CONFIG`.

## Motivation

#491 reads `IDP_NAME` / `IDP_USER_URL_TEMPLATE` / `IDP_GROUP_URL_TEMPLATE` from the frontend `AccessConfig`, which Vite inlines into the JS bundle at build time. Because the values are baked into the bundle when the image is built, a single published image cannot carry different IdP URLs for different environments. Deployments that share one built image can therefore only ever point at one IdP console. Moving the config to runtime removes that constraint.

To make this more loosely coupled, this PR introduces a backend config endpoint that the frontend calls to retrieve runtime config values.

## Validation

Confirmed new API endpoint serves as expected:

<img width="627" height="170" alt="image" src="https://github.com/user-attachments/assets/2862db0e-64d5-436a-a653-b6b879c38c03" />

Also confirmed frontend calls the new API endpoint as expected and IdP deep-links properly redirect.