### PR TITLE
fix: return MCP tool DB connections to the pool from their own task

### DIFF
--- a/api/mcp/auth/__init__.py
+++ b/api/mcp/auth/__init__.py
@@ -150,7 +150,16 @@ def requires_scope(scope: str) -> Callable[[F], F]:
 
     ``functools.wraps`` preserves the wrapped function's signature so
     FastMCP's schema introspection sees the original parameter list.
+
+    Besides enforcing the scope, the wrapper binds a per-call DB session
+    scope (via ``tool_session_scope``) so any connection the tool checks
+    out is returned to the pool from the FastMCP server task that opened
+    it — the ``/mcp`` request task's ``db.remove()`` runs in a different
+    task and would otherwise leak it (see ``api.mcp.db``).
     """
+    # Imported lazily to keep the auth package importable without the DB
+    # facade during config validation / lightweight tooling.
+    from api.mcp.db import tool_session_scope
 
     def decorator(fn: F) -> F:
         @functools.wraps(fn)
@@ -159,7 +168,8 @@ def requires_scope(scope: str) -> Callable[[F], F]:
                 require_scope(scope)
             except MCPScopeError as e:
                 return json.dumps({"error": str(e)})
-            return await fn(*args, **kwargs)
+            async with tool_session_scope():
+                return await fn(*args, **kwargs)
 
         return wrapper  # type: ignore[return-value]
 

--- a/api/mcp/db.py
+++ b/api/mcp/db.py
@@ -1,26 +1,72 @@
-"""Per-tool database session helper.
+"""Per-tool database session helpers.
 
 REST routers go through ``Depends(get_db)`` in ``api/database.py`` which
 commits or rolls back on the way out. MCP tools don't run through FastAPI
-dependencies, so they need an equivalent. This context manager wraps the
-existing scoped session and applies the same commit-on-success /
+dependencies, so they need an equivalent. ``mcp_db_session`` wraps the
+scoped session and applies the same commit-on-success /
 rollback-on-exception behavior.
 
-Read-only tools can use ``db.session`` directly without going through this
-helper — the request-scoped session is already wired up by
-``RequestIdMiddleware`` for any incoming HTTP request (including the
-``/mcp`` route). The helper exists for tools that need the commit/rollback
-discipline a write operation requires.
+Session-scope lifecycle
+-----------------------
+MCP tool handlers do **not** execute in the ``/mcp`` HTTP request task.
+FastMCP's ``StreamableHTTPSessionManager`` runs the server (and therefore
+the tool) in its own task, inside the session manager's task group. That
+matters for connection lifecycle: ``RequestIdMiddleware`` calls
+``db.remove()`` from the *request* task, but a connection a tool checks
+out belongs to the *server* task. Closing an async connection from a
+different task than the one that opened it does not return it to the pool
+— it stays checked out until the garbage collector reaps it, which is
+exactly what raises SQLAlchemy's "The garbage collector is trying to
+clean up non-checked-in connection ..." warning.
+
+``tool_session_scope`` fixes this: it binds a fresh session scope for the
+duration of a single tool call and removes it *in the same task the tool
+ran in*, so the connection is returned to the pool by its owning task.
+``requires_scope`` (the wrapper every tool passes through) enters it, so
+both read-only tools (``db.session`` directly) and write tools
+(``mcp_db_session``) are covered without per-tool boilerplate.
 """
 
 from __future__ import annotations
 
