### PR TITLE
fix: reuse a process-wide singleton Cloud SQL Connector

### DIFF
--- a/api/extensions.py
+++ b/api/extensions.py
@@ -15,6 +15,7 @@ sets and clears this var per request.
 from __future__ import annotations
 
 import contextvars
+import threading
 from typing import Any, Callable, Optional
 
 from google.cloud.sql.connector import Connector, IPTypes
@@ -134,23 +135,53 @@ db = _DB()
 Db = _DB
 
 
+# Process-wide singleton Connector, shared by every engine/creator for the
+# life of the worker. The Connector owns a background event loop + aiohttp
+# session and a RefreshAheadCache that renews the ephemeral client cert ahead
+# of expiry, and it caches connection info per (instance, enable_iam_auth)
+# internally — so a single instance serves every Cloud SQL target.
+#
+# The previous `with Connector()` built and closed one *per connection*, which
+# (a) tore the loop/session down while the background cert refresh to
+# sqladmin.googleapis.com was still in flight — racing it and surfacing
+# ServerDisconnectedError / "Task pending" errors — and (b) gave every
+# connection a fresh empty cache, defeating the refresh-ahead design.
+_connector: Optional[Connector] = None
+_connector_lock = threading.Lock()
+
+
+def _get_connector() -> Connector:
+    """Return the process-wide Connector, building it on first use.
+
+    Built lazily (double-checked lock; the SQLAlchemy pool may call the creator
+    from multiple threads) so the Connector's background thread is spawned
+    inside the worker process, after any gunicorn fork — a thread created in a
+    preloaded master would not survive fork() and the loop would be dead in the
+    workers.
+    """
+    global _connector
+    if _connector is None:
+        with _connector_lock:
+            if _connector is None:
+                _connector = Connector()
+    return _connector
+
+
 def get_cloudsql_conn(
     cloudsql_connection_name: str,
     db_user: Optional[str] = "root",
     db_name: Optional[str] = "access",
     uses_public_ip: Optional[bool] = False,
-) -> Callable[[], Connector]:
-    def _get_conn() -> Connector:
-        with Connector() as connector:
-            conn = connector.connect(
-                cloudsql_connection_name,
-                "pg8000",
-                user=db_user,
-                db=db_name,
-                ip_type=IPTypes.PUBLIC if uses_public_ip else IPTypes.PRIVATE,
-                enable_iam_auth=True,
-            )
-            return conn
+) -> Callable[[], Any]:
+    def _get_conn() -> Any:
+        return _get_connector().connect(
+            cloudsql_connection_name,
+            "pg8000",
+            user=db_user,
+            db=db_name,
+            ip_type=IPTypes.PUBLIC if uses_public_ip else IPTypes.PRIVATE,
+            enable_iam_auth=True,
+        )
 
     return _get_conn
 


### PR DESCRIPTION
# Summary
Reuse a process-wide singleton Cloud SQL `Connector` for all DB connections instead of building and tearing one down per connection. This eliminates the `ServerDisconnectedError` / `RuntimeError: Task pending` noise coming from the connector's background certificate refresh.
**Urgency**: ~5 days (noisy alerting, not user-facing)
**Expected review effort**: MEDIUM — small diff, but the reasoning (fork-safety, thread-safety, single-loop model) warrants a careful read.

# Motivation
`get_cloudsql_conn` wrapped each connection in `with Connector(): connector.connect(...)`, so SQLAlchemy's pool built a brand-new `Connector` for **every** physical connection and `close()`d it the instant `.connect()` returned. The `Connector` owns a private background event loop + aiohttp session and a `RefreshAheadCache` that renews the ephemeral client cert ahead of expiry. Closing it per-connection:

1. **Raced the teardown against the in-flight cert refresh.** `close()` stops the loop / closes the aiohttp session while the background refresh's request to `sqladmin.googleapis.com` may still be resolving DNS or reading — surfacing `RuntimeError: Task <… TCPConnector._resolve_host …> … Future exception was never retrieved` (Sentry `ACCESS-FASTAPI-G`/`-H`) and the transient `ServerDisconnectedError` reraised on the fire-and-forget refresh task (`ACCESS-FASTAPI-8`).
2. **Defeated the refresh cache** — every connection got a fresh empty cache and re-fetched the cert, multiplying Admin API round-trips (and thus exposure to transient disconnects).

These were dormant under Flask (serial WSGI workers rarely overlapped a refresh) and began firing under FastAPI's threadpool concurrency, amplified by the larger pool + 30-min recycle from #496. A shared singleton `Connector` is the connector's documented usage and removes both failure modes.

# Description of Changes
- `api/extensions.py`: introduce a **module-level, process-wide singleton** `Connector` (`_connector` + `_get_connector()`), and have `get_cloudsql_conn`'s creator use it instead of `with Connector()` per call.
  - **Process-wide**, not closure-local: one Connector for the whole worker regardless of how many engines/creators are built (the Connector caches connection info per `(instance, enable_iam_auth)` internally, so a single instance serves any target).
  - **Lazy** (built on first `connect()`) so the connector's background thread is created inside the worker process, *after* any gunicorn fork — a thread created in a preloaded master would not survive `fork()`. (The deploy currently runs without `--preload`, but lazy init makes it robust either way.)
  - **Double-checked `threading.Lock`** guards construction only, because the pool may invoke the creator from multiple uvicorn threadpool threads concurrently. After construction, the sync `connect()` funnels all work onto the connector's single internal loop via `run_coroutine_threadsafe`, so no further locking is needed and no cross-loop race is introduced.

# Validation of Changes
- `ruff check` / `ruff format --check`: clean.
- `python -m py_compile api/extensions.py`: passes.
- `pytest tests/test_concurrency_config.py tests/test_oidc.py`: 46 passed — includes `test_build_engine_applies_pool_settings`, which exercises the CloudSQL `creator` path through `build_engine`.
- The CloudSQL connect path itself has no unit coverage (tests use sqlite-in-memory), so end-to-end behavior should be confirmed against staging: deploy and verify `ACCESS-FASTAPI-8/-G/-H` stop recurring.

# Guidance for Reviewers
Single file. The load-bearing decisions to sanity-check: (1) module-level singleton lifetime, (2) lazy init for fork-safety, (3) the double-checked lock only guards construction, (4) we keep the **sync** `connect()` (not `connect_async`) so all async work stays on the connector's own loop — no app-loop sharing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
