### PR TITLE
Plugin group config in group requests

### DIFF
--- a/api/models/core_models.py
+++ b/api/models/core_models.py
@@ -974,6 +974,18 @@ class GroupRequest(Base):
         default=list,
         server_default="[]",
     )
+    # Plugin group config supplied with the request, in the same shape as a
+    # group's plugin_data: {plugin_id: {configuration: {...}}}. No status is
+    # stored -- the lifecycle hook populates that after the group is created.
+    requested_plugin_data: Mapped[Dict[str, Any]] = mapped_column(
+        mutable_json_type(
+            dbtype=JSON().with_variant(JSONB, "postgresql"),
+            nested=True,
+        ),
+        nullable=False,
+        default=dict,
+        server_default="{}",
+    )
     # Will also be used to populate owner access reason field
     request_reason: Mapped[str] = mapped_column(Unicode(1024), nullable=False, default="")
 
@@ -994,6 +1006,17 @@ class GroupRequest(Base):
         nullable=False,
         default=list,
         server_default="[]",
+    )
+    # Resolver-editable copy of the plugin config; applied (falling back to
+    # requested_plugin_data) to the AppGroup created on approval.
+    resolved_plugin_data: Mapped[Dict[str, Any]] = mapped_column(
+        mutable_json_type(
+            dbtype=JSON().with_variant(JSONB, "postgresql"),
+            nested=True,
+        ),
+        nullable=False,
+        default=dict,
+        server_default="{}",
     )
     resolution_reason: Mapped[str] = mapped_column(Unicode(1024), nullable=False, default="")
 

--- a/api/operations/approve_group_request.py
+++ b/api/operations/approve_group_request.py
@@ -10,6 +10,7 @@ from api.exceptions import ConflictError
 from api.extensions import db
 from api.models import (
     AccessRequestStatus,
+    App,
     AppGroup,
     GroupRequest,
     OktaGroup,
@@ -118,6 +119,11 @@ class ApproveGroupRequest:
             if group_request.resolved_group_tags
             else group_request.requested_group_tags
         )
+        resolved_plugin_data = (
+            group_request.resolved_plugin_data
+            if group_request.resolved_plugin_data
+            else group_request.requested_plugin_data
+        )
 
         # authorization
         access_owner_ids = {u.id for u in await get_access_owners()}
@@ -206,6 +212,24 @@ class ApproveGroupRequest:
                 description=resolved_description,
                 app_id=resolved_app_id,
             )
+            # Carry the request's plugin config onto the group so the
+            # group_created hook (fired inside CreateGroup) sees it. Re-validate
+            # defensively: the app or its config may have changed since filing.
+            if resolved_plugin_data:
+                resolved_app = await db.session.get(App, resolved_app_id)
+                plugin_id = resolved_app.app_group_lifecycle_plugin if resolved_app is not None else None
+                if plugin_id is not None:
+                    from api.plugins.app_group_lifecycle import (
+                        validate_app_group_lifecycle_plugin_group_config,
+                    )
+
+                    plugin_errors = validate_app_group_lifecycle_plugin_group_config(
+                        resolved_plugin_data,
+                        plugin_id,
+                    )
+                    if plugin_errors:
+                        raise ValueError(f"plugin_data: {plugin_errors}")
+                    new_group.plugin_data = resolved_plugin_data
         else:
             new_group = OktaGroup(
                 name=resolved_name,

--- a/api/operations/approve_group_request.py
+++ b/api/operations/approve_group_request.py
@@ -1,11 +1,11 @@
+import copy
+import logging
 from typing import Optional
 
-import logging
-
-from api.context import get_request_context
 from sqlalchemy import func, select
 from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload, with_polymorphic
 
+from api.context import get_request_context
 from api.exceptions import ConflictError
 from api.extensions import db
 from api.models import (
@@ -23,12 +23,14 @@ from api.models import (
 from api.models.access_request import get_all_possible_request_approvers
 from api.models.app_group import get_access_owners
 from api.models.tag import coalesce_ended_at
+from api.operations._fan_out import defer_notification
 from api.operations.constraints.check_for_self_add import CheckForSelfAdd
 from api.operations.create_group import CreateGroup
 from api.operations.modify_group_users import ModifyGroupUsers
-from api.operations._fan_out import defer_notification
 from api.plugins import NotificationHook
 from api.schemas import AuditLogSchema, EventType
+
+logger = logging.getLogger(__name__)
 
 
 class ApproveGroupRequest:
@@ -229,7 +231,17 @@ class ApproveGroupRequest:
                     )
                     if plugin_errors:
                         raise ValueError(f"plugin_data: {plugin_errors}")
-                    new_group.plugin_data = resolved_plugin_data
+                    # Deep-copy so the created group and the persisted request
+                    # don't share nested plugin_data objects: the group_created
+                    # hook may mutate the group's copy (e.g. writing status),
+                    # which must not leak back into the immutable request record.
+                    new_group.plugin_data = copy.deepcopy(resolved_plugin_data)
+                else:
+                    logger.warning(
+                        f"Group request {group_request.id} carried plugin_data, "
+                        f"but app {resolved_app_id} has no app_group_lifecycle_plugin; "
+                        "dropping the supplied config."
+                    )
         else:
             new_group = OktaGroup(
                 name=resolved_name,

--- a/api/operations/approve_group_request.py
+++ b/api/operations/approve_group_request.py
@@ -1,6 +1,6 @@
 import copy
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload, with_polymorphic
@@ -162,6 +162,7 @@ class ApproveGroupRequest:
             if not is_admin:
                 return group_request
 
+        # Validation
         if resolved_type != "app_group" and resolved_name.startswith(AppGroup.APP_GROUP_NAME_PREFIX):
             return group_request
 
@@ -182,6 +183,38 @@ class ApproveGroupRequest:
         ).first()
         if existing_group is not None:
             return group_request
+
+        # Resolve the plugin config the new group will carry, and re-validate it here
+        # with the rest of the validation: the app or its plugin config may have
+        # changed since the request was filed, so this can legitimately fail. Raising
+        # after the group_request_approve audit event below would leave an "approved"
+        # audit entry for an approval that never completed — re-emitted on every retry.
+        new_group_plugin_data: dict[str, Any] = {}
+        if resolved_type == "app_group" and resolved_plugin_data:
+            resolved_app = await db.session.get(App, resolved_app_id)
+            plugin_id = resolved_app.app_group_lifecycle_plugin if resolved_app is not None else None
+            if plugin_id is None:
+                logger.warning(
+                    f"Group request {group_request.id} carried plugin_data, "
+                    f"but app {resolved_app_id} has no app_group_lifecycle_plugin; "
+                    "dropping the supplied config."
+                )
+            else:
+                from api.plugins.app_group_lifecycle import (
+                    validate_app_group_lifecycle_plugin_group_config,
+                )
+
+                plugin_errors = validate_app_group_lifecycle_plugin_group_config(
+                    resolved_plugin_data,
+                    plugin_id,
+                )
+                if plugin_errors:
+                    raise ValueError(f"plugin_data: {plugin_errors}")
+                # Deep-copy so the created group and the persisted request don't share
+                # nested plugin_data objects: the group_created hook may mutate the
+                # group's copy (e.g. writing status), which must not leak back into the
+                # immutable request record.
+                new_group_plugin_data = copy.deepcopy(resolved_plugin_data)
 
         await db.session.commit()
 
@@ -214,34 +247,10 @@ class ApproveGroupRequest:
                 description=resolved_description,
                 app_id=resolved_app_id,
             )
-            # Carry the request's plugin config onto the group so the
-            # group_created hook (fired inside CreateGroup) sees it. Re-validate
-            # defensively: the app or its config may have changed since filing.
-            if resolved_plugin_data:
-                resolved_app = await db.session.get(App, resolved_app_id)
-                plugin_id = resolved_app.app_group_lifecycle_plugin if resolved_app is not None else None
-                if plugin_id is not None:
-                    from api.plugins.app_group_lifecycle import (
-                        validate_app_group_lifecycle_plugin_group_config,
-                    )
-
-                    plugin_errors = validate_app_group_lifecycle_plugin_group_config(
-                        resolved_plugin_data,
-                        plugin_id,
-                    )
-                    if plugin_errors:
-                        raise ValueError(f"plugin_data: {plugin_errors}")
-                    # Deep-copy so the created group and the persisted request
-                    # don't share nested plugin_data objects: the group_created
-                    # hook may mutate the group's copy (e.g. writing status),
-                    # which must not leak back into the immutable request record.
-                    new_group.plugin_data = copy.deepcopy(resolved_plugin_data)
-                else:
-                    logger.warning(
-                        f"Group request {group_request.id} carried plugin_data, "
-                        f"but app {resolved_app_id} has no app_group_lifecycle_plugin; "
-                        "dropping the supplied config."
-                    )
+            # Carry the config resolved and validated above onto the group so the
+            # group_created hook (fired inside CreateGroup) sees it.
+            if new_group_plugin_data:
+                new_group.plugin_data = new_group_plugin_data
         else:
             new_group = OktaGroup(
                 name=resolved_name,

--- a/api/operations/create_group_request.py
+++ b/api/operations/create_group_request.py
@@ -39,6 +39,7 @@ class CreateGroupRequest:
         requested_group_tags: Optional[List[str]] = None,
         requested_ownership_ending_at: Optional[datetime] = None,
         request_reason: str = "",
+        requested_plugin_data: Optional[dict] = None,
     ):
         self.id = self.__generate_id()
 
@@ -51,6 +52,7 @@ class CreateGroupRequest:
         self.requested_group_tags = requested_group_tags if requested_group_tags is not None else []
         self.requested_ownership_ending_at = requested_ownership_ending_at
         self.request_reason = request_reason
+        self.requested_plugin_data = requested_plugin_data if requested_plugin_data is not None else {}
 
     async def execute(self) -> Optional[GroupRequest]:
         requester = await db.session.get(OktaUser, self.requester_user_id)
@@ -129,6 +131,7 @@ class CreateGroupRequest:
             requested_group_tags=self.requested_group_tags,
             requested_ownership_ending_at=coalesced_ownership_ending_at,
             request_reason=self.request_reason,
+            requested_plugin_data=self.requested_plugin_data,
         )
 
         db.session.add(group_request)

--- a/api/plugins/app_group_lifecycle.py
+++ b/api/plugins/app_group_lifecycle.py
@@ -1,9 +1,10 @@
 import logging
 from dataclasses import asdict, dataclass
 from enum import StrEnum
-from typing import Any, Literal
+from typing import Any, Literal, NoReturn
 
 import pluggy
