### PR TITLE
fix: 404 missing hashed assets instead of the SPA shell, add explicit Cache-Control

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -416,9 +416,27 @@ def create_app(testing: Optional[bool] = False) -> FastAPI:
             except (ValueError, OSError):
                 raise HTTPException(status_code=404, detail="Not Found")
             if candidate.is_file():
-                return FileResponse(candidate)
+                if spa_path.startswith("assets/"):
+                    # Vite content-hashes this directory's filenames, so a
+                    # given URL can never resolve to different bytes later.
+                    # Safe to cache indefinitely.
+                    headers = {"Cache-Control": "public, max-age=31536000, immutable"}
+                else:
+                    headers = {}
+                return FileResponse(candidate, headers=headers)
+            if spa_path.startswith("assets/"):
+                # Everything under assets/ is a content-hashed build
+                # artifact. If it's not on disk it's genuinely missing (e.g.
+                # a request that landed on a pod running a different build
+                # during a rolling deploy), not a client-side route for
+                # React Router to handle, and it must not be cached as a
+                # false negative once the file is actually available again.
+                raise HTTPException(status_code=404, detail="Not Found", headers={"Cache-Control": "no-store"})
             # Anything else falls back to index.html so React Router can
-            # handle the path on the client.
-            return FileResponse(BUILD_DIR / "index.html")
+            # handle the path on the client. This response must never be
+            # cached: it's the only thing that says which asset hashes are
+            # currently valid, and a cached copy could keep pointing at
+            # hashes a future deploy has already removed.
+            return FileResponse(BUILD_DIR / "index.html", headers={"Cache-Control": "no-cache, must-revalidate"})
 
     return app

--- a/tests/test_spa.py
+++ b/tests/test_spa.py
@@ -1,0 +1,59 @@
+"""Tests for the SPA catch-all route in `api.app.create_app` (`serve_spa`).
+
+CI doesn't run the Vite build, so `api.app.BUILD_DIR` doesn't exist by
+default and the catch-all route never registers against the shared `app`
+fixture. Each test here builds its own app with `BUILD_DIR` monkeypatched to
+a stub directory before `create_app()` runs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Generator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api import app as app_module
+from api.app import create_app
+from api.extensions import Db
+
+
+@pytest.fixture
+def stub_build_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    build_dir = tmp_path / "build"
+    (build_dir / "assets").mkdir(parents=True)
+    (build_dir / "index.html").write_text("<html><body>shell</body></html>")
+    (build_dir / "assets" / "index-existing.js").write_text('console.log("hi");')
+    monkeypatch.setattr(app_module, "BUILD_DIR", build_dir)
+    return build_dir
+
+
+@pytest.fixture
+def spa_client(db: Db, stub_build_dir: Path) -> Generator[TestClient, None, None]:
+    app: FastAPI = create_app(testing=True)
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+
+
+def test_existing_asset_is_served_with_immutable_cache_control(spa_client: TestClient) -> None:
+    resp = spa_client.get("/assets/index-existing.js")
+    assert resp.status_code == 200
+    assert resp.text == 'console.log("hi");'
+    assert resp.headers["cache-control"] == "public, max-age=31536000, immutable"
+    assert "javascript" in resp.headers["content-type"]
+
+
+def test_missing_asset_returns_404_not_the_spa_shell(spa_client: TestClient) -> None:
+    resp = spa_client.get("/assets/index-missing.js")
+    assert resp.status_code == 404
+    assert resp.headers["cache-control"] == "no-store"
+    assert "shell" not in resp.text
+
+
+def test_unknown_route_falls_back_to_spa_shell_without_caching(spa_client: TestClient) -> None:
+    resp = spa_client.get("/apps/Github")
+    assert resp.status_code == 200
+    assert resp.text == "<html><body>shell</body></html>"
+    assert resp.headers["cache-control"] == "no-cache, must-revalidate"


### PR DESCRIPTION
# Summary
The SPA catch-all route serves `index.html` with a 200 for any path it can't find on disk, including paths that look like static assets. Missing hashed assets under `assets/` now return a real 404, and asset/shell responses get explicit `Cache-Control` so neither a correct nor an incorrect response can be cached longer than intended.

**Urgency**: a few days
**Expected review effort**: LOW

# Motivation
During a rolling deployment, a request for a content-hashed JS/CSS file can be routed to a replica running a different build that doesn't have that exact file on disk. The catch-all route can't distinguish "this is a client-side route for React Router" from "this asset is genuinely missing on this replica" — both look identical (no file at that path) — so it served the SPA shell (`index.html`, 200) for the missing asset too. A caching layer in front of the app then cached that response under the asset's URL, since nothing told it the response's `Content-Type` didn't match what a JS/CSS extension implies. Browsers refuse to execute a `<script type="module">` whose response isn't a JS content type, so any client that hit this during a deploy saw a blank page, and the cached copy kept serving the same wrong response well after the deploy had finished.

# Description of Changes
In `api/app.py`'s `serve_spa`:
- A missing file under `assets/` now raises a `404` (with `Cache-Control: no-store`, so the 404 itself can't get stuck cached once the file becomes available again) instead of falling back to `index.html`.
- An existing file under `assets/` gets `Cache-Control: public, max-age=31536000, immutable` — safe, since Vite content-hashes these filenames, so a given URL can never later point at different bytes.
- The `index.html` shell fallback (the legitimate case, for real client-side routes) gets `Cache-Control: no-cache, must-revalidate` — it's the only place that says which asset hashes are currently valid, so it must never be served stale.

# Validation of Changes
- Added `tests/test_spa.py` covering all three branches: existing asset served with the immutable header, missing asset under `assets/` returns 404 with `no-store`, and an unmapped route still falls back to the shell with `no-cache`.
- Full suite passes (567 tests).
- `ruff check`, `ruff format --check`, and `mypy` all clean on the changed files.

# Guidance for Reviewers
Single logical change in one function — review as one unit. The main thing worth double-checking: the `assets/` prefix is used both to decide "should a missing file 404 instead of falling back" and "should an existing file get the long-lived immutable cache header." That scoping means root-level static files (favicon, robots.txt, etc.) are untouched by this change and keep the old permissive behavior, which is intentional — they aren't content-hashed, so treating a miss there as a hard 404 wasn't part of the bug being fixed.