### PR TITLE
gitignore superpowers brainstorming specs and plans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,9 @@ db.sqlite3-journal
 # Sphinx documentation
 docs/_build/
 
+# Superpowers brainstorming specs and plans
+docs/superpowers/
+
 # PyBuilder
 .pybuilder/
 target/


### PR DESCRIPTION
# Summary
Adds `docs/superpowers/` to `.gitignore` so locally-generated brainstorming specs and implementation plans stay untracked.

**Urgency**: low — no deadline
**Expected review effort**: LOW (Single-line `.gitignore` addition; nothing else.)

# Motivation
The superpowers brainstorming/planning workflow writes design specs and plans under `docs/superpowers/`. These are local working artifacts that should not be committed to the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)