### PR TITLE
fix: pass ACCESS_CONFIG_OVERRIDE secret via env to avoid CSV parse error

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -40,6 +40,8 @@ jobs:
       - id: docker-push-tagged
         name: Tag Docker image and push to Google Artifact Registry
         uses: docker/build-push-action@v7
+        env:
+          ACCESS_CONFIG_OVERRIDE: ${{ secrets.ACCESS_CONFIG_OVERRIDE }}
         with:
           push: true
           tags: |
@@ -51,4 +53,5 @@ jobs:
             "SENTRY_ORG=${{ secrets.SENTRY_ORG }}"
             "SENTRY_PROJECT=${{ secrets.SENTRY_PROJECT }}"
             "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}"
-            "ACCESS_CONFIG_OVERRIDE=${{ secrets.ACCESS_CONFIG_OVERRIDE }}"
+          secret-envs: |
+            ACCESS_CONFIG_OVERRIDE=ACCESS_CONFIG_OVERRIDE


### PR DESCRIPTION
# Summary
The Docker release job on `main` fails to push the image because the `ACCESS_CONFIG_OVERRIDE` build secret contains double quotes that break `build-push-action`'s CSV parser. This routes that one secret through the step `env` + `secret-envs` instead, which is not CSV-parsed.
**Urgency**: 1 day (blocks every push-to-main image release)
**Expected review effort**: LOW

# Motivation
Every push to `main` now fails at the "Tag Docker image and push to Google Artifact Registry" step with:

```
ERROR: failed to parse csv secret: parse error on line 1, column 4: bare " in non-quoted-field
```

`build-push-action` CSV-parses each line of the `secrets:` input. A quoted entry (`"KEY=value"`) requires any inner `"` to be doubled, and an unquoted entry may not contain `"` or `,` at all. The `ACCESS_CONFIG_OVERRIDE` value is JSON, so it contains both. GitHub Actions expressions have no `replace()` function, so the secret cannot be escaped inline. The `SENTRY_*` values contain no special characters, which is why they have always parsed fine.

# Description of Changes
- Pass `ACCESS_CONFIG_OVERRIDE` to the build step via `env` and reference it with `secret-envs`, bypassing CSV parsing of the value.
- Leave the three `SENTRY_*` secrets in `secrets:` unchanged (minimal diff).
- Secret ids are unchanged, so the Dockerfile's `--mount=type=secret,id=...` mounts need no changes.

# Validation of Changes
- [ ] Confirmed the secret ids consumed by the Dockerfile (`ACCESS_CONFIG_OVERRIDE`, `SENTRY_*`) are unchanged, so the mounts still resolve.
- [ ] Full end-to-end validation happens post-merge, since this workflow only runs on push to `main`. Watch the first release run after merge.

# Guidance for Reviewers
Single-file change. Confirm `secret-envs` maps `<secret-id>=<ENV_VAR_NAME>` as expected and that the id stays `ACCESS_CONFIG_OVERRIDE` to match the Dockerfile mount.
