### PR TITLE
perf: trim eager loads that routes never emit (POST_MIGRATION_TODO #4)

### DIFF
--- a/POST_MIGRATION_TODO.md
+++ b/POST_MIGRATION_TODO.md
@@ -6,26 +6,6 @@ Items grouped roughly by surface area; ordering within each group is rough prior
 
 ---
 
-## Database / SQLAlchemy
-
-### 4. Eager-loading hygiene
-
-**Strict serialization landed.** `api/schemas/_serialize.py` exposes
-`dump_orm`, which runs each adapter with `from_attributes=True` and lets
-`InvalidRequestError` on unloaded relationships surface to the test
-suite. The eager-load topology covering every field on
-`OktaUserGroupMemberDetail`, `RoleGroupMapDetail`,
-`OktaGroupTagMapDetail` is centralized in `api/routers/_eager.py` and
-re-used across `apps.py`, `groups.py`, `tags.py`, `users.py`,
-`role_requests.py`, and `audit.py`, so the loader stays in lockstep
-with the schema. 281/281 tests green.
-
-**Still to do under this item:**
-- Per-route `DEFAULT_LOAD_OPTIONS` for redundant joins; some routes
-  pre-load more than they emit.
-
----
-
 ## Tooling
 
 ### 14. Strict type checking on routers + schemas

--- a/api/routers/group_requests.py
+++ b/api/routers/group_requests.py
@@ -28,12 +28,15 @@ router = APIRouter(prefix="/api/group-requests", tags=["group-requests"], depend
 
 
 def _load_options() -> tuple:
+    # `GroupRequestDetail` — the response schema for every route below (list
+    # included) — serializes only `requester` / `resolver` and the
+    # `approved_group_id` *column*. It exposes neither `active_requester`,
+    # `active_resolver`, nor the `approved_group` relationship, and no handler
+    # reads them (the approve/resolve operations re-query their own graph), so
+    # eager-loading them just adds dead JOINs to every row of every page.
     return (
         joinedload(GroupRequest.requester),
-        joinedload(GroupRequest.active_requester),
         joinedload(GroupRequest.resolver),
-        joinedload(GroupRequest.active_resolver),
-        joinedload(GroupRequest.approved_group),
     )
 
 

--- a/api/routers/roles.py
+++ b/api/routers/roles.py
@@ -60,10 +60,10 @@ async def list_roles(
     current_user_id: CurrentUserId,
     q_args: Annotated[SearchRoleQuery, Query()],
 ) -> Page[RoleGroupListItem]:
-    # Flask `RoleList.get()` `only=(id, type, name, description, created_at,
-    # updated_at)` — `RoleGroupListItem` matches that shape exactly. The list
-    # shape exposes none of the eager-loaded relationships, so we attach no
-    # load options here at all (each would be an extra round trip discarded).
+    # `RoleGroupListItem` is the list shape — id, type, name, description,
+    # created_at, updated_at — and exposes none of the eager-loaded
+    # relationships, so we attach no load options here at all (each would be an
+    # extra round trip discarded).
     stmt = select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).order_by(func.lower(RoleGroup.name))
 
     # Filter to roles owned by `owner_id` (id or email; supports `@me`).

--- a/api/routers/roles.py
+++ b/api/routers/roles.py
@@ -21,9 +21,11 @@ from api.models import OktaGroup, OktaUser, OktaUserGroupMember, RoleGroup, Role
 from api.operations import ModifyRoleGroups
 from fastapi_pagination.ext.sqlalchemy import apaginate
 
+from sqlalchemy.orm import selectinload
+
 from api.pagination import Page, validated
+from api.routers._eager import group_tag_map_options, role_group_map_options
 from api.routers._fan_out import defer_fan_out
-from api.routers.groups import DEFAULT_LOAD_OPTIONS as _GROUP_LOAD_OPTIONS
 from api.schemas import (
     RoleGroupListItem,
     GroupDetail,
@@ -37,6 +39,19 @@ router = APIRouter(prefix="/api/roles", tags=["roles"], dependencies=[Depends(de
 # `api/routers/groups.py`.
 _role_adapter: TypeAdapter[Any] = TypeAdapter(GroupDetail)
 
+# `get_role` fetches `select(RoleGroup)` and serializes it as `RoleGroupDetail`,
+# which exposes only `active_group_tags` and the role→group *association*
+# mappings. Reusing groups' polymorphic `DEFAULT_LOAD_OPTIONS` here also
+# selectin-loaded the own-group `active_role_member/owner_mappings` — which are
+# structurally empty for a role (a role can't be the target of a RoleGroupMap),
+# so two wasted round-trips per fetch — plus AppGroup-only loaders that never
+# apply to a role row. Load exactly what the schema emits instead.
+_ROLE_LOAD_OPTIONS = (
+    selectinload(RoleGroup.active_group_tags).options(*group_tag_map_options()),
+    selectinload(RoleGroup.active_role_associated_group_member_mappings).options(*role_group_map_options()),
+    selectinload(RoleGroup.active_role_associated_group_owner_mappings).options(*role_group_map_options()),
+)
+
 
 @router.get("", name="roles")
 async def list_roles(
@@ -46,10 +61,9 @@ async def list_roles(
     q_args: Annotated[SearchRoleQuery, Query()],
 ) -> Page[RoleGroupListItem]:
     # Flask `RoleList.get()` `only=(id, type, name, description, created_at,
-    # updated_at)` — `RoleGroupListItem` matches that shape exactly. We
-    # deliberately don't reuse `_GROUP_LOAD_OPTIONS` here: those eager-loads
-    # populate fields the list shape doesn't expose, so each call would
-    # issue extra round trips for data that gets discarded.
+    # updated_at)` — `RoleGroupListItem` matches that shape exactly. The list
+    # shape exposes none of the eager-loaded relationships, so we attach no
+    # load options here at all (each would be an extra round trip discarded).
     stmt = select(RoleGroup).where(RoleGroup.deleted_at.is_(None)).order_by(func.lower(RoleGroup.name))
 
     # Filter to roles owned by `owner_id` (id or email; supports `@me`).
@@ -90,7 +104,7 @@ async def get_role(role_id: str, db: DbSession, current_user_id: CurrentUserId) 
     role = (
         await db.scalars(
             select(RoleGroup)
-            .options(*_GROUP_LOAD_OPTIONS)
+            .options(*_ROLE_LOAD_OPTIONS)
             .where(or_(RoleGroup.id == role_id, RoleGroup.name == role_id))
             .order_by(nullsfirst(RoleGroup.deleted_at.desc()))
         )


### PR DESCRIPTION
Completes the remaining bullet of POST_MIGRATION_TODO item 4 (eager-loading
hygiene): a couple of read routes eager-loaded relationships their response
schema never serializes and no handler reads, so each request paid for dead
JOINs / selectin round-trips.

- **`group_requests._load_options()`** — dropped `active_requester`,
  `active_resolver`, and the `approved_group` relationship. `GroupRequestDetail`
  (the schema for both the detail response and the paginated list) exposes only
  `requester` / `resolver` and the `approved_group_id` *column*, so those three
  JOINs were discarded on every row of every page. The approve/resolve
  operations re-query their own object graph, so no handler needed them.
- **`roles.get_role`** — stopped reusing groups' polymorphic
  `DEFAULT_LOAD_OPTIONS` and now uses a role-specific loader. `RoleGroupDetail`
  serializes only tags and the role→group *association* mappings; the shared
  tuple additionally selectin-loaded the own-group
  `active_role_member/owner_mappings` (structurally empty for a role — a role
  can't be the target of a `RoleGroupMap`, so two wasted round-trips) plus
  AppGroup-only loaders that never apply to a role row.

The strict serialization path (`validated` / `dump_orm`, which raises on any
unloaded `lazy="raise_on_sql"` relationship a response touches) is the safety
net: the full suite stays green, so nothing actually serialized was trimmed.
Routers that already split detail vs. summary loaders (`access_requests`,
`role_requests`, `groups`, `apps`, `users`, `tags`, `audit`) were audited and
left unchanged.