### PR TITLE
perf!: paginate apps to reduce large ORM graphs causing OOMKilled

### DIFF
--- a/api/pagination.py
+++ b/api/pagination.py
@@ -16,7 +16,7 @@ from typing import Any, TypeVar
 
 from fastapi import Query
 from fastapi_pagination import Page as _BasePage
-from fastapi_pagination.customization import CustomizedPage, UseParams
+from fastapi_pagination.customization import CustomizedPage, UseParams, UseParamsFields
 from fastapi_pagination.default import Params as _DefaultParams
 from pydantic import TypeAdapter
 
@@ -36,15 +36,6 @@ class PageParams(_DefaultParams):
     size: int = Query(DEFAULT_SIZE, ge=1, le=MAX_SIZE, description="Items per page")
 
 
-class AppGroupsPageParams(_DefaultParams):
-    """Params for `GET /api/apps/{id}/groups`: `size` defaults to and is capped
-    at APP_GROUPS_SIZE so a single response can't load an unbounded number of
-    groups' memberships."""
-
-    page: int = Query(1, ge=1, description="Page number")
-    size: int = Query(APP_GROUPS_SIZE, ge=1, le=APP_GROUPS_SIZE, description="Items per page")
-
-
 # `Page[T]` re-export with our `PageParams` defaults pre-applied so router
 # signatures stay short: `-> Page[OktaUserSummary]`.
 T = TypeVar("T")
@@ -52,9 +43,12 @@ Page = CustomizedPage[
     _BasePage[T],
     UseParams(PageParams),
 ]
+# `GET /api/apps/{id}/groups` caps `size` at APP_GROUPS_SIZE so one page can't
+# load an unbounded number of groups' memberships. Override just the `size`
+# field on `Page` rather than defining a whole Params subclass.
 AppGroupsPage = CustomizedPage[
-    _BasePage[T],
-    UseParams(AppGroupsPageParams),
+    Page[T],
+    UseParamsFields(size=Query(APP_GROUPS_SIZE, ge=1, le=APP_GROUPS_SIZE, description="Items per page")),
 ]
 
 
