### PR TITLE
fix(sentry): stop alerting on ignored errors wrapped by the MCP tool layer

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -118,12 +118,12 @@ def _drop_wrapped_validation_errors(event: dict, hint: dict) -> Optional[dict]:
     from pydantic import ValidationError
 
     exc = (hint or {}).get("exc_info", (None, None, None))[1]
-    depth = 0
-    while exc is not None and depth < 20:
+    seen: set[int] = set()
+    while exc is not None and id(exc) not in seen:
         if isinstance(exc, ValidationError):
             return None
+        seen.add(id(exc))
         exc = exc.__cause__
-        depth += 1
     return event
 
 

--- a/api/app.py
+++ b/api/app.py
@@ -105,6 +105,28 @@ def _configure_logging() -> None:
     logging.root.addFilter(token_filter)
 
 
+def _drop_wrapped_validation_errors(event: dict, hint: dict) -> Optional[dict]:
+    """Sentry before_send: drop events whose root cause is a pydantic ValidationError.
+
+    ``ignore_errors`` only matches the top-level exception type. The MCP server
+    re-raises tool argument-validation failures as a ToolError via
+    ``raise ToolError(...) from e``, so a client passing a bad tool argument
+    surfaces as ToolError (not ignored) wrapping the ValidationError we do want
+    to ignore. Walk the explicit cause chain and drop the event when a
+    ValidationError is its root.
+    """
+    from pydantic import ValidationError
+
+    exc = (hint or {}).get("exc_info", (None, None, None))[1]
+    depth = 0
+    while exc is not None and depth < 20:
+        if isinstance(exc, ValidationError):
+            return None
+        exc = exc.__cause__
+        depth += 1
+    return event
+
+
 def _configure_sentry() -> None:
     if settings.ENV in ("development", "test"):
         return
@@ -140,6 +162,7 @@ def _configure_sentry() -> None:
             ValidationError,
             OIDCRedirectRequired,
         ],
+        before_send=_drop_wrapped_validation_errors,
     )
 
 

--- a/api/app.py
+++ b/api/app.py
@@ -105,22 +105,37 @@ def _configure_logging() -> None:
     logging.root.addFilter(token_filter)
 
 
-def _drop_wrapped_validation_errors(event: dict, hint: dict) -> Optional[dict]:
-    """Sentry before_send: drop events whose root cause is a pydantic ValidationError.
+def _drop_wrapped_ignored_errors(event: dict, hint: dict) -> Optional[dict]:
+    """Sentry before_send: drop events whose cause chain contains a type we
+    already list in ``ignore_errors``.
 
-    ``ignore_errors`` only matches the top-level exception type. The MCP server
-    re-raises tool argument-validation failures as a ToolError via
-    ``raise ToolError(...) from e``, so a client passing a bad tool argument
-    surfaces as ToolError (not ignored) wrapping the ValidationError we do want
-    to ignore. Walk the explicit cause chain and drop the event when a
-    ValidationError is its root.
+    ``ignore_errors`` only matches the top-level exception type, but the MCP
+    server wraps every exception a tool raises in a ToolError via
+    ``raise ToolError(...) from e`` — so an ignored error raised inside a tool
+    (today: a pydantic ValidationError from argument validation) surfaces as a
+    non-ignored ToolError and leaks through. Walk the explicit ``__cause__``
+    chain — not implicit ``__context__`` — so a genuine failure that merely ran
+    while handling an ignored error still alerts. Keep this set in sync with
+    ``_configure_sentry``'s ``ignore_errors``.
     """
+    from fastapi import HTTPException
+    from fastapi.exceptions import RequestValidationError
     from pydantic import ValidationError
+    from starlette.exceptions import HTTPException as StarletteHTTPException
 
+    from api.auth.dependencies import OIDCRedirectRequired
+
+    ignored = (
+        HTTPException,
+        StarletteHTTPException,
+        RequestValidationError,
+        ValidationError,
+        OIDCRedirectRequired,
+    )
     exc = (hint or {}).get("exc_info", (None, None, None))[1]
     seen: set[int] = set()
     while exc is not None and id(exc) not in seen:
-        if isinstance(exc, ValidationError):
+        if isinstance(exc, ignored):
             return None
         seen.add(id(exc))
         exc = exc.__cause__
@@ -162,7 +177,7 @@ def _configure_sentry() -> None:
             ValidationError,
             OIDCRedirectRequired,
         ],
-        before_send=_drop_wrapped_validation_errors,
+        before_send=_drop_wrapped_ignored_errors,
     )
 
 

--- a/tests/test_sentry_filter.py
+++ b/tests/test_sentry_filter.py
@@ -1,17 +1,19 @@
 """Tests for the Sentry `before_send` filter in `api.app`.
 