+import uuid
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.extensions import db as _db_shim
+from api.extensions import _session_scope, db as _db_shim
+
+
+@asynccontextmanager
+async def tool_session_scope() -> AsyncIterator[None]:
+    """Bind a fresh DB session scope for one MCP tool call and tear it
+    down in the calling task.
+
+    Each tool invocation gets its own ``async_scoped_session`` key so the
+    session it uses (via ``db.session``) is created and removed within the
+    FastMCP server task, guaranteeing the connection returns to the pool
+    from the task that checked it out. See the module docstring for why
+    the ``/mcp`` request task's ``db.remove()`` can't do this.
+    """
+    token = _session_scope.set(f"mcp-tool-{uuid.uuid4().hex}")
+    try:
+        yield
+    finally:
+        try:
+            # Swallow teardown errors so a failed close never masks the
+            # tool's result (or its own exception) — mirrors the
+            # RequestIdMiddleware teardown.
+            await _db_shim.remove()
+        except Exception:
+            pass
+        finally:
+            try:
+                _session_scope.reset(token)
+            except ValueError:
+                # Scope was set on a context copy; the token isn't valid
+                # here. Fall back to the process-global default.
+                _session_scope.set("__default__")
 
 
 @asynccontextmanager

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -260,35 +260,40 @@ async def test_read_tool_over_http_returns_its_db_connection(
 
     engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'mcp_leak.db'}")
     _db.init_app(engine=engine)
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    app = create_app(testing=True)
-    headers = {"Content-Type": "application/json", "Accept": "application/json, text/event-stream"}
-    body = {
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "tools/call",
-        "params": {"name": "list_groups", "arguments": {}},
-    }
-
-    # A fresh /mcp request owns its session scope in production; make the
-    # ambient scope the default so RequestIdMiddleware behaves the same here.
-    token = _session_scope.set("__default__")
+    # `_db` is process-global; dispose the engine no matter what so a failed
+    # assertion below can't leak it into unrelated downstream tests (mirrors
+    # the `db` fixture's own teardown).
     try:
-        async with _mcp_client(app) as client:
-            for _ in range(3):
-                r = await client.post("/mcp", headers=headers, content=json.dumps(body))
-                assert r.status_code == 200, r.text
-    finally:
-        _session_scope.reset(token)
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
 
