### PR TITLE
perf: stop re-fetching a group's own row per granting role mapping

### DIFF
--- a/api/mcp/tools.py
+++ b/api/mcp/tools.py
@@ -86,9 +86,11 @@ from api.models import (
     Tag,
 )
 from api.routers._eager import (
+    bind_role_group_map_own_group,
     group_tag_map_options,
     polymorphic_group_options,
     role_group_map_options,
+    role_group_map_options_for_own_group,
     user_group_member_options,
 )
 from api.schemas import (
@@ -223,8 +225,8 @@ def _group_load_options() -> tuple:
         selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
         selectinload(OktaGroup.active_user_memberships).options(*user_group_member_options()),
         selectinload(OktaGroup.active_user_ownerships).options(*user_group_member_options()),
-        selectinload(OktaGroup.active_role_member_mappings).options(*role_group_map_options()),
-        selectinload(OktaGroup.active_role_owner_mappings).options(*role_group_map_options()),
+        selectinload(OktaGroup.active_role_member_mappings).options(*role_group_map_options_for_own_group()),
+        selectinload(OktaGroup.active_role_owner_mappings).options(*role_group_map_options_for_own_group()),
         selectinload(RoleGroup.active_role_associated_group_member_mappings).options(*role_group_map_options()),
         selectinload(RoleGroup.active_role_associated_group_owner_mappings).options(*role_group_map_options()),
         joinedload(AppGroup.app),
@@ -456,6 +458,8 @@ def _register_group_tools(mcp: "FastMCP") -> None:
         ).first()
         if group is None:
             return _error("Group not found")
+        bind_role_group_map_own_group(group, group.active_role_member_mappings)
+        bind_role_group_map_own_group(group, group.active_role_owner_mappings)
         validated = _group_adapter.validate_python(group, from_attributes=True)
         return _group_adapter.dump_json(validated).decode()
 
@@ -581,6 +585,8 @@ def _register_role_tools(mcp: "FastMCP") -> None:
         ).first()
         if role is None:
             return _error("Role not found")
+        bind_role_group_map_own_group(role, role.active_role_member_mappings)
+        bind_role_group_map_own_group(role, role.active_role_owner_mappings)
         return _group_adapter.dump_json(_group_adapter.validate_python(role, from_attributes=True)).decode()
 
 

--- a/api/mcp/tools.py
+++ b/api/mcp/tools.py
@@ -86,7 +86,7 @@ from api.models import (
     Tag,
 )
 from api.routers._eager import (
-    bind_role_group_map_own_group,
+    bind_role_group_map_own_groups,
     group_tag_map_options,
     polymorphic_group_options,
     role_group_map_options,
@@ -458,8 +458,7 @@ def _register_group_tools(mcp: "FastMCP") -> None:
         ).first()
         if group is None:
             return _error("Group not found")
-        bind_role_group_map_own_group(group, group.active_role_member_mappings)
-        bind_role_group_map_own_group(group, group.active_role_owner_mappings)
+        bind_role_group_map_own_groups(group)
         validated = _group_adapter.validate_python(group, from_attributes=True)
         return _group_adapter.dump_json(validated).decode()
 
@@ -585,8 +584,6 @@ def _register_role_tools(mcp: "FastMCP") -> None:
         ).first()
         if role is None:
             return _error("Role not found")
-        bind_role_group_map_own_group(role, role.active_role_member_mappings)
-        bind_role_group_map_own_group(role, role.active_role_owner_mappings)
         return _group_adapter.dump_json(_group_adapter.validate_python(role, from_attributes=True)).decode()
 
 

--- a/api/routers/_eager.py
+++ b/api/routers/_eager.py
@@ -54,13 +54,22 @@ def user_group_member_options() -> tuple:
     )
 
 
