### PR TITLE
fix: return 503 for transient Okta errors and scope the pooled-connection retry

### DIFF
--- a/api/exception_handlers.py
+++ b/api/exception_handlers.py
@@ -31,6 +31,7 @@ from starlette.requests import Request
 from api.auth.dependencies import OIDCRedirectRequired
 from api.exceptions import AccessException
 from api.plugins.app_group_lifecycle import PluginNotFoundError
+from api.services.okta_service import OktaTransientError
 
 logger = logging.getLogger(__name__)
 
@@ -174,6 +175,20 @@ async def access_exception_handler(request: Request, exc: AccessException) -> JS
     return _problem(status_code=exc.status_code, detail=exc.detail)
 
 
+async def okta_transient_error_handler(request: Request, exc: OktaTransientError) -> JSONResponse:
+    # A transient Okta failure (timeout, rate-limit exhaustion, 5xx gateway
+    # error, or a dropped connection) reached a request handler. It's expected
+    # and retryable — upstream weather, not an application bug — so surface a 503
+    # the caller can retry and log at WARNING, keeping it out of the
+    # unhandled-exception path that logs a full ERROR traceback and would
+    # otherwise page.
+    logger.warning("Transient Okta error on %s %s: %s", request.method, request.url.path, exc)
+    return _problem(
+        status_code=503,
+        detail="Okta is temporarily unavailable. Please retry.",
+    )
+
+
 async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse | HTMLResponse:
     logger.exception("Unhandled exception", exc_info=exc)
     if _is_api(request):
@@ -194,4 +209,5 @@ def install(app: FastAPI) -> None:
     app.add_exception_handler(OIDCRedirectRequired, oidc_redirect_handler)  # type: ignore[arg-type]
     app.add_exception_handler(PluginNotFoundError, plugin_not_found_handler)  # type: ignore[arg-type]
     app.add_exception_handler(AccessException, access_exception_handler)  # type: ignore[arg-type]
+    app.add_exception_handler(OktaTransientError, okta_transient_error_handler)  # type: ignore[arg-type]
     app.add_exception_handler(Exception, unhandled_exception_handler)

--- a/api/services/okta_service.py
+++ b/api/services/okta_service.py
@@ -32,13 +32,13 @@ TRANSIENT_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
 # Page size for cursor-paginated list endpoints. Okta caps most list endpoints
 # at 200 per page; the facade drives the ``after`` cursor to walk pages.
 LIST_PAGE_LIMIT = 200
-# Extra attempts for a call that raises ``OktaTransientError``. Transient Okta
-# failures (a 429/5xx or timeout, and — via the reclassification in ``_call`` — a
-# pooled keep-alive connection Okta dropped server-side, which the SDK surfaces as
-# a None-response error) are worth one immediate retry: it gets a fresh connection
-# and usually succeeds, recovering within the run instead of skipping the resource
-# until the next reconcile. Kept at 1 so a genuinely-degraded endpoint, or a
-# lingering 429, still gives up quickly rather than amplifying load.
+# Extra attempts for a *connection-level* ``OktaTransientError`` — chiefly a
+# pooled keep-alive connection Okta dropped server-side, which the SDK surfaces
+# as a None-response error. One immediate retry gets a fresh connection and
+# usually succeeds, recovering within the run instead of skipping the resource
+# until the next reconcile. A 429/5xx or timeout is *not* retried (see
+# ``_is_retryable_okta_error``): the SDK already spent its budget, so re-issuing
+# into an active rate-limit storm only amplifies load and latency.
 OKTA_TRANSIENT_RETRIES = 1
 
 
@@ -57,16 +57,22 @@ UserSchemaAttribute.model_rebuild(force=True)
 
 
 class OktaTransientError(Exception):
-    """Raised when an Okta request times out or hits a transient failure.
+    """Raised when an Okta request hits a transient failure.
 
     Surfaced when the SDK gives up on a request: its ``requestTimeout`` is
-    exceeded, a 429 outlives its rate-limit retries, or the response is a
-    transient upstream/gateway error (5xx). Callers that can tolerate a slow or
-    flaky Okta call (the membership/ownership fan-out) catch this and continue;
-    the syncer reconciles the drift later.
+    exceeded, a 429 outlives its rate-limit retries, the response is a transient
+    upstream/gateway error (5xx), or a pooled connection was dropped. Callers
+    that can tolerate a slow or flaky Okta call (the membership/ownership
+    fan-out) catch this and continue; the syncer reconciles the drift later, and
+    request handlers surface it as a 503.
+
+    ``retryable`` marks a connection-level failure a fresh connection could fix
+    (see ``_is_retryable_okta_error``); ``_WrapperClient`` retries only those.
     """
 
-    pass
+    def __init__(self, message: str, *, retryable: bool = False) -> None:
+        super().__init__(message)
+        self.retryable = retryable
 
 
 # On a gateway failure that yields no response object, the SDK returns
@@ -100,6 +106,27 @@ def _is_transient_okta_error(error: Any) -> bool:
     return str(error) == "Request Timeout exceeded."
 
 
+def _is_retryable_okta_error(error: Any) -> bool:
+    """Whether a transient failure is worth one immediate in-run retry.
+
+    Only a *connection-level* blip benefits — chiefly a pooled keep-alive
+    connection Okta dropped server-side, which the SDK surfaces as the
+    None-response ``AttributeError`` above; a retry gets a fresh connection and
+    usually succeeds. A definitive rate-limit/gateway HTTP status (429 or a 5xx)
+    or an exhausted request timeout is *not* retried: the SDK already spent its
+    retry/timeout budget, so re-issuing into an active storm only amplifies load
+    and latency. Those still raise ``OktaTransientError`` — just without the
+    extra attempt. Assumes ``error`` was already classified transient.
+    """
+    if getattr(error, "status", None) in TRANSIENT_STATUS_CODES:
+        return False
+    if isinstance(error, asyncio.TimeoutError):
+        return False
+    if str(error) == "Request Timeout exceeded.":
+        return False
+    return True
+
+
 class _WrapperClient:
     """Proxy over an Okta client that routes every async API call through ``OktaService._call``.
 
