### PR TITLE
perf(syncer): batch concurrent Okta reads and reuse group scans

### DIFF
--- a/api/cli.py
+++ b/api/cli.py
@@ -251,6 +251,7 @@ async def sync(sync_groups_authoritatively: bool, sync_group_memberships_authori
     from sentry_sdk import start_transaction
 
     from api.config import settings
+    from api.services import okta
     from api.syncer import (
         expire_access_requests,
         sync_group_memberships,
@@ -259,13 +260,42 @@ async def sync(sync_groups_authoritatively: bool, sync_group_memberships_authori
         sync_users,
     )
 
-    with start_transaction(op="sync"):
-        await sync_users()
-        await sync_groups(act_as_authority=sync_groups_authoritatively)
-        await sync_group_memberships(act_as_authority=sync_group_memberships_authoritatively)
-        if settings.OKTA_USE_GROUP_OWNERS_API:
-            await sync_group_ownerships(act_as_authority=sync_group_memberships_authoritatively)
-        await expire_access_requests()
+    # Pool one Okta client (and its aiohttp connector) for the whole run so the
+    # concurrent per-group membership/ownership fan-out reuses connections.
+    # No-op when Okta isn't configured (dev/test).
+    await okta.start_pooled_client()
+    try:
+        with start_transaction(op="sync"):
+            await sync_users()
+
+            # Fetch the active group rules once and reuse them across every pass
+            # — group rules don't change over the course of a sync run.
+            group_ids_with_group_rules = await okta.list_groups_with_active_rules()
+
+            await sync_groups(
+                act_as_authority=sync_groups_authoritatively,
+                group_ids_with_group_rules=group_ids_with_group_rules,
+            )
+
+            # Re-list groups once after sync_groups (which can create or delete
+            # groups in authoritative mode) and reuse the snapshot for both the
+            # membership and ownership passes — neither mutates the group set.
+            groups = await okta.list_groups()
+
+            await sync_group_memberships(
+                act_as_authority=sync_group_memberships_authoritatively,
+                groups=groups,
+                group_ids_with_group_rules=group_ids_with_group_rules,
+            )
+            if settings.OKTA_USE_GROUP_OWNERS_API:
+                await sync_group_ownerships(
+                    act_as_authority=sync_group_memberships_authoritatively,
+                    groups=groups,
+                    group_ids_with_group_rules=group_ids_with_group_rules,
+                )
+            await expire_access_requests()
+    finally:
+        await okta.stop_pooled_client()
 
 
 @cli.command("fix-unmanaged-groups")

--- a/api/cli.py
+++ b/api/cli.py
@@ -248,14 +248,15 @@ async def _init_builtin_apps(admin_okta_user_email: str) -> None:
 @click.option(
     "--group-batch-size",
     type=click.IntRange(min=1),
-    default=None,
-    help="Groups whose Okta memberships/ownerships are fetched concurrently per batch (default: SYNC_GROUP_BATCH_SIZE).",
+    default=10,
+    show_default=True,
+    help="Groups whose Okta memberships/ownerships are fetched concurrently per batch.",
 )
 @_with_app_context
 async def sync(
     sync_groups_authoritatively: bool,
     sync_group_memberships_authoritatively: bool,
-    group_batch_size: int | None,
+    group_batch_size: int,
 ) -> None:
     """Sync users/groups/memberships from Okta to Access and expire stale requests."""
     from sentry_sdk import start_transaction
@@ -269,10 +270,6 @@ async def sync(
         sync_groups,
         sync_users,
     )
-
-    # The --group-batch-size flag overrides the SYNC_GROUP_BATCH_SIZE setting
-    # when provided; resolve it once and pass the concrete size down.
-    batch_size = group_batch_size if group_batch_size is not None else settings.SYNC_GROUP_BATCH_SIZE
 
     # Pool one Okta client (and its aiohttp connector) for the whole run so the
     # concurrent per-group membership/ownership fan-out reuses connections.
@@ -300,14 +297,14 @@ async def sync(
                 act_as_authority=sync_group_memberships_authoritatively,
                 groups=groups,
                 group_ids_with_group_rules=group_ids_with_group_rules,
-                batch_size=batch_size,
+                batch_size=group_batch_size,
             )
             if settings.OKTA_USE_GROUP_OWNERS_API:
                 await sync_group_ownerships(
                     act_as_authority=sync_group_memberships_authoritatively,
                     groups=groups,
                     group_ids_with_group_rules=group_ids_with_group_rules,
-                    batch_size=batch_size,
+                    batch_size=group_batch_size,
                 )
             await expire_access_requests()
     finally:

--- a/api/cli.py
+++ b/api/cli.py
@@ -270,6 +270,10 @@ async def sync(
         sync_users,
     )
 
+    # The --group-batch-size flag overrides the SYNC_GROUP_BATCH_SIZE setting
+    # when provided; resolve it once and pass the concrete size down.
+    batch_size = group_batch_size if group_batch_size is not None else settings.SYNC_GROUP_BATCH_SIZE
+
     # Pool one Okta client (and its aiohttp connector) for the whole run so the
     # concurrent per-group membership/ownership fan-out reuses connections.
     # No-op when Okta isn't configured (dev/test).
@@ -296,14 +300,14 @@ async def sync(
                 act_as_authority=sync_group_memberships_authoritatively,
                 groups=groups,
                 group_ids_with_group_rules=group_ids_with_group_rules,
-                batch_size=group_batch_size,
+                batch_size=batch_size,
             )
             if settings.OKTA_USE_GROUP_OWNERS_API:
                 await sync_group_ownerships(
                     act_as_authority=sync_group_memberships_authoritatively,
                     groups=groups,
                     group_ids_with_group_rules=group_ids_with_group_rules,
-                    batch_size=group_batch_size,
+                    batch_size=batch_size,
                 )
             await expire_access_requests()
     finally:

--- a/api/cli.py
+++ b/api/cli.py
@@ -245,8 +245,18 @@ async def _init_builtin_apps(admin_okta_user_email: str) -> None:
     default=False,
     help="Sync group memberships from Access to Okta",
 )
+@click.option(
+    "--group-batch-size",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Groups whose Okta memberships/ownerships are fetched concurrently per batch (default: SYNC_GROUP_BATCH_SIZE).",
+)
 @_with_app_context
-async def sync(sync_groups_authoritatively: bool, sync_group_memberships_authoritatively: bool) -> None:
+async def sync(
+    sync_groups_authoritatively: bool,
+    sync_group_memberships_authoritatively: bool,
+    group_batch_size: int | None,
+) -> None:
     """Sync users/groups/memberships from Okta to Access and expire stale requests."""
     from sentry_sdk import start_transaction
 
@@ -286,12 +296,14 @@ async def sync(sync_groups_authoritatively: bool, sync_group_memberships_authori
                 act_as_authority=sync_group_memberships_authoritatively,
                 groups=groups,
                 group_ids_with_group_rules=group_ids_with_group_rules,
+                batch_size=group_batch_size,
             )
             if settings.OKTA_USE_GROUP_OWNERS_API:
                 await sync_group_ownerships(
                     act_as_authority=sync_group_memberships_authoritatively,
                     groups=groups,
                     group_ids_with_group_rules=group_ids_with_group_rules,
+                    batch_size=group_batch_size,
                 )
             await expire_access_requests()
     finally:

--- a/api/config.py
+++ b/api/config.py
@@ -118,12 +118,6 @@ class Settings(BaseSettings):
     USER_SEARCH_CUSTOM_ATTRIBUTES: Optional[str] = None
     MAX_ACCESS_REQUEST_AGE_SECONDS: int = 7 * 24 * 60 * 60
 
-    # Number of groups whose Okta membership/ownership lists the syncer fetches
-    # concurrently per batch before reconciling them against the DB. Higher values
-    # shorten a sync run but raise the concurrent load placed on Okta's rate
-    # limits. Overridable per run via the sync command's --group-batch-size flag.
-    SYNC_GROUP_BATCH_SIZE: int = Field(default=10, ge=1)
-
     # Cloudflare Access
     CLOUDFLARE_APPLICATION_AUDIENCE: Optional[str] = None
     CLOUDFLARE_TEAM_DOMAIN: Optional[str] = None

--- a/api/config.py
+++ b/api/config.py
@@ -118,6 +118,12 @@ class Settings(BaseSettings):
     USER_SEARCH_CUSTOM_ATTRIBUTES: Optional[str] = None
     MAX_ACCESS_REQUEST_AGE_SECONDS: int = 7 * 24 * 60 * 60
 
+    # Number of groups whose Okta membership/ownership lists the syncer fetches
+    # concurrently per batch before reconciling them against the DB. Higher values
+    # shorten a sync run but raise the concurrent load placed on Okta's rate
+    # limits. Overridable per run via the sync command's --group-batch-size flag.
+    SYNC_GROUP_BATCH_SIZE: int = Field(default=10, ge=1)
+
     # Cloudflare Access
     CLOUDFLARE_APPLICATION_AUDIENCE: Optional[str] = None
     CLOUDFLARE_TEAM_DOMAIN: Optional[str] = None

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -1,5 +1,7 @@
+import asyncio
 import logging
 from collections import defaultdict
+from collections.abc import AsyncIterator, Awaitable, Callable
 from datetime import date, datetime, timedelta, timezone
 
 from sqlalchemy import and_, func, or_, select
@@ -10,6 +12,8 @@ from sqlalchemy.orm import (
     selectinload,
     with_polymorphic,
 )
+
+from okta.models.group_rule import GroupRule as OktaGroupRuleType
 
 from api.extensions import db
 from api.models import (
@@ -34,9 +38,41 @@ from api.operations import (
 )
 from api.plugins import NotificationHook, send_notification
 from api.services import okta
-from api.services.okta_service import OktaTransientError, is_managed_group
+from api.services.okta_service import Group, OktaTransientError, User, is_managed_group
 
 logger = logging.getLogger(__name__)
+
+# Okta group rules keyed by the group id they assign users to, as returned by
+# ``okta.list_groups_with_active_rules`` and consumed by ``is_managed_group``.
+_GroupRulesByGroupId = dict[str, list[OktaGroupRuleType]]
+
+# Number of groups whose Okta membership/ownership lists are fetched concurrently
+# before the batch is reconciled against the DB. Bounds Okta rate-limit pressure
+# and the peak memory held (one batch of lists at a time).
+SYNC_GROUP_BATCH_SIZE = 10
+
+
+async def _prefetch_group_okta_lists(
+    groups: list[Group],
+    fetch: Callable[[str], Awaitable[list[User]]],
+) -> AsyncIterator[tuple[Group, list[User] | BaseException]]:
+    """Yield ``(group, okta_list)`` pairs, fetching each batch's Okta lists concurrently.
+
+    Batches ``SYNC_GROUP_BATCH_SIZE`` calls through ``asyncio.gather`` to overlap
+    the round trips while bounding both Okta rate-limit pressure and the peak
+    memory held (one batch of lists at a time). ``return_exceptions=True`` means
+    one group's Okta timeout surfaces as its paired value instead of cancelling
+    the batch, so the caller inspects each value and skips the failures.
+
+    These fetch coroutines do network I/O only and must never touch ``db.session``
+    (the concurrency rule in ``api/extensions.py``); the caller reconciles each
+    yielded pair against the DB on its own sequential code path.
+    """
+    for start in range(0, len(groups), SYNC_GROUP_BATCH_SIZE):
+        batch = groups[start : start + SYNC_GROUP_BATCH_SIZE]
+        results = await asyncio.gather(*(fetch(group.id) for group in batch), return_exceptions=True)
+        for group, result in zip(batch, results, strict=True):
+            yield group, result
 
 
 async def sync_users() -> None:
@@ -129,13 +165,17 @@ async def sync_users() -> None:
     logger.info("User sync finished.")
 
 
-async def sync_groups(act_as_authority: bool) -> None:
+async def sync_groups(
+    act_as_authority: bool,
+    group_ids_with_group_rules: _GroupRulesByGroupId | None = None,
+) -> None:
     logger.info("Group sync starting")
 
     groups_in_okta = await okta.list_groups()
     db_group_ids = set((await db.session.scalars(select(OktaGroup.id).where(OktaGroup.deleted_at.is_(None)))).all())
 
-    group_ids_with_group_rules = await okta.list_groups_with_active_rules()
+    if group_ids_with_group_rules is None:
+        group_ids_with_group_rules = await okta.list_groups_with_active_rules()
 
     for group in groups_in_okta:
         logger.info(f"Syncing group {group.id}")
@@ -185,25 +225,36 @@ async def sync_groups(act_as_authority: bool) -> None:
     logger.info("Group sync finished.")
 
 
-async def sync_group_memberships(act_as_authority: bool) -> None:
+async def sync_group_memberships(
+    act_as_authority: bool,
+    groups: list[Group] | None = None,
+    group_ids_with_group_rules: _GroupRulesByGroupId | None = None,
+) -> None:
     logger.info("Membership sync started.")
-    groups = await okta.list_groups()
+    if groups is None:
+        groups = await okta.list_groups()
 
     # Hydrate all groups into sql alchemy context at once
     # to avoid a roundtrip for each group
     _ = (await db.session.scalars(select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup])))).all()
 
