### PR TITLE
perf: index okta_user_group_member (group_id, is_owner, ended_at)

### DIFF
--- a/api/models/core_models.py
+++ b/api/models/core_models.py
@@ -82,6 +82,18 @@ class OktaUserGroupMember(Base):
         Boolean, nullable=False, server_default=expression.false(), default=False
     )
 
+    # Postgres does not index FK columns automatically; the hot lookups filter
+    # by group_id (usually with is_owner and an active-membership ended_at
+    # predicate) and seq-scan without this.
+    __table_args__ = (
+        Index(
+            "idx_okta_user_group_member_group_id_is_owner_ended_at",
+            "group_id",
+            "is_owner",
+            "ended_at",
+        ),
+    )
+
     # See more details on specifying alternative join conditions for relationships at
     # https://docs.sqlalchemy.org/en/14/orm/join_conditions.html#specifying-alternate-join-conditions
     group: Mapped["OktaGroup"] = relationship(

--- a/migrations/versions/61afb5496c0a_index_okta_user_group_member_group_.py
+++ b/migrations/versions/61afb5496c0a_index_okta_user_group_member_group_.py
@@ -19,12 +19,10 @@ depends_on = None
 def upgrade():
     # Plain (non-CONCURRENT) CREATE INDEX, deliberately: it stays transactional
     # (clean rollback, no INVALID index to clean up) at the cost of blocking
-    # writes to this one table while the index builds. Reads are unaffected.
-    # The lock_timeout makes the migration fail fast instead of stalling queued
-    # writes behind a long-running transaction holding the table lock; if it
-    # trips, just re-run the migration.
-    if op.get_bind().dialect.name == "postgresql":
-        op.execute("SET lock_timeout = '10s'")
+    # writes to this one table while the index builds. Reads are unaffected,
+    # and write volume here is low enough that queued writes clear trivially.
+    # If the migration hangs waiting on a lock, cancelling it is safe - it
+    # rolls back cleanly and can simply be re-run.
     op.create_index(
         "idx_okta_user_group_member_group_id_is_owner_ended_at",
         "okta_user_group_member",

--- a/migrations/versions/61afb5496c0a_index_okta_user_group_member_group_.py
+++ b/migrations/versions/61afb5496c0a_index_okta_user_group_member_group_.py
@@ -1,0 +1,39 @@
+"""index okta_user_group_member group lookups
+
+Revision ID: 61afb5496c0a
+Revises: dc768a8ce1ad
+Create Date: 2026-07-07 10:00:00.000000
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "61afb5496c0a"
+down_revision = "dc768a8ce1ad"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Plain (non-CONCURRENT) CREATE INDEX, deliberately: it stays transactional
+    # (clean rollback, no INVALID index to clean up) at the cost of blocking
+    # writes to this one table while the index builds. Reads are unaffected.
+    # The lock_timeout makes the migration fail fast instead of stalling queued
+    # writes behind a long-running transaction holding the table lock; if it
+    # trips, just re-run the migration.
+    if op.get_bind().dialect.name == "postgresql":
+        op.execute("SET lock_timeout = '10s'")
+    op.create_index(
+        "idx_okta_user_group_member_group_id_is_owner_ended_at",
+        "okta_user_group_member",
+        ["group_id", "is_owner", "ended_at"],
+    )
+
+
+def downgrade():
+    op.drop_index(
+        "idx_okta_user_group_member_group_id_is_owner_ended_at",
+        table_name="okta_user_group_member",
+    )

--- a/tests/test_group_membership_sync.py
+++ b/tests/test_group_membership_sync.py
@@ -369,6 +369,9 @@ async def _get_group_members(db: Db, group_id: str) -> dict[str, MembershipDetai
                 select(OktaUserGroupMember)
                 .where(OktaUserGroupMember.group_id == group_id)
                 .where(OktaUserGroupMember.is_owner.is_(False))
+                # Keyed by user_id below, so the newest row per user must win
+                # regardless of which scan plan (and row order) the DB picks.
+                .order_by(OktaUserGroupMember.id)
             )
         ).all()
     }

--- a/tests/test_group_ownership_sync.py
+++ b/tests/test_group_ownership_sync.py
@@ -424,6 +424,9 @@ async def _get_group_owners(db: Db, group_id: str) -> dict[str, OwnershipDetails
                 select(OktaUserGroupMember)
                 .where(OktaUserGroupMember.group_id == group_id)
                 .where(OktaUserGroupMember.is_owner.is_(True))
+                # Keyed by user_id below, so the newest row per user must win
+                # regardless of which scan plan (and row order) the DB picks.
+                .order_by(OktaUserGroupMember.id)
             )
         ).all()
     }


### PR DESCRIPTION
## What

Adds an index on `okta_user_group_member (group_id, is_owner, ended_at)` — a new Alembic migration plus the matching index definition on the model so dev/test databases get it too.

## Why

The access database has been pegged at 100% CPU on weekdays (Datadog monitor 231119). Digging into query stats, almost all of that time goes to a handful of queries that answer "who are the members/owners of this group?". The table behind them has about a million rows and no index on `group_id` — Postgres doesn't index foreign key columns automatically — so every one of those queries reads the entire table (~110MB) to return a few dozen rows.

The index matches the full shape of the hot queries: filter by group, member vs. owner, and "is this membership still active" (`ended_at`). Including `ended_at` matters because most of a group's rows are historical — roughly 1,000 historical vs. 33 active for a typical group — and it costs almost nothing to maintain (only ~100 updates a day touch that column).

Tested locally with 500k seeded rows: the hot query goes from reading the whole table to reading 9 pages. We expect weekday DB CPU to drop from ~100% to roughly 25–35%.

## Notes

- The migration uses a plain `CREATE INDEX`, not `CONCURRENTLY`. It blocks writes to this one table while the index builds (tens of seconds; reads are unaffected), and in exchange the migration stays transactional: if anything goes wrong it rolls back cleanly and can simply be re-run. Write volume on this table is low (~100 updates/day), so briefly queued writes clear trivially; if the run ever hangs on a lock, cancelling it is equally safe.
- Two sync tests were relying on undefined row ordering (building a per-user dict from an unordered query); the new index changed sqlite's scan order and exposed that. Fixed by adding `ORDER BY id`.

## Follow-ups (deliberately not in this PR)

- A second index on `(user_id, ended_at)` for user-side lookups.
- Rate-limit or cache the sweep traffic from discord-yay-prd (~68% of API requests).
- Consider pointing read-only machine traffic at the idle read replica.

## Testing

Full migration chain upgraded/downgraded cleanly on Postgres 15 and sqlite; `alembic check` reports no model/schema drift; pytest green on both databases; `EXPLAIN` confirms the index is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