-    # Force finalization of anything that a leak would have orphaned, then
-    # assert every checked-out connection made it back to the pool.
-    gc.collect()
-    await asyncio.sleep(0.05)
-    assert engine.pool.checkedout() == 0, "MCP tool call leaked a pooled DB connection"
-    await engine.dispose()
+        app = create_app(testing=True)
+        headers = {"Content-Type": "application/json", "Accept": "application/json, text/event-stream"}
+        body = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "list_groups", "arguments": {}},
+        }
+
+        # A fresh /mcp request owns its session scope in production; make the
+        # ambient scope the default so RequestIdMiddleware behaves the same here.
+        token = _session_scope.set("__default__")
+        try:
+            async with _mcp_client(app) as client:
+                for _ in range(3):
+                    r = await client.post("/mcp", headers=headers, content=json.dumps(body))
+                    assert r.status_code == 200, r.text
+        finally:
+            _session_scope.reset(token)
+
+        # Force finalization of anything that a leak would have orphaned, then
+        # assert every checked-out connection made it back to the pool.
+        gc.collect()
+        await asyncio.sleep(0.05)
+        assert engine.pool.checkedout() == 0, "MCP tool call leaked a pooled DB connection"
+    finally:
+        await engine.dispose()
 
 
 async def test_read_tool_requires_read_all_scope(

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -20,6 +20,8 @@ exact code path FastMCP would take, minus the JSON-RPC framing.
 
 from __future__ import annotations
 
+import asyncio
+import gc
 import json
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Generator, Optional
@@ -28,10 +30,11 @@ import httpx
 import pytest
 from fastapi import FastAPI
 from sqlalchemy import event, select
+from sqlalchemy.ext.asyncio import create_async_engine
 
 from api.config import settings
 from api.context import RequestContext, set_request_context
-from api.extensions import Db
+from api.extensions import Base, Db, _session_scope, db as _db
 from api.mcp.auth import (
     ALL_V1_SCOPES,
     MCP_SCOPE_CREATE_REQUESTS,
@@ -228,6 +231,64 @@ async def _call_tool(mcp_server: Any, tool_name: str, **kwargs: Any) -> str:
     would in production because they consult the active ContextVar."""
     tool = mcp_server._tool_manager._tools[tool_name]
     return await tool.fn(**kwargs)
+
+
+async def test_read_tool_over_http_returns_its_db_connection(
+    override_mcp_auth: Any,
+    tmp_path: Any,
+) -> None:
+    """A read tool invoked over the real Streamable-HTTP transport must
+    return its pooled DB connection to the pool.
+
+    Regression test for the connection leak where MCP tools run in the
+    FastMCP session-manager task (not the ``/mcp`` request task), so the
+    request task's ``RequestIdMiddleware`` teardown closes the session
+    from the wrong task and the connection is never checked back in —
+    surfacing later as SQLAlchemy's "garbage collector is trying to clean
+    up non-checked-in connection" warning. ``requires_scope`` now scopes
+    and removes the session inside the tool's own task; see
+    ``api.mcp.db.tool_session_scope``.
+
+    Uses a file-backed aiosqlite engine so the pool is a real
+    ``AsyncAdaptedQueuePool`` (the in-memory ``StaticPool`` the ``db``
+    fixture uses never returns connections, hiding the bug), and drives
+    the tool through an actual JSON-RPC ``tools/call`` so the decoupled
+    server task is exercised.
+    """
+    override_mcp_auth(MCPIdentity(user_id="u", scopes=ALL_V1_SCOPES))
+    from api.app import create_app
+
+    engine = create_async_engine(f"sqlite+aiosqlite:///{tmp_path / 'mcp_leak.db'}")
+    _db.init_app(engine=engine)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    app = create_app(testing=True)
+    headers = {"Content-Type": "application/json", "Accept": "application/json, text/event-stream"}
+    body = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "list_groups", "arguments": {}},
+    }
+
+    # A fresh /mcp request owns its session scope in production; make the
+    # ambient scope the default so RequestIdMiddleware behaves the same here.
+    token = _session_scope.set("__default__")
+    try:
+        async with _mcp_client(app) as client:
+            for _ in range(3):
+                r = await client.post("/mcp", headers=headers, content=json.dumps(body))
+                assert r.status_code == 200, r.text
+    finally:
+        _session_scope.reset(token)
+
+    # Force finalization of anything that a leak would have orphaned, then
+    # assert every checked-out connection made it back to the pool.
+    gc.collect()
+    await asyncio.sleep(0.05)
+    assert engine.pool.checkedout() == 0, "MCP tool call leaked a pooled DB connection"
+    await engine.dispose()
 
 
 async def test_read_tool_requires_read_all_scope(


### PR DESCRIPTION
## What & why

Production is emitting SQLAlchemy's *"The garbage collector is trying to clean up non-checked-in connection … which will be terminated"* error against `/mcp`. The leak was introduced by the async SQLAlchemy migration (#480).

MCP tool handlers run inside FastMCP's `StreamableHTTPSessionManager` **server task**, which is decoupled from the `/mcp` HTTP request task. Read-only tools use the request-scoped `db.session` directly and never commit, so the checked-out connection is only ever returned by `RequestIdMiddleware`'s `db.remove()`. That teardown runs in the *request* task — but the connection belongs to the *server* task, and closing an async connection from a different task than the one that opened it does not check it back in. It lingers until the garbage collector reaps it and logs the warning.

## The fix

Each tool call now gets its own DB session scope, bound and torn down (`db.remove()`) **inside the tool's own task** via a new `tool_session_scope` context manager. `requires_scope` — the wrapper every tool already passes through in the server task — enters it, so both read tools (`db.session`) and write tools (`mcp_db_session`) are covered with no per-tool boilerplate. The request-scoped session for `/mcp` is no longer relied on for the tool's connection, so there's no cross-task close.

## Reviewer notes

- Prompts return static text and there are no MCP resources, so `requires_scope` is the complete set of server-task DB entry points.
- The regression test drives a real JSON-RPC `tools/call` over the Streamable-HTTP transport against a file-backed aiosqlite engine (a real `AsyncAdaptedQueuePool`; the in-memory `StaticPool` the `db` fixture uses never returns connections and hides the bug) and asserts `pool.checkedout() == 0`. It fails on `main` and passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)