-    group_ids_with_group_rules = await okta.list_groups_with_active_rules()
+    if group_ids_with_group_rules is None:
+        group_ids_with_group_rules = await okta.list_groups_with_active_rules()
 
-    for group in groups:
+    async for group, members in _prefetch_group_okta_lists(groups, okta.list_users_for_group):
+        if isinstance(members, OktaTransientError):
+            logger.warning(f"Transient Okta error listing members for group {group.id}, skipping.", exc_info=members)
+            continue
+        if isinstance(members, BaseException):
+            logger.error(f"Failed to list members for group {group.id}, skipping.", exc_info=members)
+            continue
+
         try:
             is_managed = is_managed_group(group, group_ids_with_group_rules)
 
             act_authoritatively = act_as_authority and is_managed
 
             logger.info(f"Syncing group {group.id}. act_authoritatively: {act_authoritatively}")
-
-            members = await okta.list_users_for_group(group.id)
 
             logger.info(f"Fetched users list for group {group.id}")
 
@@ -281,21 +332,32 @@ async def sync_group_memberships(act_as_authority: bool) -> None:
     logger.info("Membership sync finished.")
 
 
-async def sync_group_ownerships(act_as_authority: bool) -> None:
+async def sync_group_ownerships(
+    act_as_authority: bool,
+    groups: list[Group] | None = None,
+    group_ids_with_group_rules: _GroupRulesByGroupId | None = None,
+) -> None:
     logger.info("Ownership sync started.")
