### PR TITLE
feat: strict ty type-checking on api/routers, services, and leaf modules (POST_MIGRATION_TODO #14)

### DIFF
--- a/POST_MIGRATION_TODO.md
+++ b/POST_MIGRATION_TODO.md
@@ -6,20 +6,6 @@ Items grouped roughly by surface area; ordering within each group is rough prior
 
 ---
 
-## Tooling
-
-### 14. Strict type checking on routers + schemas
-
-Tighten `ty` on `api/routers/`. It is currently listed in the relaxed
-`[[tool.ty.overrides]]` block in [`pyproject.toml`](pyproject.toml); remove
-it from the `include` list and resolve the resulting diagnostics.
-(`api/schemas/` is already checked strictly — it's not in the override.)
-Operations can stay loose initially since it's inherited from the Flask
-era. Add a CI check that fails the build on new violations in those
-directories.
-
----
-
 ## Test Ergonomics
 
 ### 16. Replace `factory_boy` with Pydantic-based builders

--- a/api/app.py
+++ b/api/app.py
@@ -177,7 +177,9 @@ def _configure_sentry() -> None:
             ValidationError,
             OIDCRedirectRequired,
         ],
-        before_send=_drop_wrapped_ignored_errors,
+        # sentry types before_send against its `Event` TypedDict; the hook works
+        # on plain event dicts, which is correct at runtime but not assignable.
+        before_send=_drop_wrapped_ignored_errors,  # ty: ignore[invalid-argument-type]
     )
 
 

--- a/api/app.py
+++ b/api/app.py
@@ -432,7 +432,7 @@ def create_app(testing: Optional[bool] = False) -> FastAPI:
         _flatten_query_param_models(schema)
         return schema
 
-    app.openapi = _patched_openapi  # type: ignore[method-assign]
+    app.openapi = _patched_openapi  # ty: ignore[invalid-assignment] (intentional openapi override)
 
     # SPA: serve `build/` from a catch-all FastAPI route so static assets
     # go through the app-wide `require_authenticated` dependency (an

--- a/api/auth/cloudflare.py
+++ b/api/auth/cloudflare.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 import json
 import logging
 import threading
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
 import httpx
 import jwt
+import jwt.algorithms
 from cachetools import TTLCache, cached
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
 from fastapi import HTTPException
@@ -88,7 +89,9 @@ def verify_cloudflare_token(token: str) -> Dict[str, Any]:
     try:
         return jwt.decode(
             token,
-            key=keys[kid],
+            # A public JWKS cert always yields a public key; `from_jwk`'s stub
+            # widens the return to the private/public union.
+            key=cast(RSAPublicKey, keys[kid]),
             audience=settings.CLOUDFLARE_APPLICATION_AUDIENCE,
             algorithms=["RS256"],
         )

--- a/api/auth/permissions.py
+++ b/api/auth/permissions.py
@@ -41,7 +41,9 @@ async def is_app_owner_group_owner(
     db: AsyncSession,
     current_user_id: str,
     *,
-    app_group: Optional[AppGroup] = None,
+    # Any group may be passed (callers hold an `OktaGroup`); the `type(...) is
+    # AppGroup` guard below returns False for non-app groups.
+    app_group: Optional[OktaGroup] = None,
     app: Optional[App] = None,
 ) -> bool:
     if app is not None:

--- a/api/cli.py
+++ b/api/cli.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import uuid
-from typing import Any, Callable, List, TypeVar
+from typing import Any, Callable, List, TypeVar, cast
 
 import click
 from sqlalchemy import func, or_, select
@@ -82,7 +82,7 @@ def _with_app_context(func: F) -> F:
 
         return asyncio.run(_run())
 
-    return wrapper  # type: ignore[return-value]
+    return cast(F, wrapper)
 
 
 @click.group()
@@ -103,8 +103,9 @@ def _load_plugin_commands() -> None:
     try:
         eps = entry_points(group="access.commands")
     except TypeError:
-        # Older importlib.metadata returns a dict
-        eps = entry_points().get("access.commands", [])
+        # Older importlib.metadata returns a dict keyed by group; `EntryPoints`
+        # (3.12+) has no `.get`, hence the ignore on this back-compat branch.
+        eps = entry_points().get("access.commands", [])  # ty: ignore[unresolved-attribute]
     for ep in eps:
         try:
             command = ep.load()

--- a/api/exception_handlers.py
+++ b/api/exception_handlers.py
@@ -202,12 +202,16 @@ async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONR
 
 
 def install(app: FastAPI) -> None:
-    app.add_exception_handler(StarletteHTTPException, http_exception_handler)  # type: ignore[arg-type]
-    app.add_exception_handler(HTTPException, http_exception_handler)  # type: ignore[arg-type]
-    app.add_exception_handler(RequestValidationError, request_validation_handler)  # type: ignore[arg-type]
-    app.add_exception_handler(ValidationError, pydantic_validation_handler)  # type: ignore[arg-type]
-    app.add_exception_handler(OIDCRedirectRequired, oidc_redirect_handler)  # type: ignore[arg-type]
-    app.add_exception_handler(PluginNotFoundError, plugin_not_found_handler)  # type: ignore[arg-type]
-    app.add_exception_handler(AccessException, access_exception_handler)  # type: ignore[arg-type]
-    app.add_exception_handler(OktaTransientError, okta_transient_error_handler)  # type: ignore[arg-type]
+    # Starlette types the handler param as `(Request, Exception) -> Response`;
+    # each handler below narrows to its specific exception subtype (and returns
+    # a concrete Response), which is correct at runtime but not assignable to
+    # that broad signature — hence the per-line ignores.
+    app.add_exception_handler(StarletteHTTPException, http_exception_handler)  # ty: ignore[invalid-argument-type]
+    app.add_exception_handler(HTTPException, http_exception_handler)  # ty: ignore[invalid-argument-type]
+    app.add_exception_handler(RequestValidationError, request_validation_handler)  # ty: ignore[invalid-argument-type]
+    app.add_exception_handler(ValidationError, pydantic_validation_handler)  # ty: ignore[invalid-argument-type]
+    app.add_exception_handler(OIDCRedirectRequired, oidc_redirect_handler)  # ty: ignore[invalid-argument-type]
+    app.add_exception_handler(PluginNotFoundError, plugin_not_found_handler)  # ty: ignore[invalid-argument-type]
+    app.add_exception_handler(AccessException, access_exception_handler)  # ty: ignore[invalid-argument-type]
+    app.add_exception_handler(OktaTransientError, okta_transient_error_handler)  # ty: ignore[invalid-argument-type]
     app.add_exception_handler(Exception, unhandled_exception_handler)

--- a/api/mcp/auth/__init__.py
+++ b/api/mcp/auth/__init__.py
@@ -20,7 +20,7 @@ import contextvars
 import functools
 import json
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable, Optional, TypeVar
+from typing import Any, Awaitable, Callable, Optional, TypeVar, cast
 
 # Scope strings used by the v1 tool surface. Tools declare a required
 # scope via ``@require_scope(MCP_SCOPE_READ_ALL)`` etc.; the
@@ -171,7 +171,7 @@ def requires_scope(scope: str) -> Callable[[F], F]:
             async with tool_session_scope():
                 return await fn(*args, **kwargs)
 
-        return wrapper  # type: ignore[return-value]
+        return cast(F, wrapper)
 
     return decorator
 