-def role_group_map_options() -> tuple:
-    """Eager-load every relationship `RoleGroupMapDetail` reads."""
+def _role_group_map_actor_and_role_options() -> tuple:
+    """The subset of `role_group_map_options()`/`role_group_map_options_for_own_group()`
+    that's identical between them: the role side and the actor columns.
+    They only disagree on how to load `.group`/`.active_group`."""
     return (
         joinedload(RoleGroupMap.role_group),
         joinedload(RoleGroupMap.active_role_group),
         joinedload(RoleGroupMap.created_actor),
         joinedload(RoleGroupMap.ended_actor),
+    )
+
+
+def role_group_map_options() -> tuple:
+    """Eager-load every relationship `RoleGroupMapDetail` reads."""
+    return (
+        *_role_group_map_actor_and_role_options(),
         selectinload(RoleGroupMap.group).options(*polymorphic_group_options()),
         selectinload(RoleGroupMap.active_group).options(*polymorphic_group_options()),
     )
@@ -75,25 +84,23 @@ def role_group_map_options_for_own_group() -> tuple:
     the group being loaded -- the mapping is *about* that group. Eagerly
     re-selecting `.group`/`.active_group` there re-fetches the exact
     `app_group`/`app` row the caller already has, once per mapping. Skip
-    the query here and use `bind_role_group_map_own_group` after load to
+    the query here and use `bind_role_group_map_own_groups` after load to
     stamp both attributes from the already-loaded group instead.
     """
     return (
-        joinedload(RoleGroupMap.role_group),
-        joinedload(RoleGroupMap.active_role_group),
-        joinedload(RoleGroupMap.created_actor),
-        joinedload(RoleGroupMap.ended_actor),
+        *_role_group_map_actor_and_role_options(),
         noload(RoleGroupMap.group),
         noload(RoleGroupMap.active_group),
     )
 
 
-def bind_role_group_map_own_group(group: OktaGroup, mappings: list[RoleGroupMap]) -> None:
-    """Stamp `.group`/`.active_group` on mappings loaded via
-    `role_group_map_options_for_own_group` without hitting the database --
-    see that function's docstring."""
+def bind_role_group_map_own_groups(group: OktaGroup) -> None:
+    """Stamp `.group`/`.active_group` on `group.active_role_member_mappings`
+    and `.active_role_owner_mappings` -- the two `RoleGroupMap` collections
+    loaded via `role_group_map_options_for_own_group` -- without hitting the
+    database. See that function's docstring for why this is correct."""
     active_group = group if group.deleted_at is None else None
-    for mapping in mappings:
+    for mapping in (*group.active_role_member_mappings, *group.active_role_owner_mappings):
         set_committed_value(mapping, "group", group)
         set_committed_value(mapping, "active_group", active_group)
 

--- a/api/routers/_eager.py
+++ b/api/routers/_eager.py
@@ -11,7 +11,8 @@ relationships.
 
 from __future__ import annotations
 
-from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload
+from sqlalchemy.orm import joinedload, noload, selectin_polymorphic, selectinload
+from sqlalchemy.orm.attributes import set_committed_value
 
 from api.models import (
     AppGroup,
@@ -63,6 +64,38 @@ def role_group_map_options() -> tuple:
         selectinload(RoleGroupMap.group).options(*polymorphic_group_options()),
         selectinload(RoleGroupMap.active_group).options(*polymorphic_group_options()),
     )
