### PR TITLE
fix: eager-load polymorphic group in PUT /requests to avoid MissingGreenlet

### DIFF
--- a/api/routers/access_requests.py
+++ b/api/routers/access_requests.py
@@ -296,11 +296,14 @@ async def put_access_request(
     from api.auth.permissions import can_manage_group
     from api.operations.constraints import CheckForReason
 
+    # Eager-load the polymorphic group subtype (+ AppGroup.app) up front. The
+    # permission check below reads AppGroup-only columns (e.g. `app_id`), and
+    # under async SQLAlchemy an implicit lazy load of unloaded subclass columns
+    # raises MissingGreenlet. `_summary_load_options()` also matches the shape
+    # the response is re-queried with, so nothing downstream lazy-loads.
     ar = (
         await db.scalars(
-            select(AccessRequest)
-            .options(joinedload(AccessRequest.active_requested_group))
-            .where(AccessRequest.id == access_request_id)
+            select(AccessRequest).options(*_summary_load_options()).where(AccessRequest.id == access_request_id)
         )
     ).first()
     if ar is None:

--- a/tests/test_access_request.py
+++ b/tests/test_access_request.py
@@ -349,6 +349,86 @@ async def test_put_access_request_by_non_owner(
     assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 1
 
 
+async def test_put_app_group_access_request_by_app_owner(
+    client: AsyncClient,
+    app: FastAPI,
+    db: Db,
+    access_app: App,
+    app_group: AppGroup,
+    user: OktaUser,
+    url_for: Any,
+) -> None:
+    """Regression for the production MissingGreenlet after the async migration (#480).
+
+    Resolving an *app group* request as a non-requester falls through
+    `can_manage_group` into `is_app_owner_group_owner`, which reads
+    `AppGroup.app_id`. If the requested group is loaded with only its base
+    `OktaGroup` columns, that read triggers an implicit lazy load of the
+    `app_group` subclass columns — illegal under async SQLAlchemy, so the PUT
+    500s instead of resolving. `test_put_access_request_by_non_owner` never
+    caught it because a plain `OktaGroup` short-circuits before `app_id` is
+    touched; only an `AppGroup` reaches the lazy load."""
+    app_owner_user = OktaUserFactory.build()
+    app_owner_group = AppGroupFactory.build()
+
+    db.session.add(user)
+    db.session.add(app_owner_user)
+    db.session.add(access_app)
+    await db.session.commit()
+
+    # The requested group is a non-owner group on the app.
+    app_group.app_id = access_app.id
+    app_group.is_owner = False
+    db.session.add(app_group)
+
+    # A separate owner group for the same app; its owners can manage the
+    # app's groups without being direct owners of `app_group`.
+    app_owner_group.app_id = access_app.id
+    app_owner_group.is_owner = True
+    db.session.add(app_owner_group)
+    await db.session.commit()
+
+    await ModifyGroupUsers(
+        group=app_owner_group,
+        members_to_add=[],
+        owners_to_add=[app_owner_user.id],
+        sync_to_okta=False,
+    ).execute()
+
+    access_request = await CreateAccessRequest(
+        requester_user=user,
+        requested_group=app_group,
+        request_ownership=False,
+        request_reason="please grant",
+    ).execute()
+    assert access_request is not None
+    assert access_request.status == AccessRequestStatus.PENDING
+
+    access_request_id = access_request.id
+    app_owner_user_id = app_owner_user.id
+
+    # Evict everything the setup loaded. The HTTP request reuses this session,
+    # so a warm identity map would serve the fully-populated AppGroup and hide
+    # the missing subclass load. Production gives each request a cold session,
+    # where the group arrives with only base columns — `expunge_all` reproduces
+    # that so the lazy load of `app_id` fails deterministically pre-fix.
+    db.session.expunge_all()
+
+    # Act as the app owner: not the requester, not a direct owner of
+    # `app_group`, so the permission gate reaches the app-owner check.
+    app.state.current_user_email = app_owner_user.email
+    access_request_url = url_for("api-access-requests.access_request_by_id", access_request_id=access_request_id)
+
+    rep = await client.put(access_request_url, json={"approved": False, "reason": "already granted elsewhere"})
+    assert rep.status_code == 200, rep.text
+    assert rep.json()["status"] == AccessRequestStatus.REJECTED
+
+    resolved = (await db.session.scalars(select(AccessRequest).where(AccessRequest.id == access_request_id))).first()
+    assert resolved is not None
+    assert resolved.status == AccessRequestStatus.REJECTED
+    assert resolved.resolver_user_id == app_owner_user_id
+
+
 async def test_create_access_request(
     app: FastAPI, client: AsyncClient, db: Db, okta_group: OktaGroup, url_for: Any
 ) -> None:


### PR DESCRIPTION
## What

Resolving an access request for an **app group** as a non-requester (e.g. an app owner rejecting a request) was 500ing in production with `MissingGreenlet: greenlet_spawn has not been called`.

The `PUT /api/requests/{id}` handler loaded the requested group with a bare `joinedload(AccessRequest.active_requested_group)`. Under `OktaGroup`'s joined-table inheritance that joins only the base `okta_group` table, so an `AppGroup` row comes back with its subclass columns (`app_id`, `is_owner`) unloaded. The permission check (`can_manage_group` → `is_app_owner_group_owner`) then reads `app_group.app_id`, which triggers an implicit lazy load. Since the async SQLAlchemy migration (#480), synchronous IO outside a greenlet is illegal, so that lazy load raises and the request 500s.

The fix loads the request with the router's shared `_summary_load_options()`, which nests `selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup])` + `joinedload(AppGroup.app)` under the group relationships — the same pattern every other load path in this router already uses (including this handler's own response re-query). The subclass columns are then present when the permission check reads them.

## Why it only surfaced now

The crash requires all of: resolver ≠ requester (enters the permission branch), resolver is not a direct group owner (falls through to the app-owner check), and the group is an `AppGroup` (only then is `app_id` read). Plain `OktaGroup`/`RoleGroup` short-circuit before touching `app_id`, which is why the existing non-owner test never caught it and why it stayed latent until an app owner rejected an app-group request in prod.

## Scope

I audited every caller of `can_manage_group` / `is_app_owner_group_owner` / `can_delete_group`. This handler was the only vulnerable one — all others load via `with_polymorphic`/`selectin_polymorphic`, query the concrete subclass directly, or pass a transient in-memory object.

## Test

Added a regression test that rejects an app-group request over HTTP as an app owner, with `expunge_all()` to reproduce production's cold per-request session. Verified it 500s with the exact `MissingGreenlet` error before the fix and passes after.