### PR TITLE
ci: bake IdP deep-link config into the frontend image from a build secret

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -51,3 +51,4 @@ jobs:
             "SENTRY_ORG=${{ secrets.SENTRY_ORG }}"
             "SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}"
             "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}"
+            "ACCESS_CONFIG_OVERRIDE=${{ secrets.ACCESS_CONFIG_OVERRIDE }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,11 @@ RUN touch .env.production
 ENV VITE_API_SERVER_URL=""
 # Set Sentry plugin environment variables for production build
 ENV NODE_ENV=production
-RUN npm run build
+# Bake the frontend config override (e.g. IdP deep-link URLs) from the build secret.
+ENV ACCESS_CONFIG_FILE=config.override.json
+RUN --mount=type=secret,id=ACCESS_CONFIG_OVERRIDE \
+  cp /run/secrets/ACCESS_CONFIG_OVERRIDE config/config.override.json && \
+  npm run build
 
 # Optional build step #2: upload source maps to Sentry
 FROM build-step AS sentry

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,15 @@ RUN touch .env.production
 ENV VITE_API_SERVER_URL=""
 # Set Sentry plugin environment variables for production build
 ENV NODE_ENV=production
-# Bake the frontend config override (e.g. IdP deep-link URLs) from the build secret.
-ENV ACCESS_CONFIG_FILE=config.override.json
+# If a frontend config override (e.g. IdP deep-link URLs) is provided as a build
+# secret, write it where Vite's config loader picks it up; otherwise build against
+# config.default.json. The secret is absent for open-source builds, so plain
+# `docker build` still works.
 RUN --mount=type=secret,id=ACCESS_CONFIG_OVERRIDE \
-  cp /run/secrets/ACCESS_CONFIG_OVERRIDE config/config.override.json && \
-  npm run build
+  if [ -s /run/secrets/ACCESS_CONFIG_OVERRIDE ]; then \
+    cp /run/secrets/ACCESS_CONFIG_OVERRIDE config/config.override.json; \
+  fi; \
+  ACCESS_CONFIG_FILE=$(test -f config/config.override.json && echo config.override.json) npm run build
 
 # Optional build step #2: upload source maps to Sentry
 FROM build-step AS sentry
@@ -38,6 +42,7 @@ RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN \
   SENTRY_AUTH_TOKEN=$(cat /run/secrets/SENTRY_AUTH_TOKEN) \
   SENTRY_ORG=$(cat /run/secrets/SENTRY_ORG) \
   SENTRY_PROJECT=$(cat /run/secrets/SENTRY_PROJECT) \
+  ACCESS_CONFIG_FILE=$(test -f config/config.override.json && echo config.override.json) \
   npm run build
 # Source maps are automatically uploaded and deleted by Vite Sentry plugin during build
 RUN touch sentry


### PR DESCRIPTION
Updates the access image build to include overrides containing IdP URL templates. This is required for #491.