@@ -122,14 +149,15 @@ class _WrapperClient:
         @functools.wraps(attr)
         async def wrapper(*args: Any, **kwargs: Any) -> Any:
             # Rebuild the coroutine each attempt — a spent coroutine can't be
-            # re-awaited — and retry a bounded number of times on a transient
-            # failure, so a stale pooled connection is recovered within the run
-            # rather than deferred to the next reconcile.
+            # re-awaited — and retry only a connection-level transient failure (a
+            # dropped pooled connection), which recovers on a fresh connection
+            # within the run. A 429/5xx or timeout is surfaced immediately: the
+            # SDK already spent its budget, so re-issuing only amplifies load.
             for attempt in range(OKTA_TRANSIENT_RETRIES + 1):
                 try:
                     return await OktaService._call(attr(*args, **kwargs))
-                except OktaTransientError:
-                    if attempt == OKTA_TRANSIENT_RETRIES:
+                except OktaTransientError as exc:
+                    if not exc.retryable or attempt == OKTA_TRANSIENT_RETRIES:
                         raise
             raise AssertionError("unreachable")  # pragma: no cover
 
@@ -234,11 +262,13 @@ class OktaService:
             result = await coro
         except Exception as exc:
             if _is_transient_okta_error(exc):
-                raise OktaTransientError(str(exc) or "Okta request timed out") from exc
+                raise OktaTransientError(
+                    str(exc) or "Okta request timed out", retryable=_is_retryable_okta_error(exc)
+                ) from exc
             raise
         error = result[-1] if isinstance(result, tuple) and result else None
         if _is_transient_okta_error(error):
-            raise OktaTransientError(str(error) or "Okta request timed out")
+            raise OktaTransientError(str(error) or "Okta request timed out", retryable=_is_retryable_okta_error(error))
         return result
 
     async def _paginate(self, list_method: Callable[..., Any], *args: Any, **kwargs: Any) -> list[Any]:

--- a/tests/test_okta_service.py
+++ b/tests/test_okta_service.py
@@ -225,38 +225,70 @@ async def test_concurrent_calls_use_isolated_clients() -> None:
     assert len({id(client) for client in clients}) == call_count
 
 
-async def test_transient_error_is_retried_then_succeeds() -> None:
-    """A transient Okta failure is retried within the same call and can recover.
+async def test_connection_level_error_is_retried_then_succeeds() -> None:
+    """A dropped pooled connection is retried within the same call and recovers.
 
