### PR TITLE
perf: bound the sync-route threadpool and size the DB pool to match

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -167,6 +167,28 @@ def _configure_okta() -> None:
         )
 
 
+def _configure_threadpool_limit() -> None:
+    """Cap the anyio threadpool that runs sync (`def`) route handlers.
+
+    FastAPI dispatches every sync route handler to anyio's default worker
+    thread pool, whose default limit is 40 threads per event loop. That lets
+    one server worker process run up to 40 handlers at once, each holding a
+    DB connection and building its own ORM object graph, so peak memory and
+    connection demand scale with that ceiling rather than the worker count.
+    Lowering it gives the server backpressure under bursts of expensive
+    requests. Setting ``THREADPOOL_MAX_WORKERS`` to 0 leaves anyio's default
+    untouched. Must be called from within the running event loop, since the
+    limiter is stored in a loop-scoped anyio ``RunVar``.
+    """
+    if settings.THREADPOOL_MAX_WORKERS <= 0:
+        return
+    import anyio.to_thread
+
+    limiter = anyio.to_thread.current_default_thread_limiter()
+    limiter.total_tokens = settings.THREADPOOL_MAX_WORKERS
+    logger.info("Sync-route threadpool limit set to %d", settings.THREADPOOL_MAX_WORKERS)
+
+
 def create_app(testing: Optional[bool] = False) -> FastAPI:
     _configure_logging()
 
@@ -194,17 +216,23 @@ def create_app(testing: Optional[bool] = False) -> FastAPI:
     # the route registration below can grab the session manager, then
     # enter its lifespan in the FastAPI lifespan so the session
     # manager's task group is running while requests are served.
+    mcp_lifespan: Optional[Any] = None
     if settings.ENABLE_MCP:
-        from api.mcp.server import create_mcp_server, mcp_lifespan
+        from api.mcp.server import create_mcp_server
+        from api.mcp.server import mcp_lifespan as mcp_lifespan
 
         create_mcp_server()
 
-        @asynccontextmanager
-        async def lifespan(_fast_app: FastAPI) -> AsyncIterator[None]:
+    @asynccontextmanager
+    async def lifespan(_fast_app: FastAPI) -> AsyncIterator[None]:
+        # Bound the sync-route threadpool inside the running event loop (the
+        # anyio limiter is loop-scoped, so this can't run at import time).
+        _configure_threadpool_limit()
+        if mcp_lifespan is not None:
             async with mcp_lifespan():
                 yield