+
+
+def role_group_map_options_for_own_group() -> tuple:
+    """Eager-load every relationship `RoleGroupMapDetail` reads, for mappings
+    reached via `OktaGroup.active_role_member_mappings` /
+    `active_role_owner_mappings`.
+
+    On those two relationships `RoleGroupMap.group_id` is always the id of
+    the group being loaded -- the mapping is *about* that group. Eagerly
+    re-selecting `.group`/`.active_group` there re-fetches the exact
+    `app_group`/`app` row the caller already has, once per mapping. Skip
+    the query here and use `bind_role_group_map_own_group` after load to
+    stamp both attributes from the already-loaded group instead.
+    """
+    return (
+        joinedload(RoleGroupMap.role_group),
+        joinedload(RoleGroupMap.active_role_group),
+        joinedload(RoleGroupMap.created_actor),
+        joinedload(RoleGroupMap.ended_actor),
+        noload(RoleGroupMap.group),
+        noload(RoleGroupMap.active_group),
+    )
+
+
+def bind_role_group_map_own_group(group: OktaGroup, mappings: list[RoleGroupMap]) -> None:
+    """Stamp `.group`/`.active_group` on mappings loaded via
+    `role_group_map_options_for_own_group` without hitting the database --
+    see that function's docstring."""
+    active_group = group if group.deleted_at is None else None
+    for mapping in mappings:
+        set_committed_value(mapping, "group", group)
+        set_committed_value(mapping, "active_group", active_group)
 
 
 def group_tag_map_options() -> tuple:

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -44,7 +44,7 @@ from fastapi_pagination.ext.sqlalchemy import paginate
 from api.pagination import Page, validated
 from api.plugins.app_group_lifecycle import merge_app_lifecycle_plugin_data
 from api.routers._eager import (
-    bind_role_group_map_own_group,
+    bind_role_group_map_own_groups,
     group_tag_map_options,
     role_group_map_options,
     role_group_map_options_for_own_group,
@@ -102,8 +102,7 @@ def _load_group_with_options(db: DbSession, group_id: str) -> OktaGroup | None:
         .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
     ).first()
     if group is not None:
-        bind_role_group_map_own_group(group, group.active_role_member_mappings)
-        bind_role_group_map_own_group(group, group.active_role_owner_mappings)
+        bind_role_group_map_own_groups(group)
     return group
 
 

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -44,8 +44,10 @@ from fastapi_pagination.ext.sqlalchemy import paginate
 from api.pagination import Page, validated
 from api.plugins.app_group_lifecycle import merge_app_lifecycle_plugin_data
 from api.routers._eager import (
+    bind_role_group_map_own_group,
     group_tag_map_options,
     role_group_map_options,
+    role_group_map_options_for_own_group,
     user_group_member_options,
 )
 from api.schemas import (
@@ -73,8 +75,8 @@ ROLE_ASSOCIATED_GROUP_TYPES = with_polymorphic(OktaGroup, [AppGroup])
 
 DEFAULT_LOAD_OPTIONS = (
     selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
-    selectinload(OktaGroup.active_role_member_mappings).options(*role_group_map_options()),
-    selectinload(OktaGroup.active_role_owner_mappings).options(*role_group_map_options()),
+    selectinload(OktaGroup.active_role_member_mappings).options(*role_group_map_options_for_own_group()),
+    selectinload(OktaGroup.active_role_owner_mappings).options(*role_group_map_options_for_own_group()),
     selectinload(RoleGroup.active_role_associated_group_member_mappings).options(*role_group_map_options()),
     selectinload(RoleGroup.active_role_associated_group_owner_mappings).options(*role_group_map_options()),
     joinedload(AppGroup.app),
@@ -93,12 +95,16 @@ def _load_group_with_options(db: DbSession, group_id: str) -> OktaGroup | None:
     # expire_on_commit=False the identity map would otherwise serve
     # pre-operation relationship state, so drop cached ORM state first.
     db.expire_all()
-    return db.scalars(
+    group = db.scalars(
         select(OktaGroup)
         .options(*DEFAULT_LOAD_OPTIONS)
         .where(or_(OktaGroup.id == group_id, OktaGroup.name == group_id))
         .order_by(nullsfirst(OktaGroup.deleted_at.desc()))
     ).first()
+    if group is not None:
+        bind_role_group_map_own_group(group, group.active_role_member_mappings)
+        bind_role_group_map_own_group(group, group.active_role_owner_mappings)
+    return group
 
 
 @router.get("", name="groups")

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -9,7 +9,7 @@ from okta.models.group import Group
 from pytest_mock import MockerFixture
 from fastapi import FastAPI
 
-from sqlalchemy import func, or_
+from sqlalchemy import event, func, or_
 from api.auth import permissions as AuthorizationHelpers
 from api.extensions import Db, db
 from api.config import settings
@@ -91,6 +91,58 @@ def test_get_group(
 
     data = rep.json()
     assert data["name"] == app_group.name
+
+
+def test_get_group_role_grants_do_not_reload_own_group(
+    client: TestClient,
+    db: Db,
+    access_app: App,
+    app_group: AppGroup,
+    url_for: Any,
+) -> None:
+    # Regression test: a group granted by several different roles was
+    # re-fetching its own app_group/app row once per role's membership/
+    # ownership mapping instead
+    # of reusing the copy already loaded for the group itself.
+    db.session.add(access_app)
+    db.session.commit()
+    app_group.app_id = access_app.id
+    db.session.add(app_group)
+    db.session.commit()
+
+    for _ in range(5):
+        granting_role = RoleGroupFactory.create()
+        db.session.add(granting_role)
+        db.session.commit()
+        ModifyRoleGroups(
+            role_group=granting_role,
+            groups_to_add=[app_group.id],
+            owner_groups_to_add=[],
+            sync_to_okta=False,
+        ).execute()
+
+    queries: list[str] = []
+
+    def _record(conn: Any, cursor: Any, statement: str, parameters: Any, context: Any, executemany: bool) -> None:
+        queries.append(statement)
+
+    event.listen(db.engine, "before_cursor_execute", _record)
+    try:
+        group_url = url_for("api-groups.group_by_id", group_id=app_group.id)
+        rep = client.get(group_url)
+    finally:
+        event.remove(db.engine, "before_cursor_execute", _record)
+
+    assert rep.status_code == 200
+    # Exactly one such query is expected: loading the group's own polymorphic
+    # (AppGroup + App) identity. Each additional occurrence is a re-fetch of
+    # that same row triggered by one of the five role mappings above.
+    own_group_reloads = [q for q in queries if "FROM okta_group JOIN app_group" in q]
+    assert len(own_group_reloads) == 1, (
+        f"expected exactly one app_group/app load, got {len(own_group_reloads)} -- "
+        "a group granted by multiple roles is re-fetching its own row once per "
+        "role mapping instead of reusing the already-loaded group"
+    )
 
 
 def test_get_group_members(client: TestClient, db: Db, okta_group: OktaGroup, user: OktaUser, url_for: Any) -> None:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -26,6 +26,7 @@ from typing import Any, Generator, Optional
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from sqlalchemy import event
 
 from api.config import settings
 from api.context import RequestContext, set_request_context
@@ -38,7 +39,7 @@ from api.mcp.auth import (
     set_mcp_identity,
 )
 from api.models import App, AppGroup, OktaGroup, OktaUser, RoleGroup
-from api.operations import ModifyGroupUsers
+from api.operations import ModifyGroupUsers, ModifyRoleGroups
 from tests.factories import RoleGroupFactory
 
 
@@ -243,6 +244,62 @@ def test_read_tool_requires_read_all_scope(
     payload = json.loads(result)
     assert "results" in payload
     assert isinstance(payload["results"], list)
+
+
+def test_get_group_tool_role_grants_do_not_reload_own_group(
+    with_mcp_enabled: None,
+    db: Db,
+    access_app: App,
+    app_group: AppGroup,
+    user: OktaUser,
+) -> None:
+    # Same bug as the REST regression test in tests/test_group.py: the
+    # `get_group` MCP tool shares `_group_load_options()` with the REST
+    # router's default loader.
+    db.session.add_all([user, access_app])
+    db.session.commit()
+    app_group.app_id = access_app.id
+    db.session.add(app_group)
+    db.session.commit()
+
+    for _ in range(5):
+        granting_role = RoleGroupFactory.create()
+        db.session.add(granting_role)
+        db.session.commit()
+        ModifyRoleGroups(
+            role_group=granting_role,
+            groups_to_add=[app_group.id],
+            owner_groups_to_add=[],
+            sync_to_okta=False,
+        ).execute()
+
+    from api.mcp.server import create_mcp_server
+
+    mcp = create_mcp_server()
+
+    queries: list[str] = []
+
+    def _record(conn: Any, cursor: Any, statement: str, parameters: Any, context: Any, executemany: bool) -> None:
+        queries.append(statement)
+
+    token = set_mcp_identity(MCPIdentity(user_id=user.id, scopes=frozenset({MCP_SCOPE_READ_ALL})))
+    event.listen(db.engine, "before_cursor_execute", _record)
+    try:
+        result = _call_tool(mcp, "get_group", group_id_or_name=app_group.id)
+    finally:
+        event.remove(db.engine, "before_cursor_execute", _record)
+        from api.mcp.auth import reset_mcp_identity
+
+        reset_mcp_identity(token)
+
+    payload = json.loads(result)
+    assert payload["id"] == app_group.id
+    own_group_reloads = [q for q in queries if "FROM okta_group JOIN app_group" in q]
+    assert len(own_group_reloads) == 1, (
+        f"expected exactly one app_group/app load, got {len(own_group_reloads)} -- "
+        "a group granted by multiple roles is re-fetching its own row once per "
+        "role mapping instead of reusing the already-loaded group"
+    )
 
 
 def test_write_tool_requires_create_requests_scope(


### PR DESCRIPTION
# Summary
Fixes an N+1 query pattern: `GET /api/groups/{group_id}` (and the equivalent MCP `get_group`/`get_role` tools) re-fetched a group's own `app_group`/`app` row once per role that grants access to it, instead of reusing the copy already loaded for the group itself.

**Urgency**: low (perf/cost cleanup, not user-facing breakage)
**Expected review effort**: MEDIUM

# Motivation
`OktaGroup.active_role_member_mappings`/`active_role_owner_mappings` (roles that grant access to *this* group) eager-load each `RoleGroupMap`'s `.group`/`.active_group` via the same generic polymorphic loader used everywhere else. For these two relationships specifically, `RoleGroupMap.group_id` is always the id of the group being loaded, so that eager-load is guaranteed to re-select a row we already have, once per granting role.

# Description of Changes
- **Commit 1** adds `role_group_map_options_for_own_group()` and `bind_role_group_map_own_group()` to `api/routers/_eager.py`. The former skips the DB query for `.group`/`.active_group` (`noload`); the latter stamps both attributes from the already-loaded group via `sqlalchemy.orm.attributes.set_committed_value`, respecting the "anchor is soft-deleted -> `active_group` is `None`" case. No behavior change by itself.
- **Commit 2** wires this into `api/routers/groups.py`'s `DEFAULT_LOAD_OPTIONS`/`_load_group_with_options`, with a regression test asserting the group's own row is loaded exactly once regardless of how many roles grant access to it.
- **Commit 3** applies the identical fix to `api/mcp/tools.py`'s `_group_load_options()` (shared by the `get_group`/`get_role` MCP tools, which have the same bug), with an equivalent regression test.

# Validation of Changes
- Added two regression tests (REST + MCP) that grant a group access via 5 different roles and assert the `app_group`/`app` query fires exactly once; both fail on `main` (3 queries) and pass with the fix (1 query).
- Full suite: `564 passed`. `ruff check`, `ruff format --check`, and `mypy` clean on all touched files.

# Guidance for Reviewers
Review commit-by-commit -- each commit passes tests on its own:
1. `_eager.py` helper (infra only, unused)
2. REST router fix + test
3. MCP tools fix + test (same bug, same fix, different surface)

The one thing worth double-checking: `bind_role_group_map_own_group` assumes `RoleGroupMap.group_id == group.id` whenever it's called on mappings from `active_role_member_mappings`/`active_role_owner_mappings` -- that's guaranteed by those relationships' own `primaryjoin` (`OktaGroup.id == RoleGroupMap.group_id`), not an incidental assumption, but it's the crux of why this is safe.

I did not touch `RoleGroup.active_role_associated_group_member_mappings`/`_owner_mappings` (the forward direction -- a role listing the groups *it* grants). There `.group`/`.active_group` legitimately differ from the anchor, and while there's a smaller residual redundancy when a *role* is reached via the reverse path (it re-loads its own forward mappings), it's a small fixed cost rather than the main issue fixed here, and safely special-casing it would require more invasive changes. Happy to file a follow-up if we want to chase that too.