### PR TITLE
Load the audit-logger example plugin in local dev; fix plugin install docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,38 @@ COPY ./config ./config
 COPY alembic.ini ./
 RUN uv sync --frozen --no-dev
 
+# --- Optional example plugins -------------------------------------------------
+# The example plugins under examples/plugins/ are opt-in. Each installs into the
+# app venv only when its build arg is set to "true" (default "false"), so the
+# default image ships without them and derived images enable just what they want:
+#   docker build --build-arg INSTALL_SLACK_NOTIFICATIONS_PLUGIN=true .
+# Installs use `uv pip install` because the venv at /app/.venv has no `pip`;
+# plain `pip` would install into the system interpreter where the app won't find
+# it. A plugin's requirements.txt is installed first when present (some examples
+# keep runtime deps there rather than in setup.py). See examples/plugins/README.md
+# for the full list and for how to bake in your own plugin.
+ARG INSTALL_AUDIT_LOGGER_PLUGIN="false"
+ARG INSTALL_CONDITIONAL_ACCESS_PLUGIN="false"
+ARG INSTALL_DATADOG_METRICS_PLUGIN="false"
+ARG INSTALL_HEALTH_CHECK_PLUGIN="false"
+ARG INSTALL_NOTIFICATIONS_PLUGIN="false"
+ARG INSTALL_SLACK_NOTIFICATIONS_PLUGIN="false"
+# Bind-mount the plugin sources for the length of this RUN only: enabled plugins
+# are installed (non-editable) into /app/.venv, so nothing needs to persist in
+# the final image and the default (all-false) build stays byte-identical.
+RUN --mount=type=bind,source=examples/plugins,target=examples/plugins \
+    set -eu; \
+    install_plugin() { \
+        if [ -f "$1/requirements.txt" ]; then uv pip install -r "$1/requirements.txt"; fi; \
+        uv pip install "$1"; \
+    }; \
+    if [ "$INSTALL_AUDIT_LOGGER_PLUGIN" = "true" ]; then install_plugin ./examples/plugins/app_group_lifecycle_audit_logger; else echo "Skipping app_group_lifecycle_audit_logger plugin"; fi; \
+    if [ "$INSTALL_CONDITIONAL_ACCESS_PLUGIN" = "true" ]; then install_plugin ./examples/plugins/conditional_access; else echo "Skipping conditional_access plugin"; fi; \
+    if [ "$INSTALL_DATADOG_METRICS_PLUGIN" = "true" ]; then install_plugin ./examples/plugins/datadog_metrics_reporter; else echo "Skipping datadog_metrics_reporter plugin"; fi; \
+    if [ "$INSTALL_HEALTH_CHECK_PLUGIN" = "true" ]; then install_plugin ./examples/plugins/health_check_plugin; else echo "Skipping health_check_plugin plugin"; fi; \
+    if [ "$INSTALL_NOTIFICATIONS_PLUGIN" = "true" ]; then install_plugin ./examples/plugins/notifications; else echo "Skipping notifications plugin"; fi; \
+    if [ "$INSTALL_SLACK_NOTIFICATIONS_PLUGIN" = "true" ]; then install_plugin ./examples/plugins/notifications_slack; else echo "Skipping notifications_slack plugin"; fi
+
 # Build an image that includes the optional sentry release push build step
 FROM false AS true
 COPY --from=sentry /app/sentry ./sentry

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,21 @@ LOCAL_DB_URI ?= sqlite:///instance/access.db
 BACKEND_PORT  ?= $(if $(PORT),$(PORT),6060)
 FRONTEND_PORT ?= $(if $(PORT),$(PORT),3000)
 
+# Space-separated example plugin directory names to install (editable) into the
+# local venv before running, e.g.:
+#   make run-backend PLUGINS="conditional_access notifications_slack"
+# Mirrors the Dockerfile's per-plugin INSTALL_*_PLUGIN build args for local dev.
+# Default empty ⇒ no extra plugins, so `make run-backend` is unchanged. The
+# audit logger is already loaded via the dev dependency group and needs no flag.
+PLUGINS ?=
+
 .PHONY: help
 help:
 	@echo "Access dev targets:"
 	@echo "  make run                Run backend (port $(BACKEND_PORT)) and frontend (port $(FRONTEND_PORT)) together"
 	@echo "  make run-backend        Run uvicorn on port $(BACKEND_PORT) with --reload"
 	@echo "  make run-frontend       Run Vite dev server on port $(FRONTEND_PORT)"