@@ -81,7 +75,6 @@ def validated(model: type) -> Callable[[Sequence[Any]], list[Any]]:
 __all__ = [
     "APP_GROUPS_SIZE",
     "AppGroupsPage",
-    "AppGroupsPageParams",
     "DEFAULT_SIZE",
     "MAX_SIZE",
     "Page",

--- a/api/pagination.py
+++ b/api/pagination.py
@@ -23,6 +23,11 @@ from pydantic import TypeAdapter
 DEFAULT_SIZE = 50
 MAX_SIZE = 1000
 
+# App-groups embed every group's full membership per item, so this page is
+# bound tighter than the default: one page can materialize at most this many
+# groups' worth of members regardless of how many groups an app owns.
+APP_GROUPS_SIZE = 10
+
 
 class PageParams(_DefaultParams):
     """Default `Params` subclass: 1-indexed `page`, `size` capped at MAX_SIZE."""
@@ -31,12 +36,25 @@ class PageParams(_DefaultParams):
     size: int = Query(DEFAULT_SIZE, ge=1, le=MAX_SIZE, description="Items per page")
 
 
+class AppGroupsPageParams(_DefaultParams):
+    """Params for `GET /api/apps/{id}/groups`: `size` defaults to and is capped
+    at APP_GROUPS_SIZE so a single response can't load an unbounded number of
+    groups' memberships."""
+
+    page: int = Query(1, ge=1, description="Page number")
+    size: int = Query(APP_GROUPS_SIZE, ge=1, le=APP_GROUPS_SIZE, description="Items per page")
+
+
 # `Page[T]` re-export with our `PageParams` defaults pre-applied so router
 # signatures stay short: `-> Page[OktaUserSummary]`.
 T = TypeVar("T")
 Page = CustomizedPage[
     _BasePage[T],
     UseParams(PageParams),
+]
+AppGroupsPage = CustomizedPage[
+    _BasePage[T],
+    UseParams(AppGroupsPageParams),
 ]
 
 
@@ -61,6 +79,9 @@ def validated(model: type) -> Callable[[Sequence[Any]], list[Any]]:
 
 
 __all__ = [
+    "APP_GROUPS_SIZE",
+    "AppGroupsPage",
+    "AppGroupsPageParams",
     "DEFAULT_SIZE",
     "MAX_SIZE",
     "Page",

--- a/api/routers/apps.py
+++ b/api/routers/apps.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Annotated, Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
@@ -21,16 +21,19 @@ from api.models import (
     AppGroup,
     AppTagMap,
     OktaGroup,
+    OktaUser,
+    OktaUserGroupMember,
 )
 from fastapi_pagination.ext.sqlalchemy import paginate
 
-from api.pagination import Page, validated
+from api.pagination import AppGroupsPage, Page, validated
 from api.routers._eager import (
     user_group_member_options,
 )
 from api.schemas import (
     AppSummary,
     AppDetail,
+    AppGroupForAppDetail,
     CreateAppBody,
     DeleteMessage,
     SearchAppQuery,
@@ -52,8 +55,6 @@ APP_LOAD_OPTIONS = (
         joinedload(AppTagMap.active_tag),
         joinedload(AppTagMap.active_app),
     ),
-    selectinload(App.active_owner_app_groups).options(*_APP_GROUP_LOAD),
-    selectinload(App.active_non_owner_app_groups).options(*_APP_GROUP_LOAD),
 )
 
 
@@ -85,6 +86,60 @@ def get_app(app_id: str, db: DbSession, current_user_id: CurrentUserId) -> AppDe
     if app is None:
         raise HTTPException(404, "Not Found")
     return AppDetail.model_validate(app, from_attributes=True)
+
+
+@router.get("/{app_id}/groups", name="app_groups_by_id")
+def get_app_groups(
+    app_id: str,
+    db: DbSession,
+    current_user_id: CurrentUserId,
+    owner: Annotated[Optional[bool], Query()] = None,
+    q: Annotated[Optional[str], Query()] = None,
+) -> AppGroupsPage[AppGroupForAppDetail]:
+    """Paginated app-groups for an app, owners first then by name. Each item
+    carries its members inline; the page is bounded (`AppGroupsPageParams`) so a
+    single response materializes at most that many groups' memberships, rather
+    than every group of an app at once.
+
+    `owner` filters to owner / non-owner app-groups. `q` filters to groups that
+    have an active member matching the query by name or email — the app page's
+    user search, computed in SQL so it doesn't need every member client-side."""
+    resolved_app_id = db.scalars(
+        select(App.id).where(App.deleted_at.is_(None)).where(or_(App.id == app_id, App.name == app_id))
+    ).first()
+    if resolved_app_id is None:
+        raise HTTPException(404, "Not Found")
+    stmt = (
+        select(AppGroup)
+        .options(joinedload(AppGroup.app), *_APP_GROUP_LOAD)
+        .where(AppGroup.app_id == resolved_app_id)
+        .where(AppGroup.deleted_at.is_(None))
+    )
+    if owner is not None:
+        stmt = stmt.where(AppGroup.is_owner.is_(owner))
+    if q:
+        like = f"%{q}%"
+        member_match = (
+            select(OktaUserGroupMember.id)
+            .join(OktaUser, OktaUser.id == OktaUserGroupMember.user_id)
+            .where(OktaUserGroupMember.group_id == AppGroup.id)
+            .where(OktaUser.deleted_at.is_(None))
+            .where(or_(OktaUserGroupMember.ended_at.is_(None), OktaUserGroupMember.ended_at > func.now()))
+            .where(
+                or_(
+                    OktaUser.email.ilike(like),
+                    OktaUser.display_name.ilike(like),
+                    OktaUser.first_name.ilike(like),
+                    OktaUser.last_name.ilike(like),
+                )
+            )
+            .exists()
+        )
+        stmt = stmt.where(member_match)
+    # AppGroup.id is a unique final tiebreaker so rows that tie on
+    # (is_owner, lower(name)) have a stable order across LIMIT/OFFSET pages.
+    stmt = stmt.order_by(AppGroup.is_owner.desc(), func.lower(AppGroup.name), AppGroup.id)
+    return paginate(db, stmt, transformer=validated(AppGroupForAppDetail))
 
 
 @router.post("", name="apps_create", status_code=201)

--- a/api/routers/apps.py
+++ b/api/routers/apps.py
@@ -27,9 +27,6 @@ from api.models import (
 from fastapi_pagination.ext.sqlalchemy import paginate
 
 from api.pagination import AppGroupsPage, Page, validated
-from api.routers._eager import (
-    user_group_member_options,
-)
 from api.schemas import (
     AppSummary,
     AppDetail,
@@ -41,15 +38,6 @@ from api.schemas import (
 )
 
 
-# Eager-load options for an `App` response. `AppGroupForAppDetail` only
-# exposes user memberships/ownerships on the nested app groups — Flask's
-# `DEFAULT_SCHEMA_DISPLAY_EXCLUSIONS` strips role-mapping and group-tag
-# arrays via dotted-path entries — so we deliberately don't pull those
-# loaders here.
-_APP_GROUP_LOAD = (
-    selectinload(AppGroup.active_user_memberships).options(*user_group_member_options()),
-    selectinload(AppGroup.active_user_ownerships).options(*user_group_member_options()),
-)
 APP_LOAD_OPTIONS = (
     selectinload(App.active_app_tags).options(
         joinedload(AppTagMap.active_tag),
@@ -96,10 +84,11 @@ def get_app_groups(
     owner: Annotated[Optional[bool], Query()] = None,
     q: Annotated[Optional[str], Query()] = None,
 ) -> AppGroupsPage[AppGroupForAppDetail]:
-    """Paginated app-groups for an app, owners first then by name. Each item
-    carries its members inline; the page is bounded (`AppGroupsPageParams`) so a
-    single response materializes at most that many groups' memberships, rather
-    than every group of an app at once.
+    """Paginated app-groups for an app, owners first then by name. Members are
+    NOT inlined — each item carries `member_count` / `owner_count` only, so the
+    response is bounded by the number of groups on the page regardless of how
+    many members any single group has. The UI fetches a group's members on
+    demand from `GET /api/groups/{id}/member-details`.
 
     `owner` filters to owner / non-owner app-groups. `q` filters to groups that
     have an active member matching the query by name or email — the app page's
@@ -111,7 +100,7 @@ def get_app_groups(
         raise HTTPException(404, "Not Found")
     stmt = (
         select(AppGroup)
-        .options(joinedload(AppGroup.app), *_APP_GROUP_LOAD)
+        .options(joinedload(AppGroup.app))
         .where(AppGroup.app_id == resolved_app_id)
         .where(AppGroup.deleted_at.is_(None))
     )
@@ -139,7 +128,27 @@ def get_app_groups(
     # AppGroup.id is a unique final tiebreaker so rows that tie on
     # (is_owner, lower(name)) have a stable order across LIMIT/OFFSET pages.
     stmt = stmt.order_by(AppGroup.is_owner.desc(), func.lower(AppGroup.name), AppGroup.id)
-    return paginate(db, stmt, transformer=validated(AppGroupForAppDetail))
+
+    def _with_counts(groups: Any) -> list[Any]:
+        ids = [g.id for g in groups]
+        counts: dict[tuple[str, bool], int] = {}
+        if ids:
+            rows = db.execute(
+                select(OktaUserGroupMember.group_id, OktaUserGroupMember.is_owner, func.count())
+                .where(OktaUserGroupMember.group_id.in_(ids))
+                .where(or_(OktaUserGroupMember.ended_at.is_(None), OktaUserGroupMember.ended_at > func.now()))
+                .group_by(OktaUserGroupMember.group_id, OktaUserGroupMember.is_owner)
+            ).all()
+            for gid, is_owner, count in rows:
+                counts[(gid, is_owner)] = count
+        # Stash the aggregates on the ORM instances so `from_attributes` picks
+        # them up (these are plain, non-mapped attributes).
+        for g in groups:
+            g.member_count = counts.get((g.id, False), 0)
+            g.owner_count = counts.get((g.id, True), 0)
+        return validated(AppGroupForAppDetail)(groups)
+
+    return paginate(db, stmt, transformer=_with_counts)
 
 
 @router.post("", name="apps_create", status_code=201)

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -12,7 +12,7 @@ GET    /api/groups/{group_id}/audit         redirects to /api/audit/users
 
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Annotated, Any, Optional
 
 from fastapi import APIRouter, HTTPException, Query
 
@@ -54,6 +54,7 @@ from api.schemas import (
     DeleteMessage,
     GroupDetail,
     GroupMembersSummary,
+    OktaUserGroupMemberDetail,
     SearchGroupQuery,
     UpdateGroupBody,
 )
@@ -72,8 +73,6 @@ ROLE_ASSOCIATED_GROUP_TYPES = with_polymorphic(OktaGroup, [AppGroup])
 
 DEFAULT_LOAD_OPTIONS = (
     selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
-    selectinload(OktaGroup.active_user_memberships).options(*user_group_member_options()),
-    selectinload(OktaGroup.active_user_ownerships).options(*user_group_member_options()),
     selectinload(OktaGroup.active_role_member_mappings).options(*role_group_map_options()),
     selectinload(OktaGroup.active_role_owner_mappings).options(*role_group_map_options()),
     selectinload(RoleGroup.active_role_associated_group_member_mappings).options(*role_group_map_options()),
@@ -463,6 +462,66 @@ def get_group_members(group_id: str, db: DbSession, current_user_id: CurrentUser
         members=[r.user_id for r in rows if not r.is_owner],
         owners=[r.user_id for r in rows if r.is_owner],
     )
+
+
+@router.get("/{group_id}/member-details", name="group_member_details_by_id")
+def get_group_member_details(
+    group_id: str,
+    db: DbSession,
+    current_user_id: CurrentUserId,
+    owner: Annotated[Optional[bool], Query()] = None,
+) -> Page[OktaUserGroupMemberDetail]:
+    """Paginated, fully-hydrated active membership rows for a group. `owner=true`
+    returns ownerships, `owner=false` memberships, omitted returns both. Lets the
+    group page page through members instead of inlining every row in the group
+    detail response.
+
+    Pagination is by distinct *user*, not by membership row: a user can hold
+    several active rows for one group (a direct grant plus role-granted ones),
+    and the UI renders one row per user. Paging by user keeps `total` aligned
+    with the de-duplicated list the UI shows and keeps all of a user's rows on
+    the same page. Note `total` and `size` count users, so a page can contain
+    more than `size` items (rows) when users hold multiple rows; consumers must
+    not assume ``len(items) == size``."""
+    resolved_group_id = db.scalars(
+        select(OktaGroup.id)
+        .where(OktaGroup.deleted_at.is_(None))
+        .where(or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
+    ).first()
+    if resolved_group_id is None:
+        raise HTTPException(404, "Not Found")
+
+    active = or_(
+        OktaUserGroupMember.ended_at.is_(None),
+        OktaUserGroupMember.ended_at > func.now(),
+    )
+
+    # Page over distinct user ids (stable order by user id); total is then the
+    # distinct user count.
+    user_stmt = (
+        select(OktaUserGroupMember.user_id).where(OktaUserGroupMember.group_id == resolved_group_id).where(active)
+    )
+    if owner is not None:
+        user_stmt = user_stmt.where(OktaUserGroupMember.is_owner.is_(owner))
+    user_stmt = user_stmt.distinct().order_by(OktaUserGroupMember.user_id)
+
+    def _load_rows(user_rows: Any) -> list[Any]:
+        user_ids = [r if isinstance(r, str) else r[0] for r in user_rows]
+        if not user_ids:
+            return []
+        detail_stmt = (
+            select(OktaUserGroupMember)
+            .options(*user_group_member_options())
+            .where(OktaUserGroupMember.group_id == resolved_group_id)
+            .where(active)
+            .where(OktaUserGroupMember.user_id.in_(user_ids))
+        )
+        if owner is not None:
+            detail_stmt = detail_stmt.where(OktaUserGroupMember.is_owner.is_(owner))
+        detail_stmt = detail_stmt.order_by(OktaUserGroupMember.user_id, OktaUserGroupMember.id)
+        return validated(OktaUserGroupMemberDetail)(db.scalars(detail_stmt).all())
+
+    return paginate(db, user_stmt, transformer=_load_rows)
 
 
 @router.put("/{group_id}/members", name="group_members_by_id_put")

--- a/api/schemas/core_schemas.py
+++ b/api/schemas/core_schemas.py
@@ -328,12 +328,13 @@ class AppGroupDetail(_GroupBase):
 
 
 class AppGroupForAppDetail(BaseModel):
-    """Slimmer shape used inside `AppDetail.active_*_app_groups`.
+    """Slimmer shape used by the paginated `GET /api/apps/{id}/groups` endpoint.
 
-    Drops `active_role_member_mappings`, `active_role_owner_mappings`, and
-    `active_group_tags` on the nested app-groups. The outer `AppGroupDetail`
-    retains them for direct `GET /api/groups/{id}` calls; this variant omits
-    them when the same rows are embedded inside an `AppDetail` payload."""
+    Members are NOT inlined: a single group can have thousands, and inlining
+    them made even a 10-group page able to ship megabytes. Instead each item
+    carries `member_count` / `owner_count` (cheap SQL aggregates); the UI fetches
+    a group's members on demand from the paginated
+    `GET /api/groups/{id}/member-details` endpoint."""
 
     model_config = ConfigDict(from_attributes=True)
     id: str
@@ -349,8 +350,8 @@ class AppGroupForAppDetail(BaseModel):
     is_owner: bool = False
     plugin_data: Optional[dict[str, Any]] = None
     app: Optional[AppIdRef] = None
-    active_user_memberships: list[OktaUserGroupMemberDetail] = Field(default_factory=list)
-    active_user_ownerships: list[OktaUserGroupMemberDetail] = Field(default_factory=list)
+    member_count: int = 0
+    owner_count: int = 0
 
 
 # Named via `TypeAliasType` so FastAPI emits a single `GroupDetail` schema

--- a/api/schemas/core_schemas.py
+++ b/api/schemas/core_schemas.py
@@ -121,21 +121,18 @@ class AppSummary(BaseModel):
 
 
 class AppDetail(AppSummary):
-    """Full App detail."""
+    """Full App detail.
+
+    The app's groups are intentionally NOT inlined here. An app can own
+    hundreds of groups, and inlining each group's full membership made a
+    single detail response materialize thousands of member rows. Groups (with
+    their members) are served by the paginated `GET /api/apps/{id}/groups`
+    endpoint (`AppGroupForAppDetail`) so the cost is bounded per page.
+    """
 
     app_group_lifecycle_plugin: Optional[str] = None
     plugin_data: Optional[dict[str, Any]] = None
     active_app_tags: list[AppTagMapDetail] = Field(default_factory=list)
-    # Flask `AppResource.get()` `DEFAULT_SCHEMA_DISPLAY_EXCLUSIONS` strips
-    # `active_role_member_mappings`, `active_role_owner_mappings`, and
-    # `active_group_tags` on the *nested* app groups (those land via
-    # `active_owner_app_groups.<dotted-path>` exclude entries). Use a
-    # dedicated slimmer shape — `AppGroupForAppDetail` — instead of
-    # `AppGroupDetail` so the App-detail response doesn't pull every
-    # role-association mapping per nested group. Forward refs resolved
-    # via `model_rebuild()` at the bottom of this file.
-    active_owner_app_groups: list["AppGroupForAppDetail"] = Field(default_factory=list)
-    active_non_owner_app_groups: list["AppGroupForAppDetail"] = Field(default_factory=list)
 
 
 # --- Users ------------------------------------------------------------------
@@ -301,8 +298,10 @@ class _GroupBase(BaseModel):
     created_at: FlexibleDatetime
     updated_at: FlexibleDatetime
     deleted_at: Optional[FlexibleDatetime] = None
-    active_user_memberships: list[OktaUserGroupMemberDetail] = Field(default_factory=list)
-    active_user_ownerships: list[OktaUserGroupMemberDetail] = Field(default_factory=list)
+    # Members are intentionally NOT inlined: a group can have thousands, and
+    # inlining them made the detail response (and, via the app endpoint, every
+    # group of an app) materialize unbounded member rows. They are served by
+    # the paginated `GET /api/groups/{id}/member-details` endpoint instead.
     active_group_tags: list[OktaGroupTagMapDetail] = Field(default_factory=list)
 
 

--- a/src/api/apiComponents.ts
+++ b/src/api/apiComponents.ts
@@ -113,7 +113,7 @@ export type AccessRequestsVariables = {
 
 export const fetchAccessRequests = (variables: AccessRequestsVariables, signal?: AbortSignal) =>
   apiFetch<
-    Schemas.PageTypeVarCustomizedAccessRequestSummary,
+    Schemas.PageTCustomizedAccessRequestSummary,
     AccessRequestsError,
     undefined,
     {},
@@ -123,14 +123,12 @@ export const fetchAccessRequests = (variables: AccessRequestsVariables, signal?:
 
 export function accessRequestsQuery(variables: AccessRequestsVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedAccessRequestSummary>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedAccessRequestSummary>;
 };
 
 export function accessRequestsQuery(variables: AccessRequestsVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
-  queryFn:
-    | ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedAccessRequestSummary>)
-    | reactQuery.SkipToken;
+  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedAccessRequestSummary>) | reactQuery.SkipToken;
 };
 
 export function accessRequestsQuery(variables: AccessRequestsVariables | reactQuery.SkipToken) {
@@ -147,30 +145,30 @@ export function accessRequestsQuery(variables: AccessRequestsVariables | reactQu
   };
 }
 
-export const useSuspenseAccessRequests = <TData = Schemas.PageTypeVarCustomizedAccessRequestSummary>(
+export const useSuspenseAccessRequests = <TData = Schemas.PageTCustomizedAccessRequestSummary>(
   variables: AccessRequestsVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedAccessRequestSummary, AccessRequestsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedAccessRequestSummary, AccessRequestsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useSuspenseQuery<Schemas.PageTypeVarCustomizedAccessRequestSummary, AccessRequestsError, TData>({
+  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedAccessRequestSummary, AccessRequestsError, TData>({
     ...accessRequestsQuery(deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
   });
 };
 
-export const useAccessRequests = <TData = Schemas.PageTypeVarCustomizedAccessRequestSummary>(
+export const useAccessRequests = <TData = Schemas.PageTCustomizedAccessRequestSummary>(
   variables: AccessRequestsVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedAccessRequestSummary, AccessRequestsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedAccessRequestSummary, AccessRequestsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTypeVarCustomizedAccessRequestSummary, AccessRequestsError, TData>({
+  return reactQuery.useQuery<Schemas.PageTCustomizedAccessRequestSummary, AccessRequestsError, TData>({
     ...accessRequestsQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
@@ -367,7 +365,7 @@ export type AppsVariables = {
 } & ApiContext['fetcherOptions'];
 
 export const fetchApps = (variables: AppsVariables, signal?: AbortSignal) =>
-  apiFetch<Schemas.PageTypeVarCustomizedAppSummary, AppsError, undefined, {}, AppsQueryParams, {}>({
+  apiFetch<Schemas.PageTCustomizedAppSummary, AppsError, undefined, {}, AppsQueryParams, {}>({
     url: '/api/apps',
     method: 'get',
     ...variables,
@@ -376,12 +374,12 @@ export const fetchApps = (variables: AppsVariables, signal?: AbortSignal) =>
 
 export function appsQuery(variables: AppsVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedAppSummary>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedAppSummary>;
 };
 
 export function appsQuery(variables: AppsVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
-  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedAppSummary>) | reactQuery.SkipToken;
+  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedAppSummary>) | reactQuery.SkipToken;
 };
 
 export function appsQuery(variables: AppsVariables | reactQuery.SkipToken) {
@@ -398,30 +396,30 @@ export function appsQuery(variables: AppsVariables | reactQuery.SkipToken) {
   };
 }
 
-export const useSuspenseApps = <TData = Schemas.PageTypeVarCustomizedAppSummary>(
+export const useSuspenseApps = <TData = Schemas.PageTCustomizedAppSummary>(
   variables: AppsVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedAppSummary, AppsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedAppSummary, AppsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useSuspenseQuery<Schemas.PageTypeVarCustomizedAppSummary, AppsError, TData>({
+  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedAppSummary, AppsError, TData>({
     ...appsQuery(deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
   });
 };
 
-export const useApps = <TData = Schemas.PageTypeVarCustomizedAppSummary>(
+export const useApps = <TData = Schemas.PageTCustomizedAppSummary>(
   variables: AppsVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedAppSummary, AppsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedAppSummary, AppsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTypeVarCustomizedAppSummary, AppsError, TData>({
+  return reactQuery.useQuery<Schemas.PageTCustomizedAppSummary, AppsError, TData>({
     ...appsQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
@@ -596,6 +594,144 @@ export const useAppByIdDelete = (
   });
 };
 
+export type AppGroupsByIdPathParams = {
+  appId: string;
+};
+
+export type AppGroupsByIdQueryParams = {
+  owner?: boolean | null;
+  q?: string | null;
+  /**
+   * Page number
+   *
+   * @minimum 1
+   * @default 1
+   */
+  page?: number;
+  /**
+   * Items per page
+   *
+   * @maximum 10
+   * @minimum 1
+   * @default 10
+   */
+  size?: number;
+};
+
+export type AppGroupsByIdError = Fetcher.ErrorWrapper<{
+  status: Exclude<ClientErrorStatus | ServerErrorStatus, 200>;
+  payload: Schemas.ProblemDetail;
+}>;
+
+export type AppGroupsByIdVariables = {
+  pathParams: AppGroupsByIdPathParams;
+  queryParams?: AppGroupsByIdQueryParams;
+} & ApiContext['fetcherOptions'];
+
+/**
+ * Paginated app-groups for an app, owners first then by name. Each item
+ * carries its members inline; the page is bounded (`AppGroupsPageParams`) so a
+ * single response materializes at most that many groups' memberships, rather
+ * than every group of an app at once.
+ *
+ * `owner` filters to owner / non-owner app-groups. `q` filters to groups that
+ * have an active member matching the query by name or email — the app page's
+ * user search, computed in SQL so it doesn't need every member client-side.
+ */
+export const fetchAppGroupsById = (variables: AppGroupsByIdVariables, signal?: AbortSignal) =>
+  apiFetch<
+    Schemas.PageTCustomizedAppGroupForAppDetail,
+    AppGroupsByIdError,
+    undefined,
+    {},
+    AppGroupsByIdQueryParams,
+    AppGroupsByIdPathParams
+  >({url: '/api/apps/{appId}/groups', method: 'get', ...variables, signal});
+
+/**
+ * Paginated app-groups for an app, owners first then by name. Each item
+ * carries its members inline; the page is bounded (`AppGroupsPageParams`) so a
+ * single response materializes at most that many groups' memberships, rather
+ * than every group of an app at once.
+ *
+ * `owner` filters to owner / non-owner app-groups. `q` filters to groups that
+ * have an active member matching the query by name or email — the app page's
+ * user search, computed in SQL so it doesn't need every member client-side.
+ */
+export function appGroupsByIdQuery(variables: AppGroupsByIdVariables): {
+  queryKey: reactQuery.QueryKey;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedAppGroupForAppDetail>;
+};
+
+export function appGroupsByIdQuery(variables: AppGroupsByIdVariables | reactQuery.SkipToken): {
+  queryKey: reactQuery.QueryKey;
+  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedAppGroupForAppDetail>) | reactQuery.SkipToken;
+};
+
+export function appGroupsByIdQuery(variables: AppGroupsByIdVariables | reactQuery.SkipToken) {
+  return {
+    queryKey: queryKeyFn({
+      path: '/api/apps/{appId}/groups',
+      operationId: 'appGroupsById',
+      variables,
+    }),
+    queryFn:
+      variables === reactQuery.skipToken
+        ? reactQuery.skipToken
+        : ({signal}: QueryFnOptions) => fetchAppGroupsById(variables, signal),
+  };
+}
+
+/**
+ * Paginated app-groups for an app, owners first then by name. Each item
+ * carries its members inline; the page is bounded (`AppGroupsPageParams`) so a
+ * single response materializes at most that many groups' memberships, rather
+ * than every group of an app at once.
+ *
+ * `owner` filters to owner / non-owner app-groups. `q` filters to groups that
+ * have an active member matching the query by name or email — the app page's
+ * user search, computed in SQL so it doesn't need every member client-side.
+ */
+export const useSuspenseAppGroupsById = <TData = Schemas.PageTCustomizedAppGroupForAppDetail>(
+  variables: AppGroupsByIdVariables,
+  options?: Omit<
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedAppGroupForAppDetail, AppGroupsByIdError, TData>,
+    'queryKey' | 'queryFn' | 'initialData'
+  >,
+) => {
+  const {queryOptions, fetcherOptions} = useApiContext(options);
+  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedAppGroupForAppDetail, AppGroupsByIdError, TData>({
+    ...appGroupsByIdQuery(deepMerge(fetcherOptions, variables)),
+    ...options,
+    ...queryOptions,
+  });
+};
+
+/**
+ * Paginated app-groups for an app, owners first then by name. Each item
+ * carries its members inline; the page is bounded (`AppGroupsPageParams`) so a
+ * single response materializes at most that many groups' memberships, rather
+ * than every group of an app at once.
+ *
+ * `owner` filters to owner / non-owner app-groups. `q` filters to groups that
+ * have an active member matching the query by name or email — the app page's
+ * user search, computed in SQL so it doesn't need every member client-side.
+ */
+export const useAppGroupsById = <TData = Schemas.PageTCustomizedAppGroupForAppDetail>(
+  variables: AppGroupsByIdVariables | reactQuery.SkipToken,
+  options?: Omit<
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedAppGroupForAppDetail, AppGroupsByIdError, TData>,
+    'queryKey' | 'queryFn' | 'initialData'
+  >,
+) => {
+  const {queryOptions, fetcherOptions} = useApiContext(options);
+  return reactQuery.useQuery<Schemas.PageTCustomizedAppGroupForAppDetail, AppGroupsByIdError, TData>({
+    ...appGroupsByIdQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
+    ...options,
+    ...queryOptions,
+  });
+};
+
 export type UsersAndGroupsQueryParams = {
   q?: string | null;
   owner?: boolean | null;
@@ -642,25 +778,18 @@ export type UsersAndGroupsVariables = {
 } & ApiContext['fetcherOptions'];
 
 export const fetchUsersAndGroups = (variables: UsersAndGroupsVariables, signal?: AbortSignal) =>
-  apiFetch<
-    Schemas.PageTypeVarCustomizedAuditUserGroupRow,
-    UsersAndGroupsError,
-    undefined,
-    {},
-    UsersAndGroupsQueryParams,
-    {}
-  >({url: '/api/audit/users', method: 'get', ...variables, signal});
+  apiFetch<Schemas.PageTCustomizedAuditUserGroupRow, UsersAndGroupsError, undefined, {}, UsersAndGroupsQueryParams, {}>(
+    {url: '/api/audit/users', method: 'get', ...variables, signal},
+  );
 
 export function usersAndGroupsQuery(variables: UsersAndGroupsVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedAuditUserGroupRow>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedAuditUserGroupRow>;
 };
 
 export function usersAndGroupsQuery(variables: UsersAndGroupsVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
-  queryFn:
-    | ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedAuditUserGroupRow>)
-    | reactQuery.SkipToken;
+  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedAuditUserGroupRow>) | reactQuery.SkipToken;
 };
 
 export function usersAndGroupsQuery(variables: UsersAndGroupsVariables | reactQuery.SkipToken) {
@@ -677,30 +806,30 @@ export function usersAndGroupsQuery(variables: UsersAndGroupsVariables | reactQu
   };
 }
 
-export const useSuspenseUsersAndGroups = <TData = Schemas.PageTypeVarCustomizedAuditUserGroupRow>(
+export const useSuspenseUsersAndGroups = <TData = Schemas.PageTCustomizedAuditUserGroupRow>(
   variables: UsersAndGroupsVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedAuditUserGroupRow, UsersAndGroupsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedAuditUserGroupRow, UsersAndGroupsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useSuspenseQuery<Schemas.PageTypeVarCustomizedAuditUserGroupRow, UsersAndGroupsError, TData>({
+  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedAuditUserGroupRow, UsersAndGroupsError, TData>({
     ...usersAndGroupsQuery(deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
   });
 };
 
-export const useUsersAndGroups = <TData = Schemas.PageTypeVarCustomizedAuditUserGroupRow>(
+export const useUsersAndGroups = <TData = Schemas.PageTCustomizedAuditUserGroupRow>(
   variables: UsersAndGroupsVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedAuditUserGroupRow, UsersAndGroupsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedAuditUserGroupRow, UsersAndGroupsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTypeVarCustomizedAuditUserGroupRow, UsersAndGroupsError, TData>({
+  return reactQuery.useQuery<Schemas.PageTCustomizedAuditUserGroupRow, UsersAndGroupsError, TData>({
     ...usersAndGroupsQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
@@ -755,25 +884,18 @@ export type GroupsAndRolesVariables = {
 } & ApiContext['fetcherOptions'];
 
 export const fetchGroupsAndRoles = (variables: GroupsAndRolesVariables, signal?: AbortSignal) =>
-  apiFetch<
-    Schemas.PageTypeVarCustomizedAuditGroupRoleRow,
-    GroupsAndRolesError,
-    undefined,
-    {},
-    GroupsAndRolesQueryParams,
-    {}
-  >({url: '/api/audit/groups', method: 'get', ...variables, signal});
+  apiFetch<Schemas.PageTCustomizedAuditGroupRoleRow, GroupsAndRolesError, undefined, {}, GroupsAndRolesQueryParams, {}>(
+    {url: '/api/audit/groups', method: 'get', ...variables, signal},
+  );
 
 export function groupsAndRolesQuery(variables: GroupsAndRolesVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedAuditGroupRoleRow>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedAuditGroupRoleRow>;
 };
 
 export function groupsAndRolesQuery(variables: GroupsAndRolesVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
-  queryFn:
-    | ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedAuditGroupRoleRow>)
-    | reactQuery.SkipToken;
+  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedAuditGroupRoleRow>) | reactQuery.SkipToken;
 };
 
 export function groupsAndRolesQuery(variables: GroupsAndRolesVariables | reactQuery.SkipToken) {
@@ -790,30 +912,30 @@ export function groupsAndRolesQuery(variables: GroupsAndRolesVariables | reactQu
   };
 }
 
-export const useSuspenseGroupsAndRoles = <TData = Schemas.PageTypeVarCustomizedAuditGroupRoleRow>(
+export const useSuspenseGroupsAndRoles = <TData = Schemas.PageTCustomizedAuditGroupRoleRow>(
   variables: GroupsAndRolesVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedAuditGroupRoleRow, GroupsAndRolesError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedAuditGroupRoleRow, GroupsAndRolesError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useSuspenseQuery<Schemas.PageTypeVarCustomizedAuditGroupRoleRow, GroupsAndRolesError, TData>({
+  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedAuditGroupRoleRow, GroupsAndRolesError, TData>({
     ...groupsAndRolesQuery(deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
   });
 };
 
-export const useGroupsAndRoles = <TData = Schemas.PageTypeVarCustomizedAuditGroupRoleRow>(
+export const useGroupsAndRoles = <TData = Schemas.PageTCustomizedAuditGroupRoleRow>(
   variables: GroupsAndRolesVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedAuditGroupRoleRow, GroupsAndRolesError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedAuditGroupRoleRow, GroupsAndRolesError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTypeVarCustomizedAuditGroupRoleRow, GroupsAndRolesError, TData>({
+  return reactQuery.useQuery<Schemas.PageTCustomizedAuditGroupRoleRow, GroupsAndRolesError, TData>({
     ...groupsAndRolesQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
@@ -891,25 +1013,21 @@ export type GroupRequestsVariables = {
 } & ApiContext['fetcherOptions'];
 
 export const fetchGroupRequests = (variables: GroupRequestsVariables, signal?: AbortSignal) =>
-  apiFetch<
-    Schemas.PageTypeVarCustomizedGroupRequestDetail,
-    GroupRequestsError,
-    undefined,
-    {},
-    GroupRequestsQueryParams,
-    {}
-  >({url: '/api/group-requests', method: 'get', ...variables, signal});
+  apiFetch<Schemas.PageTCustomizedGroupRequestDetail, GroupRequestsError, undefined, {}, GroupRequestsQueryParams, {}>({
+    url: '/api/group-requests',
+    method: 'get',
+    ...variables,
+    signal,
+  });
 
 export function groupRequestsQuery(variables: GroupRequestsVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedGroupRequestDetail>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedGroupRequestDetail>;
 };
 
 export function groupRequestsQuery(variables: GroupRequestsVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
-  queryFn:
-    | ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedGroupRequestDetail>)
-    | reactQuery.SkipToken;
+  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedGroupRequestDetail>) | reactQuery.SkipToken;
 };
 
 export function groupRequestsQuery(variables: GroupRequestsVariables | reactQuery.SkipToken) {
@@ -926,30 +1044,30 @@ export function groupRequestsQuery(variables: GroupRequestsVariables | reactQuer
   };
 }
 
-export const useSuspenseGroupRequests = <TData = Schemas.PageTypeVarCustomizedGroupRequestDetail>(
+export const useSuspenseGroupRequests = <TData = Schemas.PageTCustomizedGroupRequestDetail>(
   variables: GroupRequestsVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedGroupRequestDetail, GroupRequestsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedGroupRequestDetail, GroupRequestsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useSuspenseQuery<Schemas.PageTypeVarCustomizedGroupRequestDetail, GroupRequestsError, TData>({
+  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedGroupRequestDetail, GroupRequestsError, TData>({
     ...groupRequestsQuery(deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
   });
 };
 
-export const useGroupRequests = <TData = Schemas.PageTypeVarCustomizedGroupRequestDetail>(
+export const useGroupRequests = <TData = Schemas.PageTCustomizedGroupRequestDetail>(
   variables: GroupRequestsVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedGroupRequestDetail, GroupRequestsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedGroupRequestDetail, GroupRequestsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTypeVarCustomizedGroupRequestDetail, GroupRequestsError, TData>({
+  return reactQuery.useQuery<Schemas.PageTCustomizedGroupRequestDetail, GroupRequestsError, TData>({
     ...groupRequestsQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
@@ -1146,7 +1264,7 @@ export type GroupsVariables = {
 } & ApiContext['fetcherOptions'];
 
 export const fetchGroups = (variables: GroupsVariables, signal?: AbortSignal) =>
-  apiFetch<Schemas.PageTypeVarCustomizedGroupSummary, GroupsError, undefined, {}, GroupsQueryParams, {}>({
+  apiFetch<Schemas.PageTCustomizedGroupSummary, GroupsError, undefined, {}, GroupsQueryParams, {}>({
     url: '/api/groups',
     method: 'get',
     ...variables,
@@ -1155,12 +1273,12 @@ export const fetchGroups = (variables: GroupsVariables, signal?: AbortSignal) =>
 
 export function groupsQuery(variables: GroupsVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedGroupSummary>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedGroupSummary>;
 };
 
 export function groupsQuery(variables: GroupsVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
-  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedGroupSummary>) | reactQuery.SkipToken;
+  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedGroupSummary>) | reactQuery.SkipToken;
 };
 
 export function groupsQuery(variables: GroupsVariables | reactQuery.SkipToken) {
@@ -1177,30 +1295,30 @@ export function groupsQuery(variables: GroupsVariables | reactQuery.SkipToken) {
   };
 }
 
-export const useSuspenseGroups = <TData = Schemas.PageTypeVarCustomizedGroupSummary>(
+export const useSuspenseGroups = <TData = Schemas.PageTCustomizedGroupSummary>(
   variables: GroupsVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedGroupSummary, GroupsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedGroupSummary, GroupsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useSuspenseQuery<Schemas.PageTypeVarCustomizedGroupSummary, GroupsError, TData>({
+  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedGroupSummary, GroupsError, TData>({
     ...groupsQuery(deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
   });
 };
 
-export const useGroups = <TData = Schemas.PageTypeVarCustomizedGroupSummary>(
+export const useGroups = <TData = Schemas.PageTCustomizedGroupSummary>(
   variables: GroupsVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedGroupSummary, GroupsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedGroupSummary, GroupsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTypeVarCustomizedGroupSummary, GroupsError, TData>({
+  return reactQuery.useQuery<Schemas.PageTCustomizedGroupSummary, GroupsError, TData>({
     ...groupsQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
@@ -1595,6 +1713,140 @@ export const useGroupMembersByIdPut = (
     mutationFn: (variables: GroupMembersByIdPutVariables) =>
       fetchGroupMembersByIdPut(deepMerge(fetcherOptions, variables)),
     ...options,
+  });
+};
+
+export type GroupMemberDetailsByIdPathParams = {
+  groupId: string;
+};
+
+export type GroupMemberDetailsByIdQueryParams = {
+  owner?: boolean | null;
+  /**
+   * Page number
+   *
+   * @minimum 1
+   * @default 1
+   */
+  page?: number;
+  /**
+   * Items per page
+   *
+   * @maximum 1000
+   * @minimum 1
+   * @default 50
+   */
+  size?: number;
+};
+
+export type GroupMemberDetailsByIdError = Fetcher.ErrorWrapper<{
+  status: Exclude<ClientErrorStatus | ServerErrorStatus, 200>;
+  payload: Schemas.ProblemDetail;
+}>;
+
+export type GroupMemberDetailsByIdVariables = {
+  pathParams: GroupMemberDetailsByIdPathParams;
+  queryParams?: GroupMemberDetailsByIdQueryParams;
+} & ApiContext['fetcherOptions'];
+
+/**
+ * Paginated, fully-hydrated active membership rows for a group. `owner=true`
+ * returns ownerships, `owner=false` memberships, omitted returns both. Lets the
+ * group page page through members instead of inlining every row in the group
+ * detail response.
+ */
+export const fetchGroupMemberDetailsById = (variables: GroupMemberDetailsByIdVariables, signal?: AbortSignal) =>
+  apiFetch<
+    Schemas.PageTCustomizedOktaUserGroupMemberDetail,
+    GroupMemberDetailsByIdError,
+    undefined,
+    {},
+    GroupMemberDetailsByIdQueryParams,
+    GroupMemberDetailsByIdPathParams
+  >({
+    url: '/api/groups/{groupId}/member-details',
+    method: 'get',
+    ...variables,
+    signal,
+  });
+
+/**
+ * Paginated, fully-hydrated active membership rows for a group. `owner=true`
+ * returns ownerships, `owner=false` memberships, omitted returns both. Lets the
+ * group page page through members instead of inlining every row in the group
+ * detail response.
+ */
+export function groupMemberDetailsByIdQuery(variables: GroupMemberDetailsByIdVariables): {
+  queryKey: reactQuery.QueryKey;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedOktaUserGroupMemberDetail>;
+};
+
+export function groupMemberDetailsByIdQuery(variables: GroupMemberDetailsByIdVariables | reactQuery.SkipToken): {
+  queryKey: reactQuery.QueryKey;
+  queryFn:
+    | ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedOktaUserGroupMemberDetail>)
+    | reactQuery.SkipToken;
+};
+
+export function groupMemberDetailsByIdQuery(variables: GroupMemberDetailsByIdVariables | reactQuery.SkipToken) {
+  return {
+    queryKey: queryKeyFn({
+      path: '/api/groups/{groupId}/member-details',
+      operationId: 'groupMemberDetailsById',
+      variables,
+    }),
+    queryFn:
+      variables === reactQuery.skipToken
+        ? reactQuery.skipToken
+        : ({signal}: QueryFnOptions) => fetchGroupMemberDetailsById(variables, signal),
+  };
+}
+
+/**
+ * Paginated, fully-hydrated active membership rows for a group. `owner=true`
+ * returns ownerships, `owner=false` memberships, omitted returns both. Lets the
+ * group page page through members instead of inlining every row in the group
+ * detail response.
+ */
+export const useSuspenseGroupMemberDetailsById = <TData = Schemas.PageTCustomizedOktaUserGroupMemberDetail>(
+  variables: GroupMemberDetailsByIdVariables,
+  options?: Omit<
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedOktaUserGroupMemberDetail, GroupMemberDetailsByIdError, TData>,
+    'queryKey' | 'queryFn' | 'initialData'
+  >,
+) => {
+  const {queryOptions, fetcherOptions} = useApiContext(options);
+  return reactQuery.useSuspenseQuery<
+    Schemas.PageTCustomizedOktaUserGroupMemberDetail,
+    GroupMemberDetailsByIdError,
+    TData
+  >({
+    ...groupMemberDetailsByIdQuery(deepMerge(fetcherOptions, variables)),
+    ...options,
+    ...queryOptions,
+  });
+};
+
+/**
+ * Paginated, fully-hydrated active membership rows for a group. `owner=true`
+ * returns ownerships, `owner=false` memberships, omitted returns both. Lets the
+ * group page page through members instead of inlining every row in the group
+ * detail response.
+ */
+export const useGroupMemberDetailsById = <TData = Schemas.PageTCustomizedOktaUserGroupMemberDetail>(
+  variables: GroupMemberDetailsByIdVariables | reactQuery.SkipToken,
+  options?: Omit<
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedOktaUserGroupMemberDetail, GroupMemberDetailsByIdError, TData>,
+    'queryKey' | 'queryFn' | 'initialData'
+  >,
+) => {
+  const {queryOptions, fetcherOptions} = useApiContext(options);
+  return reactQuery.useQuery<Schemas.PageTCustomizedOktaUserGroupMemberDetail, GroupMemberDetailsByIdError, TData>({
+    ...groupMemberDetailsByIdQuery(
+      variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables),
+    ),
+    ...options,
+    ...queryOptions,
   });
 };
 
@@ -2136,25 +2388,21 @@ export type RoleRequestsVariables = {
 } & ApiContext['fetcherOptions'];
 
 export const fetchRoleRequests = (variables: RoleRequestsVariables, signal?: AbortSignal) =>
-  apiFetch<
-    Schemas.PageTypeVarCustomizedRoleRequestSummary,
-    RoleRequestsError,
-    undefined,
-    {},
-    RoleRequestsQueryParams,
-    {}
-  >({url: '/api/role-requests', method: 'get', ...variables, signal});
+  apiFetch<Schemas.PageTCustomizedRoleRequestSummary, RoleRequestsError, undefined, {}, RoleRequestsQueryParams, {}>({
+    url: '/api/role-requests',
+    method: 'get',
+    ...variables,
+    signal,
+  });
 
 export function roleRequestsQuery(variables: RoleRequestsVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedRoleRequestSummary>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedRoleRequestSummary>;
 };
 
 export function roleRequestsQuery(variables: RoleRequestsVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
-  queryFn:
-    | ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedRoleRequestSummary>)
-    | reactQuery.SkipToken;
+  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedRoleRequestSummary>) | reactQuery.SkipToken;
 };
 
 export function roleRequestsQuery(variables: RoleRequestsVariables | reactQuery.SkipToken) {
@@ -2171,30 +2419,30 @@ export function roleRequestsQuery(variables: RoleRequestsVariables | reactQuery.
   };
 }
 
-export const useSuspenseRoleRequests = <TData = Schemas.PageTypeVarCustomizedRoleRequestSummary>(
+export const useSuspenseRoleRequests = <TData = Schemas.PageTCustomizedRoleRequestSummary>(
   variables: RoleRequestsVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedRoleRequestSummary, RoleRequestsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedRoleRequestSummary, RoleRequestsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useSuspenseQuery<Schemas.PageTypeVarCustomizedRoleRequestSummary, RoleRequestsError, TData>({
+  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedRoleRequestSummary, RoleRequestsError, TData>({
     ...roleRequestsQuery(deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
   });
 };
 
-export const useRoleRequests = <TData = Schemas.PageTypeVarCustomizedRoleRequestSummary>(
+export const useRoleRequests = <TData = Schemas.PageTCustomizedRoleRequestSummary>(
   variables: RoleRequestsVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedRoleRequestSummary, RoleRequestsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedRoleRequestSummary, RoleRequestsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTypeVarCustomizedRoleRequestSummary, RoleRequestsError, TData>({
+  return reactQuery.useQuery<Schemas.PageTCustomizedRoleRequestSummary, RoleRequestsError, TData>({
     ...roleRequestsQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
@@ -2380,7 +2628,7 @@ export type RolesVariables = {
 } & ApiContext['fetcherOptions'];
 
 export const fetchRoles = (variables: RolesVariables, signal?: AbortSignal) =>
-  apiFetch<Schemas.PageTypeVarCustomizedRoleGroupListItem, RolesError, undefined, {}, RolesQueryParams, {}>({
+  apiFetch<Schemas.PageTCustomizedRoleGroupListItem, RolesError, undefined, {}, RolesQueryParams, {}>({
     url: '/api/roles',
     method: 'get',
     ...variables,
@@ -2389,14 +2637,12 @@ export const fetchRoles = (variables: RolesVariables, signal?: AbortSignal) =>
 
 export function rolesQuery(variables: RolesVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedRoleGroupListItem>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedRoleGroupListItem>;
 };
 
 export function rolesQuery(variables: RolesVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
-  queryFn:
-    | ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedRoleGroupListItem>)
-    | reactQuery.SkipToken;
+  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedRoleGroupListItem>) | reactQuery.SkipToken;
 };
 
 export function rolesQuery(variables: RolesVariables | reactQuery.SkipToken) {
@@ -2413,30 +2659,30 @@ export function rolesQuery(variables: RolesVariables | reactQuery.SkipToken) {
   };
 }
 
-export const useSuspenseRoles = <TData = Schemas.PageTypeVarCustomizedRoleGroupListItem>(
+export const useSuspenseRoles = <TData = Schemas.PageTCustomizedRoleGroupListItem>(
   variables: RolesVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedRoleGroupListItem, RolesError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedRoleGroupListItem, RolesError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useSuspenseQuery<Schemas.PageTypeVarCustomizedRoleGroupListItem, RolesError, TData>({
+  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedRoleGroupListItem, RolesError, TData>({
     ...rolesQuery(deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
   });
 };
 
-export const useRoles = <TData = Schemas.PageTypeVarCustomizedRoleGroupListItem>(
+export const useRoles = <TData = Schemas.PageTCustomizedRoleGroupListItem>(
   variables: RolesVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedRoleGroupListItem, RolesError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedRoleGroupListItem, RolesError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTypeVarCustomizedRoleGroupListItem, RolesError, TData>({
+  return reactQuery.useQuery<Schemas.PageTCustomizedRoleGroupListItem, RolesError, TData>({
     ...rolesQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
@@ -2736,7 +2982,7 @@ export type TagsVariables = {
 } & ApiContext['fetcherOptions'];
 
 export const fetchTags = (variables: TagsVariables, signal?: AbortSignal) =>
-  apiFetch<Schemas.PageTypeVarCustomizedTagListItem, TagsError, undefined, {}, TagsQueryParams, {}>({
+  apiFetch<Schemas.PageTCustomizedTagListItem, TagsError, undefined, {}, TagsQueryParams, {}>({
     url: '/api/tags',
     method: 'get',
     ...variables,
@@ -2745,12 +2991,12 @@ export const fetchTags = (variables: TagsVariables, signal?: AbortSignal) =>
 
 export function tagsQuery(variables: TagsVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedTagListItem>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedTagListItem>;
 };
 
 export function tagsQuery(variables: TagsVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
-  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedTagListItem>) | reactQuery.SkipToken;
+  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedTagListItem>) | reactQuery.SkipToken;
 };
 
 export function tagsQuery(variables: TagsVariables | reactQuery.SkipToken) {
@@ -2767,30 +3013,30 @@ export function tagsQuery(variables: TagsVariables | reactQuery.SkipToken) {
   };
 }
 
-export const useSuspenseTags = <TData = Schemas.PageTypeVarCustomizedTagListItem>(
+export const useSuspenseTags = <TData = Schemas.PageTCustomizedTagListItem>(
   variables: TagsVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedTagListItem, TagsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedTagListItem, TagsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useSuspenseQuery<Schemas.PageTypeVarCustomizedTagListItem, TagsError, TData>({
+  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedTagListItem, TagsError, TData>({
     ...tagsQuery(deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
   });
 };
 
-export const useTags = <TData = Schemas.PageTypeVarCustomizedTagListItem>(
+export const useTags = <TData = Schemas.PageTCustomizedTagListItem>(
   variables: TagsVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedTagListItem, TagsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedTagListItem, TagsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTypeVarCustomizedTagListItem, TagsError, TData>({
+  return reactQuery.useQuery<Schemas.PageTCustomizedTagListItem, TagsError, TData>({
     ...tagsQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
@@ -2994,7 +3240,7 @@ export type UsersVariables = {
 } & ApiContext['fetcherOptions'];
 
 export const fetchUsers = (variables: UsersVariables, signal?: AbortSignal) =>
-  apiFetch<Schemas.PageTypeVarCustomizedOktaUserSummary, UsersError, undefined, {}, UsersQueryParams, {}>({
+  apiFetch<Schemas.PageTCustomizedOktaUserSummary, UsersError, undefined, {}, UsersQueryParams, {}>({
     url: '/api/users',
     method: 'get',
     ...variables,
@@ -3003,12 +3249,12 @@ export const fetchUsers = (variables: UsersVariables, signal?: AbortSignal) =>
 
 export function usersQuery(variables: UsersVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedOktaUserSummary>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedOktaUserSummary>;
 };
 
 export function usersQuery(variables: UsersVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
-  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedOktaUserSummary>) | reactQuery.SkipToken;
+  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedOktaUserSummary>) | reactQuery.SkipToken;
 };
 
 export function usersQuery(variables: UsersVariables | reactQuery.SkipToken) {
@@ -3025,30 +3271,30 @@ export function usersQuery(variables: UsersVariables | reactQuery.SkipToken) {
   };
 }
 
-export const useSuspenseUsers = <TData = Schemas.PageTypeVarCustomizedOktaUserSummary>(
+export const useSuspenseUsers = <TData = Schemas.PageTCustomizedOktaUserSummary>(
   variables: UsersVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedOktaUserSummary, UsersError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedOktaUserSummary, UsersError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useSuspenseQuery<Schemas.PageTypeVarCustomizedOktaUserSummary, UsersError, TData>({
+  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedOktaUserSummary, UsersError, TData>({
     ...usersQuery(deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
   });
 };
 
-export const useUsers = <TData = Schemas.PageTypeVarCustomizedOktaUserSummary>(
+export const useUsers = <TData = Schemas.PageTCustomizedOktaUserSummary>(
   variables: UsersVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedOktaUserSummary, UsersError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTCustomizedOktaUserSummary, UsersError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTypeVarCustomizedOktaUserSummary, UsersError, TData>({
+  return reactQuery.useQuery<Schemas.PageTCustomizedOktaUserSummary, UsersError, TData>({
     ...usersQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
@@ -3226,6 +3472,11 @@ export type QueryOperation =
       variables: AppByIdVariables | reactQuery.SkipToken;
     }
   | {
+      path: '/api/apps/{appId}/groups';
+      operationId: 'appGroupsById';
+      variables: AppGroupsByIdVariables | reactQuery.SkipToken;
+    }
+  | {
       path: '/api/audit/users';
       operationId: 'usersAndGroups';
       variables: UsersAndGroupsVariables | reactQuery.SkipToken;
@@ -3264,6 +3515,11 @@ export type QueryOperation =
       path: '/api/groups/{groupId}/members';
       operationId: 'groupMembersById';
       variables: GroupMembersByIdVariables | reactQuery.SkipToken;
+    }
+  | {
+      path: '/api/groups/{groupId}/member-details';
+      operationId: 'groupMemberDetailsById';
+      variables: GroupMemberDetailsByIdVariables | reactQuery.SkipToken;
     }
   | {
       path: '/api/plugins/app-group-lifecycle';

--- a/src/api/apiComponents.ts
+++ b/src/api/apiComponents.ts
@@ -23,12 +23,7 @@ export type HealthCheckError = Fetcher.ErrorWrapper<{
 export type HealthCheckVariables = ApiContext['fetcherOptions'];
 
 export const fetchHealthCheck = (variables: HealthCheckVariables, signal?: AbortSignal) =>
-  apiFetch<void, HealthCheckError, undefined, {}, {}, {}>({
-    url: '/api/healthz',
-    method: 'get',
-    ...variables,
-    signal,
-  });
+  apiFetch<void, HealthCheckError, undefined, {}, {}, {}>({url: '/api/healthz', method: 'get', ...variables, signal});
 
 export function healthCheckQuery(variables: HealthCheckVariables): {
   queryKey: reactQuery.QueryKey;
@@ -309,12 +304,7 @@ export const fetchAccessRequestByIdPut = (variables: AccessRequestByIdPutVariabl
     {},
     {},
     AccessRequestByIdPutPathParams
-  >({
-    url: '/api/requests/{accessRequestId}',
-    method: 'put',
-    ...variables,
-    signal,
-  });
+  >({url: '/api/requests/{accessRequestId}', method: 'put', ...variables, signal});
 
 export const useAccessRequestByIdPut = (
   options?: Omit<
@@ -629,10 +619,11 @@ export type AppGroupsByIdVariables = {
 } & ApiContext['fetcherOptions'];
 
 /**
- * Paginated app-groups for an app, owners first then by name. Each item
- * carries its members inline; the page is bounded (`AppGroupsPageParams`) so a
- * single response materializes at most that many groups' memberships, rather
- * than every group of an app at once.
+ * Paginated app-groups for an app, owners first then by name. Members are
+ * NOT inlined — each item carries `member_count` / `owner_count` only, so the
+ * response is bounded by the number of groups on the page regardless of how
+ * many members any single group has. The UI fetches a group's members on
+ * demand from `GET /api/groups/{id}/member-details`.
  *
  * `owner` filters to owner / non-owner app-groups. `q` filters to groups that
  * have an active member matching the query by name or email — the app page's
@@ -649,10 +640,11 @@ export const fetchAppGroupsById = (variables: AppGroupsByIdVariables, signal?: A
   >({url: '/api/apps/{appId}/groups', method: 'get', ...variables, signal});
 
 /**
- * Paginated app-groups for an app, owners first then by name. Each item
- * carries its members inline; the page is bounded (`AppGroupsPageParams`) so a
- * single response materializes at most that many groups' memberships, rather
- * than every group of an app at once.
+ * Paginated app-groups for an app, owners first then by name. Members are
+ * NOT inlined — each item carries `member_count` / `owner_count` only, so the
+ * response is bounded by the number of groups on the page regardless of how
+ * many members any single group has. The UI fetches a group's members on
+ * demand from `GET /api/groups/{id}/member-details`.
  *
  * `owner` filters to owner / non-owner app-groups. `q` filters to groups that
  * have an active member matching the query by name or email — the app page's
@@ -683,10 +675,11 @@ export function appGroupsByIdQuery(variables: AppGroupsByIdVariables | reactQuer
 }
 
 /**
- * Paginated app-groups for an app, owners first then by name. Each item
- * carries its members inline; the page is bounded (`AppGroupsPageParams`) so a
- * single response materializes at most that many groups' memberships, rather
- * than every group of an app at once.
+ * Paginated app-groups for an app, owners first then by name. Members are
+ * NOT inlined — each item carries `member_count` / `owner_count` only, so the
+ * response is bounded by the number of groups on the page regardless of how
+ * many members any single group has. The UI fetches a group's members on
+ * demand from `GET /api/groups/{id}/member-details`.
  *
  * `owner` filters to owner / non-owner app-groups. `q` filters to groups that
  * have an active member matching the query by name or email — the app page's
@@ -708,10 +701,11 @@ export const useSuspenseAppGroupsById = <TData = Schemas.PageTCustomizedAppGroup
 };
 
 /**
- * Paginated app-groups for an app, owners first then by name. Each item
- * carries its members inline; the page is bounded (`AppGroupsPageParams`) so a
- * single response materializes at most that many groups' memberships, rather
- * than every group of an app at once.
+ * Paginated app-groups for an app, owners first then by name. Members are
+ * NOT inlined — each item carries `member_count` / `owner_count` only, so the
+ * response is bounded by the number of groups on the page regardless of how
+ * many members any single group has. The UI fetches a group's members on
+ * demand from `GET /api/groups/{id}/member-details`.
  *
  * `owner` filters to owner / non-owner app-groups. `q` filters to groups that
  * have an active member matching the query by name or email — the app page's
@@ -1213,12 +1207,7 @@ export const fetchGroupRequestByIdPut = (variables: GroupRequestByIdPutVariables
     {},
     {},
     GroupRequestByIdPutPathParams
-  >({
-    url: '/api/group-requests/{groupRequestId}',
-    method: 'put',
-    ...variables,
-    signal,
-  });
+  >({url: '/api/group-requests/{groupRequestId}', method: 'put', ...variables, signal});
 
 export const useGroupRequestByIdPut = (
   options?: Omit<
@@ -1695,12 +1684,7 @@ export const fetchGroupMembersByIdPut = (variables: GroupMembersByIdPutVariables
     {},
     {},
     GroupMembersByIdPutPathParams
-  >({
-    url: '/api/groups/{groupId}/members',
-    method: 'put',
-    ...variables,
-    signal,
-  });
+  >({url: '/api/groups/{groupId}/members', method: 'put', ...variables, signal});
 
 export const useGroupMembersByIdPut = (
   options?: Omit<
@@ -1754,6 +1738,14 @@ export type GroupMemberDetailsByIdVariables = {
  * returns ownerships, `owner=false` memberships, omitted returns both. Lets the
  * group page page through members instead of inlining every row in the group
  * detail response.
+ *
+ * Pagination is by distinct *user*, not by membership row: a user can hold
+ * several active rows for one group (a direct grant plus role-granted ones),
+ * and the UI renders one row per user. Paging by user keeps `total` aligned
+ * with the de-duplicated list the UI shows and keeps all of a user's rows on
+ * the same page. Note `total` and `size` count users, so a page can contain
+ * more than `size` items (rows) when users hold multiple rows; consumers must
+ * not assume ``len(items) == size``.
  */
 export const fetchGroupMemberDetailsById = (variables: GroupMemberDetailsByIdVariables, signal?: AbortSignal) =>
   apiFetch<
@@ -1763,18 +1755,21 @@ export const fetchGroupMemberDetailsById = (variables: GroupMemberDetailsByIdVar
     {},
     GroupMemberDetailsByIdQueryParams,
     GroupMemberDetailsByIdPathParams
-  >({
-    url: '/api/groups/{groupId}/member-details',
-    method: 'get',
-    ...variables,
-    signal,
-  });
+  >({url: '/api/groups/{groupId}/member-details', method: 'get', ...variables, signal});
 
 /**
  * Paginated, fully-hydrated active membership rows for a group. `owner=true`
  * returns ownerships, `owner=false` memberships, omitted returns both. Lets the
  * group page page through members instead of inlining every row in the group
  * detail response.
+ *
+ * Pagination is by distinct *user*, not by membership row: a user can hold
+ * several active rows for one group (a direct grant plus role-granted ones),
+ * and the UI renders one row per user. Paging by user keeps `total` aligned
+ * with the de-duplicated list the UI shows and keeps all of a user's rows on
+ * the same page. Note `total` and `size` count users, so a page can contain
+ * more than `size` items (rows) when users hold multiple rows; consumers must
+ * not assume ``len(items) == size``.
  */
 export function groupMemberDetailsByIdQuery(variables: GroupMemberDetailsByIdVariables): {
   queryKey: reactQuery.QueryKey;
@@ -1807,6 +1802,14 @@ export function groupMemberDetailsByIdQuery(variables: GroupMemberDetailsByIdVar
  * returns ownerships, `owner=false` memberships, omitted returns both. Lets the
  * group page page through members instead of inlining every row in the group
  * detail response.
+ *
+ * Pagination is by distinct *user*, not by membership row: a user can hold
+ * several active rows for one group (a direct grant plus role-granted ones),
+ * and the UI renders one row per user. Paging by user keeps `total` aligned
+ * with the de-duplicated list the UI shows and keeps all of a user's rows on
+ * the same page. Note `total` and `size` count users, so a page can contain
+ * more than `size` items (rows) when users hold multiple rows; consumers must
+ * not assume ``len(items) == size``.
  */
 export const useSuspenseGroupMemberDetailsById = <TData = Schemas.PageTCustomizedOktaUserGroupMemberDetail>(
   variables: GroupMemberDetailsByIdVariables,
@@ -1832,6 +1835,14 @@ export const useSuspenseGroupMemberDetailsById = <TData = Schemas.PageTCustomize
  * returns ownerships, `owner=false` memberships, omitted returns both. Lets the
  * group page page through members instead of inlining every row in the group
  * detail response.
+ *
+ * Pagination is by distinct *user*, not by membership row: a user can hold
+ * several active rows for one group (a direct grant plus role-granted ones),
+ * and the UI renders one row per user. Paging by user keeps `total` aligned
+ * with the de-duplicated list the UI shows and keeps all of a user's rows on
+ * the same page. Note `total` and `size` count users, so a page can contain
+ * more than `size` items (rows) when users hold multiple rows; consumers must
+ * not assume ``len(items) == size``.
  */
 export const useGroupMemberDetailsById = <TData = Schemas.PageTCustomizedOktaUserGroupMemberDetail>(
   variables: GroupMemberDetailsByIdVariables | reactQuery.SkipToken,
@@ -1945,12 +1956,7 @@ export const fetchAppGroupLifecyclePluginAppConfigProps = (
     {},
     {},
     AppGroupLifecyclePluginAppConfigPropsPathParams
-  >({
-    url: '/api/plugins/app-group-lifecycle/{pluginId}/app-config-props',
-    method: 'get',
-    ...variables,
-    signal,
-  });
+  >({url: '/api/plugins/app-group-lifecycle/{pluginId}/app-config-props', method: 'get', ...variables, signal});
 
 export function appGroupLifecyclePluginAppConfigPropsQuery(variables: AppGroupLifecyclePluginAppConfigPropsVariables): {
   queryKey: reactQuery.QueryKey;
@@ -2052,12 +2058,7 @@ export const fetchAppGroupLifecyclePluginGroupConfigProps = (
     {},
     {},
     AppGroupLifecyclePluginGroupConfigPropsPathParams
-  >({
-    url: '/api/plugins/app-group-lifecycle/{pluginId}/group-config-props',
-    method: 'get',
-    ...variables,
-    signal,
-  });
+  >({url: '/api/plugins/app-group-lifecycle/{pluginId}/group-config-props', method: 'get', ...variables, signal});
 
 export function appGroupLifecyclePluginGroupConfigPropsQuery(
   variables: AppGroupLifecyclePluginGroupConfigPropsVariables,
@@ -2161,12 +2162,7 @@ export const fetchAppGroupLifecyclePluginAppStatusProps = (
     {},
     {},
     AppGroupLifecyclePluginAppStatusPropsPathParams
-  >({
-    url: '/api/plugins/app-group-lifecycle/{pluginId}/app-status-props',
-    method: 'get',
-    ...variables,
-    signal,
-  });
+  >({url: '/api/plugins/app-group-lifecycle/{pluginId}/app-status-props', method: 'get', ...variables, signal});
 
 export function appGroupLifecyclePluginAppStatusPropsQuery(variables: AppGroupLifecyclePluginAppStatusPropsVariables): {
   queryKey: reactQuery.QueryKey;
@@ -2268,12 +2264,7 @@ export const fetchAppGroupLifecyclePluginGroupStatusProps = (
     {},
     {},
     AppGroupLifecyclePluginGroupStatusPropsPathParams
-  >({
-    url: '/api/plugins/app-group-lifecycle/{pluginId}/group-status-props',
-    method: 'get',
-    ...variables,
-    signal,
-  });
+  >({url: '/api/plugins/app-group-lifecycle/{pluginId}/group-status-props', method: 'get', ...variables, signal});
 
 export function appGroupLifecyclePluginGroupStatusPropsQuery(
   variables: AppGroupLifecyclePluginGroupStatusPropsVariables,
@@ -2577,12 +2568,7 @@ export const fetchRoleRequestByIdPut = (variables: RoleRequestByIdPutVariables, 
     {},
     {},
     RoleRequestByIdPutPathParams
-  >({
-    url: '/api/role-requests/{roleRequestId}',
-    method: 'put',
-    ...variables,
-    signal,
-  });
+  >({url: '/api/role-requests/{roleRequestId}', method: 'put', ...variables, signal});
 
 export const useRoleRequestByIdPut = (
   options?: Omit<
@@ -2932,12 +2918,7 @@ export const fetchRoleMembersByIdPut = (variables: RoleMembersByIdPutVariables, 
     {},
     {},
     RoleMembersByIdPutPathParams
-  >({
-    url: '/api/roles/{roleId}/members',
-    method: 'put',
-    ...variables,
-    signal,
-  });
+  >({url: '/api/roles/{roleId}/members', method: 'put', ...variables, signal});
 
 export const useRoleMembersByIdPut = (
   options?: Omit<

--- a/src/api/apiComponents.ts
+++ b/src/api/apiComponents.ts
@@ -23,7 +23,12 @@ export type HealthCheckError = Fetcher.ErrorWrapper<{
 export type HealthCheckVariables = ApiContext['fetcherOptions'];
 
 export const fetchHealthCheck = (variables: HealthCheckVariables, signal?: AbortSignal) =>
-  apiFetch<void, HealthCheckError, undefined, {}, {}, {}>({url: '/api/healthz', method: 'get', ...variables, signal});
+  apiFetch<void, HealthCheckError, undefined, {}, {}, {}>({
+    url: '/api/healthz',
+    method: 'get',
+    ...variables,
+    signal,
+  });
 
 export function healthCheckQuery(variables: HealthCheckVariables): {
   queryKey: reactQuery.QueryKey;
@@ -108,7 +113,7 @@ export type AccessRequestsVariables = {
 
 export const fetchAccessRequests = (variables: AccessRequestsVariables, signal?: AbortSignal) =>
   apiFetch<
-    Schemas.PageTCustomizedAccessRequestSummary,
+    Schemas.PageTypeVarCustomizedAccessRequestSummary,
     AccessRequestsError,
     undefined,
     {},
@@ -118,12 +123,14 @@ export const fetchAccessRequests = (variables: AccessRequestsVariables, signal?:
 
 export function accessRequestsQuery(variables: AccessRequestsVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedAccessRequestSummary>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedAccessRequestSummary>;
 };
 
 export function accessRequestsQuery(variables: AccessRequestsVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
-  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedAccessRequestSummary>) | reactQuery.SkipToken;
+  queryFn:
+    | ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedAccessRequestSummary>)
+    | reactQuery.SkipToken;
 };
 
 export function accessRequestsQuery(variables: AccessRequestsVariables | reactQuery.SkipToken) {
@@ -140,30 +147,30 @@ export function accessRequestsQuery(variables: AccessRequestsVariables | reactQu
   };
 }
 
-export const useSuspenseAccessRequests = <TData = Schemas.PageTCustomizedAccessRequestSummary>(
+export const useSuspenseAccessRequests = <TData = Schemas.PageTypeVarCustomizedAccessRequestSummary>(
   variables: AccessRequestsVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedAccessRequestSummary, AccessRequestsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedAccessRequestSummary, AccessRequestsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedAccessRequestSummary, AccessRequestsError, TData>({
+  return reactQuery.useSuspenseQuery<Schemas.PageTypeVarCustomizedAccessRequestSummary, AccessRequestsError, TData>({
     ...accessRequestsQuery(deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
   });
 };
 
-export const useAccessRequests = <TData = Schemas.PageTCustomizedAccessRequestSummary>(
+export const useAccessRequests = <TData = Schemas.PageTypeVarCustomizedAccessRequestSummary>(
   variables: AccessRequestsVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedAccessRequestSummary, AccessRequestsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedAccessRequestSummary, AccessRequestsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTCustomizedAccessRequestSummary, AccessRequestsError, TData>({
+  return reactQuery.useQuery<Schemas.PageTypeVarCustomizedAccessRequestSummary, AccessRequestsError, TData>({
     ...accessRequestsQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
@@ -304,7 +311,12 @@ export const fetchAccessRequestByIdPut = (variables: AccessRequestByIdPutVariabl
     {},
     {},
     AccessRequestByIdPutPathParams
-  >({url: '/api/requests/{accessRequestId}', method: 'put', ...variables, signal});
+  >({
+    url: '/api/requests/{accessRequestId}',
+    method: 'put',
+    ...variables,
+    signal,
+  });
 
 export const useAccessRequestByIdPut = (
   options?: Omit<
@@ -355,7 +367,7 @@ export type AppsVariables = {
 } & ApiContext['fetcherOptions'];
 
 export const fetchApps = (variables: AppsVariables, signal?: AbortSignal) =>
-  apiFetch<Schemas.PageTCustomizedAppSummary, AppsError, undefined, {}, AppsQueryParams, {}>({
+  apiFetch<Schemas.PageTypeVarCustomizedAppSummary, AppsError, undefined, {}, AppsQueryParams, {}>({
     url: '/api/apps',
     method: 'get',
     ...variables,
@@ -364,12 +376,12 @@ export const fetchApps = (variables: AppsVariables, signal?: AbortSignal) =>
 
 export function appsQuery(variables: AppsVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedAppSummary>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedAppSummary>;
 };
 
 export function appsQuery(variables: AppsVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
-  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedAppSummary>) | reactQuery.SkipToken;
+  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedAppSummary>) | reactQuery.SkipToken;
 };
 
 export function appsQuery(variables: AppsVariables | reactQuery.SkipToken) {
@@ -386,30 +398,30 @@ export function appsQuery(variables: AppsVariables | reactQuery.SkipToken) {
   };
 }
 
-export const useSuspenseApps = <TData = Schemas.PageTCustomizedAppSummary>(
+export const useSuspenseApps = <TData = Schemas.PageTypeVarCustomizedAppSummary>(
   variables: AppsVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedAppSummary, AppsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedAppSummary, AppsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedAppSummary, AppsError, TData>({
+  return reactQuery.useSuspenseQuery<Schemas.PageTypeVarCustomizedAppSummary, AppsError, TData>({
     ...appsQuery(deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
   });
 };
 
-export const useApps = <TData = Schemas.PageTCustomizedAppSummary>(
+export const useApps = <TData = Schemas.PageTypeVarCustomizedAppSummary>(
   variables: AppsVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedAppSummary, AppsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedAppSummary, AppsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTCustomizedAppSummary, AppsError, TData>({
+  return reactQuery.useQuery<Schemas.PageTypeVarCustomizedAppSummary, AppsError, TData>({
     ...appsQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
@@ -631,7 +643,7 @@ export type AppGroupsByIdVariables = {
  */
 export const fetchAppGroupsById = (variables: AppGroupsByIdVariables, signal?: AbortSignal) =>
   apiFetch<
-    Schemas.PageTCustomizedAppGroupForAppDetail,
+    Schemas.PageTypeVarCustomizedAppGroupForAppDetail,
     AppGroupsByIdError,
     undefined,
     {},
@@ -652,12 +664,14 @@ export const fetchAppGroupsById = (variables: AppGroupsByIdVariables, signal?: A
  */
 export function appGroupsByIdQuery(variables: AppGroupsByIdVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedAppGroupForAppDetail>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedAppGroupForAppDetail>;
 };
 
 export function appGroupsByIdQuery(variables: AppGroupsByIdVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
-  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedAppGroupForAppDetail>) | reactQuery.SkipToken;
+  queryFn:
+    | ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedAppGroupForAppDetail>)
+    | reactQuery.SkipToken;
 };
 
 export function appGroupsByIdQuery(variables: AppGroupsByIdVariables | reactQuery.SkipToken) {
@@ -685,15 +699,15 @@ export function appGroupsByIdQuery(variables: AppGroupsByIdVariables | reactQuer
  * have an active member matching the query by name or email — the app page's
  * user search, computed in SQL so it doesn't need every member client-side.
  */
-export const useSuspenseAppGroupsById = <TData = Schemas.PageTCustomizedAppGroupForAppDetail>(
+export const useSuspenseAppGroupsById = <TData = Schemas.PageTypeVarCustomizedAppGroupForAppDetail>(
   variables: AppGroupsByIdVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedAppGroupForAppDetail, AppGroupsByIdError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedAppGroupForAppDetail, AppGroupsByIdError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedAppGroupForAppDetail, AppGroupsByIdError, TData>({
+  return reactQuery.useSuspenseQuery<Schemas.PageTypeVarCustomizedAppGroupForAppDetail, AppGroupsByIdError, TData>({
     ...appGroupsByIdQuery(deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
@@ -711,15 +725,15 @@ export const useSuspenseAppGroupsById = <TData = Schemas.PageTCustomizedAppGroup
  * have an active member matching the query by name or email — the app page's
  * user search, computed in SQL so it doesn't need every member client-side.
  */
-export const useAppGroupsById = <TData = Schemas.PageTCustomizedAppGroupForAppDetail>(
+export const useAppGroupsById = <TData = Schemas.PageTypeVarCustomizedAppGroupForAppDetail>(
   variables: AppGroupsByIdVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedAppGroupForAppDetail, AppGroupsByIdError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedAppGroupForAppDetail, AppGroupsByIdError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTCustomizedAppGroupForAppDetail, AppGroupsByIdError, TData>({
+  return reactQuery.useQuery<Schemas.PageTypeVarCustomizedAppGroupForAppDetail, AppGroupsByIdError, TData>({
     ...appGroupsByIdQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
@@ -772,18 +786,25 @@ export type UsersAndGroupsVariables = {
 } & ApiContext['fetcherOptions'];
 
 export const fetchUsersAndGroups = (variables: UsersAndGroupsVariables, signal?: AbortSignal) =>
-  apiFetch<Schemas.PageTCustomizedAuditUserGroupRow, UsersAndGroupsError, undefined, {}, UsersAndGroupsQueryParams, {}>(
-    {url: '/api/audit/users', method: 'get', ...variables, signal},
-  );
+  apiFetch<
+    Schemas.PageTypeVarCustomizedAuditUserGroupRow,
+    UsersAndGroupsError,
+    undefined,
+    {},
+    UsersAndGroupsQueryParams,
+    {}
+  >({url: '/api/audit/users', method: 'get', ...variables, signal});
 
 export function usersAndGroupsQuery(variables: UsersAndGroupsVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedAuditUserGroupRow>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedAuditUserGroupRow>;
 };
 
 export function usersAndGroupsQuery(variables: UsersAndGroupsVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
-  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedAuditUserGroupRow>) | reactQuery.SkipToken;
+  queryFn:
+    | ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedAuditUserGroupRow>)
+    | reactQuery.SkipToken;
 };
 
 export function usersAndGroupsQuery(variables: UsersAndGroupsVariables | reactQuery.SkipToken) {
@@ -800,30 +821,30 @@ export function usersAndGroupsQuery(variables: UsersAndGroupsVariables | reactQu
   };
 }
 
-export const useSuspenseUsersAndGroups = <TData = Schemas.PageTCustomizedAuditUserGroupRow>(
+export const useSuspenseUsersAndGroups = <TData = Schemas.PageTypeVarCustomizedAuditUserGroupRow>(
   variables: UsersAndGroupsVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedAuditUserGroupRow, UsersAndGroupsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedAuditUserGroupRow, UsersAndGroupsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedAuditUserGroupRow, UsersAndGroupsError, TData>({
+  return reactQuery.useSuspenseQuery<Schemas.PageTypeVarCustomizedAuditUserGroupRow, UsersAndGroupsError, TData>({
     ...usersAndGroupsQuery(deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
   });
 };
 
-export const useUsersAndGroups = <TData = Schemas.PageTCustomizedAuditUserGroupRow>(
+export const useUsersAndGroups = <TData = Schemas.PageTypeVarCustomizedAuditUserGroupRow>(
   variables: UsersAndGroupsVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedAuditUserGroupRow, UsersAndGroupsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedAuditUserGroupRow, UsersAndGroupsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTCustomizedAuditUserGroupRow, UsersAndGroupsError, TData>({
+  return reactQuery.useQuery<Schemas.PageTypeVarCustomizedAuditUserGroupRow, UsersAndGroupsError, TData>({
     ...usersAndGroupsQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
@@ -878,18 +899,25 @@ export type GroupsAndRolesVariables = {
 } & ApiContext['fetcherOptions'];
 
 export const fetchGroupsAndRoles = (variables: GroupsAndRolesVariables, signal?: AbortSignal) =>
-  apiFetch<Schemas.PageTCustomizedAuditGroupRoleRow, GroupsAndRolesError, undefined, {}, GroupsAndRolesQueryParams, {}>(
-    {url: '/api/audit/groups', method: 'get', ...variables, signal},
-  );
+  apiFetch<
+    Schemas.PageTypeVarCustomizedAuditGroupRoleRow,
+    GroupsAndRolesError,
+    undefined,
+    {},
+    GroupsAndRolesQueryParams,
+    {}
+  >({url: '/api/audit/groups', method: 'get', ...variables, signal});
 
 export function groupsAndRolesQuery(variables: GroupsAndRolesVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedAuditGroupRoleRow>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedAuditGroupRoleRow>;
 };
 
 export function groupsAndRolesQuery(variables: GroupsAndRolesVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
-  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedAuditGroupRoleRow>) | reactQuery.SkipToken;
+  queryFn:
+    | ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedAuditGroupRoleRow>)
+    | reactQuery.SkipToken;
 };
 
 export function groupsAndRolesQuery(variables: GroupsAndRolesVariables | reactQuery.SkipToken) {
@@ -906,30 +934,30 @@ export function groupsAndRolesQuery(variables: GroupsAndRolesVariables | reactQu
   };
 }
 
-export const useSuspenseGroupsAndRoles = <TData = Schemas.PageTCustomizedAuditGroupRoleRow>(
+export const useSuspenseGroupsAndRoles = <TData = Schemas.PageTypeVarCustomizedAuditGroupRoleRow>(
   variables: GroupsAndRolesVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedAuditGroupRoleRow, GroupsAndRolesError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedAuditGroupRoleRow, GroupsAndRolesError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedAuditGroupRoleRow, GroupsAndRolesError, TData>({
+  return reactQuery.useSuspenseQuery<Schemas.PageTypeVarCustomizedAuditGroupRoleRow, GroupsAndRolesError, TData>({
     ...groupsAndRolesQuery(deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
   });
 };
 
-export const useGroupsAndRoles = <TData = Schemas.PageTCustomizedAuditGroupRoleRow>(
+export const useGroupsAndRoles = <TData = Schemas.PageTypeVarCustomizedAuditGroupRoleRow>(
   variables: GroupsAndRolesVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedAuditGroupRoleRow, GroupsAndRolesError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedAuditGroupRoleRow, GroupsAndRolesError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTCustomizedAuditGroupRoleRow, GroupsAndRolesError, TData>({
+  return reactQuery.useQuery<Schemas.PageTypeVarCustomizedAuditGroupRoleRow, GroupsAndRolesError, TData>({
     ...groupsAndRolesQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
@@ -1007,21 +1035,25 @@ export type GroupRequestsVariables = {
 } & ApiContext['fetcherOptions'];
 
 export const fetchGroupRequests = (variables: GroupRequestsVariables, signal?: AbortSignal) =>
-  apiFetch<Schemas.PageTCustomizedGroupRequestDetail, GroupRequestsError, undefined, {}, GroupRequestsQueryParams, {}>({
-    url: '/api/group-requests',
-    method: 'get',
-    ...variables,
-    signal,
-  });
+  apiFetch<
+    Schemas.PageTypeVarCustomizedGroupRequestDetail,
+    GroupRequestsError,
+    undefined,
+    {},
+    GroupRequestsQueryParams,
+    {}
+  >({url: '/api/group-requests', method: 'get', ...variables, signal});
 
 export function groupRequestsQuery(variables: GroupRequestsVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedGroupRequestDetail>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedGroupRequestDetail>;
 };
 
 export function groupRequestsQuery(variables: GroupRequestsVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
-  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedGroupRequestDetail>) | reactQuery.SkipToken;
+  queryFn:
+    | ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedGroupRequestDetail>)
+    | reactQuery.SkipToken;
 };
 
 export function groupRequestsQuery(variables: GroupRequestsVariables | reactQuery.SkipToken) {
@@ -1038,30 +1070,30 @@ export function groupRequestsQuery(variables: GroupRequestsVariables | reactQuer
   };
 }
 
-export const useSuspenseGroupRequests = <TData = Schemas.PageTCustomizedGroupRequestDetail>(
+export const useSuspenseGroupRequests = <TData = Schemas.PageTypeVarCustomizedGroupRequestDetail>(
   variables: GroupRequestsVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedGroupRequestDetail, GroupRequestsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedGroupRequestDetail, GroupRequestsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedGroupRequestDetail, GroupRequestsError, TData>({
+  return reactQuery.useSuspenseQuery<Schemas.PageTypeVarCustomizedGroupRequestDetail, GroupRequestsError, TData>({
     ...groupRequestsQuery(deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
   });
 };
 
-export const useGroupRequests = <TData = Schemas.PageTCustomizedGroupRequestDetail>(
+export const useGroupRequests = <TData = Schemas.PageTypeVarCustomizedGroupRequestDetail>(
   variables: GroupRequestsVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedGroupRequestDetail, GroupRequestsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedGroupRequestDetail, GroupRequestsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTCustomizedGroupRequestDetail, GroupRequestsError, TData>({
+  return reactQuery.useQuery<Schemas.PageTypeVarCustomizedGroupRequestDetail, GroupRequestsError, TData>({
     ...groupRequestsQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
@@ -1207,7 +1239,12 @@ export const fetchGroupRequestByIdPut = (variables: GroupRequestByIdPutVariables
     {},
     {},
     GroupRequestByIdPutPathParams
-  >({url: '/api/group-requests/{groupRequestId}', method: 'put', ...variables, signal});
+  >({
+    url: '/api/group-requests/{groupRequestId}',
+    method: 'put',
+    ...variables,
+    signal,
+  });
 
 export const useGroupRequestByIdPut = (
   options?: Omit<
@@ -1253,7 +1290,7 @@ export type GroupsVariables = {
 } & ApiContext['fetcherOptions'];
 
 export const fetchGroups = (variables: GroupsVariables, signal?: AbortSignal) =>
-  apiFetch<Schemas.PageTCustomizedGroupSummary, GroupsError, undefined, {}, GroupsQueryParams, {}>({
+  apiFetch<Schemas.PageTypeVarCustomizedGroupSummary, GroupsError, undefined, {}, GroupsQueryParams, {}>({
     url: '/api/groups',
     method: 'get',
     ...variables,
@@ -1262,12 +1299,12 @@ export const fetchGroups = (variables: GroupsVariables, signal?: AbortSignal) =>
 
 export function groupsQuery(variables: GroupsVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedGroupSummary>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedGroupSummary>;
 };
 
 export function groupsQuery(variables: GroupsVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
-  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedGroupSummary>) | reactQuery.SkipToken;
+  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedGroupSummary>) | reactQuery.SkipToken;
 };
 
 export function groupsQuery(variables: GroupsVariables | reactQuery.SkipToken) {
@@ -1284,30 +1321,30 @@ export function groupsQuery(variables: GroupsVariables | reactQuery.SkipToken) {
   };
 }
 
-export const useSuspenseGroups = <TData = Schemas.PageTCustomizedGroupSummary>(
+export const useSuspenseGroups = <TData = Schemas.PageTypeVarCustomizedGroupSummary>(
   variables: GroupsVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedGroupSummary, GroupsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedGroupSummary, GroupsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedGroupSummary, GroupsError, TData>({
+  return reactQuery.useSuspenseQuery<Schemas.PageTypeVarCustomizedGroupSummary, GroupsError, TData>({
     ...groupsQuery(deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
   });
 };
 
-export const useGroups = <TData = Schemas.PageTCustomizedGroupSummary>(
+export const useGroups = <TData = Schemas.PageTypeVarCustomizedGroupSummary>(
   variables: GroupsVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedGroupSummary, GroupsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedGroupSummary, GroupsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTCustomizedGroupSummary, GroupsError, TData>({
+  return reactQuery.useQuery<Schemas.PageTypeVarCustomizedGroupSummary, GroupsError, TData>({
     ...groupsQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
@@ -1684,7 +1721,12 @@ export const fetchGroupMembersByIdPut = (variables: GroupMembersByIdPutVariables
     {},
     {},
     GroupMembersByIdPutPathParams
-  >({url: '/api/groups/{groupId}/members', method: 'put', ...variables, signal});
+  >({
+    url: '/api/groups/{groupId}/members',
+    method: 'put',
+    ...variables,
+    signal,
+  });
 
 export const useGroupMembersByIdPut = (
   options?: Omit<
@@ -1749,13 +1791,18 @@ export type GroupMemberDetailsByIdVariables = {
  */
 export const fetchGroupMemberDetailsById = (variables: GroupMemberDetailsByIdVariables, signal?: AbortSignal) =>
   apiFetch<
-    Schemas.PageTCustomizedOktaUserGroupMemberDetail,
+    Schemas.PageTypeVarCustomizedOktaUserGroupMemberDetail,
     GroupMemberDetailsByIdError,
     undefined,
     {},
     GroupMemberDetailsByIdQueryParams,
     GroupMemberDetailsByIdPathParams
-  >({url: '/api/groups/{groupId}/member-details', method: 'get', ...variables, signal});
+  >({
+    url: '/api/groups/{groupId}/member-details',
+    method: 'get',
+    ...variables,
+    signal,
+  });
 
 /**
  * Paginated, fully-hydrated active membership rows for a group. `owner=true`
@@ -1773,13 +1820,13 @@ export const fetchGroupMemberDetailsById = (variables: GroupMemberDetailsByIdVar
  */
 export function groupMemberDetailsByIdQuery(variables: GroupMemberDetailsByIdVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedOktaUserGroupMemberDetail>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedOktaUserGroupMemberDetail>;
 };
 
 export function groupMemberDetailsByIdQuery(variables: GroupMemberDetailsByIdVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
   queryFn:
-    | ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedOktaUserGroupMemberDetail>)
+    | ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedOktaUserGroupMemberDetail>)
     | reactQuery.SkipToken;
 };
 
@@ -1811,16 +1858,20 @@ export function groupMemberDetailsByIdQuery(variables: GroupMemberDetailsByIdVar
  * more than `size` items (rows) when users hold multiple rows; consumers must
  * not assume ``len(items) == size``.
  */
-export const useSuspenseGroupMemberDetailsById = <TData = Schemas.PageTCustomizedOktaUserGroupMemberDetail>(
+export const useSuspenseGroupMemberDetailsById = <TData = Schemas.PageTypeVarCustomizedOktaUserGroupMemberDetail>(
   variables: GroupMemberDetailsByIdVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedOktaUserGroupMemberDetail, GroupMemberDetailsByIdError, TData>,
+    reactQuery.UseQueryOptions<
+      Schemas.PageTypeVarCustomizedOktaUserGroupMemberDetail,
+      GroupMemberDetailsByIdError,
+      TData
+    >,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
   return reactQuery.useSuspenseQuery<
-    Schemas.PageTCustomizedOktaUserGroupMemberDetail,
+    Schemas.PageTypeVarCustomizedOktaUserGroupMemberDetail,
     GroupMemberDetailsByIdError,
     TData
   >({
@@ -1844,15 +1895,23 @@ export const useSuspenseGroupMemberDetailsById = <TData = Schemas.PageTCustomize
  * more than `size` items (rows) when users hold multiple rows; consumers must
  * not assume ``len(items) == size``.
  */
-export const useGroupMemberDetailsById = <TData = Schemas.PageTCustomizedOktaUserGroupMemberDetail>(
+export const useGroupMemberDetailsById = <TData = Schemas.PageTypeVarCustomizedOktaUserGroupMemberDetail>(
   variables: GroupMemberDetailsByIdVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedOktaUserGroupMemberDetail, GroupMemberDetailsByIdError, TData>,
+    reactQuery.UseQueryOptions<
+      Schemas.PageTypeVarCustomizedOktaUserGroupMemberDetail,
+      GroupMemberDetailsByIdError,
+      TData
+    >,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTCustomizedOktaUserGroupMemberDetail, GroupMemberDetailsByIdError, TData>({
+  return reactQuery.useQuery<
+    Schemas.PageTypeVarCustomizedOktaUserGroupMemberDetail,
+    GroupMemberDetailsByIdError,
+    TData
+  >({
     ...groupMemberDetailsByIdQuery(
       variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables),
     ),
@@ -1956,7 +2015,12 @@ export const fetchAppGroupLifecyclePluginAppConfigProps = (
     {},
     {},
     AppGroupLifecyclePluginAppConfigPropsPathParams
-  >({url: '/api/plugins/app-group-lifecycle/{pluginId}/app-config-props', method: 'get', ...variables, signal});
+  >({
+    url: '/api/plugins/app-group-lifecycle/{pluginId}/app-config-props',
+    method: 'get',
+    ...variables,
+    signal,
+  });
 
 export function appGroupLifecyclePluginAppConfigPropsQuery(variables: AppGroupLifecyclePluginAppConfigPropsVariables): {
   queryKey: reactQuery.QueryKey;
@@ -2058,7 +2122,12 @@ export const fetchAppGroupLifecyclePluginGroupConfigProps = (
     {},
     {},
     AppGroupLifecyclePluginGroupConfigPropsPathParams
-  >({url: '/api/plugins/app-group-lifecycle/{pluginId}/group-config-props', method: 'get', ...variables, signal});
+  >({
+    url: '/api/plugins/app-group-lifecycle/{pluginId}/group-config-props',
+    method: 'get',
+    ...variables,
+    signal,
+  });
 
 export function appGroupLifecyclePluginGroupConfigPropsQuery(
   variables: AppGroupLifecyclePluginGroupConfigPropsVariables,
@@ -2162,7 +2231,12 @@ export const fetchAppGroupLifecyclePluginAppStatusProps = (
     {},
     {},
     AppGroupLifecyclePluginAppStatusPropsPathParams
-  >({url: '/api/plugins/app-group-lifecycle/{pluginId}/app-status-props', method: 'get', ...variables, signal});
+  >({
+    url: '/api/plugins/app-group-lifecycle/{pluginId}/app-status-props',
+    method: 'get',
+    ...variables,
+    signal,
+  });
 
 export function appGroupLifecyclePluginAppStatusPropsQuery(variables: AppGroupLifecyclePluginAppStatusPropsVariables): {
   queryKey: reactQuery.QueryKey;
@@ -2264,7 +2338,12 @@ export const fetchAppGroupLifecyclePluginGroupStatusProps = (
     {},
     {},
     AppGroupLifecyclePluginGroupStatusPropsPathParams
-  >({url: '/api/plugins/app-group-lifecycle/{pluginId}/group-status-props', method: 'get', ...variables, signal});
+  >({
+    url: '/api/plugins/app-group-lifecycle/{pluginId}/group-status-props',
+    method: 'get',
+    ...variables,
+    signal,
+  });
 
 export function appGroupLifecyclePluginGroupStatusPropsQuery(
   variables: AppGroupLifecyclePluginGroupStatusPropsVariables,
@@ -2379,21 +2458,25 @@ export type RoleRequestsVariables = {
 } & ApiContext['fetcherOptions'];
 
 export const fetchRoleRequests = (variables: RoleRequestsVariables, signal?: AbortSignal) =>
-  apiFetch<Schemas.PageTCustomizedRoleRequestSummary, RoleRequestsError, undefined, {}, RoleRequestsQueryParams, {}>({
-    url: '/api/role-requests',
-    method: 'get',
-    ...variables,
-    signal,
-  });
+  apiFetch<
+    Schemas.PageTypeVarCustomizedRoleRequestSummary,
+    RoleRequestsError,
+    undefined,
+    {},
+    RoleRequestsQueryParams,
+    {}
+  >({url: '/api/role-requests', method: 'get', ...variables, signal});
 
 export function roleRequestsQuery(variables: RoleRequestsVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedRoleRequestSummary>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedRoleRequestSummary>;
 };
 
 export function roleRequestsQuery(variables: RoleRequestsVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
-  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedRoleRequestSummary>) | reactQuery.SkipToken;
+  queryFn:
+    | ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedRoleRequestSummary>)
+    | reactQuery.SkipToken;
 };
 
 export function roleRequestsQuery(variables: RoleRequestsVariables | reactQuery.SkipToken) {
@@ -2410,30 +2493,30 @@ export function roleRequestsQuery(variables: RoleRequestsVariables | reactQuery.
   };
 }
 
-export const useSuspenseRoleRequests = <TData = Schemas.PageTCustomizedRoleRequestSummary>(
+export const useSuspenseRoleRequests = <TData = Schemas.PageTypeVarCustomizedRoleRequestSummary>(
   variables: RoleRequestsVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedRoleRequestSummary, RoleRequestsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedRoleRequestSummary, RoleRequestsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedRoleRequestSummary, RoleRequestsError, TData>({
+  return reactQuery.useSuspenseQuery<Schemas.PageTypeVarCustomizedRoleRequestSummary, RoleRequestsError, TData>({
     ...roleRequestsQuery(deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
   });
 };
 
-export const useRoleRequests = <TData = Schemas.PageTCustomizedRoleRequestSummary>(
+export const useRoleRequests = <TData = Schemas.PageTypeVarCustomizedRoleRequestSummary>(
   variables: RoleRequestsVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedRoleRequestSummary, RoleRequestsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedRoleRequestSummary, RoleRequestsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTCustomizedRoleRequestSummary, RoleRequestsError, TData>({
+  return reactQuery.useQuery<Schemas.PageTypeVarCustomizedRoleRequestSummary, RoleRequestsError, TData>({
     ...roleRequestsQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
@@ -2568,7 +2651,12 @@ export const fetchRoleRequestByIdPut = (variables: RoleRequestByIdPutVariables, 
     {},
     {},
     RoleRequestByIdPutPathParams
-  >({url: '/api/role-requests/{roleRequestId}', method: 'put', ...variables, signal});
+  >({
+    url: '/api/role-requests/{roleRequestId}',
+    method: 'put',
+    ...variables,
+    signal,
+  });
 
 export const useRoleRequestByIdPut = (
   options?: Omit<
@@ -2614,7 +2702,7 @@ export type RolesVariables = {
 } & ApiContext['fetcherOptions'];
 
 export const fetchRoles = (variables: RolesVariables, signal?: AbortSignal) =>
-  apiFetch<Schemas.PageTCustomizedRoleGroupListItem, RolesError, undefined, {}, RolesQueryParams, {}>({
+  apiFetch<Schemas.PageTypeVarCustomizedRoleGroupListItem, RolesError, undefined, {}, RolesQueryParams, {}>({
     url: '/api/roles',
     method: 'get',
     ...variables,
@@ -2623,12 +2711,14 @@ export const fetchRoles = (variables: RolesVariables, signal?: AbortSignal) =>
 
 export function rolesQuery(variables: RolesVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedRoleGroupListItem>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedRoleGroupListItem>;
 };
 
 export function rolesQuery(variables: RolesVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
-  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedRoleGroupListItem>) | reactQuery.SkipToken;
+  queryFn:
+    | ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedRoleGroupListItem>)
+    | reactQuery.SkipToken;
 };
 
 export function rolesQuery(variables: RolesVariables | reactQuery.SkipToken) {
@@ -2645,30 +2735,30 @@ export function rolesQuery(variables: RolesVariables | reactQuery.SkipToken) {
   };
 }
 
-export const useSuspenseRoles = <TData = Schemas.PageTCustomizedRoleGroupListItem>(
+export const useSuspenseRoles = <TData = Schemas.PageTypeVarCustomizedRoleGroupListItem>(
   variables: RolesVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedRoleGroupListItem, RolesError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedRoleGroupListItem, RolesError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedRoleGroupListItem, RolesError, TData>({
+  return reactQuery.useSuspenseQuery<Schemas.PageTypeVarCustomizedRoleGroupListItem, RolesError, TData>({
     ...rolesQuery(deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
   });
 };
 
-export const useRoles = <TData = Schemas.PageTCustomizedRoleGroupListItem>(
+export const useRoles = <TData = Schemas.PageTypeVarCustomizedRoleGroupListItem>(
   variables: RolesVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedRoleGroupListItem, RolesError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedRoleGroupListItem, RolesError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTCustomizedRoleGroupListItem, RolesError, TData>({
+  return reactQuery.useQuery<Schemas.PageTypeVarCustomizedRoleGroupListItem, RolesError, TData>({
     ...rolesQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
@@ -2918,7 +3008,12 @@ export const fetchRoleMembersByIdPut = (variables: RoleMembersByIdPutVariables, 
     {},
     {},
     RoleMembersByIdPutPathParams
-  >({url: '/api/roles/{roleId}/members', method: 'put', ...variables, signal});
+  >({
+    url: '/api/roles/{roleId}/members',
+    method: 'put',
+    ...variables,
+    signal,
+  });
 
 export const useRoleMembersByIdPut = (
   options?: Omit<
@@ -2963,7 +3058,7 @@ export type TagsVariables = {
 } & ApiContext['fetcherOptions'];
 
 export const fetchTags = (variables: TagsVariables, signal?: AbortSignal) =>
-  apiFetch<Schemas.PageTCustomizedTagListItem, TagsError, undefined, {}, TagsQueryParams, {}>({
+  apiFetch<Schemas.PageTypeVarCustomizedTagListItem, TagsError, undefined, {}, TagsQueryParams, {}>({
     url: '/api/tags',
     method: 'get',
     ...variables,
@@ -2972,12 +3067,12 @@ export const fetchTags = (variables: TagsVariables, signal?: AbortSignal) =>
 
 export function tagsQuery(variables: TagsVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedTagListItem>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedTagListItem>;
 };
 
 export function tagsQuery(variables: TagsVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
-  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedTagListItem>) | reactQuery.SkipToken;
+  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedTagListItem>) | reactQuery.SkipToken;
 };
 
 export function tagsQuery(variables: TagsVariables | reactQuery.SkipToken) {
@@ -2994,30 +3089,30 @@ export function tagsQuery(variables: TagsVariables | reactQuery.SkipToken) {
   };
 }
 
-export const useSuspenseTags = <TData = Schemas.PageTCustomizedTagListItem>(
+export const useSuspenseTags = <TData = Schemas.PageTypeVarCustomizedTagListItem>(
   variables: TagsVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedTagListItem, TagsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedTagListItem, TagsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedTagListItem, TagsError, TData>({
+  return reactQuery.useSuspenseQuery<Schemas.PageTypeVarCustomizedTagListItem, TagsError, TData>({
     ...tagsQuery(deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
   });
 };
 
-export const useTags = <TData = Schemas.PageTCustomizedTagListItem>(
+export const useTags = <TData = Schemas.PageTypeVarCustomizedTagListItem>(
   variables: TagsVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedTagListItem, TagsError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedTagListItem, TagsError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTCustomizedTagListItem, TagsError, TData>({
+  return reactQuery.useQuery<Schemas.PageTypeVarCustomizedTagListItem, TagsError, TData>({
     ...tagsQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
@@ -3221,7 +3316,7 @@ export type UsersVariables = {
 } & ApiContext['fetcherOptions'];
 
 export const fetchUsers = (variables: UsersVariables, signal?: AbortSignal) =>
-  apiFetch<Schemas.PageTCustomizedOktaUserSummary, UsersError, undefined, {}, UsersQueryParams, {}>({
+  apiFetch<Schemas.PageTypeVarCustomizedOktaUserSummary, UsersError, undefined, {}, UsersQueryParams, {}>({
     url: '/api/users',
     method: 'get',
     ...variables,
@@ -3230,12 +3325,12 @@ export const fetchUsers = (variables: UsersVariables, signal?: AbortSignal) =>
 
 export function usersQuery(variables: UsersVariables): {
   queryKey: reactQuery.QueryKey;
-  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTCustomizedOktaUserSummary>;
+  queryFn: (options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedOktaUserSummary>;
 };
 
 export function usersQuery(variables: UsersVariables | reactQuery.SkipToken): {
   queryKey: reactQuery.QueryKey;
-  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTCustomizedOktaUserSummary>) | reactQuery.SkipToken;
+  queryFn: ((options: QueryFnOptions) => Promise<Schemas.PageTypeVarCustomizedOktaUserSummary>) | reactQuery.SkipToken;
 };
 
 export function usersQuery(variables: UsersVariables | reactQuery.SkipToken) {
@@ -3252,30 +3347,30 @@ export function usersQuery(variables: UsersVariables | reactQuery.SkipToken) {
   };
 }
 
-export const useSuspenseUsers = <TData = Schemas.PageTCustomizedOktaUserSummary>(
+export const useSuspenseUsers = <TData = Schemas.PageTypeVarCustomizedOktaUserSummary>(
   variables: UsersVariables,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedOktaUserSummary, UsersError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedOktaUserSummary, UsersError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useSuspenseQuery<Schemas.PageTCustomizedOktaUserSummary, UsersError, TData>({
+  return reactQuery.useSuspenseQuery<Schemas.PageTypeVarCustomizedOktaUserSummary, UsersError, TData>({
     ...usersQuery(deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,
   });
 };
 
-export const useUsers = <TData = Schemas.PageTCustomizedOktaUserSummary>(
+export const useUsers = <TData = Schemas.PageTypeVarCustomizedOktaUserSummary>(
   variables: UsersVariables | reactQuery.SkipToken,
   options?: Omit<
-    reactQuery.UseQueryOptions<Schemas.PageTCustomizedOktaUserSummary, UsersError, TData>,
+    reactQuery.UseQueryOptions<Schemas.PageTypeVarCustomizedOktaUserSummary, UsersError, TData>,
     'queryKey' | 'queryFn' | 'initialData'
   >,
 ) => {
   const {queryOptions, fetcherOptions} = useApiContext(options);
-  return reactQuery.useQuery<Schemas.PageTCustomizedOktaUserSummary, UsersError, TData>({
+  return reactQuery.useQuery<Schemas.PageTypeVarCustomizedOktaUserSummary, UsersError, TData>({
     ...usersQuery(variables === reactQuery.skipToken ? variables : deepMerge(fetcherOptions, variables)),
     ...options,
     ...queryOptions,

--- a/src/api/apiSchemas.ts
+++ b/src/api/apiSchemas.ts
@@ -676,7 +676,7 @@ export type OktaUserSummary = {
   deleted_at?: string | null;
 };
 
-export type PageTCustomizedAccessRequestSummary = {
+export type PageTypeVarCustomizedAccessRequestSummary = {
   items: AccessRequestSummary[];
   /**
    * @minimum 0
@@ -696,7 +696,7 @@ export type PageTCustomizedAccessRequestSummary = {
   pages: number;
 };
 
-export type PageTCustomizedAppGroupForAppDetail = {
+export type PageTypeVarCustomizedAppGroupForAppDetail = {
   items: AppGroupForAppDetail[];
   /**
    * @minimum 0
@@ -716,7 +716,7 @@ export type PageTCustomizedAppGroupForAppDetail = {
   pages: number;
 };
 
-export type PageTCustomizedAppSummary = {
+export type PageTypeVarCustomizedAppSummary = {
   items: AppSummary[];
   /**
    * @minimum 0
@@ -736,7 +736,7 @@ export type PageTCustomizedAppSummary = {
   pages: number;
 };
 
-export type PageTCustomizedAuditGroupRoleRow = {
+export type PageTypeVarCustomizedAuditGroupRoleRow = {
   items: AuditGroupRoleRow[];
   /**
    * @minimum 0
@@ -756,7 +756,7 @@ export type PageTCustomizedAuditGroupRoleRow = {
   pages: number;
 };
 
-export type PageTCustomizedAuditUserGroupRow = {
+export type PageTypeVarCustomizedAuditUserGroupRow = {
   items: AuditUserGroupRow[];
   /**
    * @minimum 0
@@ -776,7 +776,7 @@ export type PageTCustomizedAuditUserGroupRow = {
   pages: number;
 };
 
-export type PageTCustomizedGroupRequestDetail = {
+export type PageTypeVarCustomizedGroupRequestDetail = {
   items: GroupRequestDetail[];
   /**
    * @minimum 0
@@ -796,7 +796,7 @@ export type PageTCustomizedGroupRequestDetail = {
   pages: number;
 };
 
-export type PageTCustomizedGroupSummary = {
+export type PageTypeVarCustomizedGroupSummary = {
   items: GroupSummary[];
   /**
    * @minimum 0
@@ -816,7 +816,7 @@ export type PageTCustomizedGroupSummary = {
   pages: number;
 };
 
-export type PageTCustomizedOktaUserGroupMemberDetail = {
+export type PageTypeVarCustomizedOktaUserGroupMemberDetail = {
   items: OktaUserGroupMemberDetail[];
   /**
    * @minimum 0
@@ -836,7 +836,7 @@ export type PageTCustomizedOktaUserGroupMemberDetail = {
   pages: number;
 };
 
-export type PageTCustomizedOktaUserSummary = {
+export type PageTypeVarCustomizedOktaUserSummary = {
   items: OktaUserSummary[];
   /**
    * @minimum 0
@@ -856,7 +856,7 @@ export type PageTCustomizedOktaUserSummary = {
   pages: number;
 };
 
-export type PageTCustomizedRoleGroupListItem = {
+export type PageTypeVarCustomizedRoleGroupListItem = {
   items: RoleGroupListItem[];
   /**
    * @minimum 0
@@ -876,7 +876,7 @@ export type PageTCustomizedRoleGroupListItem = {
   pages: number;
 };
 
-export type PageTCustomizedRoleRequestSummary = {
+export type PageTypeVarCustomizedRoleRequestSummary = {
   items: RoleRequestSummary[];
   /**
    * @minimum 0
@@ -896,7 +896,7 @@ export type PageTCustomizedRoleRequestSummary = {
   pages: number;
 };
 
-export type PageTCustomizedTagListItem = {
+export type PageTypeVarCustomizedTagListItem = {
   items: TagListItem[];
   /**
    * @minimum 0

--- a/src/api/apiSchemas.ts
+++ b/src/api/apiSchemas.ts
@@ -96,6 +96,12 @@ export type AccessRequestSummary = {
 
 /**
  * Full App detail.
+ *
+ * The app's groups are intentionally NOT inlined here. An app can own
+ * hundreds of groups, and inlining each group's full membership made a
+ * single detail response materialize thousands of member rows. Groups (with
+ * their members) are served by the paginated `GET /api/apps/{id}/groups`
+ * endpoint (`AppGroupForAppDetail`) so the cost is bounded per page.
  */
 export type AppDetail = {
   id: string;
@@ -109,8 +115,6 @@ export type AppDetail = {
     [key: string]: any;
   } | null;
   active_app_tags?: AppTagMapDetail[];
-  active_owner_app_groups?: AppGroupForAppDetail[];
-  active_non_owner_app_groups?: AppGroupForAppDetail[];
 };
 
 export type AppGroupDetail = {
@@ -130,8 +134,6 @@ export type AppGroupDetail = {
   created_at: string | null;
   updated_at: string | null;
   deleted_at?: string | null;
-  active_user_memberships?: OktaUserGroupMemberDetail[];
-  active_user_ownerships?: OktaUserGroupMemberDetail[];
   active_group_tags?: OktaGroupTagMapDetail[];
   /**
    * @default app_group
@@ -542,8 +544,6 @@ export type OktaGroupDetail = {
   created_at: string | null;
   updated_at: string | null;
   deleted_at?: string | null;
-  active_user_memberships?: OktaUserGroupMemberDetail[];
-  active_user_ownerships?: OktaUserGroupMemberDetail[];
   active_group_tags?: OktaGroupTagMapDetail[];
   /**
    * @default okta_group
@@ -669,7 +669,7 @@ export type OktaUserSummary = {
   deleted_at?: string | null;
 };
 
-export type PageTypeVarCustomizedAccessRequestSummary = {
+export type PageTCustomizedAccessRequestSummary = {
   items: AccessRequestSummary[];
   /**
    * @minimum 0
@@ -689,7 +689,27 @@ export type PageTypeVarCustomizedAccessRequestSummary = {
   pages: number;
 };
 
-export type PageTypeVarCustomizedAppSummary = {
+export type PageTCustomizedAppGroupForAppDetail = {
+  items: AppGroupForAppDetail[];
+  /**
+   * @minimum 0
+   */
+  total: number;
+  /**
+   * @minimum 1
+   */
+  page: number;
+  /**
+   * @minimum 1
+   */
+  size: number;
+  /**
+   * @minimum 0
+   */
+  pages: number;
+};
+
+export type PageTCustomizedAppSummary = {
   items: AppSummary[];
   /**
    * @minimum 0
@@ -709,7 +729,7 @@ export type PageTypeVarCustomizedAppSummary = {
   pages: number;
 };
 
-export type PageTypeVarCustomizedAuditGroupRoleRow = {
+export type PageTCustomizedAuditGroupRoleRow = {
   items: AuditGroupRoleRow[];
   /**
    * @minimum 0
@@ -729,7 +749,7 @@ export type PageTypeVarCustomizedAuditGroupRoleRow = {
   pages: number;
 };
 
-export type PageTypeVarCustomizedAuditUserGroupRow = {
+export type PageTCustomizedAuditUserGroupRow = {
   items: AuditUserGroupRow[];
   /**
    * @minimum 0
@@ -749,7 +769,7 @@ export type PageTypeVarCustomizedAuditUserGroupRow = {
   pages: number;
 };
 
-export type PageTypeVarCustomizedGroupRequestDetail = {
+export type PageTCustomizedGroupRequestDetail = {
   items: GroupRequestDetail[];
   /**
    * @minimum 0
@@ -769,7 +789,7 @@ export type PageTypeVarCustomizedGroupRequestDetail = {
   pages: number;
 };
 
-export type PageTypeVarCustomizedGroupSummary = {
+export type PageTCustomizedGroupSummary = {
   items: GroupSummary[];
   /**
    * @minimum 0
@@ -789,7 +809,27 @@ export type PageTypeVarCustomizedGroupSummary = {
   pages: number;
 };
 
-export type PageTypeVarCustomizedOktaUserSummary = {
+export type PageTCustomizedOktaUserGroupMemberDetail = {
+  items: OktaUserGroupMemberDetail[];
+  /**
+   * @minimum 0
+   */
+  total: number;
+  /**
+   * @minimum 1
+   */
+  page: number;
+  /**
+   * @minimum 1
+   */
+  size: number;
+  /**
+   * @minimum 0
+   */
+  pages: number;
+};
+
+export type PageTCustomizedOktaUserSummary = {
   items: OktaUserSummary[];
   /**
    * @minimum 0
@@ -809,7 +849,7 @@ export type PageTypeVarCustomizedOktaUserSummary = {
   pages: number;
 };
 
-export type PageTypeVarCustomizedRoleGroupListItem = {
+export type PageTCustomizedRoleGroupListItem = {
   items: RoleGroupListItem[];
   /**
    * @minimum 0
@@ -829,7 +869,7 @@ export type PageTypeVarCustomizedRoleGroupListItem = {
   pages: number;
 };
 
-export type PageTypeVarCustomizedRoleRequestSummary = {
+export type PageTCustomizedRoleRequestSummary = {
   items: RoleRequestSummary[];
   /**
    * @minimum 0
@@ -849,7 +889,7 @@ export type PageTypeVarCustomizedRoleRequestSummary = {
   pages: number;
 };
 
-export type PageTypeVarCustomizedTagListItem = {
+export type PageTCustomizedTagListItem = {
   items: TagListItem[];
   /**
    * @minimum 0
@@ -993,8 +1033,6 @@ export type RoleGroupDetail = {
   created_at: string | null;
   updated_at: string | null;
   deleted_at?: string | null;
-  active_user_memberships?: OktaUserGroupMemberDetail[];
-  active_user_ownerships?: OktaUserGroupMemberDetail[];
   active_group_tags?: OktaGroupTagMapDetail[];
   /**
    * @default role_group

--- a/src/api/apiSchemas.ts
+++ b/src/api/apiSchemas.ts
@@ -153,12 +153,13 @@ export type AppGroupDetail = {
 };
 
 /**
- * Slimmer shape used inside `AppDetail.active_*_app_groups`.
+ * Slimmer shape used by the paginated `GET /api/apps/{id}/groups` endpoint.
  *
- * Drops `active_role_member_mappings`, `active_role_owner_mappings`, and
- * `active_group_tags` on the nested app-groups. The outer `AppGroupDetail`
- * retains them for direct `GET /api/groups/{id}` calls; this variant omits
- * them when the same rows are embedded inside an `AppDetail` payload.
+ * Members are NOT inlined: a single group can have thousands, and inlining
+ * them made even a 10-group page able to ship megabytes. Instead each item
+ * carries `member_count` / `owner_count` (cheap SQL aggregates); the UI fetches
+ * a group's members on demand from the paginated
+ * `GET /api/groups/{id}/member-details` endpoint.
  */
 export type AppGroupForAppDetail = {
   id: string;
@@ -190,8 +191,14 @@ export type AppGroupForAppDetail = {
     [key: string]: any;
   } | null;
   app?: AppIdRef | null;
-  active_user_memberships?: OktaUserGroupMemberDetail[];
-  active_user_ownerships?: OktaUserGroupMemberDetail[];
+  /**
+   * @default 0
+   */
+  member_count?: number;
+  /**
+   * @default 0
+   */
+  owner_count?: number;
 };
 
 /**

--- a/src/api/infiniteAppGroups.ts
+++ b/src/api/infiniteAppGroups.ts
@@ -1,0 +1,32 @@
+import {useInfiniteQuery} from '@tanstack/react-query';
+
+import {fetchAppGroupsById} from './apiComponents';
+import {useApiContext} from './apiContext';
+import {deepMerge} from './apiUtils';
+
+/**
+ * Infinite-scroll variant of `useAppGroupsById`: pages an app's groups
+ * (owners-first, 10/page) and accumulates them across pages so the app page can
+ * load more on scroll instead of via a page-number control. `owner` filters
+ * owner vs non-owner groups; `q` is the server-side member search (omitted when
+ * empty so the fetcher doesn't serialize it as the literal "undefined"). Reuses
+ * the generated fetcher + API context so auth options are injected like the
+ * generated hooks.
+ */
+export function useInfiniteAppGroups(appId: string, owner: boolean, q = '', enabled = true) {
+  const {fetcherOptions} = useApiContext();
+  return useInfiniteQuery({
+    queryKey: ['appGroups', appId, {owner, q}],
+    initialPageParam: 1,
+    queryFn: ({pageParam, signal}) =>
+      fetchAppGroupsById(
+        deepMerge(fetcherOptions, {
+          pathParams: {appId},
+          queryParams: Object.assign({owner, page: pageParam as number}, q ? {q} : null),
+        }),
+        signal,
+      ),
+    getNextPageParam: (lastPage) => (lastPage.page < lastPage.pages ? lastPage.page + 1 : undefined),
+    enabled: enabled && !!appId,
+  });
+}

--- a/src/components/InfiniteScrollSentinel.tsx
+++ b/src/components/InfiniteScrollSentinel.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+/**
+ * Renders an empty element that calls `onVisible` whenever it scrolls into
+ * view. Place it at the bottom of a list to drive infinite scroll: wire
+ * `onVisible` to fetch the next page (the parent should no-op when there's
+ * nothing more to load or a fetch is already in flight).
+ */
+export const InfiniteScrollSentinel: React.FC<{onVisible: () => void; disabled?: boolean}> = ({
+  onVisible,
+  disabled = false,
+}) => {
+  const ref = React.useRef<HTMLDivElement>(null);
+  const cb = React.useRef(onVisible);
+  cb.current = onVisible;
+
+  React.useEffect(() => {
+    if (disabled) {
+      return;
+    }
+    const el = ref.current;
+    if (!el) {
+      return;
+    }
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((e) => e.isIntersecting)) {
+        cb.current();
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [disabled]);
+
+  return <div ref={ref} aria-hidden style={{height: 1}} />;
+};

--- a/src/pages/apps/Read.tsx
+++ b/src/pages/apps/Read.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import {useParams} from 'react-router-dom';
 
+import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
-import Paper from '@mui/material/Paper';
+import Pagination from '@mui/material/Pagination';
 
-import {useAppById} from '../../api/apiComponents';
-import {AppDetail, AppGroupDetail} from '../../api/apiSchemas';
+import {useAppById, useAppGroupsById} from '../../api/apiComponents';
+import {AppDetail} from '../../api/apiSchemas';
 
 import {useCurrentUser} from '../../authentication';
 import NotFound from '../NotFound';
@@ -19,42 +20,48 @@ export default function ReadApp() {
   const currentUser = useCurrentUser();
 
   const {id} = useParams();
+  const appId = id ?? '';
+
   const {data, isError, isLoading} = useAppById({
-    pathParams: {appId: id ?? ''},
+    pathParams: {appId},
   });
-  const [nonOwnerAppGroups, setNonOwnerAppGroups] = React.useState<AppGroupDetail[]>([]);
+
+  // App groups are no longer inlined on the app payload; they're paginated
+  // (owners and non-owners fetched separately) so one response can't
+  // materialize every group's membership. Member-based filtering is computed
+  // server-side via the `q` query param.
+  const [page, setPage] = React.useState(1);
+  const [searchQuery, setSearchQuery] = React.useState('');
   const [isExpanded, setIsExpanded] = React.useState(false);
-  const [isSearchActive, setIsSearchActive] = React.useState(false);
 
-  const app = data ?? ({} as AppDetail);
-
-  const initialNonOwnerAppGroups = React.useMemo(() => {
-    return app?.active_non_owner_app_groups || [];
-  }, [app?.active_non_owner_app_groups]);
-
+  // React Router reuses this component instance when only :id changes, so the
+  // pagination/search state would otherwise leak across apps (e.g. show app B
+  // filtered by app A's query at page 2). Reset it whenever the app changes.
   React.useEffect(() => {
-    setNonOwnerAppGroups(initialNonOwnerAppGroups);
-  }, [initialNonOwnerAppGroups]);
+    setPage(1);
+    setSearchQuery('');
+  }, [id]);
+
+  const {data: ownerGroupsData} = useAppGroupsById({
+    pathParams: {appId},
+    queryParams: {owner: true},
+  });
+
+  const {data: nonOwnerGroupsData} = useAppGroupsById({
+    pathParams: {appId},
+    // Omit `q` entirely when there's no search — the generated fetcher runs
+    // queryParams through URLSearchParams, which serializes `undefined` to the
+    // literal string "undefined" (`q=undefined`) rather than dropping it.
+    queryParams: Object.assign({owner: false, page}, searchQuery ? {q: searchQuery} : null),
+  });
 
   const handleToggleExpand = React.useCallback((expanded: boolean) => {
-    setIsExpanded((prev) => {
-      // Only update if the value actually changed
-      if (prev === expanded) {
-        return prev;
-      }
-      return expanded;
-    });
+    setIsExpanded((prev) => (prev === expanded ? prev : expanded));
   }, []);
 
-  const handleSearchSubmit = React.useCallback((newAppGroups: AppGroupDetail[], isActive: boolean) => {
-    setNonOwnerAppGroups((prev) => {
-      // Only update if the groups actually changed
-      if (prev.length === newAppGroups.length && prev.every((group, index) => group.id === newAppGroups[index]?.id)) {
-        return prev;
-      }
-      return newAppGroups;
-    });
-    setIsSearchActive((prev) => (prev === isActive ? prev : isActive));
+  const handleSearchChange = React.useCallback((q: string) => {
+    setSearchQuery((prev) => (prev === q ? prev : q));
+    setPage(1);
   }, []);
 
   if (isError) {
@@ -64,6 +71,12 @@ export default function ReadApp() {
   if (isLoading) {
     return <Loading />;
   }
+
+  const app = data ?? ({} as AppDetail);
+  const ownerGroups = ownerGroupsData?.items ?? [];
+  const nonOwnerGroups = nonOwnerGroupsData?.items ?? [];
+  const totalPages = nonOwnerGroupsData?.pages ?? 0;
+  const isSearchActive = searchQuery.length > 0;
 
   return (
     <React.Fragment>
@@ -89,26 +102,32 @@ export default function ReadApp() {
               />
             </Grid>
           )}
-          {app.active_owner_app_groups && (
+          {ownerGroups.length > 0 && (
             <AppsAccordionListGroup
-              app_group={app.active_owner_app_groups}
+              app_group={ownerGroups}
               list_group_title={'Owner Group'}
               list_group_description={'Owners can manage all app groups as implicit owners'}
             />
           )}
           <AppsAdminActionGroup
+            key={id}
             app={app}
             currentUser={currentUser}
-            onSearchSubmit={handleSearchSubmit}
+            onSearchChange={handleSearchChange}
             onToggleExpand={handleToggleExpand}
             isExpanded={isExpanded}
           />
-          {app.active_non_owner_app_groups && (
-            <AppsAccordionListGroup
-              app_group={nonOwnerAppGroups}
-              list_group_title={nonOwnerAppGroups.length > 1 ? 'App Groups' : 'App Group'}
-              isExpanded={isExpanded || isSearchActive}
-            />
+          <AppsAccordionListGroup
+            app_group={nonOwnerGroups}
+            list_group_title={nonOwnerGroups.length > 1 ? 'App Groups' : 'App Group'}
+            isExpanded={isExpanded || isSearchActive}
+          />
+          {totalPages > 1 && (
+            <Grid item xs={12}>
+              <Box sx={{display: 'flex', justifyContent: 'center'}}>
+                <Pagination count={totalPages} page={page} onChange={(_, value) => setPage(value)} color="primary" />
+              </Box>
+            </Grid>
           )}
         </Grid>
       </Container>

--- a/src/pages/apps/Read.tsx
+++ b/src/pages/apps/Read.tsx
@@ -2,16 +2,18 @@ import React from 'react';
 import {useParams} from 'react-router-dom';
 
 import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
 import Container from '@mui/material/Container';
 import Grid from '@mui/material/Grid';
-import Pagination from '@mui/material/Pagination';
 
 import {useAppById, useAppGroupsById} from '../../api/apiComponents';
+import {useInfiniteAppGroups} from '../../api/infiniteAppGroups';
 import {AppDetail} from '../../api/apiSchemas';
 
 import {useCurrentUser} from '../../authentication';
 import NotFound from '../NotFound';
 import Loading from '../../components/Loading';
+import {InfiniteScrollSentinel} from '../../components/InfiniteScrollSentinel';
 import {AppsAccordionListGroup, AppsAdminActionGroup, AppsHeader} from './components/';
 import ChangeTitle from '../../tab-title';
 import AppGroupLifecyclePluginData from '../../components/AppGroupLifecyclePluginData';
@@ -26,19 +28,16 @@ export default function ReadApp() {
     pathParams: {appId},
   });
 
-  // App groups are no longer inlined on the app payload; they're paginated
-  // (owners and non-owners fetched separately) so one response can't
-  // materialize every group's membership. Member-based filtering is computed
-  // server-side via the `q` query param.
-  const [page, setPage] = React.useState(1);
+  // App groups are no longer inlined on the app payload. Owners (few) are
+  // fetched whole; non-owner groups load page-by-page on scroll. Member-based
+  // filtering is computed server-side via the `q` query param.
   const [searchQuery, setSearchQuery] = React.useState('');
   const [isExpanded, setIsExpanded] = React.useState(false);
 
-  // React Router reuses this component instance when only :id changes, so the
-  // pagination/search state would otherwise leak across apps (e.g. show app B
-  // filtered by app A's query at page 2). Reset it whenever the app changes.
+  // React Router reuses this component instance when only :id changes; reset
+  // the search so it doesn't leak across apps (the infinite query is keyed by
+  // app id + query, so it refetches on its own).
   React.useEffect(() => {
-    setPage(1);
     setSearchQuery('');
   }, [id]);
 
@@ -47,13 +46,7 @@ export default function ReadApp() {
     queryParams: {owner: true},
   });
 
-  const {data: nonOwnerGroupsData} = useAppGroupsById({
-    pathParams: {appId},
-    // Omit `q` entirely when there's no search — the generated fetcher runs
-    // queryParams through URLSearchParams, which serializes `undefined` to the
-    // literal string "undefined" (`q=undefined`) rather than dropping it.
-    queryParams: Object.assign({owner: false, page}, searchQuery ? {q: searchQuery} : null),
-  });
+  const nonOwnerGroupsQuery = useInfiniteAppGroups(appId, false, searchQuery);
 
   const handleToggleExpand = React.useCallback((expanded: boolean) => {
     setIsExpanded((prev) => (prev === expanded ? prev : expanded));
@@ -61,7 +54,6 @@ export default function ReadApp() {
 
   const handleSearchChange = React.useCallback((q: string) => {
     setSearchQuery((prev) => (prev === q ? prev : q));
-    setPage(1);
   }, []);
 
   if (isError) {
@@ -74,8 +66,7 @@ export default function ReadApp() {
 
   const app = data ?? ({} as AppDetail);
   const ownerGroups = ownerGroupsData?.items ?? [];
-  const nonOwnerGroups = nonOwnerGroupsData?.items ?? [];
-  const totalPages = nonOwnerGroupsData?.pages ?? 0;
+  const nonOwnerGroups = nonOwnerGroupsQuery.data?.pages.flatMap((p) => p.items) ?? [];
   const isSearchActive = searchQuery.length > 0;
 
   return (
@@ -122,13 +113,20 @@ export default function ReadApp() {
             list_group_title={nonOwnerGroups.length > 1 ? 'App Groups' : 'App Group'}
             isExpanded={isExpanded || isSearchActive}
           />
-          {totalPages > 1 && (
+          {nonOwnerGroupsQuery.isFetchingNextPage && (
             <Grid item xs={12}>
               <Box sx={{display: 'flex', justifyContent: 'center'}}>
-                <Pagination count={totalPages} page={page} onChange={(_, value) => setPage(value)} color="primary" />
+                <CircularProgress size={24} />
               </Box>
             </Grid>
           )}
+          {/* Load the next page of app groups when this scrolls into view. */}
+          <Grid item xs={12} sx={{py: 0}}>
+            <InfiniteScrollSentinel
+              onVisible={() => nonOwnerGroupsQuery.fetchNextPage()}
+              disabled={!nonOwnerGroupsQuery.hasNextPage || nonOwnerGroupsQuery.isFetchingNextPage}
+            />
+          </Grid>
         </Grid>
       </Container>
     </React.Fragment>

--- a/src/pages/apps/components/AppsAccordionListGroup.tsx
+++ b/src/pages/apps/components/AppsAccordionListGroup.tsx
@@ -241,8 +241,11 @@ export const AppsAccordionListGroup: React.FC<AppAccordionListGroupProps> = Reac
     const appGroupRef = React.useRef(app_group);
     appGroupRef.current = app_group;
 
-    const groupNamesKey = React.useMemo(() => (app_group ?? []).map((g) => g.name).join('|'), [app_group]);
-
+    // Apply expand/collapse-all ONLY when the toggle flips — not when the group
+    // list changes. Infinite scroll grows the list as you scroll (and a member
+    // page-change can trigger a fetch), and re-running this on every list change
+    // used to reset (collapse) accordions the user had opened. New groups follow
+    // the current `isExpanded` via the render default below.
     React.useEffect(() => {
       const currentAppGroup = appGroupRef.current;
       if (currentAppGroup) {
@@ -260,7 +263,7 @@ export const AppsAccordionListGroup: React.FC<AppAccordionListGroupProps> = Reac
           return hasChanges ? newExpanded : prevExpanded;
         });
       }
-    }, [isExpanded, groupNamesKey]);
+    }, [isExpanded]);
 
     const handleChange = React.useCallback(
       (id: string) => (event: React.SyntheticEvent, newExpanded: boolean) => {
@@ -300,7 +303,7 @@ export const AppsAccordionListGroup: React.FC<AppAccordionListGroupProps> = Reac
             <AccordionItem
               key={appGroup.id}
               appGroup={appGroup}
-              expanded={expanded[appGroup.name] || false}
+              expanded={expanded[appGroup.name] ?? isExpanded}
               onToggle={handleChange}
             />
           ))}

--- a/src/pages/apps/components/AppsAccordionListGroup.tsx
+++ b/src/pages/apps/components/AppsAccordionListGroup.tsx
@@ -3,9 +3,11 @@ import {
   AccordionDetails,
   AccordionSummary,
   Box,
+  CircularProgress,
   Divider,
   Grid,
   Link,
+  Pagination,
   Paper,
   Stack,
   Table,
@@ -18,29 +20,27 @@ import {
   Typography,
 } from '@mui/material';
 import {AppGroupForAppDetail, OktaUserGroupMemberDetail} from '../../../api/apiSchemas';
+import {useGroupMemberDetailsById} from '../../../api/apiComponents';
 import React from 'react';
-import {displayUserName, groupBy, groupMemberships, sortGroupMembers} from '../../../helpers';
+import {displayUserName, groupMemberships, sortGroupMembers} from '../../../helpers';
 import {EmptyListEntry} from '../../../components/EmptyListEntry';
 import Ending from '../../../components/Ending';
 import MarkdownDescription from '../../../components/MarkdownDescription';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import {Link as RouterLink, useParams} from 'react-router-dom';
+import {Link as RouterLink} from 'react-router-dom';
+
+// Owners are few and rendered inline (un-paginated); fetch up to this many.
+// Members page 50 distinct users at a time via the paginated control.
+const OWNER_FETCH_SIZE = 100;
 
 interface GroupDetailListProps {
   member_list: any[];
   title?: string;
-  groupName?: string;
+  loading?: boolean;
 }
 
-// Cap how many members render inline in the app-detail accordion. A few groups
-// have thousands of members; rendering them all here janks the page. The full,
-// paginated list lives on the group page, linked from the overflow row.
-const MAX_INLINE_MEMBERS = 100;
-
 const GroupDetailList: React.FC<GroupDetailListProps> = React.memo(
-  ({member_list, title, groupName}) => {
-    const shown = member_list.slice(0, MAX_INLINE_MEMBERS);
-    const overflow = member_list.length - shown.length;
+  ({member_list, title, loading}) => {
     return (
       <Stack direction="column" spacing={1}>
         {title && (
@@ -50,7 +50,7 @@ const GroupDetailList: React.FC<GroupDetailListProps> = React.memo(
         )}
 
         <TableContainer component={Paper}>
-          <Table sx={{minWidth: 325}} size="small" aria-label="app owners">
+          <Table sx={{minWidth: 325}} size="small" aria-label="app group members">
             <TableHead>
               <TableRow>
                 <TableCell>Name</TableCell>
@@ -59,16 +59,19 @@ const GroupDetailList: React.FC<GroupDetailListProps> = React.memo(
               </TableRow>
             </TableHead>
             <TableBody>
-              {member_list.length > 0 ? (
-                shown.map((member: OktaUserGroupMemberDetail) => (
+              {loading ? (
+                <TableRow>
+                  <TableCell colSpan={3} align="center">
+                    <CircularProgress size={20} />
+                  </TableCell>
+                </TableRow>
+              ) : member_list.length > 0 ? (
+                member_list.map((member: OktaUserGroupMemberDetail) => (
                   <TableRow key={member.active_user?.id}>
                     <TableCell>
                       <Link
                         to={`/users/${member.active_user?.email.toLowerCase()}`}
-                        sx={{
-                          textDecoration: 'none',
-                          color: 'inherit',
-                        }}
+                        sx={{textDecoration: 'none', color: 'inherit'}}
                         component={RouterLink}>
                         {displayUserName(member.active_user)}
                       </Link>
@@ -76,10 +79,7 @@ const GroupDetailList: React.FC<GroupDetailListProps> = React.memo(
                     <TableCell>
                       <Link
                         to={`/users/${member.active_user?.email.toLowerCase()}`}
-                        sx={{
-                          textDecoration: 'none',
-                          color: 'inherit',
-                        }}
+                        sx={{textDecoration: 'none', color: 'inherit'}}
                         component={RouterLink}>
                         {member.active_user?.email.toLowerCase()}
                       </Link>
@@ -91,15 +91,6 @@ const GroupDetailList: React.FC<GroupDetailListProps> = React.memo(
                 ))
               ) : (
                 <EmptyListEntry cellProps={{colSpan: 3}} />
-              )}
-              {overflow > 0 && (
-                <TableRow>
-                  <TableCell colSpan={3}>
-                    <Link to={groupName ? `/groups/${groupName}` : '#'} component={RouterLink}>
-                      + {overflow} more — view all {member_list.length} on the group page
-                    </Link>
-                  </TableCell>
-                </TableRow>
               )}
             </TableBody>
 
@@ -114,7 +105,7 @@ const GroupDetailList: React.FC<GroupDetailListProps> = React.memo(
   (prevProps, nextProps) => {
     return (
       prevProps.title === nextProps.title &&
-      prevProps.groupName === nextProps.groupName &&
+      prevProps.loading === nextProps.loading &&
       prevProps.member_list.length === nextProps.member_list.length &&
       prevProps.member_list.every(
         (member, index) => member.active_user?.id === nextProps.member_list[index]?.active_user?.id,
@@ -123,50 +114,48 @@ const GroupDetailList: React.FC<GroupDetailListProps> = React.memo(
   },
 );
 
+const dedupeByUser = (rows: OktaUserGroupMemberDetail[] | undefined) =>
+  Object.entries(groupMemberships(rows ?? []))
+    .sort(sortGroupMembers)
+    .map((entry) => entry[1][0]);
+
 const AccordionItem: React.FC<{
   appGroup: AppGroupForAppDetail;
   expanded: boolean;
   onToggle: (id: string) => (event: React.SyntheticEvent, newExpanded: boolean) => void;
 }> = React.memo(
   ({appGroup, expanded, onToggle}) => {
-    const {owners, members} = React.useMemo(() => {
-      const owners = Object.entries(groupMemberships(appGroup.active_user_ownerships))
-        .sort(sortGroupMembers)
-        .map((memberList) => memberList[1][0]);
+    const [memberPage, setMemberPage] = React.useState(1);
 
-      const members = Object.entries(groupMemberships(appGroup.active_user_memberships))
-        .sort(sortGroupMembers)
-        .map((memberList) => memberList[1][0]);
+    // Members/owners are no longer inlined on the app payload; fetch them from
+    // the paginated member-details endpoint only when this group is expanded.
+    const ownersQuery = useGroupMemberDetailsById(
+      {pathParams: {groupId: appGroup.id}, queryParams: {owner: true, size: OWNER_FETCH_SIZE}},
+      {enabled: expanded},
+    );
+    const membersQuery = useGroupMemberDetailsById(
+      {pathParams: {groupId: appGroup.id}, queryParams: {owner: false, page: memberPage}},
+      {enabled: expanded},
+    );
 
-      return {owners, members};
-    }, [appGroup.active_user_ownerships, appGroup.active_user_memberships]);
+    const owners = React.useMemo(() => dedupeByUser(ownersQuery.data?.items), [ownersQuery.data]);
+    const members = React.useMemo(() => dedupeByUser(membersQuery.data?.items), [membersQuery.data]);
+    const memberPages = membersQuery.data?.pages ?? 0;
 
     const handleToggle = React.useMemo(() => onToggle(appGroup.name), [onToggle, appGroup.name]);
 
     return (
       <TableContainer key={appGroup.id} component={Paper}>
-        {/* unmountOnExit so collapsed groups don't render their (potentially
-            huge) member tables — keeps the page fast when an app has large groups. */}
+        {/* unmountOnExit so collapsed groups don't fetch/render members — only
+            the expanded group hits the member-details endpoint. */}
         <Accordion expanded={expanded} onChange={handleToggle} TransitionProps={{unmountOnExit: true}}>
           <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-            <Box
-              sx={{
-                display: 'inline-flex',
-                flexGrow: 1,
-              }}>
-              <Stack
-                direction="column"
-                spacing={1}
-                sx={{
-                  flexGrow: 0.95,
-                }}>
+            <Box sx={{display: 'inline-flex', flexGrow: 1}}>
+              <Stack direction="column" spacing={1} sx={{flexGrow: 0.95}}>
                 <Typography variant="h6" color="text.accent">
                   <Link
                     to={`/groups/${appGroup.name}`}
-                    sx={{
-                      textDecoration: 'none',
-                      color: 'inherit',
-                    }}
+                    sx={{textDecoration: 'none', color: 'inherit'}}
                     component={RouterLink}>
                     {appGroup.name}
                   </Link>
@@ -176,26 +165,34 @@ const AccordionItem: React.FC<{
                   sx={{mx: 0, width: 'auto', px: 0, color: 'grey'}}
                 />
               </Stack>
-              <Box
-                sx={{
-                  display: 'flex',
-                  justifyContent: 'flex-end',
-                  alignItems: 'right',
-                }}>
+              <Box sx={{display: 'flex', justifyContent: 'flex-end', alignItems: 'right'}}>
                 <Divider sx={{mx: 2}} orientation="vertical" flexItem />
-                Owners: {owners.length || 0} <br />
-                Members: {members.length || 0}
+                Owners: {appGroup.owner_count ?? 0} <br />
+                Members: {appGroup.member_count ?? 0}
               </Box>
             </Box>
           </AccordionSummary>
           <AccordionDetails>
-            <Table aria-label="app group owners">
+            <Table aria-label="app group members">
               <TableBody className="accordion-body">
                 <TableRow>
                   <TableCell colSpan={2}>
                     <Stack direction="row" useFlexGap flexWrap={'wrap'} justifyContent={'space-between'} gap={'2rem'}>
-                      <GroupDetailList member_list={owners} title={'Group Owners'} groupName={appGroup.name} />
-                      <GroupDetailList member_list={members} title={'Members'} groupName={appGroup.name} />
+                      <GroupDetailList member_list={owners} title={'Group Owners'} loading={ownersQuery.isLoading} />
+                      <Stack direction="column" spacing={1}>
+                        <GroupDetailList member_list={members} title={'Members'} loading={membersQuery.isLoading} />
+                        {memberPages > 1 && (
+                          <Box sx={{display: 'flex', justifyContent: 'center'}}>
+                            <Pagination
+                              size="small"
+                              count={memberPages}
+                              page={memberPage}
+                              onChange={(_, value) => setMemberPage(value)}
+                              color="primary"
+                            />
+                          </Box>
+                        )}
+                      </Stack>
                     </Stack>
                   </TableCell>
                 </TableRow>
@@ -212,8 +209,8 @@ const AccordionItem: React.FC<{
       prevProps.appGroup.id === nextProps.appGroup.id &&
       prevProps.appGroup.name === nextProps.appGroup.name &&
       prevProps.appGroup.description === nextProps.appGroup.description &&
-      prevProps.appGroup.active_user_ownerships === nextProps.appGroup.active_user_ownerships &&
-      prevProps.appGroup.active_user_memberships === nextProps.appGroup.active_user_memberships
+      prevProps.appGroup.member_count === nextProps.appGroup.member_count &&
+      prevProps.appGroup.owner_count === nextProps.appGroup.owner_count
     );
   },
 );
@@ -319,8 +316,8 @@ export const AppsAccordionListGroup: React.FC<AppAccordionListGroupProps> = Reac
           group.id === nextProps.app_group[index]?.id &&
           group.name === nextProps.app_group[index]?.name &&
           group.description === nextProps.app_group[index]?.description &&
-          group.active_user_ownerships === nextProps.app_group[index]?.active_user_ownerships &&
-          group.active_user_memberships === nextProps.app_group[index]?.active_user_memberships,
+          group.member_count === nextProps.app_group[index]?.member_count &&
+          group.owner_count === nextProps.app_group[index]?.owner_count,
       )
     );
   },

--- a/src/pages/apps/components/AppsAccordionListGroup.tsx
+++ b/src/pages/apps/components/AppsAccordionListGroup.tsx
@@ -17,7 +17,7 @@ import {
   TableRow,
   Typography,
 } from '@mui/material';
-import {AppDetail, AppGroupDetail, OktaUserGroupMemberDetail} from '../../../api/apiSchemas';
+import {AppGroupForAppDetail, OktaUserGroupMemberDetail} from '../../../api/apiSchemas';
 import React from 'react';
 import {displayUserName, groupBy, groupMemberships, sortGroupMembers} from '../../../helpers';
 import {EmptyListEntry} from '../../../components/EmptyListEntry';
@@ -29,10 +29,18 @@ import {Link as RouterLink, useParams} from 'react-router-dom';
 interface GroupDetailListProps {
   member_list: any[];
   title?: string;
+  groupName?: string;
 }
 
+// Cap how many members render inline in the app-detail accordion. A few groups
+// have thousands of members; rendering them all here janks the page. The full,
+// paginated list lives on the group page, linked from the overflow row.
+const MAX_INLINE_MEMBERS = 100;
+
 const GroupDetailList: React.FC<GroupDetailListProps> = React.memo(
-  ({member_list, title}) => {
+  ({member_list, title, groupName}) => {
+    const shown = member_list.slice(0, MAX_INLINE_MEMBERS);
+    const overflow = member_list.length - shown.length;
     return (
       <Stack direction="column" spacing={1}>
         {title && (
@@ -52,7 +60,7 @@ const GroupDetailList: React.FC<GroupDetailListProps> = React.memo(
             </TableHead>
             <TableBody>
               {member_list.length > 0 ? (
-                member_list.map((member: OktaUserGroupMemberDetail) => (
+                shown.map((member: OktaUserGroupMemberDetail) => (
                   <TableRow key={member.active_user?.id}>
                     <TableCell>
                       <Link
@@ -84,6 +92,15 @@ const GroupDetailList: React.FC<GroupDetailListProps> = React.memo(
               ) : (
                 <EmptyListEntry cellProps={{colSpan: 3}} />
               )}
+              {overflow > 0 && (
+                <TableRow>
+                  <TableCell colSpan={3}>
+                    <Link to={groupName ? `/groups/${groupName}` : '#'} component={RouterLink}>
+                      + {overflow} more — view all {member_list.length} on the group page
+                    </Link>
+                  </TableCell>
+                </TableRow>
+              )}
             </TableBody>
 
             <TableFooter>
@@ -97,6 +114,7 @@ const GroupDetailList: React.FC<GroupDetailListProps> = React.memo(
   (prevProps, nextProps) => {
     return (
       prevProps.title === nextProps.title &&
+      prevProps.groupName === nextProps.groupName &&
       prevProps.member_list.length === nextProps.member_list.length &&
       prevProps.member_list.every(
         (member, index) => member.active_user?.id === nextProps.member_list[index]?.active_user?.id,
@@ -106,7 +124,7 @@ const GroupDetailList: React.FC<GroupDetailListProps> = React.memo(
 );
 
 const AccordionItem: React.FC<{
-  appGroup: AppGroupDetail;
+  appGroup: AppGroupForAppDetail;
   expanded: boolean;
   onToggle: (id: string) => (event: React.SyntheticEvent, newExpanded: boolean) => void;
 }> = React.memo(
@@ -127,7 +145,9 @@ const AccordionItem: React.FC<{
 
     return (
       <TableContainer key={appGroup.id} component={Paper}>
-        <Accordion expanded={expanded} onChange={handleToggle}>
+        {/* unmountOnExit so collapsed groups don't render their (potentially
+            huge) member tables — keeps the page fast when an app has large groups. */}
+        <Accordion expanded={expanded} onChange={handleToggle} TransitionProps={{unmountOnExit: true}}>
           <AccordionSummary expandIcon={<ExpandMoreIcon />}>
             <Box
               sx={{
@@ -174,8 +194,8 @@ const AccordionItem: React.FC<{
                 <TableRow>
                   <TableCell colSpan={2}>
                     <Stack direction="row" useFlexGap flexWrap={'wrap'} justifyContent={'space-between'} gap={'2rem'}>
-                      <GroupDetailList member_list={owners} title={'Group Owners'} />
-                      <GroupDetailList member_list={members} title={'Members'} />
+                      <GroupDetailList member_list={owners} title={'Group Owners'} groupName={appGroup.name} />
+                      <GroupDetailList member_list={members} title={'Members'} groupName={appGroup.name} />
                     </Stack>
                   </TableCell>
                 </TableRow>
@@ -199,7 +219,7 @@ const AccordionItem: React.FC<{
 );
 
 interface AppAccordionListGroupProps {
-  app_group: AppGroupDetail[];
+  app_group: AppGroupForAppDetail[];
   list_group_title?: string;
   list_group_description?: string;
   isExpanded?: boolean;

--- a/src/pages/apps/components/AppsAccordionListGroup.tsx
+++ b/src/pages/apps/components/AppsAccordionListGroup.tsx
@@ -30,8 +30,9 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import {Link as RouterLink} from 'react-router-dom';
 
 // Owners are few and rendered inline (un-paginated); fetch up to this many.
-// Members page 50 distinct users at a time via the paginated control.
 const OWNER_FETCH_SIZE = 100;
+// Members page this many distinct users at a time via the page-number control.
+const MEMBER_PAGE_SIZE = 100;
 
 interface GroupDetailListProps {
   member_list: any[];
@@ -128,13 +129,15 @@ const AccordionItem: React.FC<{
     const [memberPage, setMemberPage] = React.useState(1);
 
     // Members/owners are no longer inlined on the app payload; fetch them from
-    // the paginated member-details endpoint only when this group is expanded.
+    // the member-details endpoint only when this group is expanded. Owners are
+    // few (fetched whole); members page MEMBER_PAGE_SIZE at a time via the
+    // page-number control below.
     const ownersQuery = useGroupMemberDetailsById(
       {pathParams: {groupId: appGroup.id}, queryParams: {owner: true, size: OWNER_FETCH_SIZE}},
       {enabled: expanded},
     );
     const membersQuery = useGroupMemberDetailsById(
-      {pathParams: {groupId: appGroup.id}, queryParams: {owner: false, page: memberPage}},
+      {pathParams: {groupId: appGroup.id}, queryParams: {owner: false, page: memberPage, size: MEMBER_PAGE_SIZE}},
       {enabled: expanded},
     );
 

--- a/src/pages/apps/components/AppsAdminActionGroup.tsx
+++ b/src/pages/apps/components/AppsAdminActionGroup.tsx
@@ -21,12 +21,26 @@ export const AppsAdminActionGroup: React.FC<AppsAdminActionGroupProps> = React.m
     const onSearchChangeRef = React.useRef(onSearchChange);
     onSearchChangeRef.current = onSearchChange;
 
-    // Search runs on submit, not per keystroke: `onChange` fires when the user
-    // presses Enter (freeSolo) or clears the field, so each search is one
-    // GET /api/apps/{id}/groups?q=… request rather than one per character.
+    // Search as you type, debounced: fire the query ~2s after the user stops
+    // typing rather than per keystroke (or only on Enter), so it stays responsive
+    // without a request per character.
+    const debounceRef = React.useRef<ReturnType<typeof setTimeout>>();
     const handleSearchChange = React.useCallback((_: unknown, newValue: string | null) => {
-      onSearchChangeRef.current?.(newValue?.trim() ?? '');
+      const q = newValue?.trim() ?? '';
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+      debounceRef.current = setTimeout(() => onSearchChangeRef.current?.(q), 2000);
     }, []);
+
+    React.useEffect(
+      () => () => {
+        if (debounceRef.current) {
+          clearTimeout(debounceRef.current);
+        }
+      },
+      [],
+    );
 
     const onToggleExpandRef = React.useRef(onToggleExpand);
     const isExpandedRef = React.useRef(isExpanded);
@@ -69,7 +83,7 @@ export const AppsAdminActionGroup: React.FC<AppsAdminActionGroupProps> = React.m
                 sx={{flex: '1 1 220px', minWidth: 0, maxWidth: 320}}
                 renderInput={(params) => <TextField {...params} label="Search Users" />}
                 options={[]}
-                onChange={handleSearchChange}
+                onInputChange={handleSearchChange}
                 clearOnEscape
                 freeSolo
                 autoFocus

--- a/src/pages/apps/components/AppsAdminActionGroup.tsx
+++ b/src/pages/apps/components/AppsAdminActionGroup.tsx
@@ -2,78 +2,44 @@ import {Autocomplete, Button, Grid, Paper, TextField, Box} from '@mui/material';
 import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
 import UnfoldMoreIcon from '@mui/icons-material/UnfoldMore';
 import CreateUpdateGroup from '../../groups/CreateUpdate';
-import {OktaUserDetail, AppDetail, AppGroupDetail} from '../../../api/apiSchemas';
-import {renderUserOption} from '../../../components/TableTopBar';
-import {displayUserName, sortGroupMemberRecords} from '../../../helpers';
+import {OktaUserDetail, AppDetail} from '../../../api/apiSchemas';
 import React from 'react';
 
 interface AppsAdminActionGroupProps {
   currentUser: OktaUserDetail;
   app: AppDetail;
-  onSearchSubmit?: (appGroup: AppGroupDetail[], isActive: boolean) => void;
+  // Emits the raw user search query. Group filtering by member is computed
+  // server-side (GET /api/apps/{id}/groups?q=…) so the page no longer needs
+  // every member loaded client-side.
+  onSearchChange?: (q: string) => void;
   onToggleExpand?: (expanded: boolean) => void;
   isExpanded?: boolean;
 }
 
 export const AppsAdminActionGroup: React.FC<AppsAdminActionGroupProps> = React.memo(
-  ({currentUser, app, onSearchSubmit, onToggleExpand, isExpanded = false}) => {
-    const {allMembers, memberGroups, sortedUserOptions} = React.useMemo(() => {
-      const allMembers: Record<string, OktaUserDetail> = {};
-      const memberGroups: Record<string, AppGroupDetail[]> = {};
+  ({currentUser, app, onSearchChange, onToggleExpand, isExpanded = false}) => {
+    const onSearchChangeRef = React.useRef(onSearchChange);
+    onSearchChangeRef.current = onSearchChange;
 
-      (app.active_non_owner_app_groups ?? []).forEach((appGroup) => {
-        [appGroup.active_user_ownerships, appGroup.active_user_memberships].forEach((memberList) => {
-          (memberList ?? []).forEach((member) => {
-            const activeUser = member.active_user;
-            if (activeUser) {
-              allMembers[activeUser.id] = activeUser;
-              const groups = (memberGroups[activeUser.email.toLowerCase()] ||= []);
-              if (
-                !groups.find((g) => {
-                  return g.id === appGroup.id;
-                })
-              ) {
-                groups.push(appGroup);
-              }
-            }
-          });
-        });
-      });
-
-      const sortedUserOptions = sortGroupMemberRecords(allMembers).map(
-        (row) => `${displayUserName(row)} (${row.email.toLowerCase()})`,
-      );
-
-      return {allMembers, memberGroups, sortedUserOptions};
-    }, [app.active_non_owner_app_groups]);
-
-    const allMembersRef = React.useRef(allMembers);
-    const memberGroupsRef = React.useRef(memberGroups);
-    const appGroupsRef = React.useRef(app.active_non_owner_app_groups);
-    const onSearchSubmitRef = React.useRef(onSearchSubmit);
-
-    allMembersRef.current = allMembers;
-    memberGroupsRef.current = memberGroups;
-    appGroupsRef.current = app.active_non_owner_app_groups;
-    onSearchSubmitRef.current = onSearchSubmit;
-
-    const handleSearchSubmit = React.useCallback((_: unknown, newValue: string | null) => {
-      const q = newValue?.trim().toLowerCase() ?? '';
-      const fallback = appGroupsRef.current ?? [];
-      if (!q) {
-        onSearchSubmitRef.current?.(fallback, false);
-        return;
+    // Debounce the emit so each keystroke doesn't fire its own server-side
+    // GET /api/apps/{id}/groups?q=… request; the search runs once typing settles.
+    const debounceRef = React.useRef<ReturnType<typeof setTimeout>>();
+    const handleSearchChange = React.useCallback((_: unknown, newValue: string | null) => {
+      const q = newValue?.trim() ?? '';
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
       }
-      const matchedById: Record<string, AppGroupDetail> = {};
-      Object.values(allMembersRef.current).forEach((user) => {
-        const name = displayUserName(user).toLowerCase();
-        const email = user.email.toLowerCase();
-        if (!name.includes(q) && !email.includes(q)) return;
-        (memberGroupsRef.current[email] ?? []).forEach((g) => {
-          if (g.id) matchedById[g.id] = g;
-        });
-      });
-      onSearchSubmitRef.current?.(Object.values(matchedById), true);
+      debounceRef.current = setTimeout(() => {
+        onSearchChangeRef.current?.(q);
+      }, 300);
+    }, []);
+
+    React.useEffect(() => {
+      return () => {
+        if (debounceRef.current) {
+          clearTimeout(debounceRef.current);
+        }
+      };
     }, []);
 
     const onToggleExpandRef = React.useRef(onToggleExpand);
@@ -116,9 +82,9 @@ export const AppsAdminActionGroup: React.FC<AppsAdminActionGroupProps> = React.m
                 size="small"
                 sx={{flex: '1 1 220px', minWidth: 0, maxWidth: 320}}
                 renderInput={(params) => <TextField {...params} label="Search Users" />}
-                options={sortedUserOptions}
-                onChange={handleSearchSubmit}
-                renderOption={renderUserOption}
+                options={[]}
+                onChange={handleSearchChange}
+                onInputChange={handleSearchChange}
                 clearOnEscape
                 freeSolo
                 autoFocus

--- a/src/pages/apps/components/AppsAdminActionGroup.tsx
+++ b/src/pages/apps/components/AppsAdminActionGroup.tsx
@@ -21,25 +21,11 @@ export const AppsAdminActionGroup: React.FC<AppsAdminActionGroupProps> = React.m
     const onSearchChangeRef = React.useRef(onSearchChange);
     onSearchChangeRef.current = onSearchChange;
 
-    // Debounce the emit so each keystroke doesn't fire its own server-side
-    // GET /api/apps/{id}/groups?q=… request; the search runs once typing settles.
-    const debounceRef = React.useRef<ReturnType<typeof setTimeout>>();
+    // Search runs on submit, not per keystroke: `onChange` fires when the user
+    // presses Enter (freeSolo) or clears the field, so each search is one
+    // GET /api/apps/{id}/groups?q=… request rather than one per character.
     const handleSearchChange = React.useCallback((_: unknown, newValue: string | null) => {
-      const q = newValue?.trim() ?? '';
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-      }
-      debounceRef.current = setTimeout(() => {
-        onSearchChangeRef.current?.(q);
-      }, 300);
-    }, []);
-
-    React.useEffect(() => {
-      return () => {
-        if (debounceRef.current) {
-          clearTimeout(debounceRef.current);
-        }
-      };
+      onSearchChangeRef.current?.(newValue?.trim() ?? '');
     }, []);
 
     const onToggleExpandRef = React.useRef(onToggleExpand);
@@ -84,7 +70,6 @@ export const AppsAdminActionGroup: React.FC<AppsAdminActionGroupProps> = React.m
                 renderInput={(params) => <TextField {...params} label="Search Users" />}
                 options={[]}
                 onChange={handleSearchChange}
-                onInputChange={handleSearchChange}
                 clearOnEscape
                 freeSolo
                 autoFocus

--- a/src/pages/group_requests/Read.tsx
+++ b/src/pages/group_requests/Read.tsx
@@ -63,7 +63,7 @@ import {
   TagListItem,
 } from '../../api/apiSchemas';
 import {useCurrentUser} from '../../authentication';
-import {isAccessAdmin} from '../../authorization';
+import {isAccessAdmin, isAppOwnerGroupOwner} from '../../authorization';
 import {displayUserName, minTagTime} from '../../helpers';
 
 import Loading from '../../components/Loading';
@@ -231,27 +231,20 @@ export default function ReadGroupRequest() {
   }, [requestedAppData, appSeeded]);
 
   const isAppOwner = React.useMemo<boolean>(() => {
-    if (admin || ownRequest || requestedGroupType !== 'app_group' || !requestedAppData) {
+    if (admin || ownRequest || requestedGroupType !== 'app_group' || !requestedAppId) {
       return false;
     }
-    return (requestedAppData.active_owner_app_groups ?? []).some((appGroup: AppGroupForAppDetail) =>
-      (appGroup.active_user_ownerships ?? []).some(
-        (membership: OktaUserGroupMemberDetail) => membership.active_user?.id === currentUser.id,
-      ),
-    );
-  }, [admin, ownRequest, requestedGroupType, requestedAppData, currentUser.id]);
+    // Ownership is computed from the current user's own ownership grants, not
+    // the app payload (which no longer inlines its owner groups' members).
+    return isAppOwnerGroupOwner(currentUser, requestedAppId);
+  }, [admin, ownRequest, requestedGroupType, requestedAppId, currentUser]);
 
   const {data: ownedAppsData} = useApps({queryParams: {page: 1, size: 100, q: ''}}, {enabled: isAppOwner});
 
   const ownedAppIds = React.useMemo<Set<string>>(() => {
     const ids = new Set<string>();
     for (const app of ownedAppsData?.items ?? []) {
-      const owns = ((app as AppDetail).active_owner_app_groups ?? []).some((appGroup: AppGroupForAppDetail) =>
-        (appGroup.active_user_ownerships ?? []).some(
-          (membership: OktaUserGroupMemberDetail) => membership.active_user?.id === currentUser.id,
-        ),
-      );
-      if (owns && app.id) {
+      if (app.id && isAppOwnerGroupOwner(currentUser, app.id)) {
         ids.add(app.id);
       }
     }
@@ -259,7 +252,7 @@ export default function ReadGroupRequest() {
       ids.add(requestedAppId);
     }
     return ids;
-  }, [ownedAppsData, currentUser.id, isAppOwner, requestedAppId]);
+  }, [ownedAppsData, currentUser, isAppOwner, requestedAppId]);
 
   const canApprove = (admin || isAppOwner) && !ownRequest;
   const canResolve = canApprove || ownRequest;

--- a/src/pages/groups/Read.tsx
+++ b/src/pages/groups/Read.tsx
@@ -159,7 +159,7 @@ export default function ReadGroup() {
   const {data: groupOwnerData} = useGroupMemberDetailsById(
     {
       pathParams: {groupId: id ?? ''},
-      queryParams: {owner: true, size: 1000},
+      queryParams: {owner: true, size: 100},
     },
     {
       enabled: id != null,

--- a/src/pages/groups/Read.tsx
+++ b/src/pages/groups/Read.tsx
@@ -112,16 +112,6 @@ export default function ReadGroup() {
   const [removeOwnDirectAccessDialogParameters, setRemoveOwnDirectAccessDialogParameters] =
     React.useState<RemoveOwnDirectAccessDialogParameters>({} as RemoveOwnDirectAccessDialogParameters);
 
-  const [memberPage, setMemberPage] = React.useState(1);
-
-  // This component is reused across /groups/:id and /roles/:id, so React Router
-  // keeps the same instance when only :id changes; reset the member page so a
-  // stale page number doesn't request an out-of-range (empty) page on the new
-  // group.
-  React.useEffect(() => {
-    setMemberPage(1);
-  }, [id]);
-
   const {data, isError, isLoading} = useGroupById({
     pathParams: {groupId: id ?? ''},
   });
@@ -166,14 +156,25 @@ export default function ReadGroup() {
     },
   );
 
+  // App owners = the owners of the app's owner group. The app-groups payload
+  // only carries counts now, so fetch that group's owners explicitly (apps have
+  // a single App-<name>-Owners group).
+  const appOwnerGroupId = appOwnerGroupsData?.items?.[0]?.id ?? '';
+  const {data: appOwnerMemberData} = useGroupMemberDetailsById(
+    {pathParams: {groupId: appOwnerGroupId}, queryParams: {owner: true, size: 100}},
+    {enabled: appOwnerGroupId !== ''},
+  );
+
+  // Members page MEMBER_PAGE_SIZE at a time via the page-number control below.
+  const [memberPage, setMemberPage] = React.useState(1);
+  // Reset to page 1 when the group changes (component is reused across
+  // /groups/:id and /roles/:id).
+  React.useEffect(() => {
+    setMemberPage(1);
+  }, [id]);
   const {data: groupMemberData} = useGroupMemberDetailsById(
-    {
-      pathParams: {groupId: id ?? ''},
-      queryParams: {owner: false, page: memberPage},
-    },
-    {
-      enabled: id != null,
-    },
+    {pathParams: {groupId: id ?? ''}, queryParams: {owner: false, page: memberPage, size: 100}},
+    {enabled: id != null},
   );
 
   const putGroupUsers = useGroupMembersByIdPut({
@@ -188,9 +189,7 @@ export default function ReadGroup() {
     return <Loading />;
   }
 
-  const appOwnershipsArray = (appOwnerGroupsData?.items ?? [])
-    .map((appGroup) => appGroup.active_user_ownerships ?? [])
-    .flat();
+  const appOwnershipsArray = appOwnerMemberData?.items ?? [];
   // set of app owner ids
   const appOwnershipSet: Set<string> = appOwnershipsArray.reduce(
     (out: Set<string>, user: OktaUserGroupMemberDetail) => {

--- a/src/pages/groups/Read.tsx
+++ b/src/pages/groups/Read.tsx
@@ -8,6 +8,7 @@ import Divider from '@mui/material/Divider';
 import Grid from '@mui/material/Grid';
 import IconButton from '@mui/material/IconButton';
 import Link from '@mui/material/Link';
+import Pagination from '@mui/material/Pagination';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Table from '@mui/material/Table';
@@ -44,7 +45,13 @@ import Loading from '../../components/Loading';
 import Ending from '../../components/Ending';
 import MarkdownDescription from '../../components/MarkdownDescription';
 import {groupBy, displayGroupType, displayUserName} from '../../helpers';
-import {useAppById, useGroupById, useGroupMembersByIdPut} from '../../api/apiComponents';
+import {
+  useAppById,
+  useAppGroupsById,
+  useGroupById,
+  useGroupMemberDetailsById,
+  useGroupMembersByIdPut,
+} from '../../api/apiComponents';
 import {
   AppDetail,
   AppGroupForAppDetail,
@@ -105,6 +112,16 @@ export default function ReadGroup() {
   const [removeOwnDirectAccessDialogParameters, setRemoveOwnDirectAccessDialogParameters] =
     React.useState<RemoveOwnDirectAccessDialogParameters>({} as RemoveOwnDirectAccessDialogParameters);
 
+  const [memberPage, setMemberPage] = React.useState(1);
+
+  // This component is reused across /groups/:id and /roles/:id, so React Router
+  // keeps the same instance when only :id changes; reset the member page so a
+  // stale page number doesn't request an out-of-range (empty) page on the new
+  // group.
+  React.useEffect(() => {
+    setMemberPage(1);
+  }, [id]);
+
   const {data, isError, isLoading} = useGroupById({
     pathParams: {groupId: id ?? ''},
   });
@@ -124,6 +141,41 @@ export default function ReadGroup() {
 
   const app = appData ?? ({} as AppDetail);
 
+  // Owners and members are no longer inlined on the group payload. Owners (and
+  // the app's owner groups, for app groups) are small and fetched whole;
+  // members are paginated so a large group can't materialize every row at once.
+  const {data: appOwnerGroupsData} = useAppGroupsById(
+    {
+      pathParams: {appId: ((group ?? {}) as AppGroupDetail).app?.id ?? ''},
+      queryParams: {owner: true},
+    },
+    {
+      enabled: group.type == 'app_group',
+    },
+  );
+
+  // Owners are few and rendered un-paginated, so fetch them whole (a large
+  // `size`) rather than letting the default page size silently cap them.
+  const {data: groupOwnerData} = useGroupMemberDetailsById(
+    {
+      pathParams: {groupId: id ?? ''},
+      queryParams: {owner: true, size: 1000},
+    },
+    {
+      enabled: id != null,
+    },
+  );
+
+  const {data: groupMemberData} = useGroupMemberDetailsById(
+    {
+      pathParams: {groupId: id ?? ''},
+      queryParams: {owner: false, page: memberPage},
+    },
+    {
+      enabled: id != null,
+    },
+  );
+
   const putGroupUsers = useGroupMembersByIdPut({
     onSuccess: () => navigate(0),
   });
@@ -136,8 +188,8 @@ export default function ReadGroup() {
     return <Loading />;
   }
 
-  const appOwnershipsArray = (app.active_owner_app_groups ?? [])
-    .map((appGroup: AppGroupForAppDetail) => appGroup.active_user_ownerships ?? [])
+  const appOwnershipsArray = (appOwnerGroupsData?.items ?? [])
+    .map((appGroup) => appGroup.active_user_ownerships ?? [])
     .flat();
   // set of app owner ids
   const appOwnershipSet: Set<string> = appOwnershipsArray.reduce(
@@ -148,7 +200,8 @@ export default function ReadGroup() {
     new Set<string>(),
   );
 
-  const directRoleOwnerships: Set<string> = (group.active_user_ownerships ?? []).reduce(
+  const groupOwnershipRows = groupOwnerData?.items ?? [];
+  const directRoleOwnerships: Set<string> = groupOwnershipRows.reduce(
     (out: Set<string>, user: OktaUserGroupMemberDetail) => {
       out.add(user.active_user!.id);
       return out;
@@ -156,14 +209,16 @@ export default function ReadGroup() {
     new Set<string>(),
   );
 
-  let allOwnerships: Set<OktaUserGroupMemberDetail> = new Set(group.active_user_ownerships ?? []);
+  let allOwnerships: Set<OktaUserGroupMemberDetail> = new Set(groupOwnershipRows);
   appOwnershipsArray.forEach((user: OktaUserGroupMemberDetail) => {
     directRoleOwnerships.has(user.active_user!.id) ? null : allOwnerships.add(user);
   });
 
   let ownerships = groupBy(Array.from(allOwnerships), (m: OktaUserGroupMemberDetail) => m.active_user?.id);
 
-  const memberships = groupBy(group.active_user_memberships, (m: OktaUserGroupMemberDetail) => m.active_user?.id);
+  const memberships = groupBy(groupMemberData?.items ?? [], (m: OktaUserGroupMemberDetail) => m.active_user?.id);
+  const totalMemberRows = groupMemberData?.total ?? 0;
+  const memberPageCount = groupMemberData?.pages ?? 0;
 
   let role_associated_group_owners: Record<string, RoleGroupMapDetail[]> = {};
   let role_associated_group_members: Record<string, RoleGroupMapDetail[]> = {};
@@ -717,7 +772,7 @@ export default function ReadGroup() {
                                 alignItems: 'right',
                               }}>
                               <Divider sx={{mx: 2}} orientation="vertical" flexItem />
-                              Total Members: {Object.keys(memberships).length}
+                              Total Members: {totalMemberRows}
                             </Box>
                           </Grid>
                         </Grid>
@@ -731,7 +786,7 @@ export default function ReadGroup() {
                             alignItems: 'right',
                           }}>
                           <Divider sx={{mx: 2}} orientation="vertical" flexItem />
-                          Total Members: {Object.keys(memberships).length}
+                          Total Members: {totalMemberRows}
                         </Box>
                       </TableCell>
                     )}
@@ -831,7 +886,22 @@ export default function ReadGroup() {
                   )}
                 </TableBody>
                 <TableFooter>
-                  <TableRow />
+                  {memberPageCount > 1 ? (
+                    <TableRow>
+                      <TableCell colSpan={4}>
+                        <Box sx={{display: 'flex', justifyContent: 'center'}}>
+                          <Pagination
+                            count={memberPageCount}
+                            page={memberPage}
+                            onChange={(_, value) => setMemberPage(value)}
+                            color="primary"
+                          />
+                        </Box>
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    <TableRow />
+                  )}
                 </TableFooter>
               </Table>
             </TableContainer>

--- a/src/pages/requests/Read.tsx
+++ b/src/pages/requests/Read.tsx
@@ -275,9 +275,14 @@ export default function ReadRequest() {
     },
   );
 
-  const appOwnershipsArray = (appOwnerGroupsData?.items ?? [])
-    .map((appGroup) => appGroup.active_user_ownerships ?? [])
-    .flat();
+  // App owners = owners of the app's owner group; the app-groups payload only
+  // carries counts, so fetch that group's owners explicitly.
+  const appOwnerGroupId = appOwnerGroupsData?.items?.[0]?.id ?? '';
+  const {data: appOwnerMemberData} = useGroupMemberDetailsById(
+    {pathParams: {groupId: appOwnerGroupId}, queryParams: {owner: true, size: 100}},
+    {enabled: appOwnerGroupId !== ''},
+  );
+  const appOwnershipsArray = appOwnerMemberData?.items ?? [];
   const appOwnerships = groupBy(appOwnershipsArray, (m: OktaUserGroupMemberDetail) => m.active_user?.id);
 
   const {data: accessAppOwnerGroupsData} = useAppGroupsById(
@@ -294,8 +299,14 @@ export default function ReadRequest() {
     },
   );
 
+  // Final fallback approvers = members of the Access app's owner group.
+  const accessAppOwnerGroupId = accessAppOwnerGroupsData?.items?.[0]?.id ?? '';
+  const {data: accessAppOwnerMemberData} = useGroupMemberDetailsById(
+    {pathParams: {groupId: accessAppOwnerGroupId}, queryParams: {owner: false, size: 100}},
+    {enabled: accessAppOwnerGroupId !== ''},
+  );
   const accessAppOwnerships = groupBy(
-    (accessAppOwnerGroupsData?.items ?? []).map((appGroup) => appGroup.active_user_memberships ?? []).flat(),
+    accessAppOwnerMemberData?.items ?? [],
     (m: OktaUserGroupMemberDetail) => m.active_user?.id,
   );
 

--- a/src/pages/requests/Read.tsx
+++ b/src/pages/requests/Read.tsx
@@ -257,7 +257,7 @@ export default function ReadRequest() {
   const {data: groupOwnerData} = useGroupMemberDetailsById(
     {
       pathParams: {groupId: accessRequest.requested_group?.id ?? ''},
-      queryParams: {owner: true, size: 1000},
+      queryParams: {owner: true, size: 100},
     },
     {
       enabled: accessRequest.requested_group != null && (!requestedGroupManager || ownRequest),

--- a/src/pages/requests/Read.tsx
+++ b/src/pages/requests/Read.tsx
@@ -56,6 +56,8 @@ import {
   useAccessRequestById,
   useGroupById,
   useAppById,
+  useAppGroupsById,
+  useGroupMemberDetailsById,
   useAccessRequestByIdPut,
   useUsersAndGroups,
   useGroupsAndRoles,
@@ -250,47 +252,50 @@ export default function ReadRequest() {
     }));
   }
 
-  const ownerships = groupBy(group.active_user_ownerships, (m: OktaUserGroupMemberDetail) => m.active_user?.id);
-
-  const {data: appData} = useAppById(
+  // Owner/approver lists are no longer inlined on the group/app payloads; they
+  // come from the bounded owner-filtered endpoints instead.
+  const {data: groupOwnerData} = useGroupMemberDetailsById(
     {
-      pathParams: {
-        appId: ((accessRequest.requested_group ?? {}) as AppGroupDetail).app?.id ?? '',
-      },
+      pathParams: {groupId: accessRequest.requested_group?.id ?? ''},
+      queryParams: {owner: true, size: 1000},
+    },
+    {
+      enabled: accessRequest.requested_group != null && (!requestedGroupManager || ownRequest),
+    },
+  );
+  const ownerships = groupBy(groupOwnerData?.items ?? [], (m: OktaUserGroupMemberDetail) => m.active_user?.id);
+
+  const {data: appOwnerGroupsData} = useAppGroupsById(
+    {
+      pathParams: {appId: ((accessRequest.requested_group ?? {}) as AppGroupDetail).app?.id ?? ''},
+      queryParams: {owner: true},
     },
     {
       enabled: accessRequest.requested_group?.type == 'app_group' && (!requestedGroupManager || ownRequest),
     },
   );
 
-  const app = appData ?? ({} as AppDetail);
-
-  const appOwnershipsArray = (app.active_owner_app_groups ?? [])
-    .map((appGroup: AppGroupForAppDetail) => appGroup.active_user_ownerships ?? [])
+  const appOwnershipsArray = (appOwnerGroupsData?.items ?? [])
+    .map((appGroup) => appGroup.active_user_ownerships ?? [])
     .flat();
   const appOwnerships = groupBy(appOwnershipsArray, (m: OktaUserGroupMemberDetail) => m.active_user?.id);
 
-  const {data: accessAppData} = useAppById(
+  const {data: accessAppOwnerGroupsData} = useAppGroupsById(
     {
-      pathParams: {
-        appId: ACCESS_APP_RESERVED_NAME,
-      },
+      pathParams: {appId: ACCESS_APP_RESERVED_NAME},
+      queryParams: {owner: true},
     },
     {
       enabled:
         accessRequest.requested_group != null &&
         (!requestedGroupManager || ownRequest) &&
-        group.active_user_ownerships?.length == 0 &&
+        (groupOwnerData?.items?.length ?? 0) == 0 &&
         (accessRequest.requested_group?.type != 'app_group' || appOwnershipsArray.length == 0),
     },
   );
 
-  const accessApp = accessAppData ?? ({} as AppDetail);
-
   const accessAppOwnerships = groupBy(
-    (accessApp.active_owner_app_groups ?? [])
-      .map((appGroup: AppGroupForAppDetail) => appGroup.active_user_memberships ?? [])
-      .flat(),
+    (accessAppOwnerGroupsData?.items ?? []).map((appGroup) => appGroup.active_user_memberships ?? []).flat(),
     (m: OktaUserGroupMemberDetail) => m.active_user?.id,
   );
 

--- a/src/pages/role_requests/Read.tsx
+++ b/src/pages/role_requests/Read.tsx
@@ -298,7 +298,7 @@ export default function ReadRoleRequest() {
   const {data: groupOwnerData} = useGroupMemberDetailsById(
     {
       pathParams: {groupId: roleRequest.requested_group?.id ?? ''},
-      queryParams: {owner: true, size: 1000},
+      queryParams: {owner: true, size: 100},
     },
     {
       enabled: roleRequest.requested_group != null && (!requestedGroupManager || ownRequest),

--- a/src/pages/role_requests/Read.tsx
+++ b/src/pages/role_requests/Read.tsx
@@ -60,6 +60,8 @@ import {
   useRoleRequestById,
   useGroupById,
   useAppById,
+  useAppGroupsById,
+  useGroupMemberDetailsById,
   useRoleRequestByIdPut,
   RoleRequestByIdPutError,
   RoleRequestByIdPutVariables,
@@ -291,51 +293,54 @@ export default function ReadRoleRequest() {
     }));
   }
 
-  let ownerships = groupBy(group.active_user_ownerships, (m: OktaUserGroupMemberDetail) => m.active_user?.id);
+  // Owner/approver lists are no longer inlined on the group/app payloads; they
+  // come from the bounded owner-filtered endpoints instead.
+  const {data: groupOwnerData} = useGroupMemberDetailsById(
+    {
+      pathParams: {groupId: roleRequest.requested_group?.id ?? ''},
+      queryParams: {owner: true, size: 1000},
+    },
+    {
+      enabled: roleRequest.requested_group != null && (!requestedGroupManager || ownRequest),
+    },
+  );
+  let ownerships = groupBy(groupOwnerData?.items ?? [], (m: OktaUserGroupMemberDetail) => m.active_user?.id);
   const ownerIds = Object.keys(ownerships);
 
   // If Access admin and all group owners are blocked, add a note
   const adminNoteForBlocked = tagged && admin && ownerIds.every((v) => roleMembers.includes(v)) && ownerIds.length > 0;
 
-  const {data: appData} = useAppById(
+  const {data: appOwnerGroupsData} = useAppGroupsById(
     {
-      pathParams: {
-        appId: ((roleRequest.requested_group ?? {}) as AppGroupDetail).app?.id ?? '',
-      },
+      pathParams: {appId: ((roleRequest.requested_group ?? {}) as AppGroupDetail).app?.id ?? ''},
+      queryParams: {owner: true},
     },
     {
       enabled: roleRequest.requested_group?.type == 'app_group' && (!requestedGroupManager || ownRequest),
     },
   );
 
-  const app = appData ?? ({} as AppDetail);
-
-  const appOwnershipsArray = (app.active_owner_app_groups ?? [])
-    .map((appGroup: AppGroupForAppDetail) => appGroup.active_user_ownerships ?? [])
+  const appOwnershipsArray = (appOwnerGroupsData?.items ?? [])
+    .map((appGroup) => appGroup.active_user_ownerships ?? [])
     .flat();
   const appOwnerships = groupBy(appOwnershipsArray, (m: OktaUserGroupMemberDetail) => m.active_user?.id);
 
-  const {data: accessAppData} = useAppById(
+  const {data: accessAppOwnerGroupsData} = useAppGroupsById(
     {
-      pathParams: {
-        appId: ACCESS_APP_RESERVED_NAME,
-      },
+      pathParams: {appId: ACCESS_APP_RESERVED_NAME},
+      queryParams: {owner: true},
     },
     {
       enabled:
         roleRequest.requested_group != null &&
         (!requestedGroupManager || ownRequest) &&
-        group.active_user_ownerships?.length == 0 &&
+        (groupOwnerData?.items?.length ?? 0) == 0 &&
         (roleRequest.requested_group?.type != 'app_group' || appOwnershipsArray.length == 0),
     },
   );
 
-  const accessApp = accessAppData ?? ({} as AppDetail);
-
   const accessAppOwnerships = groupBy(
-    (accessApp.active_owner_app_groups ?? [])
-      .map((appGroup: AppGroupForAppDetail) => appGroup.active_user_memberships ?? [])
-      .flat(),
+    (accessAppOwnerGroupsData?.items ?? []).map((appGroup) => appGroup.active_user_memberships ?? []).flat(),
     (m: OktaUserGroupMemberDetail) => m.active_user?.id,
   );
 

--- a/src/pages/role_requests/Read.tsx
+++ b/src/pages/role_requests/Read.tsx
@@ -320,9 +320,14 @@ export default function ReadRoleRequest() {
     },
   );
 
-  const appOwnershipsArray = (appOwnerGroupsData?.items ?? [])
-    .map((appGroup) => appGroup.active_user_ownerships ?? [])
-    .flat();
+  // App owners = owners of the app's owner group; the app-groups payload only
+  // carries counts, so fetch that group's owners explicitly.
+  const appOwnerGroupId = appOwnerGroupsData?.items?.[0]?.id ?? '';
+  const {data: appOwnerMemberData} = useGroupMemberDetailsById(
+    {pathParams: {groupId: appOwnerGroupId}, queryParams: {owner: true, size: 100}},
+    {enabled: appOwnerGroupId !== ''},
+  );
+  const appOwnershipsArray = appOwnerMemberData?.items ?? [];
   const appOwnerships = groupBy(appOwnershipsArray, (m: OktaUserGroupMemberDetail) => m.active_user?.id);
 
   const {data: accessAppOwnerGroupsData} = useAppGroupsById(
@@ -339,8 +344,14 @@ export default function ReadRoleRequest() {
     },
   );
 
+  // Final fallback approvers = members of the Access app's owner group.
+  const accessAppOwnerGroupId = accessAppOwnerGroupsData?.items?.[0]?.id ?? '';
+  const {data: accessAppOwnerMemberData} = useGroupMemberDetailsById(
+    {pathParams: {groupId: accessAppOwnerGroupId}, queryParams: {owner: false, size: 100}},
+    {enabled: accessAppOwnerGroupId !== ''},
+  );
   const accessAppOwnerships = groupBy(
-    (accessAppOwnerGroupsData?.items ?? []).map((appGroup) => appGroup.active_user_memberships ?? []).flat(),
+    accessAppOwnerMemberData?.items ?? [],
     (m: OktaUserGroupMemberDetail) => m.active_user?.id,
   );
 

--- a/src/pages/roles/AddGroups.tsx
+++ b/src/pages/roles/AddGroups.tsx
@@ -98,7 +98,7 @@ function AddGroupsDialog(props: AddGroupsDialogProps) {
   const currentUser = useCurrentUser();
 
   const currUserRoleGroupMember = (currentUser.active_group_memberships ?? []).some(
-    (membership) => membership.active_group?.id === props.group.id,
+    (membership: OktaUserGroupMemberDetail) => membership.active_group?.id === props.group.id,
   );
 
   const userOwnedNonRoleGroupIds = !isAccessAdmin(currentUser)

--- a/src/pages/roles/AddGroups.tsx
+++ b/src/pages/roles/AddGroups.tsx
@@ -97,9 +97,9 @@ function AddGroupsDialog(props: AddGroupsDialogProps) {
   const navigate = useNavigate();
   const currentUser = useCurrentUser();
 
-  const currUserRoleGroupMember =
-    props.group.active_user_memberships?.map((membership) => membership.active_user!.id).includes(currentUser.id) ??
-    false;
+  const currUserRoleGroupMember = (currentUser.active_group_memberships ?? []).some(
+    (membership) => membership.active_group?.id === props.group.id,
+  );
 
   const userOwnedNonRoleGroupIds = !isAccessAdmin(currentUser)
     ? (currentUser.active_group_ownerships ?? [])
@@ -420,8 +420,8 @@ export default function AddGroups(props: AddGroupsProps) {
 
   const isAdmin = isAccessAdmin(props.currentUser);
   const isRoleOwner = isGroupOwner(props.currentUser, props.group.id ?? '');
-  const isRoleMember = (props.group.active_user_memberships ?? []).some(
-    (membership) => membership.active_user?.id === props.currentUser.id,
+  const isRoleMember = (props.currentUser.active_group_memberships ?? []).some(
+    (membership) => membership.active_group?.id === props.group.id,
   );
 
   // The managed, non-role groups this user owns — the only groups a non-admin can add the role to.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -112,8 +112,9 @@ def test_get_app(
 
 def test_get_app_groups_paginated(client: TestClient, db: Db, user: OktaUser, url_for: Any) -> None:
     """`GET /api/apps/{app_id}/groups` returns the app's groups as a page bounded
-    to 10 per page (so an app with hundreds of groups can't materialize every
-    group's membership in one response), with each group's members still inline."""
+    to 10 per page. Members are NOT inlined — each item carries member_count /
+    owner_count, and the UI fetches members per-group from the paginated
+    member-details endpoint — so a single huge group can't bloat the response."""
     app = AppFactory.create()
     db.session.add(app)
     db.session.add(user)
@@ -145,11 +146,16 @@ def test_get_app_groups_paginated(client: TestClient, db: Db, user: OktaUser, ur
     assert data["total"] == 25
     assert data["pages"] == 3
 
-    # members stay inline on each group
+    # counts replace inline member arrays
+    assert "active_user_memberships" not in data["items"][0]
+    assert "active_user_ownerships" not in data["items"][0]
+    assert "member_count" in data["items"][0]
+    assert "owner_count" in data["items"][0]
+
     by_id = {g["id"]: g for g in data["items"]}
-    assert "active_user_memberships" in data["items"][0]
     if member_group_id in by_id:
-        assert any(m["user"]["id"] == user.id for m in by_id[member_group_id]["active_user_memberships"])
+        assert by_id[member_group_id]["member_count"] == 1
+        assert by_id[member_group_id]["owner_count"] == 0
 
 
 def test_get_app_groups_search_by_user(client: TestClient, db: Db, url_for: Any) -> None:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -22,28 +22,36 @@ from api.models import (
 )
 from api.operations import ModifyGroupUsers, ModifyRoleGroups
 from api.services import okta
-from tests.factories import AppFactory, AppGroupFactory, OktaGroupFactory
+from tests.factories import AppFactory, AppGroupFactory, OktaGroupFactory, OktaUserFactory
 
 
-def test_get_access_app_includes_owner_group(client: TestClient, db: Db, url_for: Any) -> None:
-    """The conftest seeds the built-in Access app + App-Access-Owners group.
-    Hitting /api/apps/Access must return the owner group under
-    active_owner_app_groups so the React /apps/Access page can render it."""
+def test_get_app_omits_inline_groups(client: TestClient, db: Db, url_for: Any) -> None:
+    """App detail no longer inlines its groups (and their memberships): those
+    fields are gone so the response can't materialize every group's members.
+    The React /apps page reads groups from the paginated /groups endpoint."""
     access_app_url = url_for("api-apps.app_by_id", app_id=App.ACCESS_APP_RESERVED_NAME)
     rep = client.get(access_app_url)
     assert rep.status_code == 200, rep.text
     data = rep.json()
     assert data["name"] == App.ACCESS_APP_RESERVED_NAME
-    assert "active_owner_app_groups" in data
-    assert "active_non_owner_app_groups" in data
+    assert "active_owner_app_groups" not in data
+    assert "active_non_owner_app_groups" not in data
+
+
+def test_app_groups_endpoint_returns_owner_group(client: TestClient, db: Db, url_for: Any) -> None:
+    """The conftest seeds the built-in Access app + App-Access-Owners group;
+    it must surface under the paginated /groups endpoint as an owner group."""
     expected_owner_name = (
         f"{AppGroup.APP_GROUP_NAME_PREFIX}{App.ACCESS_APP_RESERVED_NAME}"
         + f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
     )
-    owner_group_names = [g["name"] for g in data["active_owner_app_groups"]]
-    assert expected_owner_name in owner_group_names
-    # Each owner group should be type=app_group and is_owner=True
-    for g in data["active_owner_app_groups"]:
+    groups_url = url_for("api-apps.app_groups_by_id", app_id=App.ACCESS_APP_RESERVED_NAME)
+    rep = client.get(groups_url)
+    assert rep.status_code == 200, rep.text
+    items = rep.json()["items"]
+    owner_groups = [g for g in items if g["is_owner"]]
+    assert expected_owner_name in [g["name"] for g in owner_groups]
+    for g in owner_groups:
         assert g["type"] == "app_group"
         assert g["is_owner"] is True
 
@@ -100,6 +108,92 @@ def test_get_app(
     app_url = url_for("api-apps.app_by_id", app_id=role_group_id)
     rep = client.get(app_url)
     assert rep.status_code == 404
+
+
+def test_get_app_groups_paginated(client: TestClient, db: Db, user: OktaUser, url_for: Any) -> None:
+    """`GET /api/apps/{app_id}/groups` returns the app's groups as a page bounded
+    to 10 per page (so an app with hundreds of groups can't materialize every
+    group's membership in one response), with each group's members still inline."""
+    app = AppFactory.create()
+    db.session.add(app)
+    db.session.add(user)
+    db.session.commit()
+
+    groups = []
+    for _ in range(25):
+        ag = AppGroupFactory.create(app_id=app.id)
+        db.session.add(ag)
+        groups.append(ag)
+    db.session.commit()
+
+    ModifyGroupUsers(group=groups[0], members_to_add=[user.id], sync_to_okta=False).execute()
+
+    app_id = app.id
+    member_group_id = groups[0].id
+    db.session.expunge_all()
+
+    url = url_for("api-apps.app_groups_by_id", app_id=app_id)
+    rep = client.get(url)
+    assert rep.status_code == 200, rep.text
+    data = rep.json()
+
+    # fastapi-pagination wire shape
+    assert {"items", "total", "page", "size", "pages"} <= set(data.keys())
+    # bounded to 10 per page even though the app has 25 groups
+    assert data["size"] == 10
+    assert len(data["items"]) == 10
+    assert data["total"] == 25
+    assert data["pages"] == 3
+
+    # members stay inline on each group
+    by_id = {g["id"]: g for g in data["items"]}
+    assert "active_user_memberships" in data["items"][0]
+    if member_group_id in by_id:
+        assert any(m["user"]["id"] == user.id for m in by_id[member_group_id]["active_user_memberships"])
+
+
+def test_get_app_groups_search_by_user(client: TestClient, db: Db, url_for: Any) -> None:
+    """`?q=` returns only the app's groups containing a member matching the
+    query by name/email, computed server-side (the app page's user search)."""
+    app = AppFactory.create()
+    db.session.add(app)
+    db.session.commit()
+    group_a = AppGroupFactory.create(app_id=app.id)
+    group_b = AppGroupFactory.create(app_id=app.id)
+    db.session.add_all([group_a, group_b])
+    alice = OktaUserFactory.create(first_name="Alice", last_name="Xeno", email="alice.xeno@example.com")
+    bob = OktaUserFactory.create(first_name="Bob", last_name="Yon", email="bob.yon@example.com")
+    db.session.add_all([alice, bob])
+    db.session.commit()
+    ModifyGroupUsers(group=group_a, members_to_add=[alice.id], sync_to_okta=False).execute()
+    ModifyGroupUsers(group=group_b, members_to_add=[bob.id], sync_to_okta=False).execute()
+
+    app_id = app.id
+    group_a_id = group_a.id
+    db.session.expunge_all()
+
+    url = url_for("api-apps.app_groups_by_id", app_id=app_id)
+    rep = client.get(url, params={"q": "alice"})
+    assert rep.status_code == 200, rep.text
+    ids = [g["id"] for g in rep.json()["items"]]
+    assert ids == [group_a_id]
+
+    rep = client.get(url, params={"q": "bob.yon@example.com"})
+    assert [g["id"] for g in rep.json()["items"]] == [group_b.id]
+
+
+def test_get_app_groups_size_capped_at_10(client: TestClient, db: Db, url_for: Any) -> None:
+    """Requesting more than 10 per page is rejected so the bound can't be opted out of."""
+    app = AppFactory.create()
+    db.session.add(app)
+    db.session.commit()
+    app_id = app.id
+    db.session.expunge_all()
+
+    url = url_for("api-apps.app_groups_by_id", app_id=app_id)
+    rep = client.get(url, params={"size": 20})
+    assert rep.status_code == 400, rep.text
+    assert "size" in rep.text
 
 
 def test_put_app(

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1720,3 +1720,103 @@ def test_role_list_excludes_role_association_mappings(
     assert "active_role_associated_group_member_mappings" not in matched
     assert "active_role_associated_group_owner_mappings" not in matched
     assert "active_group_tags" not in matched
+
+
+def test_get_group_member_details_paginated(client: TestClient, db: Db, url_for: Any) -> None:
+    """`GET /api/groups/{id}/member-details` returns full member rows paginated,
+    so the group page can page members instead of inlining all of them. `owner`
+    filters members vs owners."""
+    group = OktaGroupFactory.create()
+    db.session.add(group)
+    db.session.commit()
+
+    members = OktaUserFactory.create_batch(60)
+    owner = OktaUserFactory.create()
+    for u in members + [owner]:
+        db.session.add(u)
+    db.session.commit()
+
+    ModifyGroupUsers(
+        group=group,
+        members_to_add=[u.id for u in members],
+        owners_to_add=[owner.id],
+        sync_to_okta=False,
+    ).execute()
+
+    group_id = group.id
+    owner_id = owner.id
+    db.session.expunge_all()
+
+    url = url_for("api-groups.group_member_details_by_id", group_id=group_id)
+
+    rep = client.get(url)
+    assert rep.status_code == 200, rep.text
+    data = rep.json()
+    assert {"items", "total", "page", "size", "pages"} <= set(data.keys())
+    assert data["total"] == 61
+    assert len(data["items"]) == 50  # default page size
+    assert "user" in data["items"][0]
+
+    rep = client.get(url, params={"owner": "true"})
+    assert rep.status_code == 200, rep.text
+    data = rep.json()
+    assert data["total"] == 1
+    assert data["items"][0]["is_owner"] is True
+    assert data["items"][0]["user"]["id"] == owner_id
+
+
+def test_get_group_omits_inline_members(client: TestClient, db: Db, url_for: Any) -> None:
+    """`GET /api/groups/{id}` no longer inlines its members; the group page
+    pages them via the member-details endpoint instead, so the detail response
+    can't materialize an unbounded member list."""
+    group = OktaGroupFactory.create()
+    db.session.add(group)
+    db.session.commit()
+    member = OktaUserFactory.create()
+    db.session.add(member)
+    db.session.commit()
+    ModifyGroupUsers(group=group, members_to_add=[member.id], sync_to_okta=False).execute()
+
+    group_id = group.id
+    db.session.expunge_all()
+
+    rep = client.get(url_for("api-groups.group_by_id", group_id=group_id))
+    assert rep.status_code == 200, rep.text
+    data = rep.json()
+    assert "active_user_memberships" not in data
+    assert "active_user_ownerships" not in data
+
+    rep2 = client.get(url_for("api-groups.group_member_details_by_id", group_id=group_id))
+    assert rep2.status_code == 200, rep2.text
+    assert rep2.json()["total"] == 1
+
+
+def test_group_member_details_counts_users_not_rows(client: TestClient, db: Db, url_for: Any) -> None:
+    """A user holding both a direct and a role-granted membership in a group is a
+    single member: member-details pages by distinct user, so total counts the
+    user once and both of their rows land on the same page."""
+    group = OktaGroupFactory.create()
+    role = RoleGroupFactory.create()
+    user = OktaUserFactory.create()
+    db.session.add_all([group, role, user])
+    db.session.commit()
+
+    # Direct membership in the group.
+    ModifyGroupUsers(group=group, members_to_add=[user.id], sync_to_okta=False).execute()
+    # Role-granted membership: user is in the role, role is a member of the group.
+    ModifyGroupUsers(group=role, members_to_add=[user.id], sync_to_okta=False).execute()
+    ModifyRoleGroups(role_group=role, groups_to_add=[group.id], sync_to_okta=False).execute()
+
+    group_id = group.id
+    user_id = user.id
+    db.session.expunge_all()
+
+    url = url_for("api-groups.group_member_details_by_id", group_id=group_id)
+    rep = client.get(url, params={"owner": "false"})
+    assert rep.status_code == 200, rep.text
+    data = rep.json()
+    # One distinct member user, even though they hold two active membership rows.
+    assert data["total"] == 1
+    # Both rows are returned so the UI can render direct + via-role chips.
+    rows = [r for r in data["items"] if r.get("active_user") and r["active_user"]["id"] == user_id]
+    assert len(rows) == 2

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1730,8 +1730,11 @@ def test_get_group_member_details_paginated(client: TestClient, db: Db, url_for:
     db.session.add(group)
     db.session.commit()
 
-    members = OktaUserFactory.create_batch(60)
-    owner = OktaUserFactory.create()
+    # Explicit, unique emails: the factory derives email from random Faker
+    # names, so 60+ users can collide and trip the okta_user.email UNIQUE
+    # constraint (flaky). Index-based emails make this deterministic.
+    members = [OktaUserFactory.create(email=f"member-{i:03d}@example.com") for i in range(60)]
+    owner = OktaUserFactory.create(email="owner@example.com")
     for u in members + [owner]:
         db.session.add(u)
     db.session.commit()


### PR DESCRIPTION
## Summary

If an app within `/api/apps` has an excessive number of groups or excessive number of users in groups (e.g., 1,000 groups each with 5 members, 5 groups with 1,000+ members, etc), the ORM graph loaded in memory is unbounded leading to OOMKilled errors. 

This issue is unbounded and scales with the number of groups, or inlined members nested within those groups.

This PR adds two things:
1. a hard 10 groups per-page limit for apps
2. pagination for inline members of groups within apps from `/api/apps/<App-Name>`

This PR also *changes* the behavior for search. Before, search ran client-side on keystroke since all groups/users were rendered and returned at once. After this PR lands, search runs server-side on submit.

## Edge Cases

There are corner cases where even the 10 groups within a single page returned from `/api/apps/<App-Name>` can still cause memory bloat. A fix is to paginate the inline members within the groups within `/api/apps/<App-Name>` to reduce the memory footprint.

The members are the main memory amplification factor so I've added inline member pagination within the group accordions.

## Testing and Validation

App group pagination (infinite scroll), inline member pagination and search:


https://github.com/user-attachments/assets/79ec11ab-b772-4826-9ce0-f4ec28340047


Tests: 552 passed