### PR TITLE
fix: swallow the Okta SDK's None-response AttributeError as transient

### DIFF
--- a/api/services/okta_service.py
+++ b/api/services/okta_service.py
@@ -61,21 +61,33 @@ class OktaTransientError(Exception):
     pass
 
 
+# On a gateway failure that yields no response object, the SDK returns
+# ``(None, None, error)`` from the request executor, then dereferences
+# ``response.status`` before checking the error on its list/get endpoints. That
+# raises this AttributeError from inside the coroutine instead of returning the
+# error in the tuple, so it must be recognised as transient here too.
+_NONE_RESPONSE_ATTRIBUTE_ERROR = "'NoneType' object has no attribute 'status'"
+
+
 def _is_transient_okta_error(error: Any) -> bool:
     """Whether an SDK error is a transient failure a caller may swallow.
 
-    The SDK returns (rather than raises) errors. Treat as transient: a request
+    The SDK usually returns (rather than raises) errors. Treat as transient: a request
     timeout — an ``asyncio.TimeoutError`` (aiohttp socket timeout) or the bare
     ``Exception("Request Timeout exceeded.")`` cumulative deadline — and any
     response carrying a transient HTTP ``status`` (429, or a 5xx gateway error).
     Both ``OktaAPIError`` (JSON error bodies) and ``HTTPError`` (non-JSON, e.g. a
-    502 HTML page) expose ``.status``.
+    502 HTML page) expose ``.status``. A gateway blip can also leave the SDK with
+    a ``None`` response that it dereferences, *raising* an ``AttributeError``; that
+    is transient too. ``_call`` routes both returned and raised errors through here.
     """
     if error is None:
         return False
     if isinstance(error, asyncio.TimeoutError):
         return True
     if getattr(error, "status", None) in TRANSIENT_STATUS_CODES:
+        return True
+    if isinstance(error, AttributeError) and str(error) == _NONE_RESPONSE_ATTRIBUTE_ERROR:
         return True
     return str(error) == "Request Timeout exceeded."
 
@@ -196,9 +208,16 @@ class OktaService:
         A transient outcome — a request timeout, a 429 that outlived the SDK's
         rate-limit retries, or a 5xx upstream/gateway error — is surfaced as
         ``OktaTransientError`` so callers can choose to swallow it; every other
-        error passes through in the returned tuple for the caller to raise.
+        error passes through in the returned tuple for the caller to raise. A
+        gateway blip can also make the SDK *raise* (rather than return) a transient
+        failure, so raised exceptions are routed through the same check.
         """
-        result = await coro
+        try:
+            result = await coro
+        except Exception as exc:
+            if _is_transient_okta_error(exc):
+                raise OktaTransientError(str(exc) or "Okta request timed out") from exc
+            raise
         error = result[-1] if isinstance(result, tuple) and result else None
         if _is_transient_okta_error(error):
             raise OktaTransientError(str(error) or "Okta request timed out")

--- a/tests/test_okta_transient_errors.py
+++ b/tests/test_okta_transient_errors.py
@@ -76,6 +76,29 @@ async def test_non_transient_http_error_not_mapped(mocker: MockerFixture, okta_s
     assert not isinstance(exc_info.value, OktaTransientError)
 
 
+async def test_none_response_attributeerror_surfaces_as_transient(
+    mocker: MockerFixture, okta_service: OktaService
+) -> None:
+    """A gateway blip (e.g. a 502) can leave the SDK with a ``None`` response that it
+    dereferences (``response.status``) before checking the error, raising AttributeError
+    from inside the coroutine rather than returning it in the tuple. Surface it as
+    OktaTransientError so the syncer fan-out swallows it instead of logging an ERROR."""
+    mocker.patch(
+        "okta.client.Client.get_user",
+        side_effect=AttributeError("'NoneType' object has no attribute 'status'"),
+    )
+    with pytest.raises(OktaTransientError):
+        await okta_service.get_user("okta_id")
+
+
+async def test_unrelated_attributeerror_not_mapped(mocker: MockerFixture, okta_service: OktaService) -> None:
+    """An AttributeError unrelated to the SDK's None-response bug must propagate, not be
+    misclassified as transient, so genuine bugs stay visible."""
+    mocker.patch("okta.client.Client.get_user", side_effect=AttributeError("'Foo' object has no attribute 'bar'"))
+    with pytest.raises(AttributeError):
+        await okta_service.get_user("okta_id")
+
+
 async def test_swallowable_call_site_absorbs_timeout(mocker: MockerFixture, okta_service: OktaService) -> None:
     """Membership mutations catch OktaTransientError and continue instead of propagating."""
     mocker.patch("okta.client.Client.assign_user_to_group", return_value=(None, asyncio.TimeoutError()))


### PR DESCRIPTION
# Summary
The syncer's fan-out logs an unhandled `AttributeError: 'NoneType' object has no attribute 'status'` from the Okta SDK during upstream gateway blips. This routes that raised error through the existing transient-error handling so it is swallowed and retried on the next reconcile, matching how returned 5xx/timeout errors are already treated.
**Urgency**: 3 days
**Expected review effort**: LOW

# Motivation
Production error monitoring flagged an unhandled `AttributeError` originating in the Okta SDK's list/get endpoints. Root cause: the SDK dereferences `response.status` before checking the error, so when a gateway failure returns no response object (`execute()` returns `(None, None, error)`), the SDK raises `AttributeError` from inside the coroutine instead of returning the error in its result tuple.

The prior change that broadened transient handling to 5xx (#544) only inspects the *returned* error tuple in `_call`, so it cannot catch a failure the SDK *raises*. The exception propagates out of `_call`, the syncer fan-out classifies it as a generic `BaseException`, and it is logged at ERROR level. This is the same class of transient upstream failure `OktaTransientError` already exists to absorb.

# Description of Changes
- `_call` now wraps `await coro` and routes raised exceptions through the existing `_is_transient_okta_error` classifier, so a transient failure that arrives as a raised exception is surfaced as `OktaTransientError` (same as one returned in the tuple).
- `_is_transient_okta_error` recognizes the SDK's None-response `AttributeError` signature (narrowly matched by message, so unrelated `AttributeError`s still propagate).
- One classifier drives both the returned-error and raised-error paths.

# Validation of Changes
- Added a failing test reproducing the raised `AttributeError`, confirmed it propagated unhandled before the fix, and that it now surfaces as `OktaTransientError`.
- Added a guard test that an unrelated `AttributeError` still propagates.
- `okta_service`, transient-error, sync (membership/ownership/group/user), and fan-out suites pass; `ruff` and `ty` clean on changed files.

# Guidance for Reviewers
- The narrow message match in `_is_transient_okta_error` is the main judgment call: a `None`-response dereference in these SDK endpoints only happens on the transport/error path, so treating it as transient is safe for the read-only listing the syncer reconciles later. Confirm you are comfortable matching on the exception message rather than something more structural.