-    else:
-        lifespan = None  # type: ignore[assignment]
+        else:
+            yield
 
     app = FastAPI(
         title=settings.APP_NAME,

--- a/api/config.py
+++ b/api/config.py
@@ -82,6 +82,34 @@ class Settings(BaseSettings):
     DATABASE_NAME: str = "access"
     DATABASE_USES_PUBLIC_IP: bool = False
 
+    # Concurrency & connection pool
+    #
+    # FastAPI runs every *sync* (`def`) route handler in an anyio worker
+    # thread. The anyio default thread limiter allows 40 such threads per
+    # event loop, so a single server worker can run up to 40 route handlers
+    # concurrently — each holding a DB connection and materializing its own
+    # ORM object graph. Peak memory and DB-connection demand therefore scale
+    # with that ceiling, not with the number of server worker processes,
+    # which makes a burst of expensive read requests able to drive a single
+    # worker's memory far higher than the process count would suggest.
+    #
+    # THREADPOOL_MAX_WORKERS caps that limiter so concurrency provides
+    # backpressure instead of unbounded fan-out. Set it to 0 to leave anyio's
+    # default (40) in place.
+    THREADPOOL_MAX_WORKERS: int = 16
+
+    # SQLAlchemy QueuePool sizing (ignored for SQLite, which uses a different
+    # pool). pool_size + max_overflow is the hard ceiling on concurrent
+    # checked-out connections per worker process; keep it at or above
+    # THREADPOOL_MAX_WORKERS so concurrent handlers aren't starved for a
+    # connection. pool_pre_ping discards connections a server-side timeout
+    # has already closed; pool_recycle proactively retires long-lived ones.
+    DB_POOL_SIZE: int = 10
+    DB_MAX_OVERFLOW: int = 10
+    DB_POOL_TIMEOUT: int = 30
+    DB_POOL_RECYCLE: int = 1800
+    DB_POOL_PRE_PING: bool = True
+
     # User attributes
     USER_DISPLAY_CUSTOM_ATTRIBUTES: str = "Title,Manager"
     USER_SEARCH_CUSTOM_ATTRIBUTES: Optional[str] = None

--- a/api/database.py
+++ b/api/database.py
@@ -36,6 +36,17 @@ def build_engine() -> Engine:
 
     if url.startswith("sqlite"):
         kwargs.setdefault("connect_args", {"check_same_thread": False})
+    else:
+        # Bound and harden the QueuePool. The defaults (size 5 / overflow 10)
+        # can be smaller than the number of sync route handlers FastAPI runs
+        # concurrently on its threadpool, which starves handlers for a
+        # connection under load; size the pool from settings instead. SQLite
+        # uses a single-connection pool and ignores these.
+        kwargs.setdefault("pool_size", settings.DB_POOL_SIZE)
+        kwargs.setdefault("max_overflow", settings.DB_MAX_OVERFLOW)
+        kwargs.setdefault("pool_timeout", settings.DB_POOL_TIMEOUT)
+        kwargs.setdefault("pool_recycle", settings.DB_POOL_RECYCLE)
+        kwargs.setdefault("pool_pre_ping", settings.DB_POOL_PRE_PING)
 
     return create_engine(url, **kwargs)
 

--- a/tests/test_concurrency_config.py
+++ b/tests/test_concurrency_config.py
@@ -1,0 +1,68 @@
+"""Concurrency + connection-pool configuration.
+
+These guard the two knobs that bound how much work a single server worker
+process takes on at once: the anyio threadpool that runs sync (`def`) route
+handlers, and the SQLAlchemy QueuePool that backs them. The defaults keep a
+burst of expensive requests from driving one worker's memory and connection
+use without bound.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import anyio
+import anyio.to_thread
+
+from api.app import _configure_threadpool_limit
+from api.config import settings
+from api.database import build_engine
+
+
+def test_build_engine_applies_pool_settings(monkeypatch: Any) -> None:
+    monkeypatch.setattr(settings, "CLOUDSQL_CONNECTION_NAME", "")
+    monkeypatch.setattr(settings, "SQLALCHEMY_DATABASE_URI", "postgresql+pg8000://u:p@localhost:5432/access")
+    monkeypatch.setattr(settings, "DB_POOL_SIZE", 7)
+    monkeypatch.setattr(settings, "DB_MAX_OVERFLOW", 3)
+
+    engine = build_engine()
+    try:
+        assert engine.pool.size() == 7
+        # max_overflow has no public accessor; QueuePool stores it here.
+        assert engine.pool._max_overflow == 3  # type: ignore[attr-defined]
+    finally:
+        engine.dispose()
+
+
+def test_build_engine_sqlite_ignores_pool_settings(monkeypatch: Any) -> None:
+    # SQLite's pool rejects pool_size/max_overflow; build_engine must not
+    # pass them for a sqlite URL.
+    monkeypatch.setattr(settings, "CLOUDSQL_CONNECTION_NAME", "")
+    monkeypatch.setattr(settings, "SQLALCHEMY_DATABASE_URI", "sqlite://")
+    engine = build_engine()
+    engine.dispose()
+
+
+def test_threadpool_limit_applied(monkeypatch: Any) -> None:
+    monkeypatch.setattr(settings, "THREADPOOL_MAX_WORKERS", 5)
+
+    async def _apply_and_read() -> float:
+        _configure_threadpool_limit()
+        return anyio.to_thread.current_default_thread_limiter().total_tokens
+
+    assert anyio.run(_apply_and_read) == 5
+
+
+def test_threadpool_limit_zero_leaves_default(monkeypatch: Any) -> None:
+    async def _read_default() -> float:
+        return anyio.to_thread.current_default_thread_limiter().total_tokens
+
+    default = anyio.run(_read_default)
+
+    monkeypatch.setattr(settings, "THREADPOOL_MAX_WORKERS", 0)
+
+    async def _apply_and_read() -> float:
+        _configure_threadpool_limit()
+        return anyio.to_thread.current_default_thread_limiter().total_tokens
+
+    assert anyio.run(_apply_and_read) == default


### PR DESCRIPTION
## Summary

FastAPI runs every **sync (`def`) route handler** in anyio's default worker thread pool. That pool defaults to **40 threads per event loop**, so a single server worker process can run up to 40 route handlers concurrently — each checking out its own DB connection and materializing its own ORM object graph. The practical effect is that **peak memory and database-connection demand scale with that hidden 40-thread ceiling, not with the number of worker processes**: a burst of expensive read requests can drive one worker's memory and connection use far higher than the process count suggests. The default `QueuePool` (size 5 + overflow 10 = 15) is also narrower than the threadpool, so handlers can starve waiting for a connection under that same burst.

This PR makes both bounds explicit and configurable, and sizes them consistently with each other.

## Changes

- **`THREADPOOL_MAX_WORKERS`** (default `16`): caps anyio's default thread limiter. Applied from the app lifespan, inside the running event loop (the limiter is loop-scoped). Set to `0` to keep anyio's default of 40.
- **DB pool settings**, applied in `build_engine()` (ignored for SQLite, which uses a single-connection pool):
  - `DB_POOL_SIZE` (default `10`)
  - `DB_MAX_OVERFLOW` (default `10`)
  - `DB_POOL_TIMEOUT` (default `30`)
  - `DB_POOL_RECYCLE` (default `1800`)
  - `DB_POOL_PRE_PING` (default `True`)
  - Total pool capacity (size + overflow = 20) sits at or above `THREADPOOL_MAX_WORKERS`, so concurrent handlers aren't starved for a connection; `pre_ping` + `recycle` guard against server-closed connections.

## Behavior change / rollout

Defaults change: the sync-route concurrency ceiling drops from 40 → 16 per worker and the connection pool is sized explicitly. This trades a little peak concurrency for bounded, predictable memory and connection use under load. To restore the prior behavior, set `THREADPOOL_MAX_WORKERS=0`, `DB_POOL_SIZE=5`, `DB_MAX_OVERFLOW=10`.

## Testing

- New `tests/test_concurrency_config.py`: verifies `build_engine()` applies the pool settings (and skips them for SQLite), and that the lifespan helper sets / respects (`=0`) the anyio limiter.
- `ruff check`, `ruff format --check`, `mypy`, and the existing router test suite pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
