### PR TITLE
docs: explain expected benign CSP console warnings under the nonce policy

### DIFF
--- a/api/middleware.py
+++ b/api/middleware.py
@@ -46,6 +46,23 @@ def build_csp(nonce: str) -> str:
     and styled-components' runtime `<style>` injections, while same-origin
     bundles/stylesheets are covered by `'self'` and Google Fonts by its host
     allowance.
+
+    Two classes of *benign* console warnings are expected under this policy and
+    are intentionally not accommodated — silencing either would weaken the
+    policy for no functional gain:
+
+    - `style-src` violations from Sentry Session Replay (rrweb). rrweb diffs
+      style changes by calling `setAttribute("style", ...)` on detached nodes.
+      A nonce cannot authorize a `style=""` *attribute* (nonces only cover
+      `<style>`/`<script>` *elements*), and `'unsafe-inline'` is ignored by the
+      browser whenever a nonce is present. The writes are on nodes that never
+      render, so there is no visual impact. The app's own inline styles are
+      unaffected because React/MUI set them via CSSOM (`element.style.x = ...`),
+      which CSP does not govern — only the string `setAttribute` form is.
+    - a single `script-src` `eval` violation from `@mui/x-data-grid`, which
+      feature-detects `eval` inside a `try/catch` to pick a fast filter path.
+      The probe is caught and the grid falls back to an interpreted path;
+      allowing it would require `'unsafe-eval'`.
     """
     return (
         "default-src 'self'; "


### PR DESCRIPTION
## What & why

The nonce-based SPA CSP shipped in #541 produces two classes of browser console warnings on deployed environments. They look alarming but are benign, and both originate in bundled third-party libraries rather than in Access's own code or the CSP itself. This adds a note to the `build_csp` docstring so the next person who sees them doesn't re-investigate — and, more importantly, doesn't relax the policy to quiet them.

The two warning classes:

- **~70 `style-src` violations** from Sentry Session Replay (rrweb). rrweb diffs style changes by calling `setAttribute("style", …)` on detached nodes. A nonce cannot authorize a `style=""` *attribute* (nonces only cover `<style>`/`<script>` *elements*), and the browser ignores `'unsafe-inline'` whenever a nonce is present. The writes land on nodes that never render, so there's no visual impact. The app's own inline styles are unaffected because React/MUI set them via CSSOM (`element.style.x = …`), which CSP does not govern — only the string `setAttribute` form is.
- **A single `script-src` `eval` violation** from `@mui/x-data-grid`, which feature-detects `eval` inside a `try/catch` to choose a fast filter path. The probe is caught and the grid falls back to an interpreted path.

Neither can be silenced without materially weakening the policy (`'unsafe-inline'` for style attributes — ignored while a nonce is present anyway — or `'unsafe-eval'` for the probe), so the deliberate choice is to accept the noise. These are console-only; they are not reported to Sentry (no `report-uri`/`report-to`, no CaptureConsole integration).

Documentation only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)