-The MCP server re-raises tool argument-validation failures as a
-`ToolError` wrapping a pydantic `ValidationError`. `ignore_errors` only
-matches the top-level type, so those client-error events leak to Sentry.
-`_drop_wrapped_validation_errors` closes that gap by walking the cause chain.
+The MCP server wraps every exception a tool raises in a `ToolError`, so an
+ignored error raised inside a tool (e.g. a pydantic `ValidationError` from
+argument validation) surfaces as a non-ignored `ToolError` and would leak to
+Sentry. `_drop_wrapped_ignored_errors` closes that gap by walking the cause
+chain for any type we already list in `ignore_errors`.
 """
 
 from __future__ import annotations
 
+from fastapi import HTTPException
 from mcp.server.fastmcp.exceptions import ToolError
 from pydantic import BaseModel, ValidationError
 
-from api.app import _drop_wrapped_validation_errors
+from api.app import _drop_wrapped_ignored_errors
 
 
 class _Args(BaseModel):
@@ -35,16 +37,25 @@ def test_drops_tool_error_wrapping_validation_error() -> None:
     try:
         raise ToolError("Error executing tool get_group") from _validation_error()
     except ToolError as exc:
-        assert _drop_wrapped_validation_errors({"event": True}, _hint(exc)) is None
+        assert _drop_wrapped_ignored_errors({"event": True}, _hint(exc)) is None
 
 
-def test_drops_bare_validation_error() -> None:
-    assert _drop_wrapped_validation_errors({"event": True}, _hint(_validation_error())) is None
+def test_drops_tool_error_wrapping_other_ignored_error() -> None:
+    """Any ignored type is dropped when wrapped, not just ValidationError."""
+    try:
+        raise ToolError("Error executing tool") from HTTPException(status_code=403)
+    except ToolError as exc:
+        assert _drop_wrapped_ignored_errors({"event": True}, _hint(exc)) is None
+
+
+def test_drops_bare_ignored_errors() -> None:
+    assert _drop_wrapped_ignored_errors({"event": True}, _hint(_validation_error())) is None
+    assert _drop_wrapped_ignored_errors({"event": True}, _hint(HTTPException(status_code=404))) is None
 
 
 def test_keeps_generic_exception() -> None:
     event = {"event": True}
-    assert _drop_wrapped_validation_errors(event, _hint(RuntimeError("boom"))) is event
+    assert _drop_wrapped_ignored_errors(event, _hint(RuntimeError("boom"))) is event
 
 
 def test_keeps_tool_error_wrapping_real_bug() -> None:
@@ -53,13 +64,13 @@ def test_keeps_tool_error_wrapping_real_bug() -> None:
     try:
         raise ToolError("Error executing tool get_group") from RuntimeError("db down")
     except ToolError as exc:
-        assert _drop_wrapped_validation_errors(event, _hint(exc)) is event
+        assert _drop_wrapped_ignored_errors(event, _hint(exc)) is event
 
 
 def test_keeps_event_when_no_exc_info() -> None:
     event = {"event": True}
-    assert _drop_wrapped_validation_errors(event, {}) is event
-    assert _drop_wrapped_validation_errors(event, None) is event  # type: ignore[arg-type]
+    assert _drop_wrapped_ignored_errors(event, {}) is event
+    assert _drop_wrapped_ignored_errors(event, None) is event  # type: ignore[arg-type]
 
 
 def test_cause_cycle_terminates() -> None:
@@ -68,4 +79,4 @@ def test_cause_cycle_terminates() -> None:
     a.__cause__ = b
     b.__cause__ = a
     event = {"event": True}
-    assert _drop_wrapped_validation_errors(event, _hint(a)) is event
+    assert _drop_wrapped_ignored_errors(event, _hint(a)) is event

--- a/tests/test_sentry_filter.py
+++ b/tests/test_sentry_filter.py
@@ -1,0 +1,71 @@
+"""Tests for the Sentry `before_send` filter in `api.app`.
+
+The MCP server re-raises tool argument-validation failures as a
+`ToolError` wrapping a pydantic `ValidationError`. `ignore_errors` only
+matches the top-level type, so those client-error events leak to Sentry.
+`_drop_wrapped_validation_errors` closes that gap by walking the cause chain.
+"""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp.exceptions import ToolError
+from pydantic import BaseModel, ValidationError
+
+from api.app import _drop_wrapped_validation_errors
+
+
+class _Args(BaseModel):
+    group_id_or_name: str
+
+
+def _validation_error() -> ValidationError:
+    try:
+        _Args(**{"group_id": "00g1423wlai2EMe85698"})
+    except ValidationError as exc:
+        return exc
+    raise AssertionError("expected ValidationError")
+
+
+def _hint(exc: BaseException) -> dict:
+    return {"exc_info": (type(exc), exc, exc.__traceback__)}
+
+
+def test_drops_tool_error_wrapping_validation_error() -> None:
+    """The real production case: a client passes a bad tool argument."""
+    try:
+        raise ToolError("Error executing tool get_group") from _validation_error()
+    except ToolError as exc:
+        assert _drop_wrapped_validation_errors({"event": True}, _hint(exc)) is None
+
+
+def test_drops_bare_validation_error() -> None:
+    assert _drop_wrapped_validation_errors({"event": True}, _hint(_validation_error())) is None
+
+
+def test_keeps_generic_exception() -> None:
+    event = {"event": True}
+    assert _drop_wrapped_validation_errors(event, _hint(RuntimeError("boom"))) is event
+
+
+def test_keeps_tool_error_wrapping_real_bug() -> None:
+    """A genuine server-side failure inside a tool must still alert."""
+    event = {"event": True}
+    try:
+        raise ToolError("Error executing tool get_group") from RuntimeError("db down")
+    except ToolError as exc:
+        assert _drop_wrapped_validation_errors(event, _hint(exc)) is event
+
+
+def test_keeps_event_when_no_exc_info() -> None:
+    event = {"event": True}
+    assert _drop_wrapped_validation_errors(event, {}) is event
+    assert _drop_wrapped_validation_errors(event, None) is event  # type: ignore[arg-type]
+
+
+def test_cause_cycle_terminates() -> None:
+    a = RuntimeError("a")
+    b = RuntimeError("b")
+    a.__cause__ = b
+    b.__cause__ = a
+    event = {"event": True}
+    assert _drop_wrapped_validation_errors(event, _hint(a)) is event


### PR DESCRIPTION
# Summary
MCP tool errors are paging Sentry even though we explicitly ignore the underlying error types. This adds a `before_send` hook that drops events whose `__cause__` chain contains any type already in `ignore_errors`, closing the gap left by the framework wrapping those errors in a `ToolError`.
**Urgency**: 3 days
**Expected review effort**: LOW

# Motivation
`_configure_sentry` lists client/control-flow error types in `ignore_errors` so they don't alert. But `ignore_errors` only matches the *top-level* exception type, and the MCP server wraps every exception a tool raises in a `ToolError` (`raise ToolError(...) from e` in FastMCP's `tools/base.py`). So an ignored error raised inside a tool surfaces as a non-ignored `ToolError` and leaks through.

Observed in production: a client called the `get_group` tool with `group_id` instead of its declared `group_id_or_name`. Argument validation raised a pydantic `ValidationError` (which we ignore), FastMCP re-raised it as a `ToolError` (which we don't), and it alerted.

Auditing the rest of the `ignore_errors` list: today only `ValidationError` is actually wrapped this way (the other types are raised in the HTTP/auth layers, outside tool bodies). But the same leak would silently reappear for any other ignored type raised inside a tool, so the filter checks the whole set rather than special-casing `ValidationError`.

# Description of Changes
- Add `_drop_wrapped_ignored_errors`, a Sentry `before_send` hook that walks the explicit `__cause__` chain and drops the event if any exception in it is an instance of a type in `ignore_errors`.
- Follows `__cause__` only (set by `raise ... from`), not implicit `__context__`, so a genuine failure that merely ran while handling an ignored error still alerts.
- Guards against a cyclic cause chain with a visited set.

# Validation of Changes
- New unit tests in `tests/test_sentry_filter.py`: the production case (`ToolError` wrapping `ValidationError` -> dropped), another ignored type wrapped (`ToolError` wrapping `HTTPException` -> dropped), bare ignored errors (dropped), a generic exception (kept), a `ToolError` wrapping a real server-side error (kept, so genuine bugs still alert), missing `exc_info` (kept), and a cyclic chain (terminates).
- `uv run ruff check` / `ty check` / `pytest tests/test_sentry_filter.py` all pass (7 passed).

# Guidance for Reviewers
The key design choice is doing this in `before_send` rather than adding `ToolError` to `ignore_errors`: FastMCP wraps *every* exception raised in *any* tool body in a `ToolError`, so ignoring `ToolError` outright would also silence genuine server-side failures. The `before_send` approach only suppresses events actually rooted in an already-ignored type. Note the ignored-type set is intentionally duplicated between `ignore_errors` and the hook (with a "keep in sync" comment) to keep the diff minimal; happy to hoist it into a shared constant if preferred.
