### PR TITLE
fix: swallow transient 5xx Okta errors; rename OktaTimeout → OktaTransientError

### DIFF
--- a/api/services/okta_service.py
+++ b/api/services/okta_service.py
@@ -10,7 +10,6 @@ from datetime import datetime
 from typing import Any, AsyncIterator, Awaitable, Callable, Optional
 
 from okta.client import Client as OktaClient
-from okta.errors.okta_api_error import OktaAPIError
 from okta.models.add_group_request import AddGroupRequest
 from okta.models.assign_group_owner_request_body import AssignGroupOwnerRequestBody
 from okta.models.group import Group as OktaGroupType
@@ -26,7 +25,10 @@ from api.config import OKTA_GROUP_PROFILE_CUSTOM_ATTR
 from api.models import OktaGroup, OktaUser
 
 REQUEST_TIMEOUT = 30
-HTTP_TOO_MANY_REQUESTS = 429
+# HTTP statuses the SDK reports as errors that we treat as transient: a caller
+# may swallow them and let the next reconcile retry. Covers rate limiting (429)
+# and upstream/gateway blips (5xx, e.g. a 502 Bad Gateway from the load balancer).
+TRANSIENT_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
 # Page size for cursor-paginated list endpoints. Okta caps most list endpoints
 # at 200 per page; the facade drives the ``after`` cursor to walk pages.
 LIST_PAGE_LIMIT = 200
@@ -47,30 +49,33 @@ UserSchemaAttribute.model_rebuild(force=True)
 
 
 class OktaTimeout(Exception):
-    """Raised when an Okta API request times out or is rate-limited out.
+    """Raised when an Okta request times out or hits a transient failure.
 
-    Surfaced when the SDK gives up on a request — either its ``requestTimeout``
-    is exceeded or a 429 outlives its rate-limit retries. Callers that can
-    tolerate a slow Okta call (the membership/ownership fan-out) catch this and
-    continue; the syncer reconciles the drift later.
+    Surfaced when the SDK gives up on a request: its ``requestTimeout`` is
+    exceeded, a 429 outlives its rate-limit retries, or the response is a
+    transient upstream/gateway error (5xx). Callers that can tolerate a slow or
+    flaky Okta call (the membership/ownership fan-out) catch this and continue;
+    the syncer reconciles the drift later.
     """
 
     pass
 
 
-def _is_timeout_or_rate_limited(error: Any) -> bool:
-    """Whether an SDK error means the request timed out or was rate-limited out.
+def _is_transient_okta_error(error: Any) -> bool:
+    """Whether an SDK error is a transient failure a caller may swallow.
 
-    The SDK returns (rather than raises) a request timeout as an
-    ``asyncio.TimeoutError`` (aiohttp socket timeout) or a bare
-    ``Exception("Request Timeout exceeded.")`` (its cumulative deadline), and a
-    429 that survived its retries as an ``OktaAPIError`` with status 429.
+    The SDK returns (rather than raises) errors. Treat as transient: a request
+    timeout — an ``asyncio.TimeoutError`` (aiohttp socket timeout) or the bare
+    ``Exception("Request Timeout exceeded.")`` cumulative deadline — and any
+    response carrying a transient HTTP ``status`` (429, or a 5xx gateway error).
+    Both ``OktaAPIError`` (JSON error bodies) and ``HTTPError`` (non-JSON, e.g. a
+    502 HTML page) expose ``.status``.
     """
     if error is None:
         return False
     if isinstance(error, asyncio.TimeoutError):
         return True
-    if isinstance(error, OktaAPIError) and getattr(error, "status", None) == HTTP_TOO_MANY_REQUESTS:
+    if getattr(error, "status", None) in TRANSIENT_STATUS_CODES:
         return True
     return str(error) == "Request Timeout exceeded."
 
