### PR TITLE
feat: nonce-based CSP for the SPA (POST_MIGRATION_TODO #20)

### DIFF
--- a/POST_MIGRATION_TODO.md
+++ b/POST_MIGRATION_TODO.md
@@ -30,15 +30,3 @@ Either:
 - Replace with [`polyfactory`](https://polyfactory.litestar.dev/) which
   generates fixtures from Pydantic models — keeps test data and request
   schemas in sync automatically.
-
----
-
-## Security follow-ups (out of scope for the migration PR)
-
-### 20. Nonce-based CSP
-
-Drop `'unsafe-inline'` from `script-src` and `style-src` in
-`api/middleware.py`. Generate a per-response nonce in
-`SecurityHeadersMiddleware` and thread it through `build/index.html`
-+ the React build pipeline so every inline `<script>` / `<style>`
-carries the nonce. Touches the frontend; not a same-PR fix.

--- a/api/app.py
+++ b/api/app.py
@@ -43,8 +43,8 @@ _SCRIPT_OR_STYLE_OPEN = re.compile(r"<(script|style)(?![^>]*\bnonce=)", re.IGNOR
 def _inject_csp_nonce(html: str, nonce: str) -> str:
     """Stamp the request's CSP nonce into the SPA shell.
 
-    With `'unsafe-inline'` dropped from `script-src`/`style-src` (see
-    `api.middleware.build_csp`), every inline `<script>`/`<style>` the build
+    `script-src`/`style-src` authorize inline content by nonce (see
+    `api.middleware.build_csp`), so every inline `<script>`/`<style>` the build
     emitted (e.g. Vite's module-preload polyfill) must carry the nonce, and
     styled-components' runtime `<style>` injections are authorized by seeding
     `window.__webpack_nonce__` before the app bundle runs. External same-origin

--- a/api/app.py
+++ b/api/app.py
@@ -8,7 +8,9 @@ present.
 
 from __future__ import annotations
 
+import json
 import logging
+import re
 import sys
 from contextlib import asynccontextmanager
 from os import environ
@@ -18,6 +20,8 @@ from typing import Any, AsyncIterator, Optional
 from fastapi import FastAPI
 from fastapi.routing import APIRoute
 from starlette.middleware.cors import CORSMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
 
 from api import exception_handlers, middleware
 from api.config import settings
@@ -30,6 +34,26 @@ from api.services import okta
 logger = logging.getLogger(__name__)
 
 BUILD_DIR = Path(__file__).resolve().parent.parent / "build"
+
+# Matches the opening of any inline `<script>`/`<style>` that isn't already
+# carrying a nonce, so `_inject_csp_nonce` can stamp one on.
+_SCRIPT_OR_STYLE_OPEN = re.compile(r"<(script|style)(?![^>]*\bnonce=)", re.IGNORECASE)
+
+
+def _inject_csp_nonce(html: str, nonce: str) -> str:
+    """Stamp the request's CSP nonce into the SPA shell.
+
+    With `'unsafe-inline'` dropped from `script-src`/`style-src` (see
+    `api.middleware.build_csp`), every inline `<script>`/`<style>` the build
+    emitted (e.g. Vite's module-preload polyfill) must carry the nonce, and
+    styled-components' runtime `<style>` injections are authorized by seeding
+    `window.__webpack_nonce__` before the app bundle runs. External same-origin
+    bundles and `<link>` stylesheets need no nonce (they're covered by `'self'`
+    / the font-host allowance), so this only touches inline tags.
+    """
+    html = _SCRIPT_OR_STYLE_OPEN.sub(lambda m: f'<{m.group(1)} nonce="{nonce}"', html)
+    setter = f'<script nonce="{nonce}">window.__webpack_nonce__={json.dumps(nonce)}</script>'
+    return re.sub(r"(<head[^>]*>)", lambda m: m.group(1) + setter, html, count=1)
 
 
 def _operation_id_from_route_name(route: APIRoute) -> str:
@@ -441,12 +465,12 @@ def create_app(testing: Optional[bool] = False) -> FastAPI:
     # above match first.
     if BUILD_DIR.exists():
         from fastapi import HTTPException
-        from fastapi.responses import FileResponse
+        from fastapi.responses import FileResponse, HTMLResponse
 
         build_dir_resolved = BUILD_DIR.resolve()
 
         @app.get("/{spa_path:path}", include_in_schema=False, name="spa")
-        def serve_spa(spa_path: str) -> FileResponse:
+        def serve_spa(spa_path: str, request: Request) -> Response:
             # Unmapped /api/* paths fall through to here; return a real 404
             # rather than the SPA index.
             if spa_path == "api" or spa_path.startswith("api/"):
@@ -479,7 +503,14 @@ def create_app(testing: Optional[bool] = False) -> FastAPI:
             # handle the path on the client. This response must never be
             # cached: it's the only thing that says which asset hashes are
             # currently valid, and a cached copy could keep pointing at
-            # hashes a future deploy has already removed.
-            return FileResponse(BUILD_DIR / "index.html", headers={"Cache-Control": "no-cache, must-revalidate"})
+            # hashes a future deploy has already removed. Because it's served
+            # dynamically (never cached), we can safely inject the per-response
+            # CSP nonce that SecurityHeadersMiddleware set on request.state.
+            headers = {"Cache-Control": "no-cache, must-revalidate"}
+            nonce = getattr(request.state, "csp_nonce", None)
+            if nonce:
+                html = (BUILD_DIR / "index.html").read_text(encoding="utf-8")
+                return HTMLResponse(content=_inject_csp_nonce(html, nonce), headers=headers)
+            return FileResponse(BUILD_DIR / "index.html", headers=headers)
 
     return app

--- a/api/middleware.py
+++ b/api/middleware.py
@@ -20,6 +20,7 @@ FastAPI route, which also runs through the app-wide dependency.
 from __future__ import annotations
 
 import logging
+import secrets
 import time
 import uuid
 from typing import Awaitable, Callable
@@ -35,18 +36,32 @@ from api.extensions import _session_scope, db
 from api.plugins._async_dispatch import run_hooks_to_completion
 from api.plugins.metrics_reporter import get_metrics_reporter_hook
 
-CSP = (
-    "default-src 'self'; "
-    "script-src 'self' 'unsafe-inline'; "
-    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
-    "font-src 'self' https://fonts.gstatic.com; "
-    "connect-src 'self' *.ingest.sentry.io; "
-    "worker-src 'self' blob:; "
-    "frame-ancestors 'none'"
-)
 
-# Relaxed CSP for development: allow Swagger UI assets served from CDN by
-# FastAPI's auto-generated `/api/docs` page.
+def build_csp(nonce: str) -> str:
+    """Production CSP for the SPA.
+
+    `'unsafe-inline'` is gone from `script-src`/`style-src`; a per-response
+    nonce (see `SecurityHeadersMiddleware`, threaded into the served
+    `index.html` by `api.app.serve_spa`) authorizes the inline bootstrap
+    `<script>` and styled-components' runtime `<style>` injections instead.
+    External same-origin bundles/stylesheets are still covered by `'self'`,
+    and Google Fonts by its host allowance.
+    """
+    return (
+        "default-src 'self'; "
+        f"script-src 'self' 'nonce-{nonce}'; "
+        f"style-src 'self' 'nonce-{nonce}' https://fonts.googleapis.com; "
+        "font-src 'self' https://fonts.gstatic.com; "
+        "connect-src 'self' *.ingest.sentry.io; "
+        "worker-src 'self' blob:; "
+        "frame-ancestors 'none'"
+    )
+
+
+# Relaxed CSP for development and the (optional) API docs: FastAPI's
+# auto-generated `/api/docs` page loads Swagger UI assets from a CDN and
+# bootstraps with an inline `<script>` that can't carry our per-response nonce,
+# so those paths keep `'unsafe-inline'` + the CDN allowance.
 DEBUG_CSP = (
     "default-src 'self'; "
     "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
@@ -132,10 +147,20 @@ class RequestContextMiddleware(BaseHTTPMiddleware):
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    # Docs endpoints whose inline Swagger bootstrap / CDN assets can't carry the
+    # per-response nonce; they keep the relaxed `DEBUG_CSP` even in production
+    # (API docs are optionally exposed there — see `settings.expose_api_docs`).
+    _DOCS_PATHS = ("/api/docs", "/api/openapi.json")
+
     async def dispatch(self, request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+        # Generate the CSP nonce before the route runs so the SPA catch-all
+        # (`api.app.serve_spa`) can stamp the *same* value into the served
+        # `index.html` (and `window.__webpack_nonce__`) that we emit in the
+        # header below.
+        nonce = secrets.token_urlsafe(16)
+        request.state.csp_nonce = nonce
         response = await call_next(request)
-        csp = DEBUG_CSP if settings.DEBUG else CSP
-        response.headers.setdefault("Content-Security-Policy", csp)
+        response.headers.setdefault("Content-Security-Policy", self._csp_for(request, nonce))
         response.headers.setdefault("X-Frame-Options", "DENY")
         response.headers.setdefault("Referrer-Policy", "no-referrer")
         response.headers.setdefault("X-Content-Type-Options", "nosniff")
@@ -145,6 +170,12 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
                 "max-age=31536000; includeSubDomains",
             )
         return response
+
+    def _csp_for(self, request: Request, nonce: str) -> str:
+        path = request.url.path
+        if settings.DEBUG or path in self._DOCS_PATHS or path.startswith("/api/swagger-ui"):
+            return DEBUG_CSP
+        return build_csp(nonce)
 
 
 class CacheControlMiddleware(BaseHTTPMiddleware):

--- a/api/middleware.py
+++ b/api/middleware.py
@@ -40,12 +40,12 @@ from api.plugins.metrics_reporter import get_metrics_reporter_hook
 def build_csp(nonce: str) -> str:
     """Production CSP for the SPA.
 
-    `'unsafe-inline'` is gone from `script-src`/`style-src`; a per-response
-    nonce (see `SecurityHeadersMiddleware`, threaded into the served
-    `index.html` by `api.app.serve_spa`) authorizes the inline bootstrap
-    `<script>` and styled-components' runtime `<style>` injections instead.
-    External same-origin bundles/stylesheets are still covered by `'self'`,
-    and Google Fonts by its host allowance.
+    `script-src`/`style-src` allow `'self'` plus a per-response nonce (see
+    `SecurityHeadersMiddleware`, threaded into the served `index.html` by
+    `api.app.serve_spa`): the nonce authorizes the inline bootstrap `<script>`
+    and styled-components' runtime `<style>` injections, while same-origin
+    bundles/stylesheets are covered by `'self'` and Google Fonts by its host
+    allowance.
     """
     return (
         "default-src 'self'; "

--- a/tests/test_spa.py
+++ b/tests/test_spa.py
@@ -14,6 +14,7 @@ that cross-loop use raises "another operation is in progress".
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import AsyncIterator
 
@@ -22,7 +23,8 @@ import pytest
 from fastapi import FastAPI
 
 from api import app as app_module
-from api.app import create_app
+from api.app import _inject_csp_nonce, create_app
+from api.config import settings
 from api.extensions import Db
 
 
@@ -64,3 +66,68 @@ async def test_unknown_route_falls_back_to_spa_shell_without_caching(spa_client:
     assert resp.status_code == 200
     assert resp.text == "<html><body>shell</body></html>"
     assert resp.headers["cache-control"] == "no-cache, must-revalidate"
+
+
+def test_inject_csp_nonce_stamps_inline_tags_and_webpack_global() -> None:
+    html = (
+        '<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"></head>'
+        "<body><style>.x{color:red}</style>"
+        '<script type="module" crossorigin src="/assets/index-abc.js"></script></body></html>'
+    )
+    out = _inject_csp_nonce(html, "TESTNONCE")
+    # Inline <script>/<style> the build emitted get the nonce...
+    assert '<script nonce="TESTNONCE" type="module" crossorigin src="/assets/index-abc.js">' in out
+    assert '<style nonce="TESTNONCE">.x{color:red}' in out
+    # ...and styled-components' runtime injections are covered by seeding the
+    # webpack nonce global first thing in <head>.
+    assert '<head><script nonce="TESTNONCE">window.__webpack_nonce__="TESTNONCE"</script>' in out
+    # No double-stamping of the setter script.
+    assert out.count("window.__webpack_nonce__") == 1
+
+
+async def test_spa_shell_injects_per_request_csp_nonce(spa_client: httpx.AsyncClient, stub_build_dir: Path) -> None:
+    # serve_spa stamps the request's nonce into the shell regardless of env
+    # (the header policy differs by env, but the body injection does not).
+    (stub_build_dir / "index.html").write_text(
+        '<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"></head>'
+        '<body><div id="root"></div>'
+        '<script type="module" crossorigin src="/assets/index-abc.js"></script></body></html>'
+    )
+    resp = await spa_client.get("/apps/Github")
+    assert resp.status_code == 200
+    body = resp.text
+
+    match = re.search(r'window\.__webpack_nonce__="([^"]+)"', body)
+    assert match is not None, body
+    nonce = match.group(1)
+    # The module script the build emitted carries the nonce...
+    assert f'<script nonce="{nonce}" type="module" crossorigin src="/assets/index-abc.js">' in body
+    # ...and the webpack-nonce setter is the first thing inside <head>.
+    assert f'<head><script nonce="{nonce}">window.__webpack_nonce__="{nonce}"</script>' in body
+
+
+async def test_prod_csp_uses_nonce_and_drops_unsafe_inline(
+    spa_client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # With DEBUG off, the app policy drops 'unsafe-inline' and authorizes inline
+    # via the per-response nonce. The header is emitted regardless of the auth
+    # outcome, so this holds without wiring up an authenticated SPA request.
+    monkeypatch.setattr(settings, "ENV", "staging")
+    resp = await spa_client.get("/apps/Github")
+    csp = resp.headers["content-security-policy"]
+    assert "unsafe-inline" not in csp
+    assert re.search(r"script-src [^;]*'nonce-[^']+'", csp), csp
+    assert re.search(r"style-src 'self' 'nonce-[^']+' https://fonts.googleapis.com", csp), csp
+
+
+async def test_docs_path_keeps_relaxed_csp_in_prod(
+    spa_client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Swagger's inline bootstrap can't carry our nonce, so docs paths keep the
+    # relaxed, CDN-allowing policy even when DEBUG is off.
+    monkeypatch.setattr(settings, "ENV", "staging")
+    resp = await spa_client.get("/api/openapi.json")
+    csp = resp.headers["content-security-policy"]
+    assert "'unsafe-inline'" in csp
+    assert "cdn.jsdelivr.net" in csp
+    assert "nonce-" not in csp

--- a/tests/test_spa.py
+++ b/tests/test_spa.py
@@ -100,6 +100,8 @@ async def test_spa_shell_injects_per_request_csp_nonce(spa_client: httpx.AsyncCl
     match = re.search(r'window\.__webpack_nonce__="([^"]+)"', body)
     assert match is not None, body
     nonce = match.group(1)
+    # CSP header must authorize the exact nonce stamped into the shell.
+    assert f"'nonce-{nonce}'" in resp.headers["content-security-policy"]
     # The module script the build emitted carries the nonce...
     assert f'<script nonce="{nonce}" type="module" crossorigin src="/assets/index-abc.js">' in body
     # ...and the webpack-nonce setter is the first thing inside <head>.


### PR DESCRIPTION
Completes POST_MIGRATION_TODO item 20. Drops `'unsafe-inline'` from `script-src`
and `style-src` in the production CSP and authorizes the app's inline content
with a per-response nonce instead — closing the main XSS-mitigation gap left by
the migration.

**How the nonce is threaded** (the non-obvious part):

- `SecurityHeadersMiddleware` generates a per-response nonce *before* the route
  runs and stashes it on `request.state`, then emits it in the CSP header.
- The SPA catch-all (`serve_spa`) reads that nonce and injects it into the
  served `index.html`: onto every inline `<script>`/`<style>`, plus a
  `window.__webpack_nonce__` setter as the first thing in `<head>`. MUI's
  styling engine is styled-components (`@mui/styled-engine-sc`), which reads
  `__webpack_nonce__` and stamps the nonce onto the `<style>` tags it injects
  at runtime — so the app's styles survive the strict policy. `index.html` is
  already served `no-cache`, so per-response injection is safe; the `assets/*`
  cache invariants are untouched.

**Docs exception:** FastAPI's auto-generated Swagger page bootstraps with an
inline script and CDN assets that can't carry our nonce, so `/api/docs` and
`/api/openapi.json` keep the relaxed CSP (which also still applies in
development, where the SPA is served by Vite rather than this route).

Verified against a real production build in a browser: the SPA renders fully
styled under the strict policy with zero CSP violations, and the
styled-components `<style>` element carries the matching nonce. Backend tests
cover the injection helper, the prod nonce policy, and the docs-path exception.