### PR TITLE
fix: paginate group members by email so the A-Z list is continuous across pages

### DIFF
--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -18,7 +18,7 @@ from fastapi import APIRouter, HTTPException, Query
 
 from fastapi.responses import RedirectResponse
 from pydantic import TypeAdapter
-from sqlalchemy import func, nullsfirst, or_, select
+from sqlalchemy import and_, func, nullsfirst, or_, select
 from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload, with_polymorphic
 from starlette.requests import Request
 
@@ -29,7 +29,7 @@ from api.auth.permissions import (
     is_app_owner_group_owner,
 )
 from api.database import DbSession
-from api.models import App, AppGroup, OktaGroup, OktaUserGroupMember, RoleGroup
+from api.models import App, AppGroup, OktaGroup, OktaUser, OktaUserGroupMember, RoleGroup
 from api.operations import (
     CreateGroup,
     DeleteGroup,
@@ -515,14 +515,21 @@ async def get_group_member_details(
         OktaUserGroupMember.ended_at > func.now(),
     )
 
-    # Page over distinct user ids (stable order by user id); total is then the
-    # distinct user count.
+    # Page over distinct users ordered by email so the alphabetical list the UI
+    # renders is continuous across pages instead of restarting A-Z on each page.
+    # Join the active (non-deleted) user both to sort by email and to keep total
+    # aligned with the rows that actually render (a member's detail row requires
+    # an active user). `email` is in the select list so SELECT DISTINCT can order
+    # by it; total is then the distinct user count.
     user_stmt = (
-        select(OktaUserGroupMember.user_id).where(OktaUserGroupMember.group_id == resolved_group_id).where(active)
+        select(OktaUserGroupMember.user_id, OktaUser.email)
+        .join(OktaUser, and_(OktaUser.id == OktaUserGroupMember.user_id, OktaUser.deleted_at.is_(None)))
+        .where(OktaUserGroupMember.group_id == resolved_group_id)
+        .where(active)
     )
     if owner is not None:
         user_stmt = user_stmt.where(OktaUserGroupMember.is_owner.is_(owner))
-    user_stmt = user_stmt.distinct().order_by(OktaUserGroupMember.user_id)
+    user_stmt = user_stmt.distinct().order_by(OktaUser.email, OktaUserGroupMember.user_id)
 
     async def _load_rows(user_rows: Any) -> list[Any]:
         user_ids = [r if isinstance(r, str) else r[0] for r in user_rows]
@@ -530,6 +537,7 @@ async def get_group_member_details(
             return []
         detail_stmt = (
             select(OktaUserGroupMember)
+            .join(OktaUser, and_(OktaUser.id == OktaUserGroupMember.user_id, OktaUser.deleted_at.is_(None)))
             .options(*user_group_member_options())
             .where(OktaUserGroupMember.group_id == resolved_group_id)
             .where(active)
@@ -537,7 +545,7 @@ async def get_group_member_details(
         )
         if owner is not None:
             detail_stmt = detail_stmt.where(OktaUserGroupMember.is_owner.is_(owner))
-        detail_stmt = detail_stmt.order_by(OktaUserGroupMember.user_id, OktaUserGroupMember.id)
+        detail_stmt = detail_stmt.order_by(OktaUser.email, OktaUserGroupMember.user_id, OktaUserGroupMember.id)
         return validated(OktaUserGroupMemberDetail)((await db.scalars(detail_stmt)).all())
 
     return await apaginate(db, user_stmt, transformer=_load_rows)

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1947,3 +1947,33 @@ async def test_group_member_details_counts_users_not_rows(client: AsyncClient, d
     # Both rows are returned so the UI can render direct + via-role chips.
     rows = [r for r in data["items"] if r.get("active_user") and r["active_user"]["id"] == user_id]
     assert len(rows) == 2
+
+
+async def test_get_group_member_details_paginates_in_email_order(client: AsyncClient, db: Db, url_for: Any) -> None:
+    """member-details pages in email order, so the alphabetical list the UI
+    renders is continuous across pages instead of restarting A-Z on every page.
+    User ids are assigned in reverse-email order to prove pages are ordered by
+    email, not by the opaque user id."""
+    group = OktaGroupFactory.create()
+    db.session.add(group)
+    await db.session.commit()
+
+    members = [OktaUserFactory.create(id=f"id-{59 - i:03d}", email=f"member-{i:03d}@example.com") for i in range(60)]
+    for u in members:
+        db.session.add(u)
+    await db.session.commit()
+
+    await ModifyGroupUsers(group=group, members_to_add=[u.id for u in members], sync_to_okta=False).execute()
+
+    group_id = group.id
+    db.session.expunge_all()
+
+    url = url_for("api-groups.group_member_details_by_id", group_id=group_id)
+
+    page1 = (await client.get(url, params={"owner": "false", "page": 1, "size": 50})).json()
+    page2 = (await client.get(url, params={"owner": "false", "page": 2, "size": 50})).json()
+
+    emails = [r["active_user"]["email"] for r in page1["items"]] + [r["active_user"]["email"] for r in page2["items"]]
+    assert emails == sorted(emails)
+    assert emails[0] == "member-000@example.com"
+    assert emails[-1] == "member-059@example.com"


### PR DESCRIPTION
# Summary
Group/role member lists were paginated by opaque user id while the UI alphabetizes each fetched page by email, so every page independently restarted at A instead of continuing the alphabet. This orders the pagination by the member's email so the A-Z list is continuous across pages.
**Urgency**: 5 days
**Expected review effort**: LOW

# Motivation
On the group detail page the member list is fetched one page at a time from `GET /api/groups/{id}/member-details` and each page is sorted alphabetically by email client-side. The backend paged over distinct users ordered by `user_id`, which is unrelated to email order, so page 1 showed an arbitrary subset sorted A-Z and page 2 showed a different arbitrary subset also sorted A-Z. The result was a list that restarts the alphabet on every page. This regressed when the member list moved from an inline (unpaginated) response to a paginated endpoint; previously the single client-side sort alphabetized the whole list.

# Description of Changes
- Order the member-details pagination query by the active user's email (with `user_id` as a stable tiebreaker) instead of by `user_id`, so page boundaries follow the same alphabetical order the UI displays.
- Order the per-page detail query by email as well, so rows within a page are also alphabetical.
- Join the active (non-deleted) user in both queries. This is required to sort by email, and it also keeps `total` aligned with the rows that actually render, since a member detail row requires an active user.
- The role detail view reuses this same endpoint, so it is covered by the same fix.

# Validation of Changes
- Added `test_get_group_member_details_paginates_in_email_order`, which assigns user ids in reverse-email order to prove pages follow email order rather than id order, and asserts the concatenated emails across two pages are globally sorted. Confirmed it fails before the change and passes after.
- Full test suite passes (565 passed). Ruff and mypy clean on the changed files.

# Guidance for Reviewers
The change is small; review `api/routers/groups.py` `get_group_member_details`. The main thing to confirm is that joining the active user to order by email is acceptable and that excluding deleted-user rows from `total` (rows that could never render anyway) is the desired behavior.