--- a/api/pagination.py
+++ b/api/pagination.py
@@ -53,11 +53,11 @@ AppGroupsPage = CustomizedPage[
 
 
 @lru_cache(maxsize=None)
-def _adapter(model: type) -> TypeAdapter[Any]:
+def _adapter(model: Any) -> TypeAdapter[Any]:
     return TypeAdapter(model)
 
 
-def validated(model: type) -> Callable[[Sequence[Any]], list[Any]]:
+def validated(model: Any) -> Callable[[Sequence[Any]], list[Any]]:
     """Build a `fastapi-pagination` `transformer=` that validates each ORM row
     through `model` with `from_attributes=True`.
 

--- a/api/pagination.py
+++ b/api/pagination.py
@@ -12,13 +12,13 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from functools import lru_cache
-from typing import Any, TypeVar
+from typing import Any, TypeVar, overload
 
 from fastapi import Query
 from fastapi_pagination import Page as _BasePage
 from fastapi_pagination.customization import CustomizedPage, UseParams, UseParamsFields
 from fastapi_pagination.default import Params as _DefaultParams
-from pydantic import TypeAdapter
+from pydantic import BaseModel, TypeAdapter
 
 DEFAULT_SIZE = 50
 MAX_SIZE = 1000
@@ -52,14 +52,30 @@ AppGroupsPage = CustomizedPage[
 ]
 
 
+M = TypeVar("M", bound=BaseModel)
+
+
 @lru_cache(maxsize=None)
-def _adapter(model: Any) -> TypeAdapter[Any]:
+def _adapter(model: type[M]) -> TypeAdapter[M]:
     return TypeAdapter(model)
+
+
+@overload
+def validated(model: type[M]) -> Callable[[Sequence[Any]], list[M]]: ...
+
+
+@overload
+def validated(model: Any) -> Callable[[Sequence[Any]], list[Any]]: ...
 
 
 def validated(model: Any) -> Callable[[Sequence[Any]], list[Any]]:
     """Build a `fastapi-pagination` `transformer=` that validates each ORM row
     through `model` with `from_attributes=True`.
+
+    Typed so `validated(OktaUserGroupMemberDetail)` yields
+    `list[OktaUserGroupMemberDetail]`; the fallback overload covers the
+    discriminated-union `TypeAliasType` shapes (e.g. `GroupSummary`), which
+    aren't a `type[BaseModel]` and resolve to `list[Any]`.
 
     This reproduces the eager-load safety net the hand-rolled `paginate()` had:
     validation runs here in the handler (session open), so an un-eager-loaded

--- a/api/routers/access_requests.py
+++ b/api/routers/access_requests.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from sqlalchemy import String, cast, or_, select
+from sqlalchemy import String, cast, false, or_, select
 from sqlalchemy.orm import aliased, joinedload, selectin_polymorphic, selectinload
 from starlette.requests import Request
 
@@ -142,7 +142,6 @@ async def list_access_requests(
                 .join(OktaGroup.active_user_ownerships)
                 .where(OktaGroup.deleted_at.is_(None))
                 .where(OktaUserGroupMember.user_id == assignee_user.id)
-                .subquery()
             )
             owner_app_group_alias = aliased(AppGroup)
             app_groups_owned_subquery = (
@@ -157,7 +156,6 @@ async def list_access_requests(
                 .join(owner_app_group_alias.active_user_ownerships)
                 .where(AppGroup.deleted_at.is_(None))
                 .where(OktaUserGroupMember.user_id == assignee_user.id)
-                .subquery()
             )
             stmt = stmt.join(AccessRequest.requested_group).where(
                 or_(
@@ -166,7 +164,7 @@ async def list_access_requests(
                 )
             )
         else:
-            stmt = stmt.where(False)
+            stmt = stmt.where(false())
 
     if q_args.resolver_user_id:
         if q_args.resolver_user_id == "@me":

--- a/api/routers/apps.py
+++ b/api/routers/apps.py
@@ -167,6 +167,7 @@ async def post_app(
 ) -> AppDetail:
     from api.models import AppGroup as _AppGroup, OktaUser, RoleGroup
     from api.operations import CreateApp
+    from api.operations.create_group import GroupDict
 
     description = body.description if body.description is not None else ""
 
@@ -244,8 +245,10 @@ async def post_app(
             f" {owner_group_name} to be able to proceed.",
         )
 
-    initial_additional_app_groups: list[dict[str, Any]] = [
-        ig.model_dump(exclude_none=True) for ig in (body.initial_additional_app_groups or [])
+    # CreateApp only reads `name`/`description` off each entry, so build the
+    # GroupDict it expects directly rather than a loose `model_dump()` dict.
+    initial_additional_app_groups: list[GroupDict] = [
+        {"name": ig.name, "description": ig.description or ""} for ig in (body.initial_additional_app_groups or [])
     ]
 
     app_obj = App(name=name, description=description)
@@ -298,7 +301,7 @@ async def put_app(
     )
     if "plugin_data" in fields_set and new_plugin_id is not None:
         try:
-            errors = validate_app_group_lifecycle_plugin_app_config(body.plugin_data, new_plugin_id)
+            errors = validate_app_group_lifecycle_plugin_app_config(body.plugin_data or {}, new_plugin_id)
         except ValueError as e:
             raise HTTPException(400, f"plugin_data: {e}") from e
         if errors:
@@ -400,6 +403,8 @@ async def put_app(
     app_id = app_obj.id
     db.expire_all()
     refreshed = (await db.scalars(select(App).options(*APP_LOAD_OPTIONS).where(App.id == app_id))).first()
+    # The app was just modified/committed above, so re-loading it by id always resolves.
+    assert refreshed is not None
 
     # Audit logging — both name renames and plugin assignment/configuration
     # changes.
@@ -455,8 +460,8 @@ async def put_app(
 async def delete_app(
     app_id: str,
     db: DbSession,
+    current_user_id: CurrentUserId,
     app_obj=Depends(require_app_owner_or_access_admin_for_app),
-    current_user_id: CurrentUserId = None,  # type: ignore[assignment]
 ) -> DeleteMessage:
     from api.operations import DeleteApp
 

--- a/api/routers/audit.py
+++ b/api/routers/audit.py
@@ -632,18 +632,14 @@ async def groups_and_roles(
         # those are the roles only an admin can resolve expiring access for.
         unowned_admin_role_ids: list[str] = []
         if await is_access_admin(db, role_owner.id):
-            owners_subquery = (
-                select(OktaUserGroupMember.group_id)
-                .where(
-                    and_(
-                        OktaUserGroupMember.is_owner.is_(True),
-                        or_(
-                            OktaUserGroupMember.ended_at.is_(None),
-                            OktaUserGroupMember.ended_at > func.now(),
-                        ),
-                    )
+            owners_subquery = select(OktaUserGroupMember.group_id).where(
+                and_(
+                    OktaUserGroupMember.is_owner.is_(True),
+                    or_(
+                        OktaUserGroupMember.ended_at.is_(None),
+                        OktaUserGroupMember.ended_at > func.now(),
+                    ),
                 )
-                .subquery()
             )
             unowned_admin_role_ids = [
                 rg.id

--- a/api/routers/group_requests.py
+++ b/api/routers/group_requests.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi_pagination.ext.sqlalchemy import apaginate
-from sqlalchemy import String, and_, cast, or_, select
+from sqlalchemy import String, and_, cast, false, or_, select
 from sqlalchemy.orm import aliased, joinedload
 from starlette.requests import Request
 
@@ -98,10 +98,10 @@ async def list_group_requests(
                         )
                     )
                 else:
-                    stmt = stmt.where(False)
+                    stmt = stmt.where(false())
             stmt = stmt.where(GroupRequest.requester_user_id != assignee_user.id)
         else:
-            stmt = stmt.where(False)
+            stmt = stmt.where(false())
 
     if q_args.resolver_user_id:
         if q_args.resolver_user_id == "@me":

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -236,7 +236,7 @@ async def put_group(
         plugin_id = get_app_group_lifecycle_plugin_to_invoke(group)
         if plugin_id is not None:
             try:
-                errors = validate_app_group_lifecycle_plugin_group_config(body.plugin_data, plugin_id)
+                errors = validate_app_group_lifecycle_plugin_group_config(body.plugin_data or {}, plugin_id)
             except ValueError as e:
                 raise HTTPException(400, f"plugin_data: {e}") from e
             if errors:
@@ -288,7 +288,10 @@ async def put_group(
                 403, "Current user is not an app owner of the target app and not allowed to reassign this group"
             )
         if body.type == group.type:
-            group.app_id = body.app_id
+            # target_app was fetched by `App.id == body.app_id`, so its id is
+            # the same non-null value — assigning it keeps `app_id: Mapped[str]`
+            # non-optional.
+            group.app_id = target_app.id
 
     tags_to_add = body.tags_to_add or []
     tags_to_remove = body.tags_to_remove or []
@@ -372,7 +375,12 @@ async def put_group(
         for k in ("name", "description", "is_managed"):
             setattr(new_group, k, getattr(group, k, None))
         if isinstance(new_group, AppGroup) and isinstance(body, _AppGroupUpdateBody):
-            new_group.app_id = body.app_id if "app_id" in fields_set else getattr(group, "app_id", None)
+            resolved_app_id = body.app_id if "app_id" in fields_set else getattr(group, "app_id", None)
+            # `app_id` is a non-nullable Mapped[str]; leave it unset (equivalently
+            # None on the transient object) when unresolved rather than assigning
+            # None, and let ModifyGroupType / the DB reject a missing app_id.
+            if resolved_app_id is not None:
+                new_group.app_id = resolved_app_id
             new_group.is_owner = False
         try:
             group = await ModifyGroupType(
@@ -401,6 +409,8 @@ async def put_group(
     ).execute()
 
     refreshed = await _load_group_with_options(db, group.id)
+    # The group was just committed above, so re-loading it by id always resolves.
+    assert refreshed is not None
 
     # Audit log — plugin configuration changes at the group level
     if old_plugin_data_for_audit != (refreshed.plugin_data or {}):

--- a/api/routers/role_requests.py
+++ b/api/routers/role_requests.py
@@ -6,7 +6,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from sqlalchemy import String, and_, cast, not_, or_, select
+from sqlalchemy import String, and_, cast, false, not_, or_, select
 from sqlalchemy.orm import aliased, joinedload, selectinload
 from starlette.requests import Request
 
@@ -147,7 +147,6 @@ async def list_role_requests(
                 .join(OktaGroup.active_user_ownerships)
                 .where(OktaGroup.deleted_at.is_(None))
                 .where(OktaUserGroupMember.user_id == assignee_user.id)
-                .subquery()
             )
             owner_app_group_alias = aliased(AppGroup)
             app_groups_owned_subquery = (
@@ -162,7 +161,6 @@ async def list_role_requests(
                 .join(owner_app_group_alias.active_user_ownerships)
                 .where(AppGroup.deleted_at.is_(None))
                 .where(OktaUserGroupMember.user_id == assignee_user.id)
-                .subquery()
             )
 
             if await is_access_admin(db, assignee_user.id):
@@ -315,7 +313,7 @@ async def list_role_requests(
             # Whether admin or not, never include the assignee's own requests.
             stmt = stmt.where(RoleRequest.requester_user_id != assignee_user.id)
         else:
-            stmt = stmt.where(False)
+            stmt = stmt.where(false())
 
     if q_args.resolver_user_id:
         if q_args.resolver_user_id == "@me":
@@ -432,6 +430,10 @@ async def post_role_request(
         request_reason=body.reason or "",
         request_ending_at=body.ending_at,
     ).execute()
+    # CreateRoleRequest.execute() returns None only for an unmanaged or role
+    # target group; both are rejected upstream in this handler, so a request
+    # is always created here.
+    assert rr is not None
     # Drop cached ORM state so the response reflects what the operation
     # committed (expire_on_commit=False keeps pre-operation state otherwise).
     rr_id = rr.id

--- a/api/routers/tags.py
+++ b/api/routers/tags.py
@@ -202,8 +202,8 @@ async def put_tag(
 async def delete_tag(
     tag_id: str,
     db: DbSession,
+    current_user_id: CurrentUserId,
     _admin: str = Depends(require_access_admin),
-    current_user_id: CurrentUserId = None,  # type: ignore[assignment]
 ) -> DeleteMessage:
     tag = (
         await db.scalars(select(Tag).where(Tag.deleted_at.is_(None)).where(or_(Tag.id == tag_id, Tag.name == tag_id)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,17 +118,18 @@ unresolved-import = "ignore"
 #     Optional query results as non-None;
 #   - the Okta service wrappers touch SDK models that type every field
 #     Optional and use custom data descriptors;
-#   - the FastAPI routers/exception handlers and MCP tools reuse the same
-#     Pydantic + query patterns.
+#   - the exception handlers and MCP tools reuse the same Pydantic + query
+#     patterns.
 # ty resolves the real types and flags these, so downgrade the affected
-# rules here. The core (api/models, api/schemas, api/database, api/config, …)
-# stays strict.
+# rules here. The core (api/models, api/schemas, api/database, api/config,
+# api/pagination, and — since POST_MIGRATION_TODO item 14 — api/routers) stays
+# strict, so `ty check .` in CI fails the build on any new router/schema
+# violation.
 [[tool.ty.overrides]]
 include = [
     "tests/**",
     "examples/**",
     "migrations/**",
-    "api/routers/**",
     "api/operations/**",
     "api/services/**",
     "api/auth/**",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,24 +114,22 @@ unresolved-import = "ignore"
 
 # Relaxed modules. These surfaces lean on runtime invariants ty can't prove
 # statically:
-#   - the SQLAlchemy-heavy operations layer and the tests dereference
-#     Optional query results as non-None;
-#   - the Okta service wrappers touch SDK models that type every field
-#     Optional and use custom data descriptors;
+#   - the SQLAlchemy-heavy operations layer and the tests dereference Optional
+#     query results as non-None, and touch Okta SDK models that type every
+#     field Optional / use custom data descriptors;
 #   - the exception handlers and MCP tools reuse the same Pydantic + query
 #     patterns.
-# ty resolves the real types and flags these, so downgrade the affected
-# rules here. The core (api/models, api/schemas, api/database, api/config,
-# api/pagination, and — since POST_MIGRATION_TODO item 14 — api/routers) stays
-# strict, so `ty check .` in CI fails the build on any new router/schema
-# violation.
+# ty resolves the real types and flags these, so downgrade the affected rules
+# here. The core (api/models, api/schemas, api/database, api/config,
+# api/pagination, api/services, and — since POST_MIGRATION_TODO item 14 —
+# api/routers) stays strict, so `ty check .` in CI fails the build on any new
+# violation there.
 [[tool.ty.overrides]]
 include = [
     "tests/**",
     "examples/**",
     "migrations/**",
     "api/operations/**",
-    "api/services/**",
     "api/auth/**",
     "api/mcp/**",
     "api/exception_handlers.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,29 +112,20 @@ python-version = "3.13"
 # them; keep unresolved imports non-fatal.
 unresolved-import = "ignore"
 
-# Relaxed modules. These surfaces lean on runtime invariants ty can't prove
-# statically:
-#   - the SQLAlchemy-heavy operations layer and the tests dereference Optional
-#     query results as non-None, and touch Okta SDK models that type every
-#     field Optional / use custom data descriptors;
-#   - the exception handlers and MCP tools reuse the same Pydantic + query
-#     patterns.
-# ty resolves the real types and flags these, so downgrade the affected rules
-# here. The core (api/models, api/schemas, api/database, api/config,
-# api/pagination, api/services, and — since POST_MIGRATION_TODO item 14 —
-# api/routers) stays strict, so `ty check .` in CI fails the build on any new
-# violation there.
+# Relaxed modules. The SQLAlchemy-heavy operations layer (plus the tests,
+# examples, and migrations) dereferences Optional query results as non-None and
+# touches Okta SDK models that type every field Optional / use custom data
+# descriptors — runtime invariants ty can't prove statically, so it flags them
+# and we downgrade the affected rules here. Everything else stays strict —
+# api/models, api/schemas, api/database, api/config, api/pagination, api/routers,
+# api/services, api/auth, api/mcp, api/exception_handlers.py, api/cli.py, and
+# api/app.py — so `ty check .` in CI fails the build on any new violation there.
 [[tool.ty.overrides]]
 include = [
     "tests/**",
     "examples/**",
     "migrations/**",
     "api/operations/**",
-    "api/auth/**",
-    "api/mcp/**",
-    "api/exception_handlers.py",
-    "api/cli.py",
-    "api/app.py",
 ]
 
 [tool.ty.overrides.rules]


### PR DESCRIPTION
Completes POST_MIGRATION_TODO item 14. Most of the backend was left in the
relaxed `[[tool.ty.overrides]]` block during the Flask→FastAPI migration to keep
that diff focused. This PR removes `api/routers`, `api/services`, `api/auth`,
`api/mcp`, `api/cli.py`, `api/app.py`, and `api/exception_handlers.py` from the
override so they're type-checked as strictly as `api/models` / `api/schemas`,
and resolves the ~37 diagnostics that surfaced. (`api/operations` — the last and
by far largest relaxed path — is the stacked follow-up in #545; after both, the
whole `api/` package is strict.)

Everything here is type-correctness only — no behavior change, full suite stays
green. The non-obvious parts:

- **`.in_(subquery)`** → pass the `Select` directly instead of `.subquery()`.
  The SQLAlchemy stubs don't model `Subquery` as a valid `IN` element; the
  emitted SQL is identical and the direct-`Select` form is the idiomatic 2.0
  spelling. (Biggest single source of noise in the routers.)
- **`.where(false())`** replaces the untyped `.where(False)` used to force an
  empty result set (SQLAlchemy already coerces the bool to `false()`).
- A few re-fetched ORM rows and `CreateRoleRequest.execute()` are `Optional` by
  signature but non-None by construction (the None paths are pre-rejected
  upstream); narrowed with an `assert` documenting the invariant.
- The spurious `current_user_id = None  # type: ignore` defaults on two delete
  endpoints are dropped by reordering the dependency params.
- **Leaf modules**: the 7 `add_exception_handler` calls and the PyJWT
  `from_jwk` key are genuine third-party-stub gaps (Starlette types handlers as
  `(Request, Exception) -> Response`; our handlers narrow the exception
  subtype), kept as targeted `ty: ignore`s. The rest are real fixes — explicit
  `import jwt.algorithms`, widening `is_app_owner_group_owner` to accept an
  `OktaGroup` (it already guards `type(...) is AppGroup` internally), `cast(F, …)`
  on the `functools.wraps` decorators, and an ignore on the dead
  `EntryPoints.get` back-compat branch.

`api/services` was already clean (0 diagnostics), so it comes out of the
override for free. No dedicated CI step is added: the whole-repo `ty check .`
already run in CI now fails on any new violation in these paths once they leave
the override, which is the guard the TODO asked for.
