### PR TITLE
perf: index okta_user_group_member (user_id, is_owner, ended_at)

### DIFF
--- a/api/models/core_models.py
+++ b/api/models/core_models.py
@@ -83,12 +83,18 @@ class OktaUserGroupMember(Base):
     )
 
     # Postgres does not index FK columns automatically; the hot lookups filter
-    # by group_id (usually with is_owner and an active-membership ended_at
-    # predicate) and seq-scan without this.
+    # by group_id or user_id (usually with is_owner and an active-membership
+    # ended_at predicate) and seq-scan without these.
     __table_args__ = (
         Index(
             "idx_okta_user_group_member_group_id_is_owner_ended_at",
             "group_id",
+            "is_owner",
+            "ended_at",
+        ),
+        Index(
+            "idx_okta_user_group_member_user_id_is_owner_ended_at",
+            "user_id",
             "is_owner",
             "ended_at",
         ),

--- a/migrations/versions/98bc5533e0f9_index_okta_user_group_member_user_.py
+++ b/migrations/versions/98bc5533e0f9_index_okta_user_group_member_user_.py
@@ -1,0 +1,37 @@
+"""index okta_user_group_member user lookups
+
+Revision ID: 98bc5533e0f9
+Revises: 61afb5496c0a
+Create Date: 2026-07-09 12:00:00.000000
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "98bc5533e0f9"
+down_revision = "61afb5496c0a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Plain (non-CONCURRENT) CREATE INDEX, deliberately: it stays transactional
+    # (clean rollback, no INVALID index to clean up) at the cost of blocking
+    # writes to this one table while the index builds. Reads are unaffected,
+    # and write volume here is low enough that queued writes clear trivially.
+    # If the migration hangs waiting on a lock, cancelling it is safe - it
+    # rolls back cleanly and can simply be re-run.
+    op.create_index(
+        "idx_okta_user_group_member_user_id_is_owner_ended_at",
+        "okta_user_group_member",
+        ["user_id", "is_owner", "ended_at"],
+    )
+
+
+def downgrade():
+    op.drop_index(
+        "idx_okta_user_group_member_user_id_is_owner_ended_at",
+        table_name="okta_user_group_member",
+    )


### PR DESCRIPTION
## What

Adds a second index on `okta_user_group_member (user_id, is_owner, ended_at)` — the user-side mirror of the group-side index from #508 — as a new Alembic migration plus the matching index definition on the model.

## Why

After #508 the weekday CPU baseline dropped from a pegged 100% to ~10–15%, but the instance still bursts to ~65% twice a day, at 06:00 and 08:00 UTC, for about 15 minutes each. Tracing those bursts through Query Insights and the pod logs: a scheduled collector walks the entire employee directory — ~3,450 calls to `GET /api/users/{email}` — and each call loads that user's active memberships and active ownerships. Both of those queries filter by `user_id`, which has no index (same root cause as #508 — Postgres doesn't index foreign key columns automatically), so every call seq-scans the million-row table twice. Those two query shapes add up to ~1,350 seconds of execution time per burst, which on a 2-vCPU instance is the entire spike.

The index shape mirrors #508 for the same reasons: `user_id` narrows a million rows down to one person's handful, and `is_owner` + `ended_at` match the "active memberships" / "active ownerships" filters the endpoint uses. The audit endpoint's `user_id`/`owner_id` filters benefit as well.

Tested locally with 500k seeded rows: the per-user lookup goes from a full table scan to a few index probes (~0.06ms).

## Notes

- Same migration approach as #508: plain `CREATE INDEX` (transactional, cleanly re-runnable), briefly blocking writes to this one table while it builds — the #508 build took a couple of seconds in prod.
- Same negligible write cost: only ~100 updates a day touch `ended_at`.

## Testing

Migration upgraded/downgraded cleanly on Postgres 15 and sqlite; `alembic check` reports no model/schema drift; pytest green on both databases; `EXPLAIN` confirms the index serves the burst queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