@@ -194,7 +199,7 @@ class OktaService:
         """
         result = await coro
         error = result[-1] if isinstance(result, tuple) and result else None
-        if _is_timeout_or_rate_limited(error):
+        if _is_transient_okta_error(error):
             raise OktaTimeout(str(error) or "Okta request timed out")
         return result
 

--- a/api/services/okta_service.py
+++ b/api/services/okta_service.py
@@ -335,7 +335,7 @@ class OktaService:
             if error is not None:
                 raise Exception(error)
         except OktaTimeout:
-            logger.warning(f"Timed out adding user {userId} to group {groupId}")
+            logger.warning(f"Transient Okta error adding user {userId} to group {groupId}")
 
     async def remove_user_from_group(self, groupId: str, userId: str) -> None:
         if groupId is None or groupId == "":
@@ -353,7 +353,7 @@ class OktaService:
             if error is not None:
                 raise Exception(error)
         except OktaTimeout:
-            logger.warning(f"Timed out removing user {userId} from group {groupId}")
+            logger.warning(f"Transient Okta error removing user {userId} from group {groupId}")
 
     # TODO: Implement fetching group membership count for fast syncing
     # GET https://{yourOktaDomain}.com/api/v1/groups/<group_id>?expand=app,stats
@@ -430,7 +430,7 @@ class OktaService:
             if error is not None and "already assigned to this group" not in str(error):
                 raise Exception(error)
         except OktaTimeout:
-            logger.warning(f"Timed out adding owner {userId} to group {groupId}")
+            logger.warning(f"Transient Okta error adding owner {userId} to group {groupId}")
 
         return
 
@@ -453,7 +453,7 @@ class OktaService:
             if error is not None:
                 raise Exception(error)
         except OktaTimeout:
-            logger.warning(f"Timed out removing owner {userId} from group {groupId}")
+            logger.warning(f"Transient Okta error removing owner {userId} from group {groupId}")
 
         return
 

--- a/api/services/okta_service.py
+++ b/api/services/okta_service.py
@@ -48,7 +48,7 @@ _unique_field.metadata = []
 UserSchemaAttribute.model_rebuild(force=True)
 
 
-class OktaTimeout(Exception):
+class OktaTransientError(Exception):
     """Raised when an Okta request times out or hits a transient failure.
 
     Surfaced when the SDK gives up on a request: its ``requestTimeout`` is
@@ -84,10 +84,11 @@ class _WrapperClient:
     """Proxy over an Okta client that routes every async API call through ``OktaService._call``.
 
     Attribute access returns the underlying client's coroutine methods wrapped
-    so their timeout / rate-limit outcomes become ``OktaTimeout``. Applying the
-    mapping here — rather than at each call site — makes it uniform and
-    impossible to forget when a new facade method is added. Non-coroutine
-    attributes (e.g. ``get_request_executor``) pass through unchanged.
+    so their transient failures (timeout, rate limit, 5xx) surface as
+    ``OktaTransientError``. Applying the mapping here — rather than at each call
+    site — makes it uniform and impossible to forget when a new facade method is
+    added. Non-coroutine attributes (e.g. ``get_request_executor``) pass through
+    unchanged.
     """
 
     def __init__(self, client: OktaClient) -> None:
@@ -188,19 +189,19 @@ class OktaService:
 
     @staticmethod
     async def _call(coro: Awaitable[Any]) -> Any:
-        """Await an Okta SDK call, mapping timeouts and rate-limit exhaustion to OktaTimeout.
+        """Await an Okta SDK call, mapping transient failures to OktaTransientError.
 
         The SDK enforces the request timeout itself (``requestTimeout`` config)
         and retries 429s internally, returning errors rather than raising them.