+from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.extensions import db
@@ -692,6 +693,76 @@ def validate_app_group_lifecycle_plugin_group_config(
                 errors.pop(name, None)
 
     return errors
+
+
+def raise_http_for_plugin_filtering_error(error: AppGroupLifecyclePluginFilteringError) -> NoReturn:
+    """Map a hook-filtering failure onto the right HTTP status; never returns.
+
+    `AppGroupLifecyclePluginFilteringError` covers two very different situations, and the
+    caller cannot be told the same thing about both:
+
+    - the id names no registered plugin, which is bad client input or stale app config
+      (e.g. an operator dropped a plugin while apps still referenced its id) -> **400**;
+    - the id *is* registered but its hook did not answer with exactly one response, which
+      is a server-side misconfiguration -> **500**, an explicit one naming the plugin
+      rather than letting the plain Exception become an unhandled stack trace.
+
+    Use this from any router that can see this error, whether raised by a validation
+    helper below or propagated out of an operation."""
+    if error.plugin_id not in [plugin.id for plugin in get_app_group_lifecycle_plugins()]:
+        raise HTTPException(400, f"The plugin {error.plugin_id} is not known")
+    raise HTTPException(500, f"Misconfigured app group lifecycle plugin '{error.plugin_id}': {error}") from error
+
+
+def validate_group_plugin_config_or_raise(
+    plugin_data: dict[str, Any],
+    app_plugin_data: dict[str, Any],
+    plugin_id: str | None,
+    old_plugin_data: dict[str, Any] | None = None,
+) -> None:
+    """Validate group-level plugin_data against the configured plugin's schema, raising
+    an HTTP error on invalid config. No-op when the app has no app group lifecycle plugin.
+
+    Shared by every router that accepts group plugin config -- group create/update and
+    app-group requests -- so they answer identically for the same bad input. Callers
+    resolve the plugin id and the owning app's plugin_data themselves, since each obtains
+    them differently (a freshly-built group can't lazy-load its app, and a group request
+    has no group yet). Callers editing an existing group also pass its current
+    plugin_data as `old_plugin_data` so the host can reject changes to immutable config
+    fields; omit it when the group does not exist yet."""
+    if plugin_id is None:
+        return
+
+    try:
+        errors = validate_app_group_lifecycle_plugin_group_config(
+            plugin_data, plugin_id, app_plugin_data, old_plugin_data=old_plugin_data
+        )
+    except ValueError as e:
+        raise HTTPException(400, f"plugin_data: {e}") from e
+    except AppGroupLifecyclePluginFilteringError as e:
+        raise_http_for_plugin_filtering_error(e)
+    if errors:
+        raise HTTPException(400, f"plugin_data: {errors}")
+
+
+def validate_app_plugin_config_or_raise(plugin_data: dict[str, Any], plugin_id: str | None) -> None:
+    """Validate app-level plugin_data against the configured plugin's schema, raising an
+    HTTP error on invalid config. No-op when no app group lifecycle plugin is configured.
+
+    The app-level counterpart of `validate_group_plugin_config_or_raise`. It takes no
+    app-context or `old_plugin_data` arguments: app config has no parent to validate
+    against, and immutable app config properties are not a concept the hook exposes."""
+    if plugin_id is None:
+        return
+
+    try:
+        errors = validate_app_group_lifecycle_plugin_app_config(plugin_data, plugin_id)
+    except ValueError as e:
+        raise HTTPException(400, f"plugin_data: {e}") from e
+    except AppGroupLifecyclePluginFilteringError as e:
+        raise_http_for_plugin_filtering_error(e)
+    if errors:
+        raise HTTPException(400, f"plugin_data: {errors}")
 
 
 def get_app_group_lifecycle_plugin_app_status_properties(

--- a/api/routers/apps.py
+++ b/api/routers/apps.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Annotated, Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-
+from fastapi_pagination.ext.sqlalchemy import apaginate
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import joinedload, selectinload
 from starlette.requests import Request
@@ -24,20 +24,17 @@ from api.models import (
     OktaUser,
     OktaUserGroupMember,
 )
-from fastapi_pagination.ext.sqlalchemy import apaginate
-
 from api.pagination import AppGroupsPage, Page, validated
 from api.routers._fan_out import defer_fan_out
 from api.schemas import (
-    AppSummary,
     AppDetail,
     AppGroupForAppDetail,
+    AppSummary,
     CreateAppBody,
     DeleteMessage,
     SearchAppQuery,
     UpdateAppBody,
 )
-
 
 APP_LOAD_OPTIONS = (
     selectinload(App.active_app_tags).options(
@@ -165,7 +162,8 @@ async def post_app(
     db: DbSession,
     current_user_id: str = Depends(require_access_admin_or_app_creator),
 ) -> AppDetail:
-    from api.models import AppGroup as _AppGroup, OktaUser, RoleGroup
+    from api.models import AppGroup as _AppGroup
+    from api.models import OktaUser, RoleGroup
     from api.operations import CreateApp
     from api.operations.create_group import GroupDict
 
@@ -282,12 +280,7 @@ async def put_app(
     from api.models import AppGroup as _AppGroup
     from api.models.app_group import app_owners_group_description
     from api.operations import ModifyAppTags, ModifyGroupDetails
-    from api.plugins.app_group_lifecycle import merge_app_lifecycle_plugin_data
-
-    from api.plugins.app_group_lifecycle import (
-        AppGroupLifecyclePluginFilteringError,
-        validate_app_group_lifecycle_plugin_app_config,
-    )
+    from api.plugins.app_group_lifecycle import merge_app_lifecycle_plugin_data, validate_app_plugin_config_or_raise
 
     fields_set = body.model_fields_set
     description = (body.description if body.description is not None else "") if "description" in fields_set else None
@@ -302,17 +295,8 @@ async def put_app(
         if "app_group_lifecycle_plugin" in fields_set
         else app_obj.app_group_lifecycle_plugin
     )
-    if "plugin_data" in fields_set and new_plugin_id is not None:
-        try:
-            errors = validate_app_group_lifecycle_plugin_app_config(body.plugin_data or {}, new_plugin_id)
-        # AppGroupLifecyclePluginFilteringError (not a ValueError) is raised when
-        # new_plugin_id names a plugin that isn't registered in this deployment,
-        # whether it came from the body or from the app's stored config. Bad input
-        # either way, so a 400 rather than an uncaught 500.
-        except (ValueError, AppGroupLifecyclePluginFilteringError) as e:
-            raise HTTPException(400, f"plugin_data: {e}") from e
-        if errors:
-            raise HTTPException(400, f"plugin_data: {errors}")
+    if "plugin_data" in fields_set:
+        validate_app_plugin_config_or_raise(body.plugin_data or {}, new_plugin_id)
 
     # Plugin config changes require access admin.
     new_plugin = (
@@ -421,10 +405,11 @@ async def put_app(
     ) or old_plugin_data_for_audit_pre != (refreshed.plugin_data or {})
 
     if name_changed or plugin_changed:
+        import logging as _logging
+
         from api.context import get_request_context
         from api.models import OktaUser
         from api.schemas import AuditLogSchema, EventType
-        import logging as _logging
 
         _ctx = get_request_context()
         email = getattr(await db.get(OktaUser, current_user_id), "email", None) if current_user_id is not None else None

--- a/api/routers/apps.py
+++ b/api/routers/apps.py
@@ -284,7 +284,10 @@ async def put_app(
     from api.operations import ModifyAppTags, ModifyGroupDetails
     from api.plugins.app_group_lifecycle import merge_app_lifecycle_plugin_data
 
-    from api.plugins.app_group_lifecycle import validate_app_group_lifecycle_plugin_app_config
+    from api.plugins.app_group_lifecycle import (
+        AppGroupLifecyclePluginFilteringError,
+        validate_app_group_lifecycle_plugin_app_config,
+    )
 
     fields_set = body.model_fields_set
     description = (body.description if body.description is not None else "") if "description" in fields_set else None
@@ -302,7 +305,11 @@ async def put_app(
     if "plugin_data" in fields_set and new_plugin_id is not None:
         try:
             errors = validate_app_group_lifecycle_plugin_app_config(body.plugin_data or {}, new_plugin_id)
-        except ValueError as e:
+        # AppGroupLifecyclePluginFilteringError (not a ValueError) is raised when
+        # new_plugin_id names a plugin that isn't registered in this deployment,
+        # whether it came from the body or from the app's stored config. Bad input
+        # either way, so a 400 rather than an uncaught 500.
+        except (ValueError, AppGroupLifecyclePluginFilteringError) as e:
             raise HTTPException(400, f"plugin_data: {e}") from e
         if errors:
             raise HTTPException(400, f"plugin_data: {errors}")

--- a/api/routers/group_requests.py
+++ b/api/routers/group_requests.py
@@ -185,6 +185,22 @@ async def post_group_request(
         if app is None:
             raise HTTPException(404, "App not found")
 
+        # Validate any supplied plugin group config against the app's lifecycle
+        # plugin. A request describes a not-yet-created group, so immutable
+        # fields stay freely settable (no old-config comparison here).
+        if app.app_group_lifecycle_plugin is not None:
+            from api.plugins.app_group_lifecycle import validate_app_group_lifecycle_plugin_group_config
+
+            try:
+                plugin_errors = validate_app_group_lifecycle_plugin_group_config(
+                    body.requested_plugin_data,
+                    app.app_group_lifecycle_plugin,
+                )
+            except ValueError as e:
+                raise HTTPException(400, f"plugin_data: {e}") from e
+            if plugin_errors:
+                raise HTTPException(400, f"plugin_data: {plugin_errors}")
+
     # Every requested tag id must resolve to a non-deleted tag.
     if body.requested_group_tags:
         tags = (
@@ -222,6 +238,7 @@ async def post_group_request(
         requested_group_tags=body.requested_group_tags,
         requested_ownership_ending_at=body.requested_ownership_ending_at,
         request_reason=body.request_reason or "",
+        requested_plugin_data=body.requested_plugin_data if isinstance(body, _AppGroupRequestBody) else {},
     ).execute()
     if gr is None:
         raise HTTPException(400, "Failed to create group request")
@@ -289,6 +306,8 @@ async def put_group_request(
         gr.resolved_group_tags = body.resolved_group_tags
     if body.resolved_ownership_ending_at is not None:
         gr.resolved_ownership_ending_at = body.resolved_ownership_ending_at
+    if body.resolved_plugin_data is not None:
+        gr.resolved_plugin_data = body.resolved_plugin_data
 
     await db.commit()
 

--- a/api/routers/group_requests.py
+++ b/api/routers/group_requests.py
@@ -15,7 +15,11 @@ from api.database import DbSession
 from api.models import AccessRequestStatus, App, GroupRequest, OktaUser, Tag
 from api.operations import ApproveGroupRequest, CreateGroupRequest, RejectGroupRequest
 from api.pagination import Page, validated
-from api.plugins.app_group_lifecycle import AppGroupLifecyclePluginFilteringError
+from api.plugins.app_group_lifecycle import (
+    AppGroupLifecyclePluginFilteringError,
+    raise_http_for_plugin_filtering_error,
+    validate_group_plugin_config_or_raise,
+)
 from api.routers._fan_out import defer_fan_out
 from api.schemas import (
     CreateGroupRequestBody,
@@ -186,24 +190,15 @@ async def post_group_request(
         if app is None:
             raise HTTPException(404, "App not found")
 
-        # Validate any supplied plugin group config against the app's lifecycle
-        # plugin. A request describes a not-yet-created group, so immutable
-        # fields stay freely settable (no old-config comparison here).
-        if app.app_group_lifecycle_plugin is not None:
-            from api.plugins.app_group_lifecycle import validate_app_group_lifecycle_plugin_group_config
-
-            try:
-                plugin_errors = validate_app_group_lifecycle_plugin_group_config(
-                    body.requested_plugin_data,
-                    app.app_group_lifecycle_plugin,
-                )
-            # AppGroupLifecyclePluginFilteringError (not a ValueError) is raised when
-            # the app names a plugin id that isn't registered in this deployment — an
-            # operator misconfiguration, so a 400 rather than an uncaught 500.
-            except (ValueError, AppGroupLifecyclePluginFilteringError) as e:
-                raise HTTPException(400, f"plugin_data: {e}") from e
-            if plugin_errors:
-                raise HTTPException(400, f"plugin_data: {plugin_errors}")
+        # Validate any supplied plugin group config against the app's lifecycle plugin,
+        # through the same helper the group create/update endpoints use. `old_plugin_data`
+        # is omitted deliberately: a request describes a not-yet-created group, so there
+        # is no prior config and immutable fields stay freely settable.
+        validate_group_plugin_config_or_raise(
+            body.requested_plugin_data,
+            app.plugin_data or {},
+            app.app_group_lifecycle_plugin,
+        )
 
     # Every requested tag id must resolve to a non-deleted tag.
     if body.requested_group_tags:
@@ -233,10 +228,10 @@ async def post_group_request(
             current_user_id=current_user_id,
         ).execute()
 
-    # execute() may auto-approve (app-owner self-approval / conditional access),
-    # which re-validates plugin config and raises ValueError on invalid input — or
-    # AppGroupLifecyclePluginFilteringError if the app's plugin id is unregistered.
-    # Surface both as a 400 just like the PUT/approve path does.
+    # execute() may auto-approve (app-owner self-approval / conditional access), which
+    # re-validates plugin config; a ValueError is bad input, while a filtering error
+    # splits 400/500 by whether the plugin id is merely unknown. Same handling as the
+    # PUT/approve path below.
     try:
         gr = await CreateGroupRequest(
             requester_user=requester,
@@ -249,8 +244,10 @@ async def post_group_request(
             request_reason=body.request_reason or "",
             requested_plugin_data=body.requested_plugin_data if isinstance(body, _AppGroupRequestBody) else {},
         ).execute()
-    except (ValueError, AppGroupLifecyclePluginFilteringError) as e:
+    except ValueError as e:
         raise HTTPException(400, f"Failed to create group request: {e}") from e
+    except AppGroupLifecyclePluginFilteringError as e:
+        raise_http_for_plugin_filtering_error(e)
     if gr is None:
         raise HTTPException(400, "Failed to create group request")
     # Drop cached ORM state so the response reflects what the operation
@@ -330,11 +327,13 @@ async def put_group_request(
                 approver_user=current_user_id,
                 approval_reason=resolution_reason,
             ).execute()
-        # Approval re-validates the resolved plugin config, which raises ValueError on
-        # invalid input and AppGroupLifecyclePluginFilteringError on an unregistered
-        # plugin id; both are the approver's input problem, not a server fault.
-        except (ValueError, AppGroupLifecyclePluginFilteringError) as e:
+        # Approval re-validates the resolved plugin config: a ValueError means the
+        # config no longer passes, while a filtering error means the app's plugin id is
+        # unknown (400) or its plugin is misconfigured (500).
+        except ValueError as e:
             raise HTTPException(400, str(e)) from e
+        except AppGroupLifecyclePluginFilteringError as e:
+            raise_http_for_plugin_filtering_error(e)
     else:
         await RejectGroupRequest(
             group_request=gr,

--- a/api/routers/group_requests.py
+++ b/api/routers/group_requests.py
@@ -15,6 +15,7 @@ from api.database import DbSession
 from api.models import AccessRequestStatus, App, GroupRequest, OktaUser, Tag
 from api.operations import ApproveGroupRequest, CreateGroupRequest, RejectGroupRequest
 from api.pagination import Page, validated
+from api.plugins.app_group_lifecycle import AppGroupLifecyclePluginFilteringError
 from api.routers._fan_out import defer_fan_out
 from api.schemas import (
     CreateGroupRequestBody,
@@ -196,7 +197,10 @@ async def post_group_request(
                     body.requested_plugin_data,
                     app.app_group_lifecycle_plugin,
                 )
-            except ValueError as e:
+            # AppGroupLifecyclePluginFilteringError (not a ValueError) is raised when
+            # the app names a plugin id that isn't registered in this deployment — an
+            # operator misconfiguration, so a 400 rather than an uncaught 500.
+            except (ValueError, AppGroupLifecyclePluginFilteringError) as e:
                 raise HTTPException(400, f"plugin_data: {e}") from e
             if plugin_errors:
                 raise HTTPException(400, f"plugin_data: {plugin_errors}")
@@ -230,8 +234,9 @@ async def post_group_request(
         ).execute()
 
     # execute() may auto-approve (app-owner self-approval / conditional access),
-    # which re-validates plugin config and raises ValueError on invalid input.
-    # Surface that as a 400 just like the PUT/approve path does.
+    # which re-validates plugin config and raises ValueError on invalid input — or
+    # AppGroupLifecyclePluginFilteringError if the app's plugin id is unregistered.
+    # Surface both as a 400 just like the PUT/approve path does.
     try:
         gr = await CreateGroupRequest(
             requester_user=requester,
@@ -244,7 +249,7 @@ async def post_group_request(
             request_reason=body.request_reason or "",
             requested_plugin_data=body.requested_plugin_data if isinstance(body, _AppGroupRequestBody) else {},
         ).execute()
-    except ValueError as e:
+    except (ValueError, AppGroupLifecyclePluginFilteringError) as e:
         raise HTTPException(400, f"Failed to create group request: {e}") from e
     if gr is None:
         raise HTTPException(400, "Failed to create group request")
@@ -325,7 +330,10 @@ async def put_group_request(
                 approver_user=current_user_id,
                 approval_reason=resolution_reason,
             ).execute()
-        except ValueError as e:
+        # Approval re-validates the resolved plugin config, which raises ValueError on
+        # invalid input and AppGroupLifecyclePluginFilteringError on an unregistered
+        # plugin id; both are the approver's input problem, not a server fault.
+        except (ValueError, AppGroupLifecyclePluginFilteringError) as e:
             raise HTTPException(400, str(e)) from e
     else:
         await RejectGroupRequest(

--- a/api/routers/group_requests.py
+++ b/api/routers/group_requests.py
@@ -229,17 +229,23 @@ async def post_group_request(
             current_user_id=current_user_id,
         ).execute()
 
-    gr = await CreateGroupRequest(
-        requester_user=requester,
-        requested_group_name=body.requested_group_name,
-        requested_group_description=body.requested_group_description or "",
-        requested_group_type=body.requested_group_type,
-        requested_app_id=requested_app_id,
-        requested_group_tags=body.requested_group_tags,
-        requested_ownership_ending_at=body.requested_ownership_ending_at,
-        request_reason=body.request_reason or "",
-        requested_plugin_data=body.requested_plugin_data if isinstance(body, _AppGroupRequestBody) else {},
-    ).execute()
+    # execute() may auto-approve (app-owner self-approval / conditional access),
+    # which re-validates plugin config and raises ValueError on invalid input.
+    # Surface that as a 400 just like the PUT/approve path does.
+    try:
+        gr = await CreateGroupRequest(
+            requester_user=requester,
+            requested_group_name=body.requested_group_name,
+            requested_group_description=body.requested_group_description or "",
+            requested_group_type=body.requested_group_type,
+            requested_app_id=requested_app_id,
+            requested_group_tags=body.requested_group_tags,
+            requested_ownership_ending_at=body.requested_ownership_ending_at,
+            request_reason=body.request_reason or "",
+            requested_plugin_data=body.requested_plugin_data if isinstance(body, _AppGroupRequestBody) else {},
+        ).execute()
+    except ValueError as e:
+        raise HTTPException(400, f"Failed to create group request: {e}") from e
     if gr is None:
         raise HTTPException(400, "Failed to create group request")
     # Drop cached ORM state so the response reflects what the operation

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -12,11 +12,12 @@ GET    /api/groups/{group_id}/audit         redirects to /api/audit/users
 
 from __future__ import annotations
 
+import copy
 from typing import Annotated, Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-
 from fastapi.responses import RedirectResponse
+from fastapi_pagination.ext.sqlalchemy import apaginate
 from pydantic import TypeAdapter
 from sqlalchemy import and_, func, nullsfirst, or_, select
 from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload, with_polymorphic
@@ -40,9 +41,8 @@ from api.operations import (
     ModifyGroupUsers,
 )
 from api.operations.constraints import CheckForReason, CheckForSelfAdd
-from fastapi_pagination.ext.sqlalchemy import apaginate
-
 from api.pagination import Page, validated
+from api.plugins.app_group_lifecycle import get_app_group_lifecycle_plugins
 from api.routers._eager import (
     bind_role_group_map_own_groups,
     group_tag_map_options,
@@ -52,11 +52,11 @@ from api.routers._eager import (
 )
 from api.routers._fan_out import defer_fan_out
 from api.schemas import (
-    GroupSummary,
     CreateGroupBody,
     DeleteMessage,
     GroupDetail,
     GroupMembersSummary,
+    GroupSummary,
     OktaUserGroupMemberDetail,
     SearchGroupQuery,
     UpdateGroupBody,
@@ -67,8 +67,6 @@ from api.schemas.requests_schemas import (
     _AppGroupUpdateBody,
     _RoleGroupCreateBody,
 )
-
-import copy
 
 router = APIRouter(prefix="/api/groups", tags=["groups"], dependencies=[Depends(defer_fan_out)])
 
@@ -137,6 +135,8 @@ def _validate_group_plugin_config(
     except ValueError as e:
         raise HTTPException(400, f"plugin_data: {e}") from e
     except AppGroupLifecyclePluginFilteringError as e:
+        if plugin_id not in [plugin.id for plugin in get_app_group_lifecycle_plugins()]:
+            raise HTTPException(400, f"The plugin {plugin_id} is not known")
         # A plugin that doesn't answer this hook with exactly one response is a server-side
         # misconfiguration, not bad client input, so surface a clear 500 rather than letting the
         # plain Exception become an unhandled stack trace.
@@ -506,10 +506,11 @@ async def put_group(
 
     # Audit log — plugin configuration changes at the group level
     if old_plugin_data_for_audit != (refreshed.plugin_data or {}):
+        import logging as _logging
+
         from api.context import get_request_context
         from api.models import OktaUser
         from api.schemas import AuditLogSchema, EventType
-        import logging as _logging
 
         _ctx = get_request_context()
         email = getattr(await db.get(OktaUser, current_user_id), "email", None) if current_user_id is not None else None

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -42,7 +42,7 @@ from api.operations import (
 )
 from api.operations.constraints import CheckForReason, CheckForSelfAdd
 from api.pagination import Page, validated
-from api.plugins.app_group_lifecycle import get_app_group_lifecycle_plugins
+from api.plugins.app_group_lifecycle import validate_group_plugin_config_or_raise
 from api.routers._eager import (
     bind_role_group_map_own_groups,
     group_tag_map_options,
@@ -105,44 +105,6 @@ async def _load_group_with_options(db: DbSession, group_id: str) -> OktaGroup | 
     if group is not None:
         bind_role_group_map_own_groups(group)
     return group
-
-
-def _validate_group_plugin_config(
-    plugin_data: dict[str, Any],
-    app_plugin_data: dict[str, Any],
-    plugin_id: str | None,
-    old_plugin_data: dict[str, Any] | None = None,
-) -> None:
-    """Validate group-level plugin_data against the configured plugin's schema, raising
-    HTTP 400 on invalid config. No-op when the app has no app group lifecycle plugin.
-
-    Callers resolve the plugin id and the owning app's plugin_data themselves, since
-    group-create and group-update obtain them differently (a freshly-built group can't
-    lazy-load its app). On update, callers also pass the existing group's plugin_data as
-    `old_plugin_data` so the host can reject changes to immutable config fields."""
-    if plugin_id is None:
-        return
-
-    from api.plugins.app_group_lifecycle import (
-        AppGroupLifecyclePluginFilteringError,
-        validate_app_group_lifecycle_plugin_group_config,
-    )
-
-    try:
-        errors = validate_app_group_lifecycle_plugin_group_config(
-            plugin_data, plugin_id, app_plugin_data, old_plugin_data=old_plugin_data
-        )
-    except ValueError as e:
-        raise HTTPException(400, f"plugin_data: {e}") from e
-    except AppGroupLifecyclePluginFilteringError as e:
-        if plugin_id not in [plugin.id for plugin in get_app_group_lifecycle_plugins()]:
-            raise HTTPException(400, f"The plugin {plugin_id} is not known")
-        # A plugin that doesn't answer this hook with exactly one response is a server-side
-        # misconfiguration, not bad client input, so surface a clear 500 rather than letting the
-        # plain Exception become an unhandled stack trace.
-        raise HTTPException(500, f"Misconfigured app group lifecycle plugin '{plugin_id}': {e}") from e
-    if errors:
-        raise HTTPException(400, f"plugin_data: {errors}")
 
 
 @router.get("", name="groups")
@@ -243,7 +205,7 @@ async def post_group(
         _app = (await db.scalars(select(App).where(App.id == group.app_id).where(App.deleted_at.is_(None)))).first()
         plugin_id = _app.app_group_lifecycle_plugin if _app is not None else None
         app_plugin_data = _app.plugin_data if _app is not None else {}
-        _validate_group_plugin_config(group.plugin_data, app_plugin_data, plugin_id)
+        validate_group_plugin_config_or_raise(group.plugin_data, app_plugin_data, plugin_id)
 
     try:
         created = await CreateGroup(group=group, tags=body.tags_to_add or [], current_user_id=current_user_id).execute()
@@ -285,7 +247,7 @@ async def put_group(
     # group is loaded with its app (joinedload), so the app's plugin config is available.
     if isinstance(body, _AppGroupUpdateBody) and "plugin_data" in fields_set and isinstance(group, AppGroup):
         app_plugin_data = group.app.plugin_data if group.app is not None else {}
-        _validate_group_plugin_config(
+        validate_group_plugin_config_or_raise(
             body.plugin_data or {},
             app_plugin_data,
             get_app_group_lifecycle_plugin_to_invoke(group),
@@ -410,7 +372,7 @@ async def put_group(
         # later as a plugin SYNC_ERROR instead of a 400). old_plugin_data=None: attaching the
         # plugin on conversion is a fresh create, so immutable fields may be set.
         if isinstance(body, _AppGroupUpdateBody) and "plugin_data" in fields_set:
-            _validate_group_plugin_config(
+            validate_group_plugin_config_or_raise(
                 body.plugin_data or {},
                 conversion_app.plugin_data or {},
                 conversion_app.app_group_lifecycle_plugin,

--- a/api/schemas/requests_schemas.py
+++ b/api/schemas/requests_schemas.py
@@ -284,6 +284,8 @@ class GroupRequestDetail(BaseModel):
     resolution_reason: Optional[str] = ""
     resolved_at: Optional[FlexibleDatetime] = None
     approved_group_id: Optional[str] = None
+    requested_plugin_data: dict[str, Any] = Field(default_factory=dict)
+    resolved_plugin_data: dict[str, Any] = Field(default_factory=dict)
     created_at: FlexibleDatetime
     updated_at: FlexibleDatetime
     requester: Optional[OktaUserSummary] = None
@@ -333,6 +335,7 @@ class _RoleGroupRequestBody(_GroupRequestBodyBase):
 class _AppGroupRequestBody(_GroupRequestBodyBase):
     requested_group_type: Literal["app_group"]
     requested_app_id: str
+    requested_plugin_data: dict[str, Any] = Field(default_factory=dict)
 
 
 CreateGroupRequestBody = Annotated[
@@ -351,6 +354,7 @@ class ResolveGroupRequestBody(BaseModel):
     resolved_app_id: Optional[str] = None
     resolved_group_tags: Optional[list[str]] = None
     resolved_ownership_ending_at: Optional[FlexibleDatetime] = None
+    resolved_plugin_data: Optional[dict[str, Any]] = None
 
 
 # --- Tags -------------------------------------------------------------------

--- a/migrations/versions/c8f9ba49f867_group_request_plugin_data.py
+++ b/migrations/versions/c8f9ba49f867_group_request_plugin_data.py
@@ -1,0 +1,44 @@
+"""group_request plugin_data
+
+Revision ID: c8f9ba49f867
+Revises: 98bc5533e0f9
+Create Date: 2026-07-17 20:17:18.906545
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "c8f9ba49f867"
+down_revision = "98bc5533e0f9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "group_request",
+        sa.Column(
+            "requested_plugin_data",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+            server_default="{}",
+        ),
+    )
+    op.add_column(
+        "group_request",
+        sa.Column(
+            "resolved_plugin_data",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=False,
+            server_default="{}",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("group_request", "resolved_plugin_data")
+    op.drop_column("group_request", "requested_plugin_data")

--- a/src/api/apiSchemas.ts
+++ b/src/api/apiSchemas.ts
@@ -517,6 +517,12 @@ export type GroupRequestDetail = {
   resolution_reason?: string | null;
   resolved_at?: string | null;
   approved_group_id?: string | null;
+  requested_plugin_data?: {
+    [key: string]: any;
+  };
+  resolved_plugin_data?: {
+    [key: string]: any;
+  };
   created_at: string | null;
   updated_at: string | null;
   requester?: OktaUserSummary | null;
@@ -1017,6 +1023,9 @@ export type ResolveGroupRequestBody = {
   resolved_app_id?: string | null;
   resolved_group_tags?: string[] | null;
   resolved_ownership_ending_at?: string | null;
+  resolved_plugin_data?: {
+    [key: string]: any;
+  } | null;
 };
 
 export type ResolveRoleRequestBody = {
@@ -1573,6 +1582,9 @@ export type AppGroupRequestBody = {
   request_reason?: string | null;
   requested_group_type: string;
   requested_app_id: string;
+  requested_plugin_data?: {
+    [key: string]: any;
+  };
 };
 
 export type AppGroupUpdateBody = {

--- a/src/components/AppGroupLifecyclePluginConfigurationForm.test.tsx
+++ b/src/components/AppGroupLifecyclePluginConfigurationForm.test.tsx
@@ -65,6 +65,8 @@ describe('ConfigField suffix', () => {
 
   it('omits the end adornment when no suffix is set', () => {
     expect(renderField({type: 'text'}).props.InputProps.endAdornment).toBeUndefined();
+  });
+});
 
 describe('groupConfigHasFields', () => {
   it('is true when the plugin declares config properties', () => {

--- a/src/components/AppGroupLifecyclePluginConfigurationForm.test.tsx
+++ b/src/components/AppGroupLifecyclePluginConfigurationForm.test.tsx
@@ -29,7 +29,7 @@ vi.mock('../api/apiComponents', () => ({
   useAppGroupLifecyclePluginGroupConfigProps: () => ({data: {}, isLoading: false}),
 }));
 
-import {ConfigField, isFieldLocked} from './AppGroupLifecyclePluginConfigurationForm';
+import {ConfigField, groupConfigHasFields, isFieldLocked} from './AppGroupLifecyclePluginConfigurationForm';
 import {PluginConfigProp} from '../api/apiSchemas';
 
 const prop = (over: Partial<PluginConfigProp>): PluginConfigProp =>
@@ -65,5 +65,15 @@ describe('ConfigField suffix', () => {
 
   it('omits the end adornment when no suffix is set', () => {
     expect(renderField({type: 'text'}).props.InputProps.endAdornment).toBeUndefined();
+
+describe('groupConfigHasFields', () => {
+  it('is true when the plugin declares config properties', () => {
+    expect(groupConfigHasFields({email: {display_name: 'Email'}})).toBe(true);
+  });
+
+  it('is false for an empty, null, or undefined property map', () => {
+    expect(groupConfigHasFields({})).toBe(false);
+    expect(groupConfigHasFields(null)).toBe(false);
+    expect(groupConfigHasFields(undefined)).toBe(false);
   });
 });

--- a/src/components/AppGroupLifecyclePluginConfigurationForm.tsx
+++ b/src/components/AppGroupLifecyclePluginConfigurationForm.tsx
@@ -27,6 +27,12 @@ import {PluginConfigProp, PluginInfo} from '../api/apiSchemas';
 // Helper-text note appended to a locked (immutable, edit-mode) config field.
 const LOCKED_NOTE = 'Cannot be changed after creation.';
 
+// Whether a plugin declares any config properties to render. Group-level config
+// with none of these should render nothing rather than an empty header.
+export function groupConfigHasFields(configProperties: Record<string, unknown> | null | undefined): boolean {
+  return !!configProperties && Object.keys(configProperties).length > 0;
+}
+
 type PluginConfiguration = {
   [propertyId: string]: any;
 };
@@ -245,6 +251,15 @@ export default function AppGroupLifecyclePluginConfigurationForm({
   }
 
   if (!plugins || plugins.length === 0) {
+    return null;
+  }
+
+  const hasConfigFields = groupConfigHasFields(configProperties);
+
+  // For a group, there is nothing to configure unless the plugin declares group
+  // config properties. Render nothing rather than an empty "Configure…" header.
+  // (App-level always renders so the plugin can be selected/changed.)
+  if (entityType === 'group' && !hasConfigFields) {
     return null;
   }
 

--- a/src/pages/group_requests/Create.tsx
+++ b/src/pages/group_requests/Create.tsx
@@ -30,10 +30,13 @@ import {
 import {
   useGroupRequestsCreate,
   useApps,
+  useAppById,
   useTags,
   GroupRequestsCreateError,
   GroupRequestsCreateVariables,
 } from '../../api/apiComponents';
+import AppGroupLifecyclePluginConfigurationForm from '../../components/AppGroupLifecyclePluginConfigurationForm';
+import {pluginIdForApp, extractRequestedPluginData} from './pluginConfig';
 import {
   AppDetail,
   AppGroupDetail,
@@ -154,6 +157,16 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
     [detectedAppName, detectedAppData],
   );
 
+  // The app a submitted request would target: explicitly-selected app, or the
+  // one detected from an "App-…-" name prefix on an okta_group request.
+  const effectiveAppId = (groupType === 'app_group' ? selectedApp?.id : detectedApp?.id) ?? null;
+  // AppSummary (from search) lacks app_group_lifecycle_plugin; fetch AppDetail for it.
+  const {data: effectiveAppDetail} = useAppById(
+    {pathParams: {appId: effectiveAppId ?? ''}},
+    {enabled: effectiveAppId != null},
+  );
+  const requestPluginId = pluginIdForApp(effectiveAppDetail);
+
   const {data: tagSearchData} = useTags({
     queryParams: {page: 1, size: 10, q: tagSearchInput},
   });
@@ -195,6 +208,8 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
       groupName = ROLE_GROUP_PREFIX + formData.name;
     }
 
+    const requestedPluginData = extractRequestedPluginData(formData as any);
+
     const body = {
       requested_group_name: groupName,
       requested_group_description: formData.description ?? '',
@@ -202,6 +217,7 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
       requested_app_id: appId,
       request_reason: formData.reason ?? '',
       requested_group_tags: selectedTags.map((t) => t.id),
+      ...(effectiveType === 'app_group' && requestPluginId ? {requested_plugin_data: requestedPluginData} : {}),
     } as Parameters<typeof createRequest.mutate>[0]['body'];
 
     if (body == null) {
@@ -374,6 +390,9 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
             required
           />
         </FormControl>
+        {requestPluginId && (
+          <AppGroupLifecyclePluginConfigurationForm entityType="group" selectedPluginId={requestPluginId} />
+        )}
       </DialogContent>
       <DialogActions>
         <Button onClick={() => props.setOpen(false)}>Cancel</Button>

--- a/src/pages/group_requests/PluginConfigDisplay.tsx
+++ b/src/pages/group_requests/PluginConfigDisplay.tsx
@@ -1,0 +1,72 @@
+/**
+ * Read-only display of an app-group-lifecycle plugin's group configuration,
+ * labeled by the plugin's group-config property display names (falling back to
+ * the raw key). Renders nothing when there is no configuration to show.
+ *
+ * When `previousConfiguration` is supplied, changed values are shown as
+ * old → new (strikethrough old value) to match the other resolved fields.
+ */
+
+import * as React from 'react';
+import Typography from '@mui/material/Typography';
+
+import {useAppGroupLifecyclePluginGroupConfigProps} from '../../api/apiComponents';
+import {PluginConfigProp} from '../../api/apiSchemas';
+import {pluginConfigRows} from './pluginConfig';
+
+interface PluginConfigDisplayProps {
+  pluginId: string;
+  configuration: Record<string, any>;
+  /** Prior config to diff against (e.g. requested, when showing the applied config). */
+  previousConfiguration?: Record<string, any> | null;
+  /** Optional heading rendered above the values (e.g. "Plugin Configuration"). */
+  label?: string;
+}
+
+export default function PluginConfigDisplay({
+  pluginId,
+  configuration,
+  previousConfiguration,
+  label,
+}: PluginConfigDisplayProps) {
+  const {data: configProps} = useAppGroupLifecyclePluginGroupConfigProps(
+    {pathParams: {pluginId}},
+    {enabled: !!pluginId},
+  );
+
+  // Only show fields that carry a value; an empty config renders nothing so
+  // callers don't need to guard on it.
+  const rows = pluginConfigRows(configuration, previousConfiguration);
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {label && (
+        <Typography variant="body2" sx={{mt: 0.5}}>
+          <b>{label}:</b>
+        </Typography>
+      )}
+      {rows.map(({key, value, changed, from}) => {
+        const prop = configProps?.[key] as PluginConfigProp | undefined;
+        return (
+          <Typography variant="body2" key={key} sx={{pl: label ? 2 : 0}}>
+            <b>{prop?.display_name ?? key}:</b>{' '}
+            {changed ? (
+              <>
+                <span style={{textDecoration: 'line-through'}}>
+                  {from === undefined || from === '' ? '—' : String(from)}
+                </span>
+                {' → '}
+                {String(value)}
+              </>
+            ) : (
+              String(value)
+            )}
+          </Typography>
+        );
+      })}
+    </>
+  );
+}

--- a/src/pages/group_requests/Read.tsx
+++ b/src/pages/group_requests/Read.tsx
@@ -66,8 +66,11 @@ import {useCurrentUser} from '../../authentication';
 import {isAccessAdmin, isAppOwnerGroupOwner} from '../../authorization';
 import {displayUserName, minTagTime} from '../../helpers';
 
+import AppGroupLifecyclePluginConfigurationForm from '../../components/AppGroupLifecyclePluginConfigurationForm';
 import Loading from '../../components/Loading';
 import accessConfig from '../../config/accessConfig';
+import {pluginIdForApp, extractRequestedPluginData} from './pluginConfig';
+import PluginConfigDisplay from './PluginConfigDisplay';
 import ChangeTitle from '../../tab-title';
 import NotFound from '../NotFound';
 
@@ -222,6 +225,9 @@ export default function ReadGroupRequest() {
     {pathParams: {appId: requestedAppId ?? ''}},
     {enabled: requestedAppId != null && requestedGroupType === 'app_group'},
   );
+  // The lifecycle plugin configured on the target app (null if none).
+  const requestPluginId = pluginIdForApp(requestedAppData);
+
   const [appSeeded, setAppSeeded] = React.useState(false);
   React.useEffect(() => {
     if (!appSeeded && requestedAppData?.name) {
@@ -471,6 +477,10 @@ export default function ReadGroupRequest() {
       reason: responseForm.reason ?? '',
     };
 
+    if (responseForm.resolved_group_type === 'app_group' && requestPluginId) {
+      resolveRequest.resolved_plugin_data = extractRequestedPluginData(responseForm as any);
+    }
+
     switch (responseForm.resolved_ownership_ending_at) {
       case 'indefinite':
       case undefined:
@@ -692,6 +702,15 @@ export default function ReadGroupRequest() {
                               <Chip key={tag.id} label={tag.name} size="small" />
                             ))}
                           </Stack>
+                        </Grid>
+                      )}
+                      {requestPluginId && (
+                        <Grid item xs={12}>
+                          <PluginConfigDisplay
+                            label="Plugin Configuration"
+                            pluginId={requestPluginId}
+                            configuration={groupRequest.requested_plugin_data?.[requestPluginId]?.configuration ?? {}}
+                          />
                         </Grid>
                       )}
                     </Grid>
@@ -916,6 +935,15 @@ export default function ReadGroupRequest() {
                                     </Grid>
                                   ) : null}
                                 </Grid>
+                                {requestPluginId && (
+                                  <AppGroupLifecyclePluginConfigurationForm
+                                    entityType="group"
+                                    selectedPluginId={requestPluginId}
+                                    currentConfig={
+                                      groupRequest.requested_plugin_data?.[requestPluginId]?.configuration ?? {}
+                                    }
+                                  />
+                                )}
                                 <Divider sx={{my: 2}} />
                               </>
                             )}
@@ -1067,6 +1095,22 @@ export default function ReadGroupRequest() {
                               );
                             })}
                           </Grid>
+                        </Box>
+                      )}
+                      {groupRequest.status === 'APPROVED' && requestPluginId && (
+                        <Box sx={{mt: 1}}>
+                          <PluginConfigDisplay
+                            label="Plugin Configuration"
+                            pluginId={requestPluginId}
+                            configuration={
+                              groupRequest.resolved_plugin_data?.[requestPluginId]?.configuration ??
+                              groupRequest.requested_plugin_data?.[requestPluginId]?.configuration ??
+                              {}
+                            }
+                            previousConfiguration={
+                              groupRequest.requested_plugin_data?.[requestPluginId]?.configuration ?? {}
+                            }
+                          />
                         </Box>
                       )}
                     </Paper>

--- a/src/pages/group_requests/pluginConfig.test.ts
+++ b/src/pages/group_requests/pluginConfig.test.ts
@@ -1,0 +1,67 @@
+import {describe, it, expect} from 'vitest';
+import {pluginIdForApp, extractRequestedPluginData, visiblePluginConfigEntries, pluginConfigRows} from './pluginConfig';
+
+describe('pluginIdForApp', () => {
+  it('returns the plugin id when the app has one', () => {
+    expect(pluginIdForApp({id: 'a1', app_group_lifecycle_plugin: 'test_plugin'})).toBe('test_plugin');
+  });
+  it('returns null when the app has no plugin', () => {
+    expect(pluginIdForApp({id: 'a1'})).toBeNull();
+    expect(pluginIdForApp({id: 'a1', app_group_lifecycle_plugin: null})).toBeNull();
+  });
+  it('returns null when no app', () => {
+    expect(pluginIdForApp(null)).toBeNull();
+    expect(pluginIdForApp(undefined)).toBeNull();
+  });
+});
+
+describe('extractRequestedPluginData', () => {
+  it('returns the plugin_data object from form values', () => {
+    const form = {plugin_data: {test_plugin: {configuration: {group_id: 'g1'}}}};
+    expect(extractRequestedPluginData(form)).toEqual({test_plugin: {configuration: {group_id: 'g1'}}});
+  });
+  it('returns an empty object when absent', () => {
+    expect(extractRequestedPluginData({})).toEqual({});
+    expect(extractRequestedPluginData({plugin_data: undefined})).toEqual({});
+  });
+});
+
+describe('visiblePluginConfigEntries', () => {
+  it('drops null, undefined, and empty-string values', () => {
+    expect(visiblePluginConfigEntries({a: 'x', b: null, c: undefined, d: ''})).toEqual([['a', 'x']]);
+  });
+  it('keeps falsy-but-meaningful values (false, 0)', () => {
+    expect(visiblePluginConfigEntries({enabled: false, count: 0})).toEqual([
+      ['enabled', false],
+      ['count', 0],
+    ]);
+  });
+  it('returns an empty array for empty/nullish config', () => {
+    expect(visiblePluginConfigEntries({})).toEqual([]);
+    expect(visiblePluginConfigEntries(null)).toEqual([]);
+    expect(visiblePluginConfigEntries(undefined)).toEqual([]);
+  });
+});
+
+describe('pluginConfigRows', () => {
+  it('marks nothing changed when no previous config is supplied', () => {
+    expect(pluginConfigRows({email: 'a@x.com'})).toEqual([
+      {key: 'email', value: 'a@x.com', changed: false, from: undefined},
+    ]);
+  });
+
+  it('flags a value that differs from the previous config, carrying the old value', () => {
+    const rows = pluginConfigRows({email: 'new@x.com'}, {email: 'old@x.com'});
+    expect(rows).toEqual([{key: 'email', value: 'new@x.com', changed: true, from: 'old@x.com'}]);
+  });
+
+  it('does not flag an unchanged value when a previous config is supplied', () => {
+    const rows = pluginConfigRows({email: 'same@x.com'}, {email: 'same@x.com'});
+    expect(rows).toEqual([{key: 'email', value: 'same@x.com', changed: false, from: 'same@x.com'}]);
+  });
+
+  it('treats a newly-added key (absent in previous) as changed with an undefined from', () => {
+    const rows = pluginConfigRows({region: 'us'}, {});
+    expect(rows).toEqual([{key: 'region', value: 'us', changed: true, from: undefined}]);
+  });
+});

--- a/src/pages/group_requests/pluginConfig.ts
+++ b/src/pages/group_requests/pluginConfig.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure helpers for collecting app-group-lifecycle plugin config in the group
+ * request flow. Kept DOM-free so they can be unit-tested in isolation.
+ */
+
+type AppLike = {id?: string | null; app_group_lifecycle_plugin?: string | null} | null | undefined;
+
+/** The lifecycle plugin id configured on an app, or null if none. */
+export function pluginIdForApp(app: AppLike): string | null {
+  return app?.app_group_lifecycle_plugin ?? null;
+}
+
+/**
+ * Pull the nested `plugin_data` object that AppGroupLifecyclePluginConfigurationForm
+ * registers (field names like `plugin_data.<pluginId>.configuration.<prop>`) out of
+ * react-hook-form values, defaulting to {} when no plugin section was rendered.
+ */
+export function extractRequestedPluginData(formValues: {plugin_data?: unknown}): Record<string, any> {
+  const data = formValues?.plugin_data;
+  return data && typeof data === 'object' ? (data as Record<string, any>) : {};
+}
+
+/**
+ * Config entries worth displaying: drops null/undefined/empty-string values but
+ * keeps falsy-but-meaningful values like `false` and `0`.
+ */
+export function visiblePluginConfigEntries(configuration: Record<string, any> | null | undefined): [string, any][] {
+  return Object.entries(configuration ?? {}).filter(
+    ([, value]) => value !== null && value !== undefined && value !== '',
+  );
+}
+
+export interface PluginConfigRow {
+  key: string;
+  value: any;
+  /** True when a comparison config was supplied and its value for this key differs. */
+  changed: boolean;
+  /** The comparison ("from") value, when a comparison config was supplied. */
+  from: any;
+}
+
+/**
+ * Rows for displaying a plugin's config, optionally diffed against a prior
+ * config (e.g. resolved-vs-requested) so a resolver's edits can be shown as
+ * old → new. `changed` is only ever true when `previousConfiguration` is given.
+ */
+export function pluginConfigRows(
+  configuration: Record<string, any> | null | undefined,
+  previousConfiguration?: Record<string, any> | null,
+): PluginConfigRow[] {
+  const hasPrevious = previousConfiguration != null;
+  return visiblePluginConfigEntries(configuration).map(([key, value]) => {
+    const from = previousConfiguration?.[key];
+    return {key, value, changed: hasPrevious && from !== value, from};
+  });
+}

--- a/tests/test_app_group_lifecycle_plugin.py
+++ b/tests/test_app_group_lifecycle_plugin.py
@@ -779,6 +779,49 @@ class TestPluginValidation:
         assert response.status_code == 400
         assert "enabled" in str(response.json())
 
+    async def test_app_config_with_unregistered_plugin_in_body_returns_400(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, url_for: Any
+    ) -> None:
+        """Pointing an app at a plugin id no registered plugin answers for. The
+        validation helpers raise AppGroupLifecyclePluginFilteringError, which is not a
+        ValueError, so the edit must still be a clean 400 and not a 500."""
+        test_app = AppFactory.build(name="TestApp15")
+
+        db.session.add(test_app)
+        await db.session.commit()
+
+        url = url_for("api-apps.app_by_id", app_id=test_app.id)
+        data = {
+            "name": test_app.name,
+            "app_group_lifecycle_plugin": "unregistered_plugin",
+            "plugin_data": {"unregistered_plugin": {"configuration": {"enabled": True, "category": "valid_id"}}},
+        }
+
+        response = await client.put(url, json=data)
+        assert response.status_code == 400, response.text
+        assert "unregistered_plugin" in str(response.json())
+
+    async def test_app_config_with_unregistered_stored_plugin_returns_400(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, url_for: Any
+    ) -> None:
+        """Same failure when the unregistered id is the app's stored config rather
+        than something the body supplied, e.g. an operator dropped the plugin from
+        the deployment while apps still referenced it."""
+        test_app = AppFactory.build(name="TestApp16", app_group_lifecycle_plugin="unregistered_plugin")
+
+        db.session.add(test_app)
+        await db.session.commit()
+
+        url = url_for("api-apps.app_by_id", app_id=test_app.id)
+        data = {
+            "name": test_app.name,
+            "plugin_data": {"unregistered_plugin": {"configuration": {"enabled": True, "category": "valid_id"}}},
+        }
+
+        response = await client.put(url, json=data)
+        assert response.status_code == 400, response.text
+        assert "unregistered_plugin" in str(response.json())
+
     async def test_valid_group_config(
         self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
     ) -> None:

--- a/tests/test_app_group_lifecycle_plugin.py
+++ b/tests/test_app_group_lifecycle_plugin.py
@@ -25,6 +25,7 @@ from api.models import AppGroup, OktaUser, OktaUserGroupMember
 from api.plugins.app_group_lifecycle import (
     AmbiguousOktaTargetError,
     AppGroupLifecyclePluginConfigProperty,
+    AppGroupLifecyclePluginFilteringError,
     AppGroupLifecyclePluginMetadata,
     AppGroupLifecyclePluginStatusProperty,
     MissingOktaTargetError,
@@ -782,9 +783,9 @@ class TestPluginValidation:
     async def test_app_config_with_unregistered_plugin_in_body_returns_400(
         self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, url_for: Any
     ) -> None:
-        """Pointing an app at a plugin id no registered plugin answers for. The
-        validation helpers raise AppGroupLifecyclePluginFilteringError, which is not a
-        ValueError, so the edit must still be a clean 400 and not a 500."""
+        """Pointing an app at a plugin id no registered plugin claims. The validation
+        helpers raise AppGroupLifecyclePluginFilteringError, which is not a ValueError;
+        an unknown id is bad input, so it must be a clean 400 and not a 500."""
         test_app = AppFactory.build(name="TestApp15")
 
         db.session.add(test_app)
@@ -821,6 +822,34 @@ class TestPluginValidation:
         response = await client.put(url, json=data)
         assert response.status_code == 400, response.text
         assert "unregistered_plugin" in str(response.json())
+
+    async def test_app_config_with_misconfigured_registered_plugin_returns_500(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
+    ) -> None:
+        """The other half of the filtering-error split: the plugin id is registered, but
+        its hook does not answer with exactly one response. That is a deployment fault
+        rather than bad input, so it stays a 500 -- an explicit one, carrying the plugin
+        id, rather than an unhandled stack trace."""
+        test_app = AppFactory.build(name="TestApp17", app_group_lifecycle_plugin=DummyPlugin.ID)
+
+        db.session.add(test_app)
+        await db.session.commit()
+
+        mocker.patch(
+            "api.plugins.app_group_lifecycle.validate_app_group_lifecycle_plugin_app_config",
+            side_effect=AppGroupLifecyclePluginFilteringError(DummyPlugin.ID, 2),
+        )
+
+        url = url_for("api-apps.app_by_id", app_id=test_app.id)
+        data = {
+            "name": test_app.name,
+            "plugin_data": {DummyPlugin.ID: {"configuration": {"enabled": True, "category": "valid_id"}}},
+        }
+
+        response = await client.put(url, json=data)
+        assert response.status_code == 500, response.text
+        assert "Misconfigured" in str(response.json())
+        assert DummyPlugin.ID in str(response.json())
 
     async def test_valid_group_config(
         self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any

--- a/tests/test_app_group_lifecycle_plugin.py
+++ b/tests/test_app_group_lifecycle_plugin.py
@@ -897,6 +897,36 @@ class TestPluginValidation:
         assert response.status_code == 400
         assert "group_id" in str(response.json())
 
+    async def test_group_config_with_unregistered_plugin_returns_400(
+        self, client: AsyncClient, db: Db, app: FastAPI, test_plugin: DummyPlugin, url_for: Any
+    ) -> None:
+        """An app can name a lifecycle plugin id that isn't registered in this
+        deployment — e.g. an operator dropped the plugin while apps still referenced
+        it. Validation then raises AppGroupLifecyclePluginFilteringError, which is not
+        a ValueError, so the edit must still be a clean 400 and not a 500."""
+        test_app = AppFactory.build(name="TestApp14", app_group_lifecycle_plugin="unregistered_plugin")
+        test_group = AppGroupFactory.build(
+            app_id=test_app.id,
+            name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{test_app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}Testgroup3",
+        )
+
+        db.session.add(test_app)
+        db.session.add(test_group)
+        await db.session.commit()
+
+        url = url_for("api-groups.group_by_id", group_id=test_group.id)
+        data = {
+            "type": "app_group",
+            "name": test_group.name,
+            "description": "",
+            "app_id": test_group.app_id,
+            "plugin_data": {"unregistered_plugin": {"configuration": {"group_id": "external_123"}}},
+        }
+
+        response = await client.put(url, json=data)
+        assert response.status_code == 400, response.text
+        assert "unregistered_plugin" in str(response.json())
+
 
 class TestPluginDataRestore:
     """Tests for the restore_unchanged_app_lifecycle_plugin_data function."""

--- a/tests/test_group_request_plugin_config.py
+++ b/tests/test_group_request_plugin_config.py
@@ -1,0 +1,343 @@
+from typing import Any, Callable, Generator
+
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient
+from okta.models import Group as OktaSdkGroup
+from pydantic import TypeAdapter
+from pytest_mock import MockerFixture
+from sqlalchemy import select
+
+from api.config import settings
+from api.extensions import Db
+from api.models import AccessRequestStatus, AppGroup, GroupRequest, OktaUser
+from api.operations import ApproveGroupRequest, CreateGroupRequest
+from api.schemas.requests_schemas import CreateGroupRequestBody, ResolveGroupRequestBody
+from api.services import okta
+from tests.factories import AppFactory, OktaUserFactory
+from tests.test_app_group_lifecycle_plugin import DummyPlugin
+
+
+@pytest.fixture
+def test_plugin(app: FastAPI, mocker: MockerFixture) -> Generator[DummyPlugin, None, None]:
+    """Register DummyPlugin (id 'test_plugin') as the app group lifecycle plugin."""
+    import pluggy
+
+    import api.plugins.app_group_lifecycle as plugin_module
+    from api.plugins.app_group_lifecycle import AppGroupLifecyclePluginSpec
+
+    instance = DummyPlugin()
+    pm = pluggy.PluginManager(plugin_module.app_group_lifecycle_plugin_name)
+    pm.add_hookspecs(AppGroupLifecyclePluginSpec)
+    pm.register(plugin_module)
+    pm.register(instance, name=DummyPlugin.ID)
+    mocker.patch.object(plugin_module, "_cached_app_group_lifecycle_hook", pm.hook)
+    mocker.patch.object(plugin_module, "_cached_plugin_registry", None)
+    yield instance
+    plugin_module._cached_app_group_lifecycle_hook = None
+    plugin_module._cached_plugin_registry = None
+
+
+async def _make_app_with_plugin(db: Db) -> Any:
+    app_obj = AppFactory.create()
+    app_obj.app_group_lifecycle_plugin = DummyPlugin.ID
+    db.session.add(app_obj)
+    await db.session.commit()
+    return app_obj
+
+
+# --- Model -----------------------------------------------------------------
+
+
+async def test_group_request_plugin_data_defaults_to_empty_dict(app: FastAPI, db: Db) -> None:
+    user: OktaUser = OktaUserFactory.create()
+    db.session.add(user)
+    await db.session.commit()
+
+    gr = GroupRequest(
+        id="reqplugindata0000001",
+        status=AccessRequestStatus.PENDING,
+        requester_user_id=user.id,
+        requested_group_name="Test Group",
+        requested_group_type="okta_group",
+    )
+    db.session.add(gr)
+    await db.session.commit()
+    await db.session.refresh(gr)
+
+    assert gr.requested_plugin_data == {}
+    assert gr.resolved_plugin_data == {}
+
+
+async def test_group_request_plugin_data_round_trips(app: FastAPI, db: Db) -> None:
+    user: OktaUser = OktaUserFactory.create()
+    db.session.add(user)
+    await db.session.commit()
+
+    payload = {"test_plugin": {"configuration": {"group_id": "g-123", "region": "us"}}}
+    gr = GroupRequest(
+        id="reqplugindata0000002",
+        status=AccessRequestStatus.PENDING,
+        requester_user_id=user.id,
+        requested_group_name="Test Group 2",
+        requested_group_type="app_group",
+        requested_plugin_data=payload,
+    )
+    db.session.add(gr)
+    await db.session.commit()
+    await db.session.refresh(gr)
+
+    assert gr.requested_plugin_data == payload
+    assert gr.resolved_plugin_data == {}
+
+
+# --- Schemas ---------------------------------------------------------------
+
+
+def test_app_group_body_accepts_requested_plugin_data() -> None:
+    adapter: TypeAdapter[Any] = TypeAdapter(CreateGroupRequestBody)
+    body = adapter.validate_python(
+        {
+            "requested_group_type": "app_group",
+            "requested_group_name": "App-Foo-Admins",
+            "requested_group_description": "desc",
+            "requested_app_id": "app00000000000000001",
+            "requested_plugin_data": {"test_plugin": {"configuration": {"group_id": "g-1"}}},
+        }
+    )
+    assert body.requested_plugin_data == {"test_plugin": {"configuration": {"group_id": "g-1"}}}
+
+
+def test_app_group_body_defaults_plugin_data_to_empty() -> None:
+    adapter: TypeAdapter[Any] = TypeAdapter(CreateGroupRequestBody)
+    body = adapter.validate_python(
+        {
+            "requested_group_type": "app_group",
+            "requested_group_name": "App-Foo-Admins",
+            "requested_group_description": "desc",
+            "requested_app_id": "app00000000000000001",
+        }
+    )
+    assert body.requested_plugin_data == {}
+
+
+def test_resolve_body_accepts_resolved_plugin_data() -> None:
+    body = ResolveGroupRequestBody.model_validate(
+        {"approved": True, "resolved_plugin_data": {"test_plugin": {"configuration": {"group_id": "g-2"}}}}
+    )
+    assert body.resolved_plugin_data == {"test_plugin": {"configuration": {"group_id": "g-2"}}}
+
+
+# --- CreateGroupRequest operation ------------------------------------------
+
+
+async def test_create_group_request_persists_requested_plugin_data(app: FastAPI, db: Db) -> None:
+    user: OktaUser = OktaUserFactory.create()
+    db.session.add(user)
+    await db.session.commit()
+    app_obj = await _make_app_with_plugin(db)
+
+    payload = {"test_plugin": {"configuration": {"group_id": "g-9"}}}
+    gr = await CreateGroupRequest(
+        requester_user=user,
+        requested_group_name=f"App-{app_obj.name}-Admins",
+        requested_group_type="app_group",
+        requested_app_id=app_obj.id,
+        requested_plugin_data=payload,
+    ).execute()
+
+    assert gr is not None
+    assert gr.requested_plugin_data == payload
+
+
+# --- POST validation (HTTP) ------------------------------------------------
+
+
+async def test_post_app_group_request_rejects_missing_required_plugin_config(
+    app: FastAPI,
+    client: AsyncClient,
+    db: Db,
+    mock_user: Callable[[Any], None],
+    url_for: Callable[..., str],
+    test_plugin: DummyPlugin,
+) -> None:
+    user: OktaUser = OktaUserFactory.create()
+    db.session.add(user)
+    await db.session.commit()
+    mock_user(user)
+    app_obj = await _make_app_with_plugin(db)
+
+    resp = await client.post(
+        url_for("api-group-requests.group_requests_create"),
+        json={
+            "requested_group_type": "app_group",
+            "requested_group_name": f"App-{app_obj.name}-Admins",
+            "requested_group_description": "desc",
+            "requested_app_id": app_obj.id,
+            "requested_plugin_data": {DummyPlugin.ID: {"configuration": {}}},
+        },
+    )
+    assert resp.status_code == 400
+    assert "group_id" in resp.text
+
+
+async def test_post_app_group_request_accepts_valid_plugin_config(
+    app: FastAPI,
+    client: AsyncClient,
+    db: Db,
+    mock_user: Callable[[Any], None],
+    url_for: Callable[..., str],
+    test_plugin: DummyPlugin,
+) -> None:
+    user: OktaUser = OktaUserFactory.create()
+    db.session.add(user)
+    await db.session.commit()
+    mock_user(user)
+    app_obj = await _make_app_with_plugin(db)
+
+    payload = {DummyPlugin.ID: {"configuration": {"group_id": "g-77"}}}
+    resp = await client.post(
+        url_for("api-group-requests.group_requests_create"),
+        json={
+            "requested_group_type": "app_group",
+            "requested_group_name": f"App-{app_obj.name}-Admins",
+            "requested_group_description": "desc",
+            "requested_app_id": app_obj.id,
+            "requested_plugin_data": payload,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["requested_plugin_data"] == payload
+
+
+# --- Approval applies plugin config ----------------------------------------
+
+
+async def test_approve_applies_resolved_plugin_data_over_requested(
+    app: FastAPI,
+    client: AsyncClient,
+    db: Db,
+    test_plugin: DummyPlugin,
+    mocker: MockerFixture,
+) -> None:
+    admin = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
+    mocker.patch.object(
+        okta, "create_group", side_effect=lambda name, desc: OktaSdkGroup.from_dict({"id": "createdgrp0000000001"})
+    )
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
+
+    requester: OktaUser = OktaUserFactory.create()
+    db.session.add(requester)
+    await db.session.commit()
+    app_obj = await _make_app_with_plugin(db)
+
+    gr = await CreateGroupRequest(
+        requester_user=requester,
+        requested_group_name=f"App-{app_obj.name}-Admins",
+        requested_group_type="app_group",
+        requested_app_id=app_obj.id,
+        requested_plugin_data={DummyPlugin.ID: {"configuration": {"group_id": "from-request"}}},
+    ).execute()
+    assert gr is not None
+
+    gr.resolved_plugin_data = {DummyPlugin.ID: {"configuration": {"group_id": "from-resolver"}}}
+    await db.session.commit()
+
+    await ApproveGroupRequest(group_request=gr, approver_user=admin, approval_reason="ok").execute()
+
+    created = await db.session.get(AppGroup, "createdgrp0000000001")
+    assert created is not None
+    assert created.plugin_data[DummyPlugin.ID]["configuration"]["group_id"] == "from-resolver"
+    assert "createdgrp0000000001" in test_plugin.group_created_calls
+
+
+async def test_approve_falls_back_to_requested_plugin_data(
+    app: FastAPI,
+    client: AsyncClient,
+    db: Db,
+    test_plugin: DummyPlugin,
+    mocker: MockerFixture,
+) -> None:
+    admin = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
+    mocker.patch.object(
+        okta, "create_group", side_effect=lambda name, desc: OktaSdkGroup.from_dict({"id": "createdgrp0000000002"})
+    )
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
+
+    requester: OktaUser = OktaUserFactory.create()
+    db.session.add(requester)
+    await db.session.commit()
+    app_obj = await _make_app_with_plugin(db)
+
+    gr = await CreateGroupRequest(
+        requester_user=requester,
+        requested_group_name=f"App-{app_obj.name}-Admins",
+        requested_group_type="app_group",
+        requested_app_id=app_obj.id,
+        requested_plugin_data={DummyPlugin.ID: {"configuration": {"group_id": "only-requested"}}},
+    ).execute()
+    assert gr is not None
+
+    await ApproveGroupRequest(group_request=gr, approver_user=admin, approval_reason="ok").execute()
+
+    created = await db.session.get(AppGroup, "createdgrp0000000002")
+    assert created is not None
+    assert created.plugin_data[DummyPlugin.ID]["configuration"]["group_id"] == "only-requested"
+
+
+# --- PUT resolve carries resolved_plugin_data through approval --------------
+
+
+async def test_put_group_request_persists_resolved_plugin_data(
+    app: FastAPI,
+    client: AsyncClient,
+    db: Db,
+    mock_user: Callable[[Any], None],
+    url_for: Callable[..., str],
+    test_plugin: DummyPlugin,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch.object(
+        okta, "create_group", side_effect=lambda name, desc: OktaSdkGroup.from_dict({"id": "createdgrp0000000003"})
+    )
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
+
+    # The seeded admin (email == CURRENT_OKTA_USER_EMAIL) is in access owners, so it
+    # passes both the router's is_access_admin check and the operation's own
+    # get_access_owners authorization without further mocking.
+    admin = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
+    requester: OktaUser = OktaUserFactory.create()
+    db.session.add(requester)
+    await db.session.commit()
+    app_obj = await _make_app_with_plugin(db)
+
+    gr = await CreateGroupRequest(
+        requester_user=requester,
+        requested_group_name=f"App-{app_obj.name}-Admins",
+        requested_group_type="app_group",
+        requested_app_id=app_obj.id,
+        requested_plugin_data={DummyPlugin.ID: {"configuration": {"group_id": "req"}}},
+    ).execute()
+    assert gr is not None
+
+    mock_user(admin)
+    resp = await client.put(
+        url_for("api-group-requests.group_request_by_id_put", group_request_id=gr.id),
+        json={
+            "approved": True,
+            "resolved_plugin_data": {DummyPlugin.ID: {"configuration": {"group_id": "resolved"}}},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    created = await db.session.get(AppGroup, "createdgrp0000000003")
+    assert created is not None
+    assert created.plugin_data[DummyPlugin.ID]["configuration"]["group_id"] == "resolved"

--- a/tests/test_group_request_plugin_config.py
+++ b/tests/test_group_request_plugin_config.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, Callable, Generator
 
 import pytest
@@ -7,14 +8,16 @@ from okta.models import Group as OktaSdkGroup
 from pydantic import TypeAdapter
 from pytest_mock import MockerFixture
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.config import settings
 from api.extensions import Db
-from api.models import AccessRequestStatus, AppGroup, GroupRequest, OktaUser
+from api.models import AccessRequestStatus, AppGroup, GroupRequest, OktaUser, OktaUserGroupMember
 from api.operations import ApproveGroupRequest, CreateGroupRequest
+from api.plugins.app_group_lifecycle import hookimpl
 from api.schemas.requests_schemas import CreateGroupRequestBody, ResolveGroupRequestBody
 from api.services import okta
-from tests.factories import AppFactory, OktaUserFactory
+from tests.factories import AppFactory, AppGroupFactory, OktaUserFactory
 from tests.test_app_group_lifecycle_plugin import DummyPlugin
 
 
@@ -44,6 +47,60 @@ async def _make_app_with_plugin(db: Db) -> Any:
     db.session.add(app_obj)
     await db.session.commit()
     return app_obj
+
+
+async def _make_app_owner(db: Db, app_obj: Any) -> OktaUser:
+    """Create a user and make them an owner of ``app_obj`` via its owner group,
+    so a group request they file auto-approves."""
+    owner = OktaUserFactory.create()
+    db.session.add(owner)
+    owner_group = AppGroupFactory.create(
+        name=(
+            f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}"
+            f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
+        ),
+        app_id=app_obj.id,
+        is_owner=True,
+    )
+    db.session.add(owner_group)
+    await db.session.commit()
+    db.session.add(OktaUserGroupMember(user_id=owner.id, group_id=owner_group.id, is_owner=True))
+    await db.session.commit()
+    return owner
+
+
+class _StatusWritingPlugin(DummyPlugin):
+    """A DummyPlugin whose ``group_created`` mutates the group's config dict in
+    place. Used to prove ApproveGroupRequest deep-copies the request's
+    plugin_data onto the new group: without that copy, this mutation would leak
+    back into the persisted request record."""
+
+    @hookimpl
+    async def group_created(self, session: AsyncSession, group: AppGroup, plugin_id: str | None) -> None:
+        if plugin_id is not None and plugin_id != self.ID:
+            return
+        group.plugin_data[self.ID]["configuration"]["group_id"] = "mutated-by-hook"
+        self.group_created_calls.append(group.id)
+
+
+@pytest.fixture
+def mutating_plugin(app: FastAPI, mocker: MockerFixture) -> Generator[_StatusWritingPlugin, None, None]:
+    """Register _StatusWritingPlugin under the test plugin id."""
+    import pluggy
+
+    import api.plugins.app_group_lifecycle as plugin_module
+    from api.plugins.app_group_lifecycle import AppGroupLifecyclePluginSpec
+
+    instance = _StatusWritingPlugin()
+    pm = pluggy.PluginManager(plugin_module.app_group_lifecycle_plugin_name)
+    pm.add_hookspecs(AppGroupLifecyclePluginSpec)
+    pm.register(plugin_module)
+    pm.register(instance, name=DummyPlugin.ID)
+    mocker.patch.object(plugin_module, "_cached_app_group_lifecycle_hook", pm.hook)
+    mocker.patch.object(plugin_module, "_cached_plugin_registry", None)
+    yield instance
+    plugin_module._cached_app_group_lifecycle_hook = None
+    plugin_module._cached_plugin_registry = None
 
 
 # --- Model -----------------------------------------------------------------
@@ -341,3 +398,144 @@ async def test_put_group_request_persists_resolved_plugin_data(
     created = await db.session.get(AppGroup, "createdgrp0000000003")
     assert created is not None
     assert created.plugin_data[DummyPlugin.ID]["configuration"]["group_id"] == "resolved"
+
+
+# --- POST surfaces an approval-time plugin error as 400 (not 500) ----------
+
+
+async def test_post_auto_approve_invalid_plugin_config_returns_400(
+    app: FastAPI,
+    client: AsyncClient,
+    db: Db,
+    mock_user: Callable[[Any], None],
+    url_for: Callable[..., str],
+    test_plugin: DummyPlugin,
+    mocker: MockerFixture,
+) -> None:
+    """An app-owner's own app-group request auto-approves inside the create
+    operation. If the plugin config is rejected at that approval step, the POST
+    must return a clean 400 (like the PUT/approve path) rather than a 500 from
+    an uncaught ValueError. We force the (defensive) approval-time validation to
+    fail while letting the router's submit-time validation pass, so the failure
+    can only be caught by the POST handler's ValueError wrapper."""
+    app_obj = await _make_app_with_plugin(db)
+    owner = await _make_app_owner(db, app_obj)
+    mock_user(owner)
+
+    # First call = router submit-time validation (passes); second = approval-time
+    # re-validation inside ApproveGroupRequest (fails).
+    mocker.patch(
+        "api.plugins.app_group_lifecycle.validate_app_group_lifecycle_plugin_group_config",
+        side_effect=[{}, {"group_id": "changed since submit"}],
+    )
+
+    resp = await client.post(
+        url_for("api-group-requests.group_requests_create"),
+        json={
+            "requested_group_type": "app_group",
+            "requested_group_name": f"App-{app_obj.name}-Admins",
+            "requested_group_description": "desc",
+            "requested_app_id": app_obj.id,
+            "requested_plugin_data": {DummyPlugin.ID: {"configuration": {"group_id": "g-1"}}},
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert "group_id" in resp.text
+    # The request must not have been approved / created despite the auto-approve attempt.
+    gr = (await db.session.scalars(select(GroupRequest))).first()
+    assert gr is not None
+    assert gr.status == AccessRequestStatus.PENDING
+
+
+# --- Approval deep-copies plugin config off the request record -------------
+
+
+async def test_approve_does_not_mutate_request_plugin_data(
+    app: FastAPI,
+    client: AsyncClient,
+    db: Db,
+    mutating_plugin: _StatusWritingPlugin,
+    mocker: MockerFixture,
+) -> None:
+    """The group_created hook may mutate the created group's plugin_data (e.g.
+    writing status). That must not leak back into the request's stored
+    requested_plugin_data, which is immutable history — ApproveGroupRequest
+    deep-copies before handing the config to the new group."""
+    admin = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
+    mocker.patch.object(
+        okta, "create_group", side_effect=lambda name, desc: OktaSdkGroup.from_dict({"id": "createdgrp0000000004"})
+    )
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
+
+    requester: OktaUser = OktaUserFactory.create()
+    db.session.add(requester)
+    await db.session.commit()
+    app_obj = await _make_app_with_plugin(db)
+
+    gr = await CreateGroupRequest(
+        requester_user=requester,
+        requested_group_name=f"App-{app_obj.name}-Admins",
+        requested_group_type="app_group",
+        requested_app_id=app_obj.id,
+        requested_plugin_data={DummyPlugin.ID: {"configuration": {"group_id": "only-requested"}}},
+    ).execute()
+    assert gr is not None
+
+    await ApproveGroupRequest(group_request=gr, approver_user=admin, approval_reason="ok").execute()
+
+    created = await db.session.get(AppGroup, "createdgrp0000000004")
+    assert created is not None
+    # The hook mutated the created group's copy...
+    assert created.plugin_data[DummyPlugin.ID]["configuration"]["group_id"] == "mutated-by-hook"
+    assert "createdgrp0000000004" in mutating_plugin.group_created_calls
+    # ...but the request's stored config is untouched.
+    assert gr.requested_plugin_data[DummyPlugin.ID]["configuration"]["group_id"] == "only-requested"
+
+
+# --- Config supplied for an app with no plugin is dropped with a warning ----
+
+
+async def test_approve_drops_plugin_data_and_warns_when_app_has_no_plugin(
+    app: FastAPI,
+    client: AsyncClient,
+    db: Db,
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """If a request carries plugin config but the (resolved) app has no
+    lifecycle plugin, the config can't be applied. Approval drops it and logs a
+    warning rather than silently discarding it."""
+    admin = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
+    mocker.patch.object(
+        okta, "create_group", side_effect=lambda name, desc: OktaSdkGroup.from_dict({"id": "createdgrp0000000005"})
+    )
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
+
+    requester: OktaUser = OktaUserFactory.create()
+    db.session.add(requester)
+    app_obj = AppFactory.create()  # no app_group_lifecycle_plugin configured
+    db.session.add(app_obj)
+    await db.session.commit()
+
+    gr = await CreateGroupRequest(
+        requester_user=requester,
+        requested_group_name=f"App-{app_obj.name}-Admins",
+        requested_group_type="app_group",
+        requested_app_id=app_obj.id,
+        requested_plugin_data={DummyPlugin.ID: {"configuration": {"group_id": "orphaned"}}},
+    ).execute()
+    assert gr is not None
+
+    with caplog.at_level(logging.WARNING, logger="api.operations.approve_group_request"):
+        await ApproveGroupRequest(group_request=gr, approver_user=admin, approval_reason="ok").execute()
+
+    created = await db.session.get(AppGroup, "createdgrp0000000005")
+    assert created is not None
+    assert created.plugin_data == {}
+    assert any("no app_group_lifecycle_plugin" in r.getMessage() for r in caplog.records)

--- a/tests/test_group_request_plugin_config.py
+++ b/tests/test_group_request_plugin_config.py
@@ -282,11 +282,13 @@ async def test_post_app_group_request_accepts_valid_plugin_config(
     assert resp.json()["requested_plugin_data"] == payload
 
 
-# --- An unregistered plugin id is a 400, not a 500 -------------------------
+# --- Filtering errors split 400 (unknown id) from 500 (misconfigured) -------
 #
-# AppGroupLifecyclePluginFilteringError subclasses Exception, not ValueError, so
-# each of the three plugin-config failure paths below has to name it explicitly or
-# the request 500s on what is really bad operator/approver input.
+# AppGroupLifecyclePluginFilteringError subclasses Exception, not ValueError, so each
+# plugin-config failure path has to name it explicitly or the request 500s on what may
+# be nothing more than an unknown plugin id. Routers hand it to
+# raise_http_for_plugin_filtering_error, which answers 400 when no registered plugin
+# claims the id and 500 when one does but its hook misbehaves.
 
 
 async def test_post_app_group_request_returns_400_when_app_plugin_is_unregistered(
@@ -316,9 +318,18 @@ async def test_post_app_group_request_returns_400_when_app_plugin_is_unregistere
     )
     assert resp.status_code == 400, resp.text
     assert UNREGISTERED_PLUGIN_ID in resp.text
+    assert "is not known" in resp.text
 
 
-async def test_post_auto_approve_unregistered_plugin_returns_400(
+@pytest.mark.parametrize(
+    ("raised_plugin_id", "expected_status", "expected_text"),
+    [
+        (UNREGISTERED_PLUGIN_ID, 400, "is not known"),
+        (DummyPlugin.ID, 500, "Misconfigured"),
+    ],
+    ids=["unknown-plugin-400", "misconfigured-plugin-500"],
+)
+async def test_post_auto_approve_filtering_error_status(
     app: FastAPI,
     client: AsyncClient,
     db: Db,
@@ -326,17 +337,21 @@ async def test_post_auto_approve_unregistered_plugin_returns_400(
     url_for: Callable[..., str],
     test_plugin: DummyPlugin,
     mocker: MockerFixture,
+    raised_plugin_id: str,
+    expected_status: int,
+    expected_text: str,
 ) -> None:
-    """Same error raised from the auto-approve inside CreateGroupRequest (an app
-    owner's own request). Submit-time validation is forced to pass so the failure
-    can only be caught by the POST handler's wrapper around the operation."""
+    """The same split applied to the auto-approve inside CreateGroupRequest (an app
+    owner's own request). Submit-time validation is forced to pass so the failure can
+    only be caught by the POST handler's wrapper around the operation; the id carried by
+    the error then decides 400 versus 500."""
     app_obj = await _make_app_with_plugin(db)
     owner = await _make_app_owner(db, app_obj)
     mock_user(owner)
 
     mocker.patch(
         "api.plugins.app_group_lifecycle.validate_app_group_lifecycle_plugin_group_config",
-        side_effect=[{}, AppGroupLifecyclePluginFilteringError(DummyPlugin.ID, 0)],
+        side_effect=[{}, AppGroupLifecyclePluginFilteringError(raised_plugin_id, 0)],
     )
 
     resp = await client.post(
@@ -349,8 +364,9 @@ async def test_post_auto_approve_unregistered_plugin_returns_400(
             "requested_plugin_data": {DummyPlugin.ID: {"configuration": {"group_id": "g-1"}}},
         },
     )
-    assert resp.status_code == 400, resp.text
-    assert "Expected one response" in resp.text
+    assert resp.status_code == expected_status, resp.text
+    assert expected_text in resp.text
+    # Either way the request must not have been approved by the failed auto-approve.
     gr = (await db.session.scalars(select(GroupRequest))).first()
     assert gr is not None
     assert gr.status == AccessRequestStatus.PENDING
@@ -393,6 +409,7 @@ async def test_put_approve_returns_400_when_app_plugin_is_unregistered(
     )
     assert resp.status_code == 400, resp.text
     assert UNREGISTERED_PLUGIN_ID in resp.text
+    assert "is not known" in resp.text
     refreshed = await db.session.get(GroupRequest, gr_id)
     assert refreshed is not None
     assert refreshed.status == AccessRequestStatus.PENDING

--- a/tests/test_group_request_plugin_config.py
+++ b/tests/test_group_request_plugin_config.py
@@ -42,7 +42,7 @@ def test_plugin(app: FastAPI, mocker: MockerFixture) -> Generator[DummyPlugin, N
 
 
 async def _make_app_with_plugin(db: Db) -> Any:
-    app_obj = AppFactory.create()
+    app_obj = await AppFactory.create_async()
     app_obj.app_group_lifecycle_plugin = DummyPlugin.ID
     db.session.add(app_obj)
     await db.session.commit()
@@ -52,9 +52,9 @@ async def _make_app_with_plugin(db: Db) -> Any:
 async def _make_app_owner(db: Db, app_obj: Any) -> OktaUser:
     """Create a user and make them an owner of ``app_obj`` via its owner group,
     so a group request they file auto-approves."""
-    owner = OktaUserFactory.create()
+    owner = await OktaUserFactory.create_async()
     db.session.add(owner)
-    owner_group = AppGroupFactory.create(
+    owner_group = await AppGroupFactory.create_async(
         name=(
             f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}"
             f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
@@ -107,7 +107,7 @@ def mutating_plugin(app: FastAPI, mocker: MockerFixture) -> Generator[_StatusWri
 
 
 async def test_group_request_plugin_data_defaults_to_empty_dict(app: FastAPI, db: Db) -> None:
-    user: OktaUser = OktaUserFactory.create()
+    user: OktaUser = await OktaUserFactory.create_async()
     db.session.add(user)
     await db.session.commit()
 
@@ -127,7 +127,7 @@ async def test_group_request_plugin_data_defaults_to_empty_dict(app: FastAPI, db
 
 
 async def test_group_request_plugin_data_round_trips(app: FastAPI, db: Db) -> None:
-    user: OktaUser = OktaUserFactory.create()
+    user: OktaUser = await OktaUserFactory.create_async()
     db.session.add(user)
     await db.session.commit()
 
@@ -189,7 +189,7 @@ def test_resolve_body_accepts_resolved_plugin_data() -> None:
 
 
 async def test_create_group_request_persists_requested_plugin_data(app: FastAPI, db: Db) -> None:
-    user: OktaUser = OktaUserFactory.create()
+    user: OktaUser = await OktaUserFactory.create_async()
     db.session.add(user)
     await db.session.commit()
     app_obj = await _make_app_with_plugin(db)
@@ -218,7 +218,7 @@ async def test_post_app_group_request_rejects_missing_required_plugin_config(
     url_for: Callable[..., str],
     test_plugin: DummyPlugin,
 ) -> None:
-    user: OktaUser = OktaUserFactory.create()
+    user: OktaUser = await OktaUserFactory.create_async()
     db.session.add(user)
     await db.session.commit()
     mock_user(user)
@@ -246,7 +246,7 @@ async def test_post_app_group_request_accepts_valid_plugin_config(
     url_for: Callable[..., str],
     test_plugin: DummyPlugin,
 ) -> None:
-    user: OktaUser = OktaUserFactory.create()
+    user: OktaUser = await OktaUserFactory.create_async()
     db.session.add(user)
     await db.session.commit()
     mock_user(user)
@@ -286,7 +286,7 @@ async def test_approve_applies_resolved_plugin_data_over_requested(
     mocker.patch.object(okta, "add_user_to_group")
     mocker.patch.object(okta, "add_owner_to_group")
 
-    requester: OktaUser = OktaUserFactory.create()
+    requester: OktaUser = await OktaUserFactory.create_async()
     db.session.add(requester)
     await db.session.commit()
     app_obj = await _make_app_with_plugin(db)
@@ -327,7 +327,7 @@ async def test_approve_falls_back_to_requested_plugin_data(
     mocker.patch.object(okta, "add_user_to_group")
     mocker.patch.object(okta, "add_owner_to_group")
 
-    requester: OktaUser = OktaUserFactory.create()
+    requester: OktaUser = await OktaUserFactory.create_async()
     db.session.add(requester)
     await db.session.commit()
     app_obj = await _make_app_with_plugin(db)
@@ -372,7 +372,7 @@ async def test_put_group_request_persists_resolved_plugin_data(
     admin = (
         await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
     ).first()
-    requester: OktaUser = OktaUserFactory.create()
+    requester: OktaUser = await OktaUserFactory.create_async()
     db.session.add(requester)
     await db.session.commit()
     app_obj = await _make_app_with_plugin(db)
@@ -470,7 +470,7 @@ async def test_approve_does_not_mutate_request_plugin_data(
     mocker.patch.object(okta, "add_user_to_group")
     mocker.patch.object(okta, "add_owner_to_group")
 
-    requester: OktaUser = OktaUserFactory.create()
+    requester: OktaUser = await OktaUserFactory.create_async()
     db.session.add(requester)
     await db.session.commit()
     app_obj = await _make_app_with_plugin(db)
@@ -517,9 +517,9 @@ async def test_approve_drops_plugin_data_and_warns_when_app_has_no_plugin(
     mocker.patch.object(okta, "add_user_to_group")
     mocker.patch.object(okta, "add_owner_to_group")
 
-    requester: OktaUser = OktaUserFactory.create()
+    requester: OktaUser = await OktaUserFactory.create_async()
     db.session.add(requester)
-    app_obj = AppFactory.create()  # no app_group_lifecycle_plugin configured
+    app_obj = await AppFactory.create_async()  # no app_group_lifecycle_plugin configured
     db.session.add(app_obj)
     await db.session.commit()
 

--- a/tests/test_group_request_plugin_config.py
+++ b/tests/test_group_request_plugin_config.py
@@ -14,11 +14,13 @@ from api.config import settings
 from api.extensions import Db
 from api.models import AccessRequestStatus, AppGroup, GroupRequest, OktaUser, OktaUserGroupMember
 from api.operations import ApproveGroupRequest, CreateGroupRequest
-from api.plugins.app_group_lifecycle import hookimpl
+from api.plugins.app_group_lifecycle import AppGroupLifecyclePluginFilteringError, hookimpl
 from api.schemas.requests_schemas import CreateGroupRequestBody, ResolveGroupRequestBody
 from api.services import okta
 from tests.factories import AppFactory, AppGroupFactory, OktaUserFactory
 from tests.test_app_group_lifecycle_plugin import DummyPlugin
+
+UNREGISTERED_PLUGIN_ID = "unregistered_plugin"
 
 
 @pytest.fixture
@@ -44,6 +46,18 @@ def test_plugin(app: FastAPI, mocker: MockerFixture) -> Generator[DummyPlugin, N
 async def _make_app_with_plugin(db: Db) -> Any:
     app_obj = await AppFactory.create_async()
     app_obj.app_group_lifecycle_plugin = DummyPlugin.ID
+    db.session.add(app_obj)
+    await db.session.commit()
+    return app_obj
+
+
+async def _make_app_with_unregistered_plugin(db: Db) -> Any:
+    """An app whose configured lifecycle plugin id isn't registered in this
+    deployment — e.g. an operator dropped the plugin while apps still referenced
+    it. Hook calls filtered to that id get no responses, so the plugin helpers
+    raise AppGroupLifecyclePluginFilteringError, which is not a ValueError."""
+    app_obj = await AppFactory.create_async()
+    app_obj.app_group_lifecycle_plugin = UNREGISTERED_PLUGIN_ID
     db.session.add(app_obj)
     await db.session.commit()
     return app_obj
@@ -265,6 +279,123 @@ async def test_post_app_group_request_accepts_valid_plugin_config(
     )
     assert resp.status_code == 201, resp.text
     assert resp.json()["requested_plugin_data"] == payload
+
+
+# --- An unregistered plugin id is a 400, not a 500 -------------------------
+#
+# AppGroupLifecyclePluginFilteringError subclasses Exception, not ValueError, so
+# each of the three plugin-config failure paths below has to name it explicitly or
+# the request 500s on what is really bad operator/approver input.
+
+
+async def test_post_app_group_request_returns_400_when_app_plugin_is_unregistered(
+    app: FastAPI,
+    client: AsyncClient,
+    db: Db,
+    mock_user: Callable[[Any], None],
+    url_for: Callable[..., str],
+    test_plugin: DummyPlugin,
+) -> None:
+    """Submit-time validation against an app whose plugin id isn't registered."""
+    user: OktaUser = await OktaUserFactory.create_async()
+    db.session.add(user)
+    await db.session.commit()
+    mock_user(user)
+    app_obj = await _make_app_with_unregistered_plugin(db)
+
+    resp = await client.post(
+        url_for("api-group-requests.group_requests_create"),
+        json={
+            "requested_group_type": "app_group",
+            "requested_group_name": f"App-{app_obj.name}-Admins",
+            "requested_group_description": "desc",
+            "requested_app_id": app_obj.id,
+            "requested_plugin_data": {UNREGISTERED_PLUGIN_ID: {"configuration": {"group_id": "g-1"}}},
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert UNREGISTERED_PLUGIN_ID in resp.text
+
+
+async def test_post_auto_approve_unregistered_plugin_returns_400(
+    app: FastAPI,
+    client: AsyncClient,
+    db: Db,
+    mock_user: Callable[[Any], None],
+    url_for: Callable[..., str],
+    test_plugin: DummyPlugin,
+    mocker: MockerFixture,
+) -> None:
+    """Same error raised from the auto-approve inside CreateGroupRequest (an app
+    owner's own request). Submit-time validation is forced to pass so the failure
+    can only be caught by the POST handler's wrapper around the operation."""
+    app_obj = await _make_app_with_plugin(db)
+    owner = await _make_app_owner(db, app_obj)
+    mock_user(owner)
+
+    mocker.patch(
+        "api.plugins.app_group_lifecycle.validate_app_group_lifecycle_plugin_group_config",
+        side_effect=[{}, AppGroupLifecyclePluginFilteringError(DummyPlugin.ID, 0)],
+    )
+
+    resp = await client.post(
+        url_for("api-group-requests.group_requests_create"),
+        json={
+            "requested_group_type": "app_group",
+            "requested_group_name": f"App-{app_obj.name}-Admins",
+            "requested_group_description": "desc",
+            "requested_app_id": app_obj.id,
+            "requested_plugin_data": {DummyPlugin.ID: {"configuration": {"group_id": "g-1"}}},
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert "Expected one response" in resp.text
+    gr = (await db.session.scalars(select(GroupRequest))).first()
+    assert gr is not None
+    assert gr.status == AccessRequestStatus.PENDING
+
+
+async def test_put_approve_returns_400_when_app_plugin_is_unregistered(
+    app: FastAPI,
+    client: AsyncClient,
+    db: Db,
+    mock_user: Callable[[Any], None],
+    url_for: Callable[..., str],
+    test_plugin: DummyPlugin,
+) -> None:
+    """Same error raised from approval-time re-validation on the resolve path."""
+    admin = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
+    requester: OktaUser = await OktaUserFactory.create_async()
+    db.session.add(requester)
+    await db.session.commit()
+    app_obj = await _make_app_with_unregistered_plugin(db)
+
+    gr = await CreateGroupRequest(
+        requester_user=requester,
+        requested_group_name=f"App-{app_obj.name}-Admins",
+        requested_group_type="app_group",
+        requested_app_id=app_obj.id,
+        requested_plugin_data={UNREGISTERED_PLUGIN_ID: {"configuration": {"group_id": "g-1"}}},
+    ).execute()
+    assert gr is not None
+    # Capture the id up front: the failed request rolls its session back, which
+    # expires every instance in the identity map, and touching `gr.id` afterwards
+    # would lazy-load outside a greenlet (MissingGreenlet).
+    gr_id = gr.id
+
+    mock_user(admin)
+    resp = await client.put(
+        url_for("api-group-requests.group_request_by_id_put", group_request_id=gr_id),
+        json={"approved": True},
+    )
+    assert resp.status_code == 400, resp.text
+    assert UNREGISTERED_PLUGIN_ID in resp.text
+    refreshed = await db.session.get(GroupRequest, gr_id)
+    assert refreshed is not None
+    assert refreshed.status == AccessRequestStatus.PENDING
+    assert refreshed.approved_group_id is None
 
 
 # --- Approval applies plugin config ----------------------------------------

--- a/tests/test_group_request_plugin_config.py
+++ b/tests/test_group_request_plugin_config.py
@@ -15,6 +15,7 @@ from api.extensions import Db
 from api.models import AccessRequestStatus, AppGroup, GroupRequest, OktaUser, OktaUserGroupMember
 from api.operations import ApproveGroupRequest, CreateGroupRequest
 from api.plugins.app_group_lifecycle import AppGroupLifecyclePluginFilteringError, hookimpl
+from api.schemas import EventType
 from api.schemas.requests_schemas import CreateGroupRequestBody, ResolveGroupRequestBody
 from api.services import okta
 from tests.factories import AppFactory, AppGroupFactory, OktaUserFactory
@@ -624,6 +625,71 @@ async def test_approve_does_not_mutate_request_plugin_data(
     assert "createdgrp0000000004" in mutating_plugin.group_created_calls
     # ...but the request's stored config is untouched.
     assert gr.requested_plugin_data[DummyPlugin.ID]["configuration"]["group_id"] == "only-requested"
+
+
+# --- A failed approval leaves no approve audit event ------------------------
+
+
+async def test_approve_invalid_plugin_config_emits_no_approve_audit_event(
+    app: FastAPI,
+    client: AsyncClient,
+    db: Db,
+    test_plugin: DummyPlugin,
+    mocker: MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Approval-time re-validation of the plugin config runs with the rest of the
+    validation, *before* the group_request_approve audit event is emitted. So a
+    config that has gone invalid since filing must leave no "approved" audit entry
+    behind for an approval that never completed — the router turns the failure into
+    a retryable 400, which would re-emit the event on every retry."""
+    admin = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
+    # Mocked so that a regression (validating after the audit log again) fails on the
+    # audit assertion below rather than on an unmocked Okta call.
+    mocker.patch.object(
+        okta, "create_group", side_effect=lambda name, desc: OktaSdkGroup.from_dict({"id": "createdgrp0000000006"})
+    )
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
+
+    requester: OktaUser = await OktaUserFactory.create_async()
+    db.session.add(requester)
+    await db.session.commit()
+    app_obj = await _make_app_with_plugin(db)
+
+    gr = await CreateGroupRequest(
+        requester_user=requester,
+        requested_group_name=f"App-{app_obj.name}-Admins",
+        requested_group_type="app_group",
+        requested_app_id=app_obj.id,
+        requested_plugin_data={DummyPlugin.ID: {"configuration": {"group_id": "valid-at-filing"}}},
+    ).execute()
+    assert gr is not None
+    gr_id = gr.id
+
+    # The plugin now rejects the stored config, as if the plugin's schema changed
+    # between filing and approval.
+    mocker.patch(
+        "api.plugins.app_group_lifecycle.validate_app_group_lifecycle_plugin_group_config",
+        return_value={"group_id": "changed since submit"},
+    )
+
+    with caplog.at_level(logging.INFO, logger="access.audit"):
+        with pytest.raises(ValueError, match="group_id"):
+            await ApproveGroupRequest(group_request=gr, approver_user=admin, approval_reason="ok").execute()
+
+    audit_messages = [r.getMessage() for r in caplog.records if r.name == "access.audit"]
+    assert not any(EventType.group_request_approve.value in message for message in audit_messages), (
+        f"approval failed but emitted a {EventType.group_request_approve.value} audit event: {audit_messages}"
+    )
+    # The group must not have been created, nor the request resolved.
+    assert await db.session.get(AppGroup, "createdgrp0000000006") is None
+    refreshed = await db.session.get(GroupRequest, gr_id)
+    assert refreshed is not None
+    assert refreshed.status == AccessRequestStatus.PENDING
+    assert refreshed.approved_group_id is None
 
 
 # --- Config supplied for an app with no plugin is dropped with a warning ----


### PR DESCRIPTION
# Summary
Lets users supply (and resolvers edit) app-group-lifecycle plugin group config when requesting an app group, validates it at submit and approval, and applies it to the group created on approval so the plugin's `group_created` hook runs against a configured group. The detail view surfaces the config under Requested/Approved details.

**Urgency**: 5 days
**Expected review effort**: MEDIUM

# Motivation
App-group-lifecycle plugins can require per-group config (e.g. a Google Group plugin needs an email prefix + display name). Today that config is only collectable in the direct group-create/edit flow. When a user *requests* a group for such an app, there is nowhere to supply it, so approval creates the group unconfigured. This adds a generic "plugin-config-in-requests" capability.

# UI
<img width="818" height="1578" alt="image" src="https://github.com/user-attachments/assets/4aace7e8-da0d-4c8f-9a9e-1ec261343e4e" />
<img width="1562" height="1330" alt="image" src="https://github.com/user-attachments/assets/8c235a16-cde4-4566-aa5a-56d8c3ba660c" />

<details>
<summary><h1>Description of Changes</h1></summary>

- **Model + migration**: `requested_plugin_data` / `resolved_plugin_data` JSON columns on `GroupRequest` (JSONB on Postgres), mirroring the existing `requested_*`/`resolved_*` pairs. Config is stored in the group `plugin_data` shape `{plugin_id: {configuration: {...}}}`.
- **Create**: `CreateGroupRequest` persists `requested_plugin_data`; the POST endpoint validates it against the app's plugin (400 on invalid/missing-required).
- **Approve**: `ApproveGroupRequest` resolves `resolved_plugin_data or requested_plugin_data`, re-validates, and sets it on the new `AppGroup` *before* `CreateGroup` runs, so `group_created` sees the config. Invalid config → 400 via the PUT handler.
- **Resolve (PUT)**: accepts a resolver's `resolved_plugin_data` edits.
- **Frontend**: the create form renders the existing plugin config form for app-group requests whose app has a plugin (fetching `AppDetail` via `useAppById`, since search summaries omit the plugin id) and submits `requested_plugin_data`; the detail view shows the config under Requested and Approved details (resolver-changed values as ~~old~~ → new); the resolver can edit before approving; the config header is hidden when a plugin declares no group fields. DOM-free helpers with unit tests. Client `plugin_data` fields hand-added to `apiSchemas.ts` (the resolved codegen renames generics across the whole client; drift-check workflow permits hand-editing). Also fixes a stale `jest-dom` import that blocked vitest.

</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

- Backend (`uv run pytest`): feature file + regressions **119 passed** (`test_group_request`, `test_group_request_plugin_config`, `test_app_group_lifecycle_plugin`). `uv run ruff check`/`ruff format` clean; `uv run ty check` clean. Migration verified up + down; single alembic head.
- Frontend: `tsc --noEmit` clean; **14** vitest unit tests pass; prettier clean.
- [x] Manual UI check: resolver form pre-fills the requester's submitted config.

</details>

# Guidance for Reviewers
Rebased onto current `main` (which had moved through the async DB/Okta refactor + Okta SDK v3); the feature and its tests were ported to the async APIs, and the migration re-chained to the current head. Review commit-by-commit — five commits by layer: (1) model + migration, (2) schemas, (3) async operations + router + backend tests, (4) TS client, (5) frontend. Most worth a look: `ApproveGroupRequest` setting `new_group.plugin_data` before `CreateGroup(...).execute()` so the async `group_created` hook sees it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)