+	@echo "                          (add PLUGINS=\"dir1 dir2\" to install example plugins)"
 	@echo ""
 	@echo "Database:"
 	@echo "  make db-migrate         alembic upgrade head"
@@ -67,12 +76,28 @@ clean:
 dev:
 	uv sync
 
+# Install any plugins named in PLUGINS into the venv after `uv sync` (which
+# would otherwise prune them). Editable, so local edits to the plugin are picked
+# up on reload. A plugin's requirements.txt is installed first when present.
+.PHONY: install-plugins
+install-plugins: dev
+	@for p in $(PLUGINS); do \
+		if [ ! -d "examples/plugins/$$p" ]; then \
+			echo "No such example plugin: examples/plugins/$$p"; exit 1; \
+		fi; \
+		echo "Installing example plugin: $$p"; \
+		if [ -f "examples/plugins/$$p/requirements.txt" ]; then \
+			uv pip install -r "examples/plugins/$$p/requirements.txt"; \
+		fi; \
+		uv pip install -e "examples/plugins/$$p"; \
+	done
+
 # ----------------------------------------------------------------------
 # Run targets
 # ----------------------------------------------------------------------
 
 .PHONY: run
-run: .env dev db-migrate
+run: .env install-plugins db-migrate
 	@mkdir -p .claude
 	@printf '%s\n' "$(BACKEND_PORT)" > .claude/.api-port
 	DATABASE_URI=$(LOCAL_DB_URI) \
@@ -84,7 +109,7 @@ run-frontend:
 	npm install && npx vite --host 0.0.0.0 --port $(FRONTEND_PORT)
 
 .PHONY: run-backend
-run-backend: .env dev db-migrate
+run-backend: .env install-plugins db-migrate
 	@mkdir -p .claude
 	@printf '%s\n' "$(BACKEND_PORT)" > .claude/.api-port
 	DATABASE_URI=$(LOCAL_DB_URI) \
@@ -125,11 +150,11 @@ db-init: db-migrate
 # ----------------------------------------------------------------------
 
 .PHONY: sync
-sync: dev
+sync: install-plugins
 	DATABASE_URI=$(LOCAL_DB_URI) uv run access sync
 
 .PHONY: notify
-notify: dev
+notify: install-plugins
 	DATABASE_URI=$(LOCAL_DB_URI) uv run access notify
 
 # ----------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -486,18 +486,7 @@ As of Access 2.0 the plugin hooks are **async** — Access is an async applicati
 
 ### Installing a Plugin in the Docker Container
 