-    groups = await okta.list_groups()
+    if groups is None:
+        groups = await okta.list_groups()
 
-    group_ids_with_group_rules = await okta.list_groups_with_active_rules()
+    if group_ids_with_group_rules is None:
+        group_ids_with_group_rules = await okta.list_groups_with_active_rules()
 
-    for group in groups:
+    async for group, owners in _prefetch_group_okta_lists(groups, okta.list_owners_for_group):
+        if isinstance(owners, OktaTransientError):
+            logger.warning(f"Transient Okta error listing owners for group {group.id}, skipping.", exc_info=owners)
+            continue
+        if isinstance(owners, BaseException):
+            logger.error(f"Failed to list owners for group {group.id}, skipping.", exc_info=owners)
+            continue
+
         try:
             is_managed = is_managed_group(group, group_ids_with_group_rules)
 
             act_authoritatively = act_as_authority and is_managed
 
             logger.info(f"Syncing group {group.id}. act_authoritatively: {act_authoritatively}")
-
-            owners = await okta.list_owners_for_group(group.id)
 
             db_all_group_owners = {
                 row.id: row.user_id

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -225,7 +225,8 @@ async def sync_group_memberships(
     act_as_authority: bool,
     groups: list[Group] | None = None,
     group_ids_with_group_rules: _GroupRulesByGroupId | None = None,
-    batch_size: int | None = None,
+    *,
+    batch_size: int,
 ) -> None:
     logger.info("Membership sync started.")
     if groups is None:
@@ -237,9 +238,6 @@ async def sync_group_memberships(
 
     if group_ids_with_group_rules is None:
         group_ids_with_group_rules = await okta.list_groups_with_active_rules()
-
-    if batch_size is None:
-        batch_size = settings.SYNC_GROUP_BATCH_SIZE
 
     async for group, members in _prefetch_group_okta_lists(groups, okta.list_users_for_group, batch_size):
         if isinstance(members, OktaTransientError):
@@ -336,7 +334,8 @@ async def sync_group_ownerships(
     act_as_authority: bool,
     groups: list[Group] | None = None,
     group_ids_with_group_rules: _GroupRulesByGroupId | None = None,
-    batch_size: int | None = None,
+    *,
+    batch_size: int,
 ) -> None:
     logger.info("Ownership sync started.")
     if groups is None:
@@ -344,9 +343,6 @@ async def sync_group_ownerships(
 
     if group_ids_with_group_rules is None:
         group_ids_with_group_rules = await okta.list_groups_with_active_rules()
-
-    if batch_size is None:
-        batch_size = settings.SYNC_GROUP_BATCH_SIZE
 
     async for group, owners in _prefetch_group_okta_lists(groups, okta.list_owners_for_group, batch_size):
         if isinstance(owners, OktaTransientError):

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -46,30 +46,26 @@ logger = logging.getLogger(__name__)
 # ``okta.list_groups_with_active_rules`` and consumed by ``is_managed_group``.
 _GroupRulesByGroupId = dict[str, list[OktaGroupRuleType]]
 
-# Number of groups whose Okta membership/ownership lists are fetched concurrently
-# before the batch is reconciled against the DB. Bounds Okta rate-limit pressure
-# and the peak memory held (one batch of lists at a time).
-SYNC_GROUP_BATCH_SIZE = 10
-
 
 async def _prefetch_group_okta_lists(
     groups: list[Group],
     fetch: Callable[[str], Awaitable[list[User]]],
+    batch_size: int,
 ) -> AsyncIterator[tuple[Group, list[User] | BaseException]]:
     """Yield ``(group, okta_list)`` pairs, fetching each batch's Okta lists concurrently.
 
-    Batches ``SYNC_GROUP_BATCH_SIZE`` calls through ``asyncio.gather`` to overlap
-    the round trips while bounding both Okta rate-limit pressure and the peak
-    memory held (one batch of lists at a time). ``return_exceptions=True`` means
-    one group's Okta timeout surfaces as its paired value instead of cancelling
-    the batch, so the caller inspects each value and skips the failures.
+    Batches ``batch_size`` calls through ``asyncio.gather`` to overlap the round
+    trips while bounding both Okta rate-limit pressure and the peak memory held
+    (one batch of lists at a time). ``return_exceptions=True`` means one group's
+    Okta timeout surfaces as its paired value instead of cancelling the batch, so
+    the caller inspects each value and skips the failures.
 
     These fetch coroutines do network I/O only and must never touch ``db.session``
     (the concurrency rule in ``api/extensions.py``); the caller reconciles each
     yielded pair against the DB on its own sequential code path.
     """
-    for start in range(0, len(groups), SYNC_GROUP_BATCH_SIZE):
-        batch = groups[start : start + SYNC_GROUP_BATCH_SIZE]
+    for start in range(0, len(groups), batch_size):
+        batch = groups[start : start + batch_size]
         results = await asyncio.gather(*(fetch(group.id) for group in batch), return_exceptions=True)
         for group, result in zip(batch, results, strict=True):
             yield group, result
@@ -229,6 +225,7 @@ async def sync_group_memberships(
     act_as_authority: bool,
     groups: list[Group] | None = None,
     group_ids_with_group_rules: _GroupRulesByGroupId | None = None,
+    batch_size: int | None = None,
 ) -> None:
     logger.info("Membership sync started.")
     if groups is None:
@@ -241,7 +238,10 @@ async def sync_group_memberships(
     if group_ids_with_group_rules is None:
         group_ids_with_group_rules = await okta.list_groups_with_active_rules()
 
-    async for group, members in _prefetch_group_okta_lists(groups, okta.list_users_for_group):
+    if batch_size is None:
+        batch_size = settings.SYNC_GROUP_BATCH_SIZE
+
+    async for group, members in _prefetch_group_okta_lists(groups, okta.list_users_for_group, batch_size):
         if isinstance(members, OktaTransientError):
             logger.warning(f"Transient Okta error listing members for group {group.id}, skipping.", exc_info=members)
             continue
@@ -336,6 +336,7 @@ async def sync_group_ownerships(
     act_as_authority: bool,
     groups: list[Group] | None = None,
     group_ids_with_group_rules: _GroupRulesByGroupId | None = None,
+    batch_size: int | None = None,
 ) -> None:
     logger.info("Ownership sync started.")
     if groups is None:
@@ -344,7 +345,10 @@ async def sync_group_ownerships(
     if group_ids_with_group_rules is None:
         group_ids_with_group_rules = await okta.list_groups_with_active_rules()
 
-    async for group, owners in _prefetch_group_okta_lists(groups, okta.list_owners_for_group):
+    if batch_size is None:
+        batch_size = settings.SYNC_GROUP_BATCH_SIZE
+
+    async for group, owners in _prefetch_group_okta_lists(groups, okta.list_owners_for_group, batch_size):
         if isinstance(owners, OktaTransientError):
             logger.warning(f"Transient Okta error listing owners for group {group.id}, skipping.", exc_info=owners)
             continue

--- a/tests/test_group_membership_sync.py
+++ b/tests/test_group_membership_sync.py
@@ -6,6 +6,7 @@ from pytest_mock import MockerFixture
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.config import settings
 from api.models import OktaGroup, OktaUser, OktaUserGroupMember
 from api.extensions import Db
 from api.services import okta
@@ -356,7 +357,7 @@ async def run_sync(
 
         mocker.patch.object(okta, "list_groups_with_active_rules", return_value=groups_with_rules)
 
-        await sync_group_memberships(act_as_authority)
+        await sync_group_memberships(act_as_authority, batch_size=settings.SYNC_GROUP_BATCH_SIZE)
 
         return list((await session.scalars(select(OktaUserGroupMember))).all())
 

--- a/tests/test_group_membership_sync.py
+++ b/tests/test_group_membership_sync.py
@@ -6,7 +6,6 @@ from pytest_mock import MockerFixture
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.config import settings
 from api.models import OktaGroup, OktaUser, OktaUserGroupMember
 from api.extensions import Db
 from api.services import okta
@@ -357,7 +356,7 @@ async def run_sync(
 
         mocker.patch.object(okta, "list_groups_with_active_rules", return_value=groups_with_rules)
 
-        await sync_group_memberships(act_as_authority, batch_size=settings.SYNC_GROUP_BATCH_SIZE)
+        await sync_group_memberships(act_as_authority, batch_size=10)
 
         return list((await session.scalars(select(OktaUserGroupMember))).all())
 

--- a/tests/test_group_ownership_sync.py
+++ b/tests/test_group_ownership_sync.py
@@ -6,7 +6,6 @@ from pytest_mock import MockerFixture
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.config import settings
 from api.models import AppGroup, OktaGroup, OktaUser, OktaUserGroupMember
 from api.extensions import Db
 from api.services import okta
@@ -412,7 +411,7 @@ async def run_sync(
 
         mocker.patch.object(okta, "list_groups_with_active_rules", return_value=groups_with_rules)
 
-        await sync_group_ownerships(act_as_authority, batch_size=settings.SYNC_GROUP_BATCH_SIZE)
+        await sync_group_ownerships(act_as_authority, batch_size=10)
 
         return list((await session.scalars(select(OktaUserGroupMember))).all())
 

--- a/tests/test_group_ownership_sync.py
+++ b/tests/test_group_ownership_sync.py
@@ -6,6 +6,7 @@ from pytest_mock import MockerFixture
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from api.config import settings
 from api.models import AppGroup, OktaGroup, OktaUser, OktaUserGroupMember
 from api.extensions import Db
 from api.services import okta
@@ -411,7 +412,7 @@ async def run_sync(
 
         mocker.patch.object(okta, "list_groups_with_active_rules", return_value=groups_with_rules)
 
-        await sync_group_ownerships(act_as_authority)
+        await sync_group_ownerships(act_as_authority, batch_size=settings.SYNC_GROUP_BATCH_SIZE)
 
         return list((await session.scalars(select(OktaUserGroupMember))).all())
 


### PR DESCRIPTION
## What & why

The group **membership** and **ownership** sync passes issued one Okta list call per group, serially, so a sync run's wall-clock scaled linearly with the number of groups — the dominant cost of a run. This makes those per-group Okta reads concurrent.

Each pass now fetches a batch of groups' member/owner lists concurrently via `asyncio.gather`, then reconciles each result against the DB **sequentially**. The serial reconciliation is deliberate: the syncer shares a single `AsyncSession`, which must never be used concurrently, so only the network reads fan out. Batching in bounded groups (rather than prefetching every group at once) keeps peak memory to one batch of lists and keeps the number of concurrent Okta requests modest, so rate-limit pressure stays low (the SDK still retries any transient errors). A per-group fetch failure is captured and skipped rather than aborting the batch.

The batch size is set by the `sync` command's `--group-batch-size` flag (default 10, minimum 1).

Supporting changes in the `sync` command:
- Pool one Okta client (and its aiohttp connector) for the whole run so the concurrent fan-out reuses connections.
- Fetch the group-rule listing and the group listing once each, reused across the membership and ownership passes.

`sync_groups` keeps its own group-list fetch on purpose — in authoritative mode it creates/deletes groups in Okta, so the shared snapshot is taken *after* it runs to keep the later passes' behavior identical. `sync_group_memberships` / `sync_group_ownerships` take the shared `groups` and group-rule data as optional parameters (defaulting to fetching them) plus a required `batch_size`, so standalone and test callers are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