-    The SDK surfaces a transient outcome (here a 503) that ``_call`` turns into an
-    ``OktaTransientError``; ``_WrapperClient`` retries it, and the next attempt —
+    A stale keep-alive connection Okta closed server-side surfaces as the SDK's
+    None-response ``AttributeError``; ``_call`` maps it to a *retryable*
+    ``OktaTransientError``, ``_WrapperClient`` retries it, and the next attempt —
     on a fresh connection in production — succeeds.
     """
     service = OktaService()
     service.initialize("fake.domain", "fake.token")
 
-    transient = (None, MagicMock(status_code=503, headers={}), MagicMock(status=503))
+    dropped = AttributeError("'NoneType' object has no attribute 'status'")
     success = (UserFactory(), MagicMock(status_code=200, headers={}), None)
-    get_user = AsyncMock(side_effect=[transient, success])
+    get_user = AsyncMock(side_effect=[dropped, success])
 
     with patch("okta.client.Client.get_user", get_user):
         user = await service.get_user("okta_id")
 
     assert user is not None
-    # One transient failure, retried once, then success.
+    # One connection-level failure, retried once, then success.
     assert get_user.call_count == 2
 
 
-async def test_transient_error_gives_up_after_bounded_retries() -> None:
-    """A persistently transient endpoint stops after the bounded retries."""
+async def test_connection_level_error_gives_up_after_bounded_retries() -> None:
+    """A persistently dropped connection stops after the bounded retries."""
     service = OktaService()
     service.initialize("fake.domain", "fake.token")
 
-    transient = (None, MagicMock(status_code=503, headers={}), MagicMock(status=503))
-    get_user = AsyncMock(return_value=transient)
+    get_user = AsyncMock(side_effect=AttributeError("'NoneType' object has no attribute 'status'"))
 
     with patch("okta.client.Client.get_user", get_user):
         with pytest.raises(OktaTransientError):
             await service.get_user("okta_id")
 
     assert get_user.call_count == OKTA_TRANSIENT_RETRIES + 1
+
+
+@pytest.mark.parametrize("status", [429, 500, 502, 503, 504])
+async def test_definitive_transient_status_is_not_retried(status: int) -> None:
+    """A 429 or 5xx is transient but *not* retried — the SDK already spent its
+    rate-limit/timeout budget, so re-issuing into an active storm would only
+    amplify load. It surfaces as ``OktaTransientError`` on the first attempt."""
+    service = OktaService()
+    service.initialize("fake.domain", "fake.token")
+
+    transient = (None, MagicMock(status_code=status, headers={}), MagicMock(status=status))
+    get_user = AsyncMock(return_value=transient)
+
+    with patch("okta.client.Client.get_user", get_user):
+        with pytest.raises(OktaTransientError):
+            await service.get_user("okta_id")
+
+    assert get_user.call_count == 1
+
+
+async def test_request_timeout_deadline_is_not_retried() -> None:
+    """An exhausted request-timeout deadline is transient but not retried."""
+    service = OktaService()
+    service.initialize("fake.domain", "fake.token")
+
+    get_user = AsyncMock(return_value=(None, None, Exception("Request Timeout exceeded.")))
+
+    with patch("okta.client.Client.get_user", get_user):
+        with pytest.raises(OktaTransientError):
+            await service.get_user("okta_id")
+
+    assert get_user.call_count == 1

--- a/tests/test_okta_transient_errors.py
+++ b/tests/test_okta_transient_errors.py
@@ -1,11 +1,15 @@
 import asyncio
+import logging
 from unittest.mock import MagicMock
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 from okta.errors.http_error import HTTPError
 from okta.errors.okta_api_error import OktaAPIError
 from pytest_mock import MockerFixture
 
+from api import exception_handlers
 from api.services.okta_service import OktaService, OktaTransientError
 from tests.factories import UserFactory
 
@@ -123,3 +127,28 @@ async def test_facade_adds_no_retry(mocker: MockerFixture, okta_service: OktaSer
 
     assert user is not None
     assert mocked_request.call_count == 1
+
+
+def test_okta_transient_error_surfaces_as_503(caplog: pytest.LogCaptureFixture) -> None:
+    """An ``OktaTransientError`` that reaches a request handler is rendered as a
+    503 problem-detail (the retryable signal the caller should see) and logged at
+    WARNING — not the ERROR traceback the unhandled-exception catch-all emits."""
+    app = FastAPI()
+    exception_handlers.install(app)
+
+    @app.get("/boom")
+    async def boom() -> None:
+        raise OktaTransientError("Okta unavailable")
+
+    client = TestClient(app, raise_server_exceptions=False)
+    with caplog.at_level(logging.WARNING):
+        response = client.get("/boom")
+
+    assert response.status_code == 503
+    assert response.headers["content-type"] == "application/problem+json"
+    body = response.json()
+    assert body["status"] == 503
+    assert "retry" in body["detail"].lower()
+    # The dedicated handler wins over the catch-all: a WARNING, not an ERROR traceback.
+    assert any(record.levelno == logging.WARNING for record in caplog.records)
+    assert not any(record.levelno >= logging.ERROR for record in caplog.records)


### PR DESCRIPTION
## What & why

Two related fixes for how transient Okta failures behave on the request path.

**1. Transient Okta errors reaching a request handler now return 503, not 500.**
`OktaTransientError` (a request timeout, a 429 that outlived the SDK's rate-limit retries, a 5xx gateway error, or a dropped connection) has always been swallowed by the syncer/fan-out, but on the synchronous request path — e.g. `POST /api/apps` creating an owner group — nothing caught it, so it fell through to the unhandled-exception catch-all: an HTTP 500 logged as a full ERROR traceback, which pages. That's the wrong signal for upstream weather. A dedicated exception handler now maps `OktaTransientError` to a **503 Service Unavailable** RFC 9457 problem-detail (the retryable semantic the caller should actually see) and logs it at **WARNING**.

**2. The in-run retry is now scoped to connection-level failures only.**
`OKTA_TRANSIENT_RETRIES` was introduced to recover a stale pooled keep-alive connection Okta drops server-side (the SDK surfaces this as a `None`-response `AttributeError`). But it retried *every* transient failure — including genuine 429/timeout storms, where re-issuing an already-rate-limited call into an active storm only amplifies load and roughly doubles latency (a contributor to the multi-hundred-second requests we saw). The retry now fires only for the connection-level signature; a definitive 429/5xx status or an exhausted request-timeout deadline surfaces immediately (still as `OktaTransientError`, just without the extra attempt), via a new `retryable` flag set when the error is classified.

Net effect on a 429 storm: one attempt instead of two, and the request returns a fast 503 the client can back off on rather than a slow 500 that pages.