-Below is an example Dockerfile that would install the example notification plugin into the Access Docker container, which was built above using the top-level application [Dockerfile](https://github.com/discord/access/blob/main/Dockerfile). The plugin is copied into the `/app/plugins` directory and installed with `uv` into the application virtualenv at `/app/.venv` (the environment gunicorn and the `access` CLI run from).
-
-```Dockerfile
-FROM access:latest
-
-WORKDIR /app/plugins
-ADD ./examples/plugins/ ./
-
-RUN uv pip install --python /app/.venv/bin/python ./notifications
-
-WORKDIR /app
-```
+See [Installing into a built image](https://github.com/discord/access/blob/main/examples/plugins/README.md#installing-a-plugin-in-the-docker-container) in the example plugins guide. It covers enabling a bundled example via its default-`false` `--build-arg`, and baking a plugin of your own into an image that builds `FROM` the Access [Dockerfile](https://github.com/discord/access/blob/main/Dockerfile). Installs go into the application virtualenv at `/app/.venv` (the environment gunicorn and the `access` CLI run from) with `uv pip install`.
 
 ## License
 

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -1,0 +1,120 @@
+# Access plugins
+
+Access is extended through **plugins**: separate Python distributions that
+register themselves against Access's plugin hooks. Operator-specific behavior —
+notifications, conditional access, metrics, external group provisioning, extra
+CLI commands — lives in a plugin, not in the Access repo itself.
+
+This directory holds runnable **example plugins**. Each is a working reference
+you can enable as-is, and a template to copy when writing your own.
+
+## Available examples
+
+| Directory | Extends | Entry-point group | Docker build arg |
+|-----------|---------|-------------------|------------------|
+| [`app_group_lifecycle_audit_logger`](./app_group_lifecycle_audit_logger) | Log app group lifecycle events (create/update/delete/membership) | `access_app_group_lifecycle` | `INSTALL_AUDIT_LOGGER_PLUGIN` |
+| [`conditional_access`](./conditional_access) | Auto approve/deny access requests | `access_conditional_access` | `INSTALL_CONDITIONAL_ACCESS_PLUGIN` |
+| [`datadog_metrics_reporter`](./datadog_metrics_reporter) | Export metrics to DataDog | `access_metrics_reporter` | `INSTALL_DATADOG_METRICS_PLUGIN` |
+| [`notifications`](./notifications) | Request/expiry notifications to logger | `access_notifications` | `INSTALL_NOTIFICATIONS_PLUGIN` |
+| [`notifications_slack`](./notifications_slack) | Request/expiry notifications to Slack | `access_notifications` | `INSTALL_SLACK_NOTIFICATIONS_PLUGIN` |
+| [`health_check_plugin`](./health_check_plugin) | A new `access` CLI command | `access.commands` | `INSTALL_HEALTH_CHECK_PLUGIN` |
+
+## How Access discovers plugins
+
+Access uses [pluggy](https://pluggy.readthedocs.io/) with setuptools
+**entry points**. At startup (and for the CLI), Access loads every installed
+distribution that advertises an entry point in one of the groups above; there
+is no registry to edit and no import path to configure. Installing the
+distribution into the same environment as the running app is all that's needed;
+if the app "sees" 0 plugins, it's almost always because the distribution landed
+in a different interpreter than the one serving requests (see
+[Installing into an image](#installing-into-a-built-image)).
+
+The hook specifications each group implements live in
+[`api/plugins/`](../../api/plugins/). Read the hookspec for the surface you're
+extending before writing an implementation.
+
+## Authoring a plugin
+
+A plugin is an ordinary Python distribution with three parts:
+
+1. **The implementation.** A module/package whose functions or class methods are
+   decorated with the `hookimpl` marker for the plugin type and match the
+   corresponding hookspec in `api/plugins/`. The effectful hooks are **async**
+   (`async def`); a hook registered as a plain `def` fails fast at load. Pure
+   schema/metadata/validation hooks stay synchronous. CLI-command plugins are
+   ordinary Click commands and drive their own `asyncio.run(...)`.
+
+2. **Entry point registration.** A `setup.py` (or `pyproject.toml`) declaring the
+   distribution and an `entry_points` mapping in the right group.
+
+3. **Dependencies.** Prefer declaring runtime deps in `install_requires` so a
+   plain `uv pip install ./your_plugin` pulls them. Some examples instead keep
+   deps in a `requirements.txt`; the image build and the `make` target below
+   both install that file first when it's present.
+
+The quickest start is to copy the example closest to your use case, change the
+distribution name, entry-point name, and hook bodies, and adjust its
+dependencies.
+
+## Installing into a built image
+
+The example sources ship inside the Access build context, but the default image
+installs **none** of them. Each is opt-in via a `--build-arg` that defaults to
+`false`, so `docker build .` produces an app image with no plugins, and a derived
+build enables exactly what it wants, e.g.:
+
+```bash
+docker build \
+  --build-arg INSTALL_CONDITIONAL_ACCESS_PLUGIN=true \
+  --build-arg INSTALL_SLACK_NOTIFICATIONS_PLUGIN=true \
+  .
+```
+
+See the table above for every arg. The build installs each enabled plugin (and
+its `requirements.txt`, when present) into the app's `uv` virtualenv at
+`/app/.venv` with `uv pip install`. Use `uv pip install`, **not** `pip`: the
+venv has no `pip`, and plain `pip` installs into the base image's system
+interpreter, where the running app never looks — the classic
+"Registered 0 plugins" symptom.
+
+### Baking in your own plugin
+
+Suppose your plugin lives in your own repo, not this one. Add it to a Dockerfile that
+builds `FROM` the Access image (or extends this build) with the same pattern:
+
+```dockerfile
+FROM access:latest
+
+WORKDIR /app/plugins
+
+COPY ./path/to/your_plugin ./your_plugin
+RUN uv pip install ./your_plugin
+
+WORKDIR /app
+```
+
+## Local development
+
+`make run-backend` (and `make run`) sync the venv with `uv sync` before starting
+the server. Two ways to get plugins into that dev venv:
+
+- **The audit logger** is wired into the `dev` dependency group with an editable
+  `[tool.uv.sources]` entry (see [`pyproject.toml`](../../pyproject.toml)), so it
+  installs and registers automatically — no flag needed. You'll see
+  `Registered 1 app group lifecycle plugin(s): ['audit_logger']` at startup.
+
+- **Any other example** can be installed for a run via the `PLUGINS` variable,
+  which names one or more directories under `examples/plugins/`:
+
+  ```bash
+  make run-backend PLUGINS="conditional_access notifications_slack"
+  ```
+
+  These are installed **editable** after `uv sync` (which would otherwise prune
+  anything not in the lockfile), so edits to the plugin are picked up on reload.
+  Because `uv sync` prunes them, pass `PLUGINS=` again on the next run — or, for
+  a plugin you use constantly, add it to the `dev` group like the audit logger.
+
+To install a plugin into the venv by hand (equivalently), use
+`uv pip install -e examples/plugins/<dir>`.

--- a/examples/plugins/app_group_lifecycle_audit_logger/README.md
+++ b/examples/plugins/app_group_lifecycle_audit_logger/README.md
@@ -38,23 +38,23 @@ The plugin doesn't integrate with any external systems—it simply logs events, 
 
 ## Installation
 
-To bake the plugin into an operator's App container image, add these lines to
-the Dockerfile. The Access image is built with `uv` and its virtualenv lives at
-`/app/.venv` (which has no `pip`), so install with `uv pip install` — plain
-`pip` would install into the system interpreter, where the running app won't
-find the plugin:
+This plugin's source ships in the Access build context under
+`examples/plugins/`, but the default image does **not** install it. Enable it at
+build time with its build arg (default `false`):
 
-```dockerfile
-# Install the audit logger plugin
-WORKDIR /app/plugins
-ADD ./examples/plugins/app_group_lifecycle_audit_logger ./app_group_lifecycle_audit_logger
-RUN uv pip install ./app_group_lifecycle_audit_logger
-
-# Reset working directory
-WORKDIR /app
+```bash
+docker build --build-arg INSTALL_AUDIT_LOGGER_PLUGIN=true .
+# or, with docker compose:
+docker compose build --build-arg INSTALL_AUDIT_LOGGER_PLUGIN=true
 ```
 
-For local development in this repo, this plugin is already wired into the `dev`
+The image installs the plugin into its `uv` virtualenv (`/app/.venv`) with
+`uv pip install` — the venv has no `pip`, and plain `pip` would install into the
+system interpreter where the running app won't find it. See
+[the plugins README](../README.md) for every plugin's build arg and for baking
+in a plugin of your own.
+
+For local development in this repo, this plugin is also wired into the `dev`
 dependency group (see `pyproject.toml` and `[tool.uv.sources]`), so `uv sync`
 and `make run-backend` install and register it automatically — no manual step
 needed.

--- a/examples/plugins/app_group_lifecycle_audit_logger/README.md
+++ b/examples/plugins/app_group_lifecycle_audit_logger/README.md
@@ -38,23 +38,26 @@ The plugin doesn't integrate with any external systems—it simply logs events, 
 
 ## Installation
 
-To install the plugin, add these lines to the App container Dockerfile:
+To bake the plugin into an operator's App container image, add these lines to
+the Dockerfile. The Access image is built with `uv` and its virtualenv lives at
+`/app/.venv` (which has no `pip`), so install with `uv pip install` — plain
+`pip` would install into the system interpreter, where the running app won't
+find the plugin:
 
 ```dockerfile
 # Install the audit logger plugin
 WORKDIR /app/plugins
 ADD ./examples/plugins/app_group_lifecycle_audit_logger ./app_group_lifecycle_audit_logger
-RUN pip install ./app_group_lifecycle_audit_logger
+RUN uv pip install ./app_group_lifecycle_audit_logger
 
 # Reset working directory
 WORKDIR /app
 ```
 
-Alternatively, for local development, install it with pip:
-
-```bash
-pip install -e examples/plugins/app_group_lifecycle_audit_logger
-```
+For local development in this repo, this plugin is already wired into the `dev`
+dependency group (see `pyproject.toml` and `[tool.uv.sources]`), so `uv sync`
+and `make run-backend` install and register it automatically — no manual step
+needed.
 
 ## Usage
 
@@ -122,9 +125,8 @@ You can use this plugin as a template for creating your own app group lifecycle 
 
 To test the plugin locally:
 
-1. Install the plugin in development mode: `pip install -e examples/plugins/app_group_lifecycle_audit_logger`
-2. Start the Access application
-3. Create/modify/delete groups and observe the logs
+1. Run `make run-backend` — the plugin is installed via the `dev` dependency group and registered automatically (you'll see `Registered 1 app group lifecycle plugin(s): ['audit_logger']` in the startup logs)
+2. Create/modify/delete groups and observe the logs
 
 You should see log messages like:
 

--- a/examples/plugins/conditional_access/Readme.md
+++ b/examples/plugins/conditional_access/Readme.md
@@ -4,18 +4,21 @@ This plugin will allow you to automatically approve or deny access requests base
 
 ## Installation
 
-Add the below to your Dockerfile to install the plugin. You can put it before the ENV section at the bottom of the file.
-```
-# Add the specific plugins and install conditional access plugin
-WORKDIR /app/plugins
-ADD ./examples/plugins/conditional_access ./conditional_access
-RUN pip install -r ./conditional_access/requirements.txt && pip install ./conditional_access
+This plugin's source ships in the Access build context under
+`examples/plugins/`, but the default image does **not** install it. Enable it at
+build time with its build arg (default `false`):
 
-# Reset working directory
-WORKDIR /app
+```bash
+docker build --build-arg INSTALL_CONDITIONAL_ACCESS_PLUGIN=true .
+# or, with docker compose:
+docker compose build --build-arg INSTALL_CONDITIONAL_ACCESS_PLUGIN=true
 ```
 
-Build and run your docker container as normal.
+The image installs the plugin into its `uv` virtualenv (`/app/.venv`) with
+`uv pip install` — the venv has no `pip`, and plain `pip` would install into the
+system interpreter where the running app won't find it. See
+[the plugins README](../README.md) for every plugin's build arg and for baking
+in a plugin of your own.
 
 
 ## Configuration

--- a/examples/plugins/datadog_metrics_reporter/README.md
+++ b/examples/plugins/datadog_metrics_reporter/README.md
@@ -4,13 +4,13 @@ This plugin integrates Discord access metrics with Datadog, allowing users to tr
 
 ## Installation
 
-Update the Dockerfile used to build the App container includes the following section for installing the metrics plugin before starting gunicorn:
+Update the Dockerfile used to build the App container to include the following section for installing the metrics plugin before starting gunicorn. The Access image is built with `uv` and its virtualenv lives at `/app/.venv` (which has no `pip`), so install with `uv pip install` — plain `pip` would install into the system interpreter, where the running app won't find the plugin:
 
 ```dockerfile
 # Add the specific plugins and install metrics
 WORKDIR /app/plugins
 ADD ./examples/plugins/metrics_reporter ./metrics_reporter
-RUN pip install -r ./metrics_reporter/requirements.txt && pip install ./metrics_reporter
+RUN uv pip install -r ./metrics_reporter/requirements.txt && uv pip install ./metrics_reporter
 
 # Reset working directory
 WORKDIR /app

--- a/examples/plugins/datadog_metrics_reporter/README.md
+++ b/examples/plugins/datadog_metrics_reporter/README.md
@@ -4,28 +4,25 @@ This plugin integrates Discord access metrics with Datadog, allowing users to tr
 
 ## Installation
 
-Update the Dockerfile used to build the App container to include the following section for installing the metrics plugin before starting gunicorn. The Access image is built with `uv` and its virtualenv lives at `/app/.venv` (which has no `pip`), so install with `uv pip install` — plain `pip` would install into the system interpreter, where the running app won't find the plugin:
+This plugin's source ships in the Access build context under
+`examples/plugins/`, but the default image does **not** install it. Enable it at
+build time with its build arg (default `false`):
 
-```dockerfile
-# Add the specific plugins and install metrics
-WORKDIR /app/plugins
-ADD ./examples/plugins/metrics_reporter ./metrics_reporter
-RUN uv pip install -r ./metrics_reporter/requirements.txt && uv pip install ./metrics_reporter
-
-# Reset working directory
-WORKDIR /app
-
-ENV ENV production
-ENV SENTRY_RELEASE $SENTRY_RELEASE
-
-EXPOSE 3000
-
-CMD ["gunicorn", "-w", "4", "-t", "600", "-b", ":3000", "-k", "uvicorn.workers.UvicornWorker", "--access-logfile", "-", "api.asgi:app"]
+```bash
+docker build --build-arg INSTALL_DATADOG_METRICS_PLUGIN=true .
+# or, with docker compose:
+docker compose build --build-arg INSTALL_DATADOG_METRICS_PLUGIN=true
 ```
+
+The image installs the plugin (and its `requirements.txt`) into the `uv`
+virtualenv (`/app/.venv`) with `uv pip install` — the venv has no `pip`, and
+plain `pip` would install into the system interpreter where the running app
+won't find it. See [the plugins README](../README.md) for every plugin's build
+arg and for baking in a plugin of your own.
 
 ## Build the Docker image, run and test
 
-You may use the original Discord Access container build processes from the primary README.md:
+Build with the arg above, then run as usual:
 ```bash
 docker compose up --build
 ```

--- a/examples/plugins/health_check_plugin/README.md
+++ b/examples/plugins/health_check_plugin/README.md
@@ -11,19 +11,21 @@ The plugin consists of the following files:
 
 ## Installation
 
-To install the plugin, add the following to the App container Dockerfile. The
-Access image is built with `uv` and its virtualenv lives at `/app/.venv` (which
-has no `pip`), so install the plugin with `uv pip install` — plain `pip` would
-install into the system interpreter, where the running app won't find it:
+This plugin's source ships in the Access build context under
+`examples/plugins/`, but the default image does **not** install it. Enable it at
+build time with its build arg (default `false`):
 
+```bash
+docker build --build-arg INSTALL_HEALTH_CHECK_PLUGIN=true .
+# or, with docker compose:
+docker compose build --build-arg INSTALL_HEALTH_CHECK_PLUGIN=true
 ```
-WORKDIR /app/plugins
-ADD ./examples/plugins/health_check_plugin ./health_check_plugin
-RUN uv pip install ./health_check_plugin
 
-# Reset working directory
-WORKDIR /app
-```
+The image installs the plugin into its `uv` virtualenv (`/app/.venv`) with
+`uv pip install` — the venv has no `pip`, and plain `pip` would install into the
+system interpreter where the running app won't find it. See
+[the plugins README](../README.md) for every plugin's build arg and for baking
+in a plugin of your own.
 
 ## Usage
 

--- a/examples/plugins/health_check_plugin/README.md
+++ b/examples/plugins/health_check_plugin/README.md
@@ -11,12 +11,15 @@ The plugin consists of the following files:
 
 ## Installation
 
-To install the plugin, add the following to the App container Dockerfile:
+To install the plugin, add the following to the App container Dockerfile. The
+Access image is built with `uv` and its virtualenv lives at `/app/.venv` (which
+has no `pip`), so install the plugin with `uv pip install` — plain `pip` would
+install into the system interpreter, where the running app won't find it:
 
 ```
 WORKDIR /app/plugins
 ADD ./examples/plugins/health_check_plugin ./health_check_plugin
-RUN pip install ./health_check_plugin
+RUN uv pip install ./health_check_plugin
 
 # Reset working directory
 WORKDIR /app

--- a/examples/plugins/notifications_slack/README.md
+++ b/examples/plugins/notifications_slack/README.md
@@ -4,12 +4,12 @@ This plugin integrates Discord access notifications with Slack, allowing users t
 
 ## Installation
 
-Update the Dockerfile used to build the App container includes the following section for installing the notifications plugin before starting gunicorn:
+Update the Dockerfile used to build the App container to include the following section for installing the notifications plugin before starting gunicorn. The Access image is built with `uv` and its virtualenv lives at `/app/.venv` (which has no `pip`), so install with `uv pip install` — plain `pip` would install into the system interpreter, where the running app won't find the plugin:
 ```dockerfile
 # Add the specific plugins and install notifications
 WORKDIR /app/plugins
 ADD ./examples/plugins/notifications_slack ./notifications_slack
-RUN pip install -r ./notifications_slack/requirements.txt && pip install ./notifications_slack
+RUN uv pip install -r ./notifications_slack/requirements.txt && uv pip install ./notifications_slack
 
 # Reset working directory
 WORKDIR /app

--- a/examples/plugins/notifications_slack/README.md
+++ b/examples/plugins/notifications_slack/README.md
@@ -4,32 +4,31 @@ This plugin integrates Discord access notifications with Slack, allowing users t
 
 ## Installation
 
-Update the Dockerfile used to build the App container to include the following section for installing the notifications plugin before starting gunicorn. The Access image is built with `uv` and its virtualenv lives at `/app/.venv` (which has no `pip`), so install with `uv pip install` — plain `pip` would install into the system interpreter, where the running app won't find the plugin:
-```dockerfile
-# Add the specific plugins and install notifications
-WORKDIR /app/plugins
-ADD ./examples/plugins/notifications_slack ./notifications_slack
-RUN uv pip install -r ./notifications_slack/requirements.txt && uv pip install ./notifications_slack
+This plugin's source ships in the Access build context under
+`examples/plugins/`, but the default image does **not** install it. Enable it at
+build time with its build arg (default `false`):
 
-# Reset working directory
-WORKDIR /app
-
-ENV ENV production
-ENV SENTRY_RELEASE $SENTRY_RELEASE
-
-EXPOSE 3000
-
-CMD ["gunicorn", "-w", "4", "-t", "600", "-b", ":3000", "-k", "uvicorn.workers.UvicornWorker", "--access-logfile", "-", "api.asgi:app"]
+```bash
+docker build --build-arg INSTALL_SLACK_NOTIFICATIONS_PLUGIN=true .
+# or, with docker compose:
+docker compose build --build-arg INSTALL_SLACK_NOTIFICATIONS_PLUGIN=true
 ```
+
+The image installs the plugin (and its `requirements.txt`, which carries
+`slack-sdk` and `aiohttp`) into the `uv` virtualenv (`/app/.venv`) with
+`uv pip install` — the venv has no `pip`, and plain `pip` would install into the
+system interpreter where the running app won't find it. See
+[the plugins README](../README.md) for every plugin's build arg and for baking
+in a plugin of your own.
 
 ## Build the Docker image, run and test
 
-You may use the original Discord Access container build processes from the primary README.md:
+Build with the arg above, then run as usual:
 ```bash
 docker compose up --build
 ```
 
-Verify Slack notifications are work as designed.
+Verify Slack notifications work as designed.
 
 ## Plugin Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,19 @@ dev = [
     "types-python-dateutil==2.9.0.20260518",
     "types-cachetools==7.0.0.20260713",
     { include-group = "test" },
+    # In-repo example plugin, installed editable (see [tool.uv.sources]) so
+    # local dev via `make run-backend` exercises the app-group-lifecycle plugin
+    # system. Dev-group only, so it is excluded from the production image
+    # (`uv sync --no-dev`).
+    "app_group_lifecycle_audit_logger",
 ]
+
+# ----------------------------------------------------------------------
+# uv sources — resolve the in-repo example plugin from its local path
+# (editable) rather than PyPI. Only referenced by the dev group above.
+# ----------------------------------------------------------------------
+[tool.uv.sources]
+app_group_lifecycle_audit_logger = { path = "examples/plugins/app_group_lifecycle_audit_logger", editable = true }
 
 # ----------------------------------------------------------------------
 # Packaging — bundle api/config/migrations, exclude tests, and ship

--- a/uv.lock
+++ b/uv.lock
@@ -40,6 +40,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "app-group-lifecycle-audit-logger" },
     { name = "faker" },
     { name = "polyfactory" },
     { name = "pytest" },
@@ -89,6 +90,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "app-group-lifecycle-audit-logger", editable = "examples/plugins/app_group_lifecycle_audit_logger" },
     { name = "faker", specifier = "==40.31.0" },
     { name = "polyfactory", specifier = "==3.3.0" },
     { name = "pytest", specifier = "==9.1.1" },
@@ -281,6 +283,17 @@ sdist = { url = "https://files.pythonhosted.org/packages/3b/72/5562aabb8dd7181e8
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/7b/90df4a0a816d98d6ea26f559d87836d494a2cf1fcf063be67df50a7bcc30/anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72", size = 124875, upload-time = "2026-06-24T20:56:04.413Z" },
 ]
+
+[[package]]
+name = "app-group-lifecycle-audit-logger"
+version = "0.1.0"
+source = { editable = "examples/plugins/app_group_lifecycle_audit_logger" }
+dependencies = [
+    { name = "sqlalchemy" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "sqlalchemy" }]
 
 [[package]]
 name = "asyncpg"


### PR DESCRIPTION
# Summary
Two related dev/docs fixes around example plugins after the migration to `uv`:
1. Wire `examples/plugins/app_group_lifecycle_audit_logger` into the `dev` dependency group (editable path source) so `uv sync` / `make run-backend` install and register it automatically, to exercise the app group lifecycle plugin behavior without any external dependencies.
2. Correct every example plugin README's install instructions, which still said `pip install` and no longer work against the `uv`-based image.

**Urgency**: MEDIUM; one week
**Expected review effort**: LOW

# Motivation
After the `uv` migration, the plugin READMEs are inaccurate: the Access image builds with `uv`, its virtualenv is `/app/.venv` (on `PATH`, with **no `pip`**), and the app runs from that venv. So a derived image's `RUN pip install ./plugin` installs into the *system* interpreter, where the running app never finds it — and locally, `pip install -e …` lands in a different env than the `uv run`-launched server (and `make run-backend`'s `uv sync` would prune it anyway). The net symptom is "Registered 0 app group lifecycle plugin(s)".

<details>
<summary><h1>Description of Changes</h1></summary>

- `pyproject.toml`: add `app_group_lifecycle_audit_logger` to the `dev` group + a `[tool.uv.sources]` editable path entry. `uv.lock` regenerated (prod build is `--frozen`). Dev-group only ⇒ excluded from prod via `uv sync --no-dev`.
- Example plugin READMEs (`app_group_lifecycle_audit_logger`, `datadog_metrics_reporter`, `health_check_plugin`, `notifications_slack`): change the Dockerfile install snippets from `pip install` to `uv pip install`, with a one-line note on why (`.venv` has no `pip`). The audit-logger's local-dev / testing instructions now point at `make run-backend` (auto-loaded via the dev group) instead of a manual `pip install -e`.

</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

- `uv sync` builds/installs the plugin editable; `entry_points().select(group='access_app_group_lifecycle')` returns `audit_logger`.
- `make run-backend` logs `Registered 1 app group lifecycle plugin(s): ['audit_logger']` and `Application startup complete`.
- Confirmed the base image ships no `pip` in `.venv` (so the old `RUN pip install` guidance was installing into the wrong interpreter).

</details>

# Guidance for Reviewers
Two commits: (1) the dev-dependency wiring, (2) README install-instruction fixes. Open question: whether the example plugin belongs in the default `dev` group (loaded for every local `make run-backend`) or an opt-in group — easy to move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)