-        The two "gave up / took too long" outcomes — a request timeout and a 429
-        that outlived the SDK's rate-limit retries — are surfaced as
-        ``OktaTimeout`` so callers can choose to swallow them; every other error
-        passes through in the returned tuple for the caller to raise.
+        A transient outcome — a request timeout, a 429 that outlived the SDK's
+        rate-limit retries, or a 5xx upstream/gateway error — is surfaced as
+        ``OktaTransientError`` so callers can choose to swallow it; every other
+        error passes through in the returned tuple for the caller to raise.
         """
         result = await coro
         error = result[-1] if isinstance(result, tuple) and result else None
         if _is_transient_okta_error(error):
-            raise OktaTimeout(str(error) or "Okta request timed out")
+            raise OktaTransientError(str(error) or "Okta request timed out")
         return result
 
     async def _paginate(self, list_method: Callable[..., Any], *args: Any, **kwargs: Any) -> list[Any]:
@@ -334,7 +335,7 @@ class OktaService:
 
             if error is not None:
                 raise Exception(error)
-        except OktaTimeout:
+        except OktaTransientError:
             logger.warning(f"Transient Okta error adding user {userId} to group {groupId}")
 
     async def remove_user_from_group(self, groupId: str, userId: str) -> None:
@@ -352,7 +353,7 @@ class OktaService:
 
             if error is not None:
                 raise Exception(error)
-        except OktaTimeout:
+        except OktaTransientError:
             logger.warning(f"Transient Okta error removing user {userId} from group {groupId}")
 
     # TODO: Implement fetching group membership count for fast syncing
@@ -429,7 +430,7 @@ class OktaService:
             # Ignore error if owner is already assigned to group
             if error is not None and "already assigned to this group" not in str(error):
                 raise Exception(error)
-        except OktaTimeout:
+        except OktaTransientError:
             logger.warning(f"Transient Okta error adding owner {userId} to group {groupId}")
 
         return
@@ -452,7 +453,7 @@ class OktaService:
 
             if error is not None:
                 raise Exception(error)
-        except OktaTimeout:
+        except OktaTransientError:
             logger.warning(f"Transient Okta error removing owner {userId} from group {groupId}")
 
         return

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -34,7 +34,7 @@ from api.operations import (
 )
 from api.plugins import NotificationHook, send_notification
 from api.services import okta
-from api.services.okta_service import OktaTimeout, is_managed_group
+from api.services.okta_service import OktaTransientError, is_managed_group
 
 logger = logging.getLogger(__name__)
 
@@ -269,7 +269,7 @@ async def sync_group_memberships(act_as_authority: bool) -> None:
             logger.info("Members in DB synced to Okta.")
 
             await db.session.commit()
-        except OktaTimeout:
+        except OktaTransientError:
             logger.warning(f"Transient Okta error syncing memberships for group {group.id}, skipping.", exc_info=True)
             await db.session.rollback()
             continue
@@ -388,7 +388,7 @@ async def sync_group_ownerships(act_as_authority: bool) -> None:
                     await ModifyGroupUsers(group=group.id, owners_to_remove=list(distinct_owner_ids)).execute()
 
             await db.session.commit()
-        except OktaTimeout:
+        except OktaTransientError:
             logger.warning(f"Transient Okta error syncing ownerships for group {group.id}, skipping.", exc_info=True)
             await db.session.rollback()
             continue

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -270,7 +270,7 @@ async def sync_group_memberships(act_as_authority: bool) -> None:
 
             await db.session.commit()
         except OktaTimeout:
-            logger.warning(f"Timed out syncing memberships for group {group.id}, skipping.", exc_info=True)
+            logger.warning(f"Transient Okta error syncing memberships for group {group.id}, skipping.", exc_info=True)
             await db.session.rollback()
             continue
         except Exception:
@@ -389,7 +389,7 @@ async def sync_group_ownerships(act_as_authority: bool) -> None:
 
             await db.session.commit()
         except OktaTimeout:
-            logger.warning(f"Timed out syncing ownerships for group {group.id}, skipping.", exc_info=True)
+            logger.warning(f"Transient Okta error syncing ownerships for group {group.id}, skipping.", exc_info=True)
             await db.session.rollback()
             continue
         except Exception:

--- a/tests/test_okta_timeout.py
+++ b/tests/test_okta_timeout.py
@@ -2,6 +2,7 @@ import asyncio
 from unittest.mock import MagicMock
 
 import pytest
+from okta.errors.http_error import HTTPError
 from okta.errors.okta_api_error import OktaAPIError
 from pytest_mock import MockerFixture
 
@@ -26,6 +27,13 @@ def _rate_limit_error() -> OktaAPIError:
     )
 
 
+def _http_error(status: int) -> HTTPError:
+    """An error shaped like what the SDK returns for a non-JSON HTTP failure —
+    e.g. a 502 Bad Gateway whose body is an HTML page rather than an Okta error."""
+    response_details = MagicMock(status=status, headers={})
+    return HTTPError("https://fake.domain/api/v1/users/okta_id", response_details, f"<html>{status}</html>")
+
+
 async def test_socket_timeout_surfaces_as_okta_timeout(mocker: MockerFixture, okta_service: OktaService) -> None:
     """The SDK returns an aiohttp/asyncio timeout as an error; the facade raises OktaTimeout."""
     mocker.patch("okta.client.Client.get_user", return_value=(None, None, asyncio.TimeoutError()))
@@ -47,6 +55,25 @@ async def test_rate_limit_exhaustion_surfaces_as_okta_timeout(mocker: MockerFixt
     mocker.patch("okta.client.Client.get_user", return_value=(None, MagicMock(), _rate_limit_error()))
     with pytest.raises(OktaTimeout):
         await okta_service.get_user("okta_id")
+
+
+@pytest.mark.parametrize("status", [500, 502, 503, 504])
+async def test_transient_5xx_surfaces_as_okta_timeout(
+    mocker: MockerFixture, okta_service: OktaService, status: int
+) -> None:
+    """A transient 5xx (e.g. a 502 Bad Gateway from the load balancer) is surfaced
+    as OktaTimeout so the syncer/fan-out swallow it instead of logging an ERROR."""
+    mocker.patch("okta.client.Client.get_user", return_value=(None, MagicMock(), _http_error(status)))
+    with pytest.raises(OktaTimeout):
+        await okta_service.get_user("okta_id")
+
+
+async def test_non_transient_http_error_not_mapped(mocker: MockerFixture, okta_service: OktaService) -> None:
+    """A non-transient HTTP error (e.g. 404) passes through and is not mapped to OktaTimeout."""
+    mocker.patch("okta.client.Client.get_user", return_value=(None, MagicMock(), _http_error(404)))
+    with pytest.raises(Exception) as exc_info:
+        await okta_service.get_user("okta_id")
+    assert not isinstance(exc_info.value, OktaTimeout)
 
 
 async def test_swallowable_call_site_absorbs_timeout(mocker: MockerFixture, okta_service: OktaService) -> None:

--- a/tests/test_okta_transient_errors.py
+++ b/tests/test_okta_transient_errors.py
@@ -6,7 +6,7 @@ from okta.errors.http_error import HTTPError
 from okta.errors.okta_api_error import OktaAPIError
 from pytest_mock import MockerFixture
 
-from api.services.okta_service import OktaService, OktaTimeout
+from api.services.okta_service import OktaService, OktaTransientError
 from tests.factories import UserFactory
 
 
@@ -35,25 +35,25 @@ def _http_error(status: int) -> HTTPError:
 
 
 async def test_socket_timeout_surfaces_as_okta_timeout(mocker: MockerFixture, okta_service: OktaService) -> None:
-    """The SDK returns an aiohttp/asyncio timeout as an error; the facade raises OktaTimeout."""
+    """The SDK returns an aiohttp/asyncio timeout as an error; the facade raises OktaTransientError."""
     mocker.patch("okta.client.Client.get_user", return_value=(None, None, asyncio.TimeoutError()))
-    with pytest.raises(OktaTimeout):
+    with pytest.raises(OktaTransientError):
         await okta_service.get_user("okta_id")
 
 
 async def test_request_timeout_deadline_surfaces_as_okta_timeout(
     mocker: MockerFixture, okta_service: OktaService
 ) -> None:
-    """The SDK's cumulative request-timeout deadline is mapped to OktaTimeout."""
+    """The SDK's cumulative request-timeout deadline is mapped to OktaTransientError."""
     mocker.patch("okta.client.Client.get_user", return_value=(None, None, Exception("Request Timeout exceeded.")))
-    with pytest.raises(OktaTimeout):
+    with pytest.raises(OktaTransientError):
         await okta_service.get_user("okta_id")
 
 
 async def test_rate_limit_exhaustion_surfaces_as_okta_timeout(mocker: MockerFixture, okta_service: OktaService) -> None:
-    """A 429 that outlived the SDK's rate-limit retries is surfaced as OktaTimeout."""
+    """A 429 that outlived the SDK's rate-limit retries is surfaced as OktaTransientError."""
     mocker.patch("okta.client.Client.get_user", return_value=(None, MagicMock(), _rate_limit_error()))
-    with pytest.raises(OktaTimeout):
+    with pytest.raises(OktaTransientError):
         await okta_service.get_user("okta_id")
 
 
@@ -62,33 +62,33 @@ async def test_transient_5xx_surfaces_as_okta_timeout(
     mocker: MockerFixture, okta_service: OktaService, status: int
 ) -> None:
     """A transient 5xx (e.g. a 502 Bad Gateway from the load balancer) is surfaced
-    as OktaTimeout so the syncer/fan-out swallow it instead of logging an ERROR."""
+    as OktaTransientError so the syncer/fan-out swallow it instead of logging an ERROR."""
     mocker.patch("okta.client.Client.get_user", return_value=(None, MagicMock(), _http_error(status)))
-    with pytest.raises(OktaTimeout):
+    with pytest.raises(OktaTransientError):
         await okta_service.get_user("okta_id")
 
 
 async def test_non_transient_http_error_not_mapped(mocker: MockerFixture, okta_service: OktaService) -> None:
-    """A non-transient HTTP error (e.g. 404) passes through and is not mapped to OktaTimeout."""
+    """A non-transient HTTP error (e.g. 404) passes through and is not mapped to OktaTransientError."""
     mocker.patch("okta.client.Client.get_user", return_value=(None, MagicMock(), _http_error(404)))
     with pytest.raises(Exception) as exc_info:
         await okta_service.get_user("okta_id")
-    assert not isinstance(exc_info.value, OktaTimeout)
+    assert not isinstance(exc_info.value, OktaTransientError)
 
 
 async def test_swallowable_call_site_absorbs_timeout(mocker: MockerFixture, okta_service: OktaService) -> None:
-    """Membership mutations catch OktaTimeout and continue instead of propagating."""
+    """Membership mutations catch OktaTransientError and continue instead of propagating."""
     mocker.patch("okta.client.Client.assign_user_to_group", return_value=(None, asyncio.TimeoutError()))
-    # Should not raise — add_user_to_group swallows OktaTimeout.
+    # Should not raise — add_user_to_group swallows OktaTransientError.
     await okta_service.add_user_to_group("group_id", "user_id")
 
 
 async def test_non_timeout_error_is_not_mapped(mocker: MockerFixture, okta_service: OktaService) -> None:
-    """Errors that aren't timeouts or 429s pass through and are not misclassified as OktaTimeout."""
+    """Errors that aren't timeouts or 429s pass through and are not misclassified as OktaTransientError."""
     mocker.patch("okta.client.Client.get_user", return_value=(None, MagicMock(), Exception("boom")))
     with pytest.raises(Exception) as exc_info:
         await okta_service.get_user("okta_id")
-    assert not isinstance(exc_info.value, OktaTimeout)
+    assert not isinstance(exc_info.value, OktaTransientError)
 
 
 async def test_facade_adds_no_retry(mocker: MockerFixture, okta_service: OktaService) -> None:


### PR DESCRIPTION
## Problem

The sync cron logs transient Okta upstream failures at **ERROR**, spamming Sentry. Observed in production:

```
Failed to sync memberships for group 00goz…, skipping.
Exception: HTTP 502 <html>…502 Bad Gateway…</html>   (Server: awselb/2.0)
```

A `502 Bad Gateway` from Okta's load balancer is a transient blip, but it surfaced as a hard `ERROR` (and a Sentry event) instead of being handled gracefully like our other transient Okta failures (request timeouts, 429 rate-limit exhaustion).

## Cause — a regression from #509

This handling existed before the Okta SDK v3 upgrade (#509). The facade's hand-rolled `_retry` treated `[429, 500, 502, 503, 504]` as retriable (`RETRIABLE_STATUS_CODES`), retrying up to 3 times with backoff — so transient gateway blips like a load-balancer 502 were absorbed and rarely surfaced as sync failures.

#509 removed that custom retry and delegated retries to the SDK, which only retries 429 (and 503/504 when they carry rate-limit headers) — **not** 500/502. So transient 5xx started slipping through. Such a response comes back from the SDK as an `HTTPError` (its body is HTML, not an Okta JSON error, so it isn't an `OktaAPIError`) carrying a 5xx `.status`, which the facade's transient-error check didn't recognize — so it propagated out of `_paginate` and the syncer logged it as a hard failure.

## Changes

- **Classify transient 5xx as swallowable.** Broaden the transient-error check to treat any transient HTTP `status` — **429 or a 5xx gateway error (500/502/503/504)** — as a transient failure. Both `OktaAPIError` (JSON error bodies) and `HTTPError` (non-JSON, e.g. a 502 HTML page) expose `.status`, so it's read uniformly. Non-transient errors (e.g. 404) still propagate.
- **Rename `OktaTimeout` → `OktaTransientError`.** The exception now covers timeouts, rate-limit exhaustion, and transient 5xx, so "timeout" undersold it. (Its test module is renamed to match.)
- **Reword the swallow-path logs** from "Timed out …" to "Transient Okta error …" in the syncer and facade methods.

This deliberately does **not** reintroduce 5xx retries — per #509, retries are the SDK's job. It restores the pre-#509 graceful handling by a different mechanism: rather than retrying a transient 5xx, it classifies it as `OktaTransientError` so the membership/ownership fan-out and syncer swallow it and let the next 15-minute reconcile retry. On the request path a 5xx still surfaces as an error (now typed `OktaTransientError`); only the fan-out/syncer callers that catch it swallow-and-reconcile.

Tests cover the 5xx classification (parametrized 500/502/503/504), the timeout/deadline/429 paths, a non-transient (404) boundary, and the swallow behavior.
