### PR TITLE
test: polyfactory-native ORM factories — create_async persistence + drop factory_boy aliases

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ from tests.factories import (
     AccessRequestFactory,
     AppFactory,
     AppGroupFactory,
+    GroupRequestFactory,
     OktaGroupFactory,
     OktaUserFactory,
     RoleGroupFactory,
@@ -79,6 +80,11 @@ def access_request() -> Any:
 @pytest.fixture
 def role_request() -> Any:
     return RoleRequestFactory.build()
+
+
+@pytest.fixture
+def group_request() -> Any:
+    return GroupRequestFactory.build()
 
 
 @pytest.fixture

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -9,8 +9,16 @@ Explicit `build(...)`/`create(...)` kwargs still override any column (managed or
 not), which the fixtures and tests rely on.
 
 The `factory_boy`-style method names (`create`, `create_batch`, `build_batch`)
-are thin aliases over polyfactory's `build`/`batch`, so test call sites use them
-directly; none persist (they just build instances).
+are thin aliases over polyfactory's `build`/`batch` — they build detached
+instances without touching the DB, so a call site that wants them persisted still
+does its own `db.session.add(...)` + `await db.session.commit()`.
+
+`await Factory.create_async(...)` (and `create_batch_async`) instead persist:
+`__async_session__` points at the active request-scoped `db.session`, so
+polyfactory adds, commits, and refreshes the built instance. That collapses the
+build/add/commit triad into one call — reach for it when a test just needs a row
+in the DB, and keep `build`/`create` for the cases that assemble an instance
+without persisting.
 
 **Okta SDK model factories** (`Group`/`User`/`UserSchema`) build the
 openapi-generated SDK Pydantic models through `from_dict` (camelCase aliases, the
@@ -41,9 +49,14 @@ from api.models import (
     AccessRequestStatus,
     App,
     AppGroup,
+    AppTagMap,
+    GroupRequest,
     OktaGroup,
+    OktaGroupTagMap,
     OktaUser,
+    OktaUserGroupMember,
     RoleGroup,
+    RoleGroupMap,
     RoleRequest,
     Tag,
 )
@@ -75,6 +88,12 @@ class _ORMFactory(SQLAlchemyFactory):
     __is_base_factory__ = True
     __set_relationships__ = False
     __set_foreign_keys__ = False
+
+    # Resolve the session lazily: the scope (and thus the bound AsyncSession)
+    # changes per test, so `create_async` must read `db.session` at call time,
+    # not at class-definition time. Only `create_async`/`create_batch_async`
+    # use it; `build`/`create` never touch the DB.
+    __async_session__ = staticmethod(lambda: db.session)
 
     # Columns this factory is responsible for generating. Anything not listed
     # (and not passed explicitly by the caller) is left unset.
@@ -178,6 +197,48 @@ class RoleRequestFactory(_ORMFactory):
     id = Use(_okta_id)
     status = AccessRequestStatus.PENDING
     request_reason = Use(lambda: _faker.paragraph(nb_sentences=5))
+
+
+class GroupRequestFactory(_ORMFactory):
+    __model__ = GroupRequest
+    # `requester_user_id` is a caller-supplied FK; the rest either generate here
+    # or fall back to their column defaults. `requested_group_name` /
+    # `requested_group_type` are NOT NULL without a default, so generate them
+    # too (an okta_group by default) to keep `create()`/`create_async()`
+    # persistable with just a requester.
+    _managed = {"id", "status", "request_reason", "requested_group_name", "requested_group_type"}
+
+    id = Use(_okta_id)
+    status = AccessRequestStatus.PENDING
+    request_reason = Use(lambda: _faker.paragraph(nb_sentences=5))
+    requested_group_name = Use(lambda: random.choice(string.ascii_uppercase) + _rand())
+    requested_group_type = "okta_group"
+
+
+# --- Membership / mapping rows ---------------------------------------------
+#
+# These association tables default every non-FK column (`is_owner` False,
+# timestamps to now, `ended_at` null → active, reason ""), and the FKs are
+# always caller-supplied, so there is nothing to generate — `_managed` is empty.
+# The factories exist for the `create_async` persistence path: `await
+# OktaUserGroupMemberFactory.create_async(user_id=u.id, group_id=g.id)` replaces
+# the add/commit triad. Pass `ended_at=...` to build an already-expired row.
+
+
+class OktaUserGroupMemberFactory(_ORMFactory):
+    __model__ = OktaUserGroupMember
+
+
+class RoleGroupMapFactory(_ORMFactory):
+    __model__ = RoleGroupMap
+
+
+class OktaGroupTagMapFactory(_ORMFactory):
+    __model__ = OktaGroupTagMap
+
+
+class AppTagMapFactory(_ORMFactory):
+    __model__ = AppTagMap
 
 
 # ---------------------------------------------------------------------------

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -5,26 +5,25 @@ polyfactory otherwise populates *every* column with random data; these factories
 instead whitelist just the columns each one sets (via `should_set_field_value` +
 `__set_foreign_keys__` / `__set_relationships__` off) and leave the rest — soft
 deletes, timestamps, discriminators, FKs, JSON config — to the model/DB defaults.
-Explicit `build(...)`/`create(...)` kwargs still override any column (managed or
-not), which the fixtures and tests rely on.
+Explicit `build(...)` kwargs still override any column (managed or not), which
+the fixtures and tests rely on.
 
-The `factory_boy`-style method names (`create`, `create_batch`, `build_batch`)
-are thin aliases over polyfactory's `build`/`batch` — they build detached
-instances without touching the DB, so a call site that wants them persisted still
-does its own `db.session.add(...)` + `await db.session.commit()`.
+Two ways to make an instance, both using polyfactory's native API:
 
-`await Factory.create_async(...)` (and `create_batch_async`) instead persist:
-`__async_session__` points at the active request-scoped `db.session`, so
-polyfactory adds, commits, and refreshes the built instance. That collapses the
-build/add/commit triad into one call — reach for it when a test just needs a row
-in the DB, and keep `build`/`create` for the cases that assemble an instance
-without persisting.
+- `build(**kwargs)` / `batch(n, **kwargs)` return detached instances without
+  touching the DB, so a call site that wants them persisted does its own
+  `db.session.add(...)` + `await db.session.commit()`.
+- `await create_async(**kwargs)` / `create_batch_async(n, **kwargs)` persist:
+  `__async_session__` points at the active request-scoped `db.session`, so
+  polyfactory adds, commits, and refreshes the instance — collapsing the
+  build/add/commit triad into one call.
 
 **Okta SDK model factories** (`Group`/`User`/`UserSchema`) build the
 openapi-generated SDK Pydantic models through `from_dict` (camelCase aliases, the
 `anyOf` `profile` union), which polyfactory's generic generation can't reproduce.
 They mock external Okta responses rather than our own schemas, so they stay
-hand-rolled builders.
+hand-rolled builders — and keep their own `create`/`create_batch` helpers, which
+are unrelated to the polyfactory API above.
 """
 
 from __future__ import annotations
@@ -104,19 +103,6 @@ class _ORMFactory(SQLAlchemyFactory):
         # `super()` returns False for fields the caller passed explicitly, so
         # `build(email=...)` overrides win over generation.
         return field_meta.name in cls._managed and super().should_set_field_value(field_meta, **kwargs)
-
-    # --- factory_boy-style aliases over build/batch (no persistence) ---------
-    @classmethod
-    def create(cls, **kwargs: Any) -> Any:
-        return cls.build(**kwargs)
-
-    @classmethod
-    def create_batch(cls, size: int, **kwargs: Any) -> list[Any]:
-        return cls.batch(size, **kwargs)
-
-    @classmethod
-    def build_batch(cls, size: int, **kwargs: Any) -> list[Any]:
-        return cls.batch(size, **kwargs)
 
 
 class OktaUserFactory(_ORMFactory):

--- a/tests/test_access_request.py
+++ b/tests/test_access_request.py
@@ -583,14 +583,13 @@ async def test_create_app_access_request_notification(
     app: FastAPI, db: Db, access_app: App, app_group: AppGroup, user: OktaUser, mocker: MockerFixture
 ) -> None:
     # test bad data
-    app_owner_user = OktaUserFactory.create()
+    app_owner_user = await OktaUserFactory.create_async()
     app_owner_group = AppGroupFactory.create()
 
     # Add App
     db.session.add(access_app)
 
     # Add Users
-    db.session.add(app_owner_user)
     db.session.add(user)
 
     await db.session.commit()
@@ -1038,8 +1037,7 @@ async def test_post_access_request_403_for_deleted_user(
     soft-deleted user."""
     from datetime import datetime, timezone
 
-    deleted_user = OktaUserFactory.create(deleted_at=datetime.now(timezone.utc))
-    db.session.add(deleted_user)
+    deleted_user = await OktaUserFactory.create_async(deleted_at=datetime.now(timezone.utc))
     db.session.add(okta_group)
     await db.session.commit()
     mock_user(deleted_user.id)
@@ -1063,11 +1061,8 @@ async def test_post_access_request_for_role_group_with_associated_groups(
     from api.operations import ModifyRoleGroups
     from tests.factories import AppFactory, AppGroupFactory, RoleGroupFactory
 
-    role = RoleGroupFactory.create(name="Role-WithAssociations")
-    test_app = AppFactory.create(name="AssocTestApp")
-    db.session.add(role)
-    db.session.add(test_app)
-    await db.session.commit()
+    role = await RoleGroupFactory.create_async(name="Role-WithAssociations")
+    test_app = await AppFactory.create_async(name="AssocTestApp")
 
     associated_app_groups = [
         AppGroupFactory.create(
@@ -1127,11 +1122,8 @@ async def test_get_access_request_detail_requested_group_for_role_group(
 
     # Wire the role to one member-group and one owner-group so both
     # association arrays have content.
-    member_group = OktaGroupFactory.create()
-    owner_group = OktaGroupFactory.create()
-    db.session.add(member_group)
-    db.session.add(owner_group)
-    await db.session.commit()
+    member_group = await OktaGroupFactory.create_async()
+    owner_group = await OktaGroupFactory.create_async()
     await ModifyRoleGroups(
         role_group=role_group,
         groups_to_add=[member_group.id],

--- a/tests/test_access_request.py
+++ b/tests/test_access_request.py
@@ -512,7 +512,7 @@ async def test_get_all_access_request(
     db.session.add(okta_group)
     await db.session.commit()
 
-    access_requests = AccessRequestFactory.create_batch(10, requester_user_id=user.id, requested_group_id=okta_group.id)
+    access_requests = AccessRequestFactory.batch(10, requester_user_id=user.id, requested_group_id=okta_group.id)
     db.session.add_all(access_requests)
     await db.session.commit()
 
@@ -584,7 +584,7 @@ async def test_create_app_access_request_notification(
 ) -> None:
     # test bad data
     app_owner_user = await OktaUserFactory.create_async()
-    app_owner_group = AppGroupFactory.create()
+    app_owner_group = AppGroupFactory.build()
 
     # Add App
     db.session.add(access_app)
@@ -665,7 +665,7 @@ async def test_get_all_possible_request_approvers(app: FastAPI, mocker: MockerFi
         await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
     ).first()
 
-    users = OktaUserFactory.build_batch(3)
+    users = OktaUserFactory.batch(3)
     db.session.add_all(users)
     await db.session.commit()
 
@@ -680,7 +680,7 @@ async def test_get_all_possible_request_approvers(app: FastAPI, mocker: MockerFi
     )
 
     req = AccessRequest()
-    req.requested_group = AppGroupFactory.create()
+    req.requested_group = AppGroupFactory.build()
 
     approvers = await get_all_possible_request_approvers(req)
 
@@ -973,10 +973,10 @@ async def test_q_search_covers_all_fields_via_http(
     requesters and groups so each search must *exclude* the other to pass
     — a regression that returns everything would still match by ID but
     fail the exclusion assertions."""
-    target_user = OktaUserFactory.create(email="zelda-target@example.com", first_name="Zelda", last_name="Target")
-    other_user = OktaUserFactory.create(email="other-noise@example.com", first_name="Other", last_name="Noise")
-    target_group = OktaGroupFactory.create(name="ZeldaTargetGroup", description="zd-desc")
-    other_group = OktaGroupFactory.create(name="OtherNoiseGroup", description="on-desc")
+    target_user = OktaUserFactory.build(email="zelda-target@example.com", first_name="Zelda", last_name="Target")
+    other_user = OktaUserFactory.build(email="other-noise@example.com", first_name="Other", last_name="Noise")
+    target_group = OktaGroupFactory.build(name="ZeldaTargetGroup", description="zd-desc")
+    other_group = OktaGroupFactory.build(name="OtherNoiseGroup", description="on-desc")
     db.session.add_all([target_user, other_user, target_group, other_group])
     await db.session.commit()
 
@@ -1065,7 +1065,7 @@ async def test_post_access_request_for_role_group_with_associated_groups(
     test_app = await AppFactory.create_async(name="AssocTestApp")
 
     associated_app_groups = [
-        AppGroupFactory.create(
+        AppGroupFactory.build(
             name=f"App-AssocTestApp-Member-{i}",
             app_id=test_app.id,
             is_owner=False,
@@ -1073,7 +1073,7 @@ async def test_post_access_request_for_role_group_with_associated_groups(
         for i in range(3)
     ]
     associated_owner_groups = [
-        AppGroupFactory.create(
+        AppGroupFactory.build(
             name=f"App-AssocTestApp-OwnerSlot-{i}",
             app_id=test_app.id,
             is_owner=False,

--- a/tests/test_access_request.py
+++ b/tests/test_access_request.py
@@ -14,7 +14,6 @@ from api.models import (
     App,
     AppGroup,
     OktaGroup,
-    OktaGroupTagMap,
     OktaUser,
     OktaUserGroupMember,
     RoleGroup,
@@ -30,7 +29,13 @@ from api.operations import (
 )
 from api.plugins import ConditionalAccessResponse, get_notification_hook
 from api.services import okta
-from tests.factories import AccessRequestFactory, AppGroupFactory, OktaGroupFactory, OktaUserFactory
+from tests.factories import (
+    AccessRequestFactory,
+    AppGroupFactory,
+    OktaGroupFactory,
+    OktaGroupTagMapFactory,
+    OktaUserFactory,
+)
 from tests.helpers import db_count
 from tests.request_factories import CreateAccessRequestBodyFactory, ResolveAccessRequestBodyFactory
 
@@ -796,8 +801,7 @@ async def test_auto_resolve_create_access_request(
     db.session.add(tag)
     await db.session.commit()
 
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tag.id)
 
     notification_hook = get_notification_hook()
     request_created_notification_spy = mocker.patch.object(notification_hook, "access_request_created")
@@ -917,8 +921,7 @@ async def test_auto_resolve_create_access_request_with_time_limit_constraint_tag
     db.session.add(tag)
     await db.session.commit()
 
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tag.id)
 
     notification_hook = get_notification_hook()
     request_created_notification_spy = mocker.patch.object(notification_hook, "access_request_created")
@@ -1194,8 +1197,7 @@ async def test_get_access_request_detail_requested_group_for_app_group(
     db.session.add(app_group)
     db.session.add(tag)
     await db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tag.id)
 
     ar = await CreateAccessRequest(
         requester_user=user,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -365,7 +365,7 @@ async def test_delete_app(
     rep = await client.delete(app_url)
     assert rep.status_code == 404
 
-    app_groups = AppGroupFactory.create_batch(3, app=access_app)
+    app_groups = AppGroupFactory.batch(3, app=access_app)
     db.session.add(access_app)
     db.session.add_all(app_groups)
     db.session.add(tag)
@@ -640,7 +640,7 @@ async def test_create_app_with_name_collision(
     app_group: AppGroup,
     url_for: Any,
 ) -> None:
-    app = AppFactory.create()
+    app = AppFactory.build()
     app.name = "Test-Staging"
     db.session.add(app)
     await db.session.commit()
@@ -746,7 +746,7 @@ async def test_create_app_additional_group_collision_converts_correct_group(
 
 async def test_get_all_app(client: AsyncClient, db: Db, url_for: Any) -> None:
     apps_url = url_for("api-apps.apps")
-    apps = AppFactory.create_batch(10)
+    apps = AppFactory.batch(10)
 
     # Prefix all the app names with A so we can query for them easily
     for app in apps:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -28,6 +28,7 @@ from tests.factories import (
     AppGroupFactory,
     AppTagMapFactory,
     OktaGroupFactory,
+    OktaGroupTagMapFactory,
     OktaUserFactory,
     OktaUserGroupMemberFactory,
 )
@@ -129,17 +130,14 @@ async def test_get_app_groups_paginated(client: AsyncClient, db: Db, user: OktaU
     to 10 per page. Members are NOT inlined — each item carries member_count /
     owner_count, and the UI fetches members per-group from the paginated
     member-details endpoint — so a single huge group can't bloat the response."""
-    app = AppFactory.create()
-    db.session.add(app)
+    app = await AppFactory.create_async()
     db.session.add(user)
     await db.session.commit()
 
     groups = []
     for _ in range(25):
-        ag = AppGroupFactory.create(app_id=app.id)
-        db.session.add(ag)
+        ag = await AppGroupFactory.create_async(app_id=app.id)
         groups.append(ag)
-    await db.session.commit()
 
     await ModifyGroupUsers(group=groups[0], members_to_add=[user.id], sync_to_okta=False).execute()
 
@@ -175,16 +173,11 @@ async def test_get_app_groups_paginated(client: AsyncClient, db: Db, user: OktaU
 async def test_get_app_groups_search_by_user(client: AsyncClient, db: Db, url_for: Any) -> None:
     """`?q=` returns only the app's groups containing a member matching the
     query by name/email, computed server-side (the app page's user search)."""
-    app = AppFactory.create()
-    db.session.add(app)
-    await db.session.commit()
-    group_a = AppGroupFactory.create(app_id=app.id)
-    group_b = AppGroupFactory.create(app_id=app.id)
-    db.session.add_all([group_a, group_b])
-    alice = OktaUserFactory.create(first_name="Alice", last_name="Xeno", email="alice.xeno@example.com")
-    bob = OktaUserFactory.create(first_name="Bob", last_name="Yon", email="bob.yon@example.com")
-    db.session.add_all([alice, bob])
-    await db.session.commit()
+    app = await AppFactory.create_async()
+    group_a = await AppGroupFactory.create_async(app_id=app.id)
+    group_b = await AppGroupFactory.create_async(app_id=app.id)
+    alice = await OktaUserFactory.create_async(first_name="Alice", last_name="Xeno", email="alice.xeno@example.com")
+    bob = await OktaUserFactory.create_async(first_name="Bob", last_name="Yon", email="bob.yon@example.com")
     await ModifyGroupUsers(group=group_a, members_to_add=[alice.id], sync_to_okta=False).execute()
     await ModifyGroupUsers(group=group_b, members_to_add=[bob.id], sync_to_okta=False).execute()
 
@@ -206,13 +199,9 @@ async def test_get_app_groups_search_by_group_name(client: AsyncClient, db: Db, 
     """`?q=` also matches an app group's own name (not just its members), so the
     app page's search box can find a specific group or a subset of groups by
     name via a case-insensitive substring."""
-    app = AppFactory.create()
-    db.session.add(app)
-    await db.session.commit()
-    prd_group = AppGroupFactory.create(app_id=app.id, name="App-Github-Prd")
-    stg_group = AppGroupFactory.create(app_id=app.id, name="App-Github-Stg")
-    db.session.add_all([prd_group, stg_group])
-    await db.session.commit()
+    app = await AppFactory.create_async()
+    prd_group = await AppGroupFactory.create_async(app_id=app.id, name="App-Github-Prd")
+    await AppGroupFactory.create_async(app_id=app.id, name="App-Github-Stg")
 
     app_id = app.id
     prd_group_id = prd_group.id
@@ -230,9 +219,7 @@ async def test_get_app_groups_search_by_group_name(client: AsyncClient, db: Db, 
 
 async def test_get_app_groups_size_capped_at_10(client: AsyncClient, db: Db, url_for: Any) -> None:
     """Requesting more than 10 per page is rejected so the bound can't be opted out of."""
-    app = AppFactory.create()
-    db.session.add(app)
-    await db.session.commit()
+    app = await AppFactory.create_async()
     app_id = app.id
     db.session.expunge_all()
 
@@ -386,8 +373,7 @@ async def test_delete_app(
 
     app_tag_map = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tag.id)
     for app_group in app_groups:
-        db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag.id, app_tag_map_id=app_tag_map.id))
-    await db.session.commit()
+        await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tag.id, app_tag_map_id=app_tag_map.id)
 
     app_id = access_app.id
     app_group_id = app_groups[0].id
@@ -722,19 +708,13 @@ async def test_create_app_additional_group_collision_converts_correct_group(
     # A pre-existing plain OktaGroup whose name collides with a requested additional
     # app group. No App-Payments-Owners group pre-exists, so with the bug
     # existing_owner_group is None.
-    plain_group = OktaGroupFactory.create(name=legacy_name)
-    db.session.add(plain_group)
-    await db.session.commit()
+    plain_group = await OktaGroupFactory.create_async(name=legacy_name)
     plain_group_id = plain_group.id
 
     # A pre-existing AppGroup attached to a *different* app that also collides — it
     # should be reattached to the new app.
-    other_app = AppFactory.create()
-    db.session.add(other_app)
-    await db.session.commit()
-    other_app_group = AppGroupFactory.create(app_id=other_app.id, name=shared_name, is_owner=False)
-    db.session.add(other_app_group)
-    await db.session.commit()
+    other_app = await AppFactory.create_async()
+    other_app_group = await AppGroupFactory.create_async(app_id=other_app.id, name=shared_name, is_owner=False)
     other_app_group_id = other_app_group.id
 
     apps_url = url_for("api-apps.apps")
@@ -964,9 +944,7 @@ async def test_create_app_succeeds_with_empty_preexisting_owner_group(
         f"{AppGroup.APP_GROUP_NAME_PREFIX}Payments"
         f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
     )
-    empty_group = OktaGroupFactory.create(name=owner_group_name)
-    db.session.add(empty_group)
-    await db.session.commit()
+    await OktaGroupFactory.create_async(name=owner_group_name)
 
     apps_url = url_for("api-apps.apps")
     rep = await client.post(apps_url, json={"name": "Payments"})
@@ -1092,10 +1070,8 @@ async def test_post_app_require_descriptions_enforced_via_http(
 
 async def test_get_apps_q_via_http(client: AsyncClient, db: Db, url_for: Any) -> None:
     """`q` is honored end-to-end on /api/apps."""
-    a1 = AppFactory.create(name="ZelaPaymentsApp", description="Handles money flows")
-    a2 = AppFactory.create(name="LoggingApp", description="Stores logs")
-    db.session.add_all([a1, a2])
-    await db.session.commit()
+    await AppFactory.create_async(name="ZelaPaymentsApp", description="Handles money flows")
+    await AppFactory.create_async(name="LoggingApp", description="Stores logs")
 
     apps_url = url_for("api-apps.apps")
     rep = await client.get(apps_url, params={"q": "ZelaPayments"})

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -23,7 +23,14 @@ from api.models import (
 )
 from api.operations import ModifyGroupUsers, ModifyRoleGroups
 from api.services import okta
-from tests.factories import AppFactory, AppGroupFactory, OktaGroupFactory, OktaUserFactory
+from tests.factories import (
+    AppFactory,
+    AppGroupFactory,
+    AppTagMapFactory,
+    OktaGroupFactory,
+    OktaUserFactory,
+    OktaUserGroupMemberFactory,
+)
 from tests.helpers import db_count
 from tests.request_factories import CreateAppBodyFactory, UpdateAppBodyFactory
 
@@ -377,9 +384,7 @@ async def test_delete_app(
     db.session.add(tag)
     await db.session.commit()
 
-    app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tag.id)
-    db.session.add(app_tag_map)
-    await db.session.commit()
+    app_tag_map = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tag.id)
     for app_group in app_groups:
         db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag.id, app_tag_map_id=app_tag_map.id))
     await db.session.commit()
@@ -928,11 +933,8 @@ async def test_create_app_fails_when_preexisting_owner_group_is_occupied(
         f"{AppGroup.APP_GROUP_NAME_PREFIX}Payments"
         f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
     )
-    squatted_group = OktaGroupFactory.create(name=owner_group_name)
-    db.session.add(squatted_group)
-    await db.session.commit()
-    db.session.add(OktaUserGroupMember(user_id=user.id, group_id=squatted_group.id, is_owner=True))
-    await db.session.commit()
+    squatted_group = await OktaGroupFactory.create_async(name=owner_group_name)
+    await OktaUserGroupMemberFactory.create_async(user_id=user.id, group_id=squatted_group.id, is_owner=True)
 
     apps_url = url_for("api-apps.apps")
     rep = await client.post(apps_url, json={"name": "Payments"})
@@ -1000,11 +1002,8 @@ async def test_create_app_succeeds_with_members_only_preexisting_owner_group(
         f"{AppGroup.APP_GROUP_NAME_PREFIX}Payments"
         f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
     )
-    group_with_members = OktaGroupFactory.create(name=owner_group_name)
-    db.session.add(group_with_members)
-    await db.session.commit()
-    db.session.add(OktaUserGroupMember(user_id=user.id, group_id=group_with_members.id, is_owner=False))
-    await db.session.commit()
+    group_with_members = await OktaGroupFactory.create_async(name=owner_group_name)
+    await OktaUserGroupMemberFactory.create_async(user_id=user.id, group_id=group_with_members.id, is_owner=False)
 
     apps_url = url_for("api-apps.apps")
     rep = await client.post(apps_url, json={"name": "Payments"})

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -16,7 +16,7 @@ from api.models import (
 )
 from api.extensions import Db
 from api.operations import ModifyGroupUsers, ModifyRoleGroups
-from tests.factories import OktaGroupFactory, OktaUserFactory, RoleGroupFactory
+from tests.factories import OktaGroupFactory, OktaGroupTagMapFactory, OktaUserFactory, RoleGroupFactory
 from typing import Any
 
 
@@ -108,8 +108,7 @@ async def test_user_audit_row_includes_group_active_group_tags(
     db.session.add(okta_group)
     db.session.add(tag)
     await db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tag.id)
     await ModifyGroupUsers(group=okta_group, members_to_add=[user.id], sync_to_okta=False).execute()
 
     rep = await client.get(url_for("api-audit.users_and_groups"), params={"user_id": user.id})

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -435,8 +435,8 @@ async def test_audit_users_default_order_is_newest_first(client: AsyncClient, db
     `order_desc=True`; the FastAPI Query Model mirrors that. Seed three
     rows with controlled `created_at` so a regression that flips the
     direction reliably fails this test."""
-    group = OktaGroupFactory.create()
-    u_old, u_mid, u_new = (OktaUserFactory.create() for _ in range(3))
+    group = OktaGroupFactory.build()
+    u_old, u_mid, u_new = (OktaUserFactory.build() for _ in range(3))
     db.session.add_all([group, u_old, u_mid, u_new])
     await db.session.commit()
     await ModifyGroupUsers(
@@ -469,8 +469,8 @@ async def test_audit_groups_default_order_is_newest_first(client: AsyncClient, d
     """Same direction-of-default contract as `users` — seed three
     `RoleGroupMap` rows at controlled `created_at` and confirm the
     response order is newest-first when no order params are provided."""
-    role = RoleGroupFactory.create()
-    g_old, g_mid, g_new = (OktaGroupFactory.create() for _ in range(3))
+    role = RoleGroupFactory.build()
+    g_old, g_mid, g_new = (OktaGroupFactory.build() for _ in range(3))
     db.session.add_all([role, g_old, g_mid, g_new])
     await db.session.commit()
     await ModifyRoleGroups(

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -5,9 +5,7 @@ from sqlalchemy import select
 from api.models import (
     App,
     AppGroup,
-    AppTagMap,
     OktaGroup,
-    OktaGroupTagMap,
     OktaUser,
     OktaUserGroupMember,
     RoleGroup,
@@ -16,7 +14,13 @@ from api.models import (
 )
 from api.extensions import Db
 from api.operations import ModifyGroupUsers, ModifyRoleGroups
-from tests.factories import OktaGroupFactory, OktaGroupTagMapFactory, OktaUserFactory, RoleGroupFactory
+from tests.factories import (
+    AppTagMapFactory,
+    OktaGroupFactory,
+    OktaGroupTagMapFactory,
+    OktaUserFactory,
+    RoleGroupFactory,
+)
 from typing import Any
 
 
@@ -218,13 +222,10 @@ async def test_get_group_audit(
     db.session.add(app_group)
     await db.session.commit()
 
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tag.id))
-    app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tag.id)
-    db.session.add(app_tag_map)
-    await db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag.id, app_tag_map_id=app_tag_map.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tag.id)
+    await OktaGroupTagMapFactory.create_async(group_id=role_group.id, tag_id=tag.id)
+    app_tag_map = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tag.id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tag.id, app_tag_map_id=app_tag_map.id)
 
     await ModifyGroupUsers(
         group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
@@ -503,11 +504,9 @@ async def test_users_audit_q_with_user_id_searches_only_groups(client: AsyncClie
     """When `user_id` is pinned, the free-text `q` filter must narrow to
     *group* columns only — `?user_id=...&q=Alice` should match group
     names but not user profile fields (the user is already pinned)."""
-    user = OktaUserFactory.create(email="alice@example.com", first_name="Alice", last_name="A")
-    matching_group = OktaGroupFactory.create(name="MatchableGroup", description="contains Alice")
-    other_group = OktaGroupFactory.create(name="UnrelatedGroup", description="no match")
-    db.session.add_all([user, matching_group, other_group])
-    await db.session.commit()
+    user = await OktaUserFactory.create_async(email="alice@example.com", first_name="Alice", last_name="A")
+    matching_group = await OktaGroupFactory.create_async(name="MatchableGroup", description="contains Alice")
+    other_group = await OktaGroupFactory.create_async(name="UnrelatedGroup", description="no match")
     await ModifyGroupUsers(group=matching_group, members_to_add=[user.id], sync_to_okta=False).execute()
     await ModifyGroupUsers(group=other_group, members_to_add=[user.id], sync_to_okta=False).execute()
 
@@ -526,11 +525,9 @@ async def test_users_audit_q_with_group_id_searches_only_users(client: AsyncClie
     """Symmetric: with `group_id` set, `q` must restrict to user columns
     so the response excludes memberships whose user doesn't match — even
     if the group name does."""
-    matching_user = OktaUserFactory.create(email="zlatan@example.com", first_name="Zlatan")
-    other_user = OktaUserFactory.create(email="other@example.com", first_name="Other")
-    group = OktaGroupFactory.create(name="GroupZlatan", description="zlatan-themed")
-    db.session.add_all([matching_user, other_user, group])
-    await db.session.commit()
+    matching_user = await OktaUserFactory.create_async(email="zlatan@example.com", first_name="Zlatan")
+    other_user = await OktaUserFactory.create_async(email="other@example.com", first_name="Other")
+    group = await OktaGroupFactory.create_async(name="GroupZlatan", description="zlatan-themed")
     await ModifyGroupUsers(group=group, members_to_add=[matching_user.id, other_user.id], sync_to_okta=False).execute()
 
     rep = await client.get(url_for("api-audit.users_and_groups"), params={"group_id": group.id, "q": "zlatan"})
@@ -544,11 +541,9 @@ async def test_users_audit_q_with_group_id_searches_only_users(client: AsyncClie
 async def test_groups_audit_q_with_role_id_searches_only_groups(client: AsyncClient, db: Db, url_for: Any) -> None:
     """When `role_id` is set on /api/audit/groups, `q` must restrict to
     the *associated group* columns and ignore the role columns."""
-    role = RoleGroupFactory.create(name="ZebraRole")
-    matching_group = OktaGroupFactory.create(name="ZebraStripeGroup")
-    other_group = OktaGroupFactory.create(name="UnrelatedGroup")
-    db.session.add_all([role, matching_group, other_group])
-    await db.session.commit()
+    role = await RoleGroupFactory.create_async(name="ZebraRole")
+    matching_group = await OktaGroupFactory.create_async(name="ZebraStripeGroup")
+    other_group = await OktaGroupFactory.create_async(name="UnrelatedGroup")
     await ModifyRoleGroups(
         role_group=role,
         groups_to_add=[matching_group.id, other_group.id],
@@ -570,11 +565,9 @@ async def test_users_audit_owner_id_excludes_owner_self_membership(client: Async
     exclude the owner's own memberships. The frontend's "expiring access"
     review surface is meant to show *other* users' access the owner owes
     a renewal on, not the owner's own."""
-    owner = OktaUserFactory.create(email="own@example.com")
-    other = OktaUserFactory.create(email="other@example.com")
-    group = OktaGroupFactory.create(name="OwnedGroup")
-    db.session.add_all([owner, other, group])
-    await db.session.commit()
+    owner = await OktaUserFactory.create_async(email="own@example.com")
+    other = await OktaUserFactory.create_async(email="other@example.com")
+    group = await OktaGroupFactory.create_async(name="OwnedGroup")
     # Owner is owner of group; owner is also a regular member of the same
     # group; another user is also a member.
     await ModifyGroupUsers(
@@ -599,11 +592,9 @@ async def test_users_audit_includes_role_associated_group_mappings_when_unfilter
     RoleGroup must surface `active_role_associated_group_member_mappings`
     and `active_role_associated_group_owner_mappings` so the React UI can
     render the role's associated-groups rollup."""
-    role = RoleGroupFactory.create(name="UnfilteredRole")
-    associated = OktaGroupFactory.create(name="UnfilteredAssociatedGroup")
-    user = OktaUserFactory.create()
-    db.session.add_all([role, associated, user])
-    await db.session.commit()
+    role = await RoleGroupFactory.create_async(name="UnfilteredRole")
+    associated = await OktaGroupFactory.create_async(name="UnfilteredAssociatedGroup")
+    user = await OktaUserFactory.create_async()
     await ModifyRoleGroups(role_group=role, groups_to_add=[associated.id], sync_to_okta=False).execute()
     await ModifyGroupUsers(group=role, members_to_add=[user.id], sync_to_okta=False).execute()
 
@@ -630,11 +621,9 @@ async def test_users_audit_omits_role_associated_group_mappings_when_user_filter
     must be suppressed on the response (eager-loading them under a
     polymorphic `with_polymorphic` query is unstable). The serializer
     must not attach those fields in this mode."""
-    role = RoleGroupFactory.create(name="FilteredRole")
-    associated = OktaGroupFactory.create(name="FilteredAssociatedGroup")
-    user = OktaUserFactory.create()
-    db.session.add_all([role, associated, user])
-    await db.session.commit()
+    role = await RoleGroupFactory.create_async(name="FilteredRole")
+    associated = await OktaGroupFactory.create_async(name="FilteredAssociatedGroup")
+    user = await OktaUserFactory.create_async()
     await ModifyRoleGroups(role_group=role, groups_to_add=[associated.id], sync_to_okta=False).execute()
     await ModifyGroupUsers(group=role, members_to_add=[user.id], sync_to_okta=False).execute()
 
@@ -655,11 +644,9 @@ async def test_users_audit_direct_flag_reorders(client: AsyncClient, db: Db, url
     supplied, the order_by re-applies using the email/created_at compound
     shape: with `?direct=true&order_by=moniker`, rows come back ordered
     by lowercased email asc rather than insertion order."""
-    group = OktaGroupFactory.create()
-    u_z = OktaUserFactory.create(email="zara@example.com")
-    u_a = OktaUserFactory.create(email="alpha@example.com")
-    db.session.add_all([group, u_a, u_z])
-    await db.session.commit()
+    group = await OktaGroupFactory.create_async()
+    u_z = await OktaUserFactory.create_async(email="zara@example.com")
+    u_a = await OktaUserFactory.create_async(email="alpha@example.com")
     # Insert in non-alphabetical order so a default unordered query would
     # surface them in insertion order rather than sorted.
     await ModifyGroupUsers(group=group, members_to_add=[u_z.id], sync_to_okta=False).execute()
@@ -683,11 +670,9 @@ async def test_users_audit_q_with_user_and_owner_pin_ands_narrow_and_broad(
     """`user_id` + `owner_id` pinned: the narrow group-only `q` filter
     AND-applies on top of the broad either-side filter. A search term that
     matches user columns but no group columns must return zero rows."""
-    user = OktaUserFactory.create(email="zzqterm@example.com", first_name="Zzqterm", last_name="Doe")
-    owner = OktaUserFactory.create(email="owner-pin@example.com", first_name="Pin", last_name="Owner")
-    group = OktaGroupFactory.create(name="GroupA", description="alpha")
-    db.session.add_all([user, owner, group])
-    await db.session.commit()
+    user = await OktaUserFactory.create_async(email="zzqterm@example.com", first_name="Zzqterm", last_name="Doe")
+    owner = await OktaUserFactory.create_async(email="owner-pin@example.com", first_name="Pin", last_name="Owner")
+    group = await OktaGroupFactory.create_async(name="GroupA", description="alpha")
     await ModifyGroupUsers(
         group=group,
         members_to_add=[user.id],
@@ -710,10 +695,8 @@ async def test_users_audit_q_with_user_and_group_pin_ands_both_narrow_filters(
     """`user_id` + `group_id` pinned: both narrow filters compose. A `q`
     that matches user columns but no group columns must filter out the
     pinned row."""
-    user = OktaUserFactory.create(email="qtfirst@example.com", first_name="Qtfirst", last_name="X")
-    group = OktaGroupFactory.create(name="GroupBeta", description="beta")
-    db.session.add_all([user, group])
-    await db.session.commit()
+    user = await OktaUserFactory.create_async(email="qtfirst@example.com", first_name="Qtfirst", last_name="X")
+    group = await OktaGroupFactory.create_async(name="GroupBeta", description="beta")
     await ModifyGroupUsers(group=group, members_to_add=[user.id], sync_to_okta=False).execute()
 
     rep = await client.get(
@@ -730,11 +713,9 @@ async def test_groups_audit_q_with_role_and_owner_pin(client: AsyncClient, db: D
     associated-group `q` filter AND-applies on top of the broad either-side
     filter. A `q` that matches role columns but no group columns must
     return zero rows."""
-    role = RoleGroupFactory.create(name="ZqxRole", description="zqx-only-role")
-    associated = OktaGroupFactory.create(name="GroupGamma", description="gamma")
-    owner = OktaUserFactory.create(email="role-pin-owner@example.com", first_name="Pin", last_name="Owner")
-    db.session.add_all([role, associated, owner])
-    await db.session.commit()
+    role = await RoleGroupFactory.create_async(name="ZqxRole", description="zqx-only-role")
+    associated = await OktaGroupFactory.create_async(name="GroupGamma", description="gamma")
+    owner = await OktaUserFactory.create_async(email="role-pin-owner@example.com", first_name="Pin", last_name="Owner")
     await ModifyRoleGroups(role_group=role, groups_to_add=[associated.id], sync_to_okta=False).execute()
     await ModifyGroupUsers(group=associated, owners_to_add=[owner.id], sync_to_okta=False).execute()
 
@@ -753,10 +734,8 @@ async def test_users_audit_returns_rows_when_user_is_soft_deleted(client: AsyncC
     eager-loaded `OktaUserGroupMember.active_user`, whose relationship carries
     `innerjoin=True` + `deleted_at IS NULL`, so SQLAlchemy emitted an INNER
     JOIN that silently dropped the row for any soft-deleted user."""
-    group = OktaGroupFactory.create()
-    user = OktaUserFactory.create()
-    db.session.add_all([group, user])
-    await db.session.commit()
+    group = await OktaGroupFactory.create_async()
+    user = await OktaUserFactory.create_async()
     await ModifyGroupUsers(group=group, members_to_add=[user.id], sync_to_okta=False).execute()
 
     user.deleted_at = datetime.now(timezone.utc)
@@ -782,10 +761,8 @@ async def test_groups_audit_returns_rows_when_role_group_is_soft_deleted(
     `joinedload(RoleGroupMap.active_role_group)`, and that relationship has
     the same `innerjoin=True` + `deleted_at IS NULL` shape, so audit rows
     were silently dropped when the role group was soft-deleted."""
-    role = RoleGroupFactory.create()
-    group = OktaGroupFactory.create()
-    db.session.add_all([role, group])
-    await db.session.commit()
+    role = await RoleGroupFactory.create_async()
+    group = await OktaGroupFactory.create_async()
     await ModifyRoleGroups(role_group=role, groups_to_add=[group.id], sync_to_okta=False).execute()
 
     role.deleted_at = datetime.now(timezone.utc)

--- a/tests/test_deferred_fan_out.py
+++ b/tests/test_deferred_fan_out.py
@@ -336,9 +336,8 @@ async def test_deferred_group_request_created_notification_reads_requested_app(
     """A deferred `access_group_request_created` hook may read the group
     request's `requested_app`, so the App must be expunged with the rest of the
     payload — left attached, `db.expire_all()` expires it and the read raises."""
-    app_obj = AppFactory.create()
+    app_obj = await AppFactory.create_async()
     db.session.add(user)
-    db.session.add(app_obj)
     await db.session.commit()
     # The requester must not be an app manager, or the request auto-approves
     # and no `access_group_request_created` notification fires.

--- a/tests/test_disallow_self_add_constraint.py
+++ b/tests/test_disallow_self_add_constraint.py
@@ -11,9 +11,7 @@ from api.extensions import Db
 from api.models import (
     App,
     AppGroup,
-    AppTagMap,
     OktaGroup,
-    OktaGroupTagMap,
     OktaUser,
     OktaUserGroupMember,
     RoleGroup,
@@ -23,7 +21,13 @@ from api.models import (
 from api.operations import ModifyGroupUsers, ModifyRoleGroups
 from api.services import okta
 from tests.helpers import db_count
-from tests.factories import OktaUserFactory, RoleGroupFactory, TagFactory
+from tests.factories import (
+    AppTagMapFactory,
+    OktaGroupTagMapFactory,
+    OktaUserFactory,
+    RoleGroupFactory,
+    TagFactory,
+)
 
 
 async def test_disallow_self_add_modify_group_users(
@@ -81,17 +85,13 @@ async def test_disallow_self_add_modify_group_users(
         sync_to_okta=False,
     ).execute()
 
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tags[0].id))
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tags[2].id))
-    db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[2].id))
-    app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tags[1].id)
-    db.session.add(app_tag_map)
-    app_tag_map2 = AppTagMap(app_id=access_app.id, tag_id=tags[2].id)
-    db.session.add(app_tag_map2)
-    await db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[1].id, app_tag_map_id=app_tag_map.id))
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tags[0].id)
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tags[2].id)
+    await OktaGroupTagMapFactory.create_async(group_id=role_group.id, tag_id=tags[2].id)
+    app_tag_map = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tags[1].id)
+    app_tag_map2 = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tags[2].id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tags[1].id, app_tag_map_id=app_tag_map.id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id)
 
     add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
     remove_user_from_group_spy = mocker.patch.object(okta, "remove_user_from_group")
@@ -551,18 +551,14 @@ async def test_disallow_self_add_modify_role_groups(
         group=role_groups[1], members_to_add=[user.id], owners_to_add=[], sync_to_okta=False
     ).execute()
 
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tags[0].id))
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tags[2].id))
-    db.session.add(OktaGroupTagMap(group_id=role_groups[0].id, tag_id=tags[2].id))
-    db.session.add(OktaGroupTagMap(group_id=role_groups[1].id, tag_id=tags[2].id))
-    app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tags[1].id)
-    db.session.add(app_tag_map)
-    app_tag_map2 = AppTagMap(app_id=access_app.id, tag_id=tags[2].id)
-    db.session.add(app_tag_map2)
-    await db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[1].id, app_tag_map_id=app_tag_map.id))
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tags[0].id)
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tags[2].id)
+    await OktaGroupTagMapFactory.create_async(group_id=role_groups[0].id, tag_id=tags[2].id)
+    await OktaGroupTagMapFactory.create_async(group_id=role_groups[1].id, tag_id=tags[2].id)
+    app_tag_map = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tags[1].id)
+    app_tag_map2 = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tags[2].id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tags[1].id, app_tag_map_id=app_tag_map.id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id)
 
     add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
     remove_user_from_group_spy = mocker.patch.object(okta, "remove_user_from_group")
@@ -1253,17 +1249,13 @@ async def test_disallow_self_add_admin_modify_group_users(
         sync_to_okta=False,
     ).execute()
 
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tags[0].id))
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tags[2].id))
-    db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[2].id))
-    app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tags[1].id)
-    db.session.add(app_tag_map)
-    app_tag_map2 = AppTagMap(app_id=access_app.id, tag_id=tags[2].id)
-    db.session.add(app_tag_map2)
-    await db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[1].id, app_tag_map_id=app_tag_map.id))
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tags[0].id)
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tags[2].id)
+    await OktaGroupTagMapFactory.create_async(group_id=role_group.id, tag_id=tags[2].id)
+    app_tag_map = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tags[1].id)
+    app_tag_map2 = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tags[2].id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tags[1].id, app_tag_map_id=app_tag_map.id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id)
 
     add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
     remove_user_from_group_spy = mocker.patch.object(okta, "remove_user_from_group")
@@ -1812,18 +1804,14 @@ async def test_disallow_self_add_admin_modify_role_groups(
         group=role_groups[1], members_to_add=[user.id], owners_to_add=[], sync_to_okta=False
     ).execute()
 
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tags[0].id))
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tags[2].id))
-    db.session.add(OktaGroupTagMap(group_id=role_groups[0].id, tag_id=tags[2].id))
-    db.session.add(OktaGroupTagMap(group_id=role_groups[1].id, tag_id=tags[2].id))
-    app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tags[1].id)
-    db.session.add(app_tag_map)
-    app_tag_map2 = AppTagMap(app_id=access_app.id, tag_id=tags[2].id)
-    db.session.add(app_tag_map2)
-    await db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[1].id, app_tag_map_id=app_tag_map.id))
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tags[0].id)
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tags[2].id)
+    await OktaGroupTagMapFactory.create_async(group_id=role_groups[0].id, tag_id=tags[2].id)
+    await OktaGroupTagMapFactory.create_async(group_id=role_groups[1].id, tag_id=tags[2].id)
+    app_tag_map = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tags[1].id)
+    app_tag_map2 = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tags[2].id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tags[1].id, app_tag_map_id=app_tag_map.id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id)
 
     add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
     remove_user_from_group_spy = mocker.patch.object(okta, "remove_user_from_group")
@@ -2476,8 +2464,7 @@ async def test_disallow_self_add_membership_blocks_direct_modify_group_users(
     )
     db.session.add_all([okta_group, current_user, tag])
     await db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tag.id)
 
     mocker.patch.object(okta, "add_user_to_group")
     mocker.patch.object(okta, "add_owner_to_group")

--- a/tests/test_disallow_self_add_constraint.py
+++ b/tests/test_disallow_self_add_constraint.py
@@ -42,10 +42,10 @@ async def test_disallow_self_add_modify_group_users(
     user: OktaUser,
     url_for: Any,
 ) -> None:
-    current_user = OktaUserFactory.create()
+    current_user = OktaUserFactory.build()
     app.state.current_user_email = current_user.email
 
-    tags = TagFactory.create_batch(
+    tags = TagFactory.batch(
         3,
         constraints={
             Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY: True,
@@ -511,12 +511,12 @@ async def test_disallow_self_add_modify_role_groups(
     user: OktaUser,
     url_for: Any,
 ) -> None:
-    current_user = OktaUserFactory.create()
+    current_user = OktaUserFactory.build()
     app.state.current_user_email = current_user.email
 
-    role_groups = RoleGroupFactory.create_batch(2)
+    role_groups = RoleGroupFactory.batch(2)
 
-    tags = TagFactory.create_batch(
+    tags = TagFactory.batch(
         3,
         constraints={
             Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY: True,
@@ -1210,7 +1210,7 @@ async def test_disallow_self_add_admin_modify_group_users(
         await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
     ).first()
 
-    tags = TagFactory.create_batch(
+    tags = TagFactory.batch(
         3,
         constraints={
             Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY: True,
@@ -1768,9 +1768,9 @@ async def test_disallow_self_add_admin_modify_role_groups(
         await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
     ).first()
 
-    role_groups = RoleGroupFactory.create_batch(2)
+    role_groups = RoleGroupFactory.batch(2)
 
-    tags = TagFactory.create_batch(
+    tags = TagFactory.batch(
         3,
         constraints={
             Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY: True,
@@ -2455,8 +2455,8 @@ async def test_disallow_self_add_membership_blocks_direct_modify_group_users(
     `DISALLOW_SELF_ADD_MEMBERSHIP` is blocked, with nothing added. The router
     path is covered above; this drives the operation directly, which is where
     the membership id list feeds `CheckForSelfAdd`."""
-    current_user = OktaUserFactory.create()
-    tag = TagFactory.create(
+    current_user = OktaUserFactory.build()
+    tag = TagFactory.build(
         constraints={
             Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY: True,
             Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY: False,

--- a/tests/test_expiring_access_notifications.py
+++ b/tests/test_expiring_access_notifications.py
@@ -709,11 +709,11 @@ async def test_owner_expiring_access_notifications_managed_group_admin(
     db: Db, app: FastAPI, mocker: MockerFixture
 ) -> None:
     # Create an externally managed group and an Access managed group
-    group1 = OktaGroupFactory.create()
+    group1 = OktaGroupFactory.build()
     group1.is_managed = False
-    group2 = OktaGroupFactory.create()
+    group2 = OktaGroupFactory.build()
 
-    user = OktaUserFactory.create()
+    user = OktaUserFactory.build()
     access_owner = (
         await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
     ).first()

--- a/tests/test_expiring_access_notifications.py
+++ b/tests/test_expiring_access_notifications.py
@@ -180,19 +180,12 @@ async def test_individual_expiring_direct_with_role_week(
 
 # Test with one owner who owns two groups, each group has a member whose access expires this week
 async def test_owner_expiring_access_notifications(db: Db, mocker: MockerFixture) -> None:
-    group1 = OktaGroupFactory.create()
-    group2 = OktaGroupFactory.create()
-    user1 = OktaUserFactory.create()
-    user2 = OktaUserFactory.create()
-    owner = OktaUserFactory.create()
+    group1 = await OktaGroupFactory.create_async()
+    group2 = await OktaGroupFactory.create_async()
+    user1 = await OktaUserFactory.create_async()
+    user2 = await OktaUserFactory.create_async()
+    owner = await OktaUserFactory.create_async()
     expiration_datetime = datetime.now() + timedelta(days=2)
-
-    db.session.add(group1)
-    db.session.add(group2)
-    db.session.add(user1)
-    db.session.add(user2)
-    db.session.add(owner)
-    await db.session.commit()
 
     await ModifyGroupUsers(
         group=group1, users_added_ended_at=expiration_datetime, members_to_add=[user1.id], sync_to_okta=False
@@ -233,13 +226,9 @@ async def test_owner_expiring_access_notifications(db: Db, mocker: MockerFixture
 
 # Test with one owner who owns one group, the owner is a member of the group and their access is expiring this week
 async def test_owner_expiring_access_notifications_owner_only_member(db: Db, mocker: MockerFixture) -> None:
-    group = OktaGroupFactory.create()
-    owner = OktaUserFactory.create()
+    group = await OktaGroupFactory.create_async()
+    owner = await OktaUserFactory.create_async()
     expiration_datetime = datetime.now() + timedelta(days=2)
-
-    db.session.add(group)
-    db.session.add(owner)
-    await db.session.commit()
 
     await ModifyGroupUsers(
         group=group, users_added_ended_at=expiration_datetime, members_to_add=[owner.id], sync_to_okta=False
@@ -257,19 +246,12 @@ async def test_owner_expiring_access_notifications_owner_only_member(db: Db, moc
 # Test with one owner who owns two groups, each group has a member whose access expires this week
 # The owner is also a group member with expiring access but their own access should not be included.
 async def test_owner_expiring_access_notifications_owner_member(db: Db, mocker: MockerFixture) -> None:
-    group1 = OktaGroupFactory.create()
-    group2 = OktaGroupFactory.create()
-    user1 = OktaUserFactory.create()
-    user2 = OktaUserFactory.create()
-    owner = OktaUserFactory.create()
+    group1 = await OktaGroupFactory.create_async()
+    group2 = await OktaGroupFactory.create_async()
+    user1 = await OktaUserFactory.create_async()
+    user2 = await OktaUserFactory.create_async()
+    owner = await OktaUserFactory.create_async()
     expiration_datetime = datetime.now() + timedelta(days=2)
-
-    db.session.add(group1)
-    db.session.add(group2)
-    db.session.add(user1)
-    db.session.add(user2)
-    db.session.add(owner)
-    await db.session.commit()
 
     await ModifyGroupUsers(
         group=group1, users_added_ended_at=expiration_datetime, members_to_add=[user1.id, owner.id], sync_to_okta=False
@@ -318,19 +300,12 @@ async def test_owner_expiring_access_notifications_owner_member(db: Db, mocker: 
 
 # Test with one owner who owns two groups, each group has a member whose access expires next week
 async def test_owner_expiring_access_notifications_week(db: Db, mocker: MockerFixture) -> None:
-    group1 = OktaGroupFactory.create()
-    group2 = OktaGroupFactory.create()
-    user1 = OktaUserFactory.create()
-    user2 = OktaUserFactory.create()
-    owner = OktaUserFactory.create()
+    group1 = await OktaGroupFactory.create_async()
+    group2 = await OktaGroupFactory.create_async()
+    user1 = await OktaUserFactory.create_async()
+    user2 = await OktaUserFactory.create_async()
+    owner = await OktaUserFactory.create_async()
     expiration_datetime = datetime.now() + timedelta(days=9)
-
-    db.session.add(group1)
-    db.session.add(group2)
-    db.session.add(user1)
-    db.session.add(user2)
-    db.session.add(owner)
-    await db.session.commit()
 
     await ModifyGroupUsers(
         group=group1, users_added_ended_at=expiration_datetime, members_to_add=[user1.id], sync_to_okta=False
@@ -371,13 +346,9 @@ async def test_owner_expiring_access_notifications_week(db: Db, mocker: MockerFi
 
 # Test with one owner who owns one group, the owner is a member of the group and their access is expiring next week
 async def test_owner_expiring_access_notifications_owner_only_member_week(db: Db, mocker: MockerFixture) -> None:
-    group = OktaGroupFactory.create()
-    owner = OktaUserFactory.create()
+    group = await OktaGroupFactory.create_async()
+    owner = await OktaUserFactory.create_async()
     expiration_datetime = datetime.now() + timedelta(days=9)
-
-    db.session.add(group)
-    db.session.add(owner)
-    await db.session.commit()
 
     await ModifyGroupUsers(
         group=group, users_added_ended_at=expiration_datetime, members_to_add=[owner.id], sync_to_okta=False
@@ -395,19 +366,12 @@ async def test_owner_expiring_access_notifications_owner_only_member_week(db: Db
 # Test with one owner who owns two groups, each group has a member whose access expires next week
 # The owner is also a group member with expiring access but their own access should not be included.
 async def test_owner_expiring_access_notifications_owner_member_week(db: Db, mocker: MockerFixture) -> None:
-    group1 = OktaGroupFactory.create()
-    group2 = OktaGroupFactory.create()
-    user1 = OktaUserFactory.create()
-    user2 = OktaUserFactory.create()
-    owner = OktaUserFactory.create()
+    group1 = await OktaGroupFactory.create_async()
+    group2 = await OktaGroupFactory.create_async()
+    user1 = await OktaUserFactory.create_async()
+    user2 = await OktaUserFactory.create_async()
+    owner = await OktaUserFactory.create_async()
     expiration_datetime = datetime.now() + timedelta(days=9)
-
-    db.session.add(group1)
-    db.session.add(group2)
-    db.session.add(user1)
-    db.session.add(user2)
-    db.session.add(owner)
-    await db.session.commit()
 
     await ModifyGroupUsers(
         group=group1, users_added_ended_at=expiration_datetime, members_to_add=[user1.id, owner.id], sync_to_okta=False
@@ -456,17 +420,11 @@ async def test_owner_expiring_access_notifications_owner_member_week(db: Db, moc
 
 # Test with one owner who owns a groups, the group has a role member whose access expires this week
 async def test_owner_expiring_access_notifications_role(db: Db, mocker: MockerFixture) -> None:
-    group1 = RoleGroupFactory.create()
-    group2 = OktaGroupFactory.create()
-    user1 = OktaUserFactory.create()
-    owner = OktaUserFactory.create()
+    group1 = await RoleGroupFactory.create_async()
+    group2 = await OktaGroupFactory.create_async()
+    user1 = await OktaUserFactory.create_async()
+    owner = await OktaUserFactory.create_async()
     expiration_datetime = datetime.now() + timedelta(days=2)
-
-    db.session.add(group1)
-    db.session.add(group2)
-    db.session.add(user1)
-    db.session.add(owner)
-    await db.session.commit()
 
     await ModifyGroupUsers(
         group=group1, users_added_ended_at=None, members_to_add=[user1.id], sync_to_okta=False
@@ -497,19 +455,12 @@ async def test_owner_expiring_access_notifications_role(db: Db, mocker: MockerFi
 
 # Test with one owner who owns two groups, each group has a role member whose access expires next week
 async def test_owner_expiring_access_notifications_role_week(db: Db, mocker: MockerFixture) -> None:
-    role = RoleGroupFactory.create()
-    group1 = OktaGroupFactory.create()
-    group2 = OktaGroupFactory.create()
-    user1 = OktaUserFactory.create()
-    owner = OktaUserFactory.create()
+    role = await RoleGroupFactory.create_async()
+    group1 = await OktaGroupFactory.create_async()
+    group2 = await OktaGroupFactory.create_async()
+    user1 = await OktaUserFactory.create_async()
+    owner = await OktaUserFactory.create_async()
     expiration_datetime = datetime.now() + timedelta(days=9)
-
-    db.session.add(role)
-    db.session.add(group1)
-    db.session.add(group2)
-    db.session.add(user1)
-    db.session.add(owner)
-    await db.session.commit()
 
     await ModifyGroupUsers(
         group=role, users_added_ended_at=None, members_to_add=[user1.id], sync_to_okta=False
@@ -596,14 +547,12 @@ async def test_individual_do_not_renew_notification_behavior(
 async def test_owner_role_do_not_renew_notification_behavior(
     db: Db, mocker: MockerFixture, role_group: RoleGroup, okta_group: OktaGroup
 ) -> None:
-    user1 = OktaUserFactory.create()
-    owner = OktaUserFactory.create()
+    user1 = await OktaUserFactory.create_async()
+    owner = await OktaUserFactory.create_async()
     expiration_datetime = datetime.now() + timedelta(days=2)
 
     db.session.add(role_group)
     db.session.add(okta_group)
-    db.session.add(user1)
-    db.session.add(owner)
     await db.session.commit()
 
     await ModifyGroupUsers(
@@ -657,19 +606,12 @@ async def test_owner_role_do_not_renew_notification_behavior(
 
 # Test with one owner who owns two role, each role is a member of a group and its access expires tomorrow
 async def test_role_owner_expiring_access_notifications_role_tomorrow(db: Db, mocker: MockerFixture) -> None:
-    role1 = RoleGroupFactory.create()
-    role2 = RoleGroupFactory.create()
-    group = OktaGroupFactory.create()
-    user1 = OktaUserFactory.create()
-    owner = OktaUserFactory.create()
+    role1 = await RoleGroupFactory.create_async()
+    role2 = await RoleGroupFactory.create_async()
+    group = await OktaGroupFactory.create_async()
+    await OktaUserFactory.create_async()
+    owner = await OktaUserFactory.create_async()
     expiration_datetime = datetime.now() + timedelta(days=1)
-
-    db.session.add(role1)
-    db.session.add(role2)
-    db.session.add(group)
-    db.session.add(user1)
-    db.session.add(owner)
-    await db.session.commit()
 
     await ModifyGroupUsers(group=role1, owners_to_add=[owner.id], sync_to_okta=False).execute()
     await ModifyGroupUsers(group=role2, owners_to_add=[owner.id], sync_to_okta=False).execute()
@@ -710,22 +652,14 @@ async def test_role_owner_expiring_access_notifications_role_tomorrow(db: Db, mo
 # Test with one owner who owns two role, each role is a member of one or more groups and its
 # access expires tomorrow or next week
 async def test_role_owner_expiring_access_notifications_role_multiple_dates(db: Db, mocker: MockerFixture) -> None:
-    role1 = RoleGroupFactory.create()
-    role2 = RoleGroupFactory.create()
-    group1 = OktaGroupFactory.create()
-    group2 = OktaGroupFactory.create()
-    user1 = OktaUserFactory.create()
-    owner = OktaUserFactory.create()
+    role1 = await RoleGroupFactory.create_async()
+    role2 = await RoleGroupFactory.create_async()
+    group1 = await OktaGroupFactory.create_async()
+    group2 = await OktaGroupFactory.create_async()
+    await OktaUserFactory.create_async()
+    owner = await OktaUserFactory.create_async()
     expiration_datetime = datetime.now() + timedelta(days=1)
     expiration_datetime2 = datetime.now() + timedelta(weeks=1)
-
-    db.session.add(role1)
-    db.session.add(role2)
-    db.session.add(group1)
-    db.session.add(group2)
-    db.session.add(user1)
-    db.session.add(owner)
-    await db.session.commit()
 
     await ModifyGroupUsers(group=role1, owners_to_add=[owner.id], sync_to_okta=False).execute()
     await ModifyGroupUsers(group=role2, owners_to_add=[owner.id], sync_to_okta=False).execute()
@@ -880,11 +814,9 @@ async def test_expiring_user_notification_hook_runs_on_loop_thread_with_usable_o
 async def test_expiring_owner_notification_hook_can_read_association_relationships(
     db: Db, mocker: MockerFixture
 ) -> None:
-    group = OktaGroupFactory.create()
-    member = OktaUserFactory.create()
-    owner = OktaUserFactory.create()
-    db.session.add_all([group, member, owner])
-    await db.session.commit()
+    group = await OktaGroupFactory.create_async()
+    member = await OktaUserFactory.create_async()
+    owner = await OktaUserFactory.create_async()
 
     await ModifyGroupUsers(
         group=group,
@@ -914,11 +846,9 @@ async def test_expiring_owner_notification_hook_can_read_association_relationshi
 async def test_expiring_role_owner_notification_hook_can_read_association_relationships(
     db: Db, mocker: MockerFixture
 ) -> None:
-    role = RoleGroupFactory.create()
-    group = OktaGroupFactory.create()
-    owner = OktaUserFactory.create()
-    db.session.add_all([role, group, owner])
-    await db.session.commit()
+    role = await RoleGroupFactory.create_async()
+    group = await OktaGroupFactory.create_async()
+    owner = await OktaUserFactory.create_async()
 
     await ModifyGroupUsers(group=role, owners_to_add=[owner.id], sync_to_okta=False).execute()
     await ModifyRoleGroups(
@@ -957,15 +887,12 @@ async def test_expiring_role_owner_notification_hook_can_read_association_relati
 async def test_owner_expiring_access_notifications_app_group_falls_back_to_app_managers(
     db: Db, mocker: MockerFixture
 ) -> None:
-    app = AppFactory.create()
-    owner_app_group = AppGroupFactory.create(app_id=app.id, is_owner=True)
-    member_app_group = AppGroupFactory.create(app_id=app.id, is_owner=False)
-    app_owner = OktaUserFactory.create()
-    member = OktaUserFactory.create()
+    app = await AppFactory.create_async()
+    owner_app_group = await AppGroupFactory.create_async(app_id=app.id, is_owner=True)
+    member_app_group = await AppGroupFactory.create_async(app_id=app.id, is_owner=False)
+    app_owner = await OktaUserFactory.create_async()
+    member = await OktaUserFactory.create_async()
     expiration_datetime = datetime.now() + timedelta(days=2)
-
-    db.session.add_all([app, owner_app_group, member_app_group, app_owner, member])
-    await db.session.commit()
 
     # app_owner administers the app by owning the app owner group.
     await ModifyGroupUsers(group=owner_app_group, owners_to_add=[app_owner.id], sync_to_okta=False).execute()

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -28,7 +28,16 @@ from api.models import (
 )
 from api.operations import CreateAccessRequest, ModifyGroupUsers, ModifyRoleGroups
 from api.services import okta
-from tests.factories import AppFactory, AppGroupFactory, OktaGroupFactory, OktaUserFactory, RoleGroupFactory
+from tests.factories import (
+    AppFactory,
+    AppGroupFactory,
+    AppTagMapFactory,
+    OktaGroupFactory,
+    OktaGroupTagMapFactory,
+    OktaUserFactory,
+    OktaUserGroupMemberFactory,
+    RoleGroupFactory,
+)
 from tests.helpers import db_count
 from tests.request_factories import (
     AppGroupCreateBodyFactory,
@@ -124,9 +133,7 @@ async def test_get_group_role_grants_do_not_reload_own_group(
     await db.session.commit()
 
     for _ in range(5):
-        granting_role = RoleGroupFactory.create()
-        db.session.add(granting_role)
-        await db.session.commit()
+        granting_role = await RoleGroupFactory.create_async()
         await ModifyRoleGroups(
             role_group=granting_role,
             groups_to_add=[app_group.id],
@@ -181,8 +188,7 @@ async def test_get_group_members(
     assert len(data["members"]) == 0
     assert len(data["owners"]) == 0
 
-    db.session.add(OktaUserGroupMember(user_id=user.id, group_id=okta_group.id))
-    await db.session.commit()
+    await OktaUserGroupMemberFactory.create_async(user_id=user.id, group_id=okta_group.id)
 
     group_url = url_for("api-groups.group_members_by_id", group_id=okta_group.id)
     rep = await client.get(group_url)
@@ -193,8 +199,7 @@ async def test_get_group_members(
     assert data["members"][0] == user.id
     assert len(data["owners"]) == 0
 
-    db.session.add(OktaUserGroupMember(user_id=user.id, group_id=okta_group.id, is_owner=True))
-    await db.session.commit()
+    await OktaUserGroupMemberFactory.create_async(user_id=user.id, group_id=okta_group.id, is_owner=True)
 
     group_url = url_for("api-groups.group_members_by_id", group_id=okta_group.id)
     rep = await client.get(group_url)
@@ -728,8 +733,7 @@ async def test_delete_group(
     # persistent fixture-loaded objects on the shared session.
     tag_id = tag.id
 
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag_id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tag_id)
 
     # test delete group
     delete_group_spy = mocker.patch.object(okta, "delete_group")
@@ -753,11 +757,8 @@ async def test_delete_group(
     db.session.add(app_group)
     await db.session.commit()
 
-    app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tag_id)
-    db.session.add(app_tag_map)
-    await db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag_id, app_tag_map_id=app_tag_map.id))
-    await db.session.commit()
+    app_tag_map = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tag_id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tag_id, app_tag_map_id=app_tag_map.id)
 
     access_request = await CreateAccessRequest(
         requester_user=user,
@@ -875,8 +876,7 @@ async def test_create_app_group(
     db.session.add(access_app)
     db.session.add(tag)
     await db.session.commit()
-    db.session.add(AppTagMap(app_id=access_app.id, tag_id=tag.id))
-    await db.session.commit()
+    await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tag.id)
 
     create_group_spy = mocker.patch.object(
         okta, "create_group", return_value=Group.from_dict({"id": cast(FakerWithPyStr, faker).pystr()})
@@ -990,11 +990,10 @@ async def test_get_all_group(client: AsyncClient, db: Db, access_app: App, url_f
 async def test_do_not_renew(
     db: Db, client: AsyncClient, mocker: MockerFixture, user: OktaUser, okta_group: OktaGroup, url_for: Any
 ) -> None:
-    user2 = OktaUserFactory.create()
+    user2 = await OktaUserFactory.create_async()
 
     db.session.add(okta_group)
     db.session.add(user)
-    db.session.add(user2)
     await db.session.commit()
 
     expiration_datetime = datetime.now() + timedelta(days=1)
@@ -1114,12 +1113,11 @@ async def test_do_not_renew_scoped_to_route_group(
     db: Db, client: AsyncClient, mocker: MockerFixture, user: OktaUser, okta_group: OktaGroup, url_for: Any
 ) -> None:
     victim_group = OktaGroup(id="victim-group-id", name="Victim-Group", type="okta_group")
-    victim_user = OktaUserFactory.create()
+    victim_user = await OktaUserFactory.create_async()
 
     db.session.add(okta_group)
     db.session.add(victim_group)
     db.session.add(user)
-    db.session.add(victim_user)
     await db.session.commit()
 
     expiration_datetime = datetime.now() + timedelta(days=1)
@@ -1825,9 +1823,7 @@ async def test_get_group_member_details_paginated(client: AsyncClient, db: Db, u
     """`GET /api/groups/{id}/member-details` returns full member rows paginated,
     so the group page can page members instead of inlining all of them. `owner`
     filters members vs owners."""
-    group = OktaGroupFactory.create()
-    db.session.add(group)
-    await db.session.commit()
+    group = await OktaGroupFactory.create_async()
 
     # Explicit, unique emails: the factory derives email from random Faker
     # names, so 60+ users can collide and trip the okta_user.email UNIQUE
@@ -1871,12 +1867,8 @@ async def test_get_group_omits_inline_members(client: AsyncClient, db: Db, url_f
     """`GET /api/groups/{id}` no longer inlines its members; the group page
     pages them via the member-details endpoint instead, so the detail response
     can't materialize an unbounded member list."""
-    group = OktaGroupFactory.create()
-    db.session.add(group)
-    await db.session.commit()
-    member = OktaUserFactory.create()
-    db.session.add(member)
-    await db.session.commit()
+    group = await OktaGroupFactory.create_async()
+    member = await OktaUserFactory.create_async()
     await ModifyGroupUsers(group=group, members_to_add=[member.id], sync_to_okta=False).execute()
 
     group_id = group.id
@@ -1929,9 +1921,7 @@ async def test_get_group_member_details_paginates_in_email_order(client: AsyncCl
     renders is continuous across pages instead of restarting A-Z on every page.
     User ids are assigned in reverse-email order to prove pages are ordered by
     email, not by the opaque user id."""
-    group = OktaGroupFactory.create()
-    db.session.add(group)
-    await db.session.commit()
+    group = await OktaGroupFactory.create_async()
 
     members = [OktaUserFactory.create(id=f"id-{59 - i:03d}", email=f"member-{i:03d}@example.com") for i in range(60)]
     for u in members:

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -408,15 +408,15 @@ async def test_put_app_group_rebind_authorization(
     app_group: AppGroup,
     url_for: Any,
 ) -> None:
-    source_app = AppFactory.create()
-    target_app = AppFactory.create()
-    source_app_owner_group = AppGroupFactory.create(
+    source_app = AppFactory.build()
+    target_app = AppFactory.build()
+    source_app_owner_group = AppGroupFactory.build(
         app_id=source_app.id,
         is_owner=True,
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{source_app.name}"
         f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
     )
-    target_app_owner_group = AppGroupFactory.create(
+    target_app_owner_group = AppGroupFactory.build(
         app_id=target_app.id,
         is_owner=True,
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{target_app.name}"
@@ -912,14 +912,14 @@ async def test_create_app_group_cannot_set_is_owner_shadow_escalation(
     ever appearing in the App-<app>-Owners member list.
     """
     # App "Foo" with its owner group, owned by non-admin Alice
-    foo = AppFactory.create()
-    owners_group = AppGroupFactory.create(
+    foo = AppFactory.build()
+    owners_group = AppGroupFactory.build(
         app_id=foo.id,
         is_owner=True,
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{foo.name}"
         f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
     )
-    alice = OktaUserFactory.create()
+    alice = OktaUserFactory.build()
     db.session.add_all([foo, owners_group, alice])
     await db.session.commit()
     foo_id = foo.id
@@ -961,10 +961,10 @@ async def test_get_all_group(client: AsyncClient, db: Db, access_app: App, url_f
     await db.session.commit()
 
     groups = []
-    groups.extend(OktaGroupFactory.create_batch(3))
-    app_groups = AppGroupFactory.create_batch(3, app_id=access_app.id)
+    groups.extend(OktaGroupFactory.batch(3))
+    app_groups = AppGroupFactory.batch(3, app_id=access_app.id)
     groups.extend(app_groups)
-    groups.extend(RoleGroupFactory.create_batch(3))
+    groups.extend(RoleGroupFactory.batch(3))
     db.session.add_all(groups)
     await db.session.commit()
 
@@ -1290,7 +1290,7 @@ async def test_cannot_convert_app_prefixed_group_to_non_app_type(
 ) -> None:
     mocker.patch.object(okta, "update_group")
 
-    app_group = AppGroupFactory.create(
+    app_group = AppGroupFactory.build(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{access_app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}Members",
         app_id=access_app.id,
         is_owner=False,
@@ -1438,8 +1438,8 @@ async def test_cannot_rename_app_group_to_non_conforming_name(
 ) -> None:
     mocker.patch.object(okta, "update_group")
 
-    target_app = AppFactory.create()
-    app_group = AppGroupFactory.create(
+    target_app = AppFactory.build()
+    app_group = AppGroupFactory.build(
         app_id=target_app.id,
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{target_app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}Conforming",
     )
@@ -1485,7 +1485,7 @@ async def test_convert_to_app_group_requires_app_name_prefix(
 ) -> None:
     mocker.patch.object(okta, "update_group")
 
-    okta_group = OktaGroupFactory.create(name="PlainGroup")
+    okta_group = OktaGroupFactory.build(name="PlainGroup")
     db.session.add_all([access_app, okta_group])
     await db.session.commit()
     app_name = access_app.name
@@ -1546,8 +1546,8 @@ async def test_legacy_non_conforming_app_group_tolerates_unchanged_name(
     the unchanged name (the frontend always sends `name`) must keep working."""
     mocker.patch.object(okta, "update_group")
 
-    target_app = AppFactory.create()
-    legacy_group = AppGroupFactory.create(app_id=target_app.id, name="App-SomethingElse-Group")
+    target_app = AppFactory.build()
+    legacy_group = AppGroupFactory.build(app_id=target_app.id, name="App-SomethingElse-Group")
     db.session.add_all([target_app, legacy_group])
     await db.session.commit()
     legacy_name = legacy_group.name
@@ -1580,7 +1580,7 @@ async def test_cannot_rename_non_app_group_to_app_prefix(
 ) -> None:
     mocker.patch.object(okta, "update_group")
 
-    okta_group = OktaGroupFactory.create(name="Payments-Owners")
+    okta_group = OktaGroupFactory.build(name="Payments-Owners")
     db.session.add(access_app)
     db.session.add(okta_group)
     await db.session.commit()
@@ -1649,7 +1649,7 @@ async def test_cannot_rename_non_role_group_to_role_prefix(
 ) -> None:
     mocker.patch.object(okta, "update_group")
 
-    okta_group = OktaGroupFactory.create(name="Some-Group")
+    okta_group = OktaGroupFactory.build(name="Some-Group")
     db.session.add(okta_group)
     await db.session.commit()
 
@@ -1679,7 +1679,7 @@ async def test_cannot_convert_role_prefixed_group_to_non_role_type(
 ) -> None:
     mocker.patch.object(okta, "update_group")
 
-    role_group = RoleGroupFactory.create(name=f"{RoleGroup.ROLE_GROUP_NAME_PREFIX}Admins")
+    role_group = RoleGroupFactory.build(name=f"{RoleGroup.ROLE_GROUP_NAME_PREFIX}Admins")
     db.session.add(role_group)
     await db.session.commit()
 
@@ -1828,8 +1828,8 @@ async def test_get_group_member_details_paginated(client: AsyncClient, db: Db, u
     # Explicit, unique emails: the factory derives email from random Faker
     # names, so 60+ users can collide and trip the okta_user.email UNIQUE
     # constraint (flaky). Index-based emails make this deterministic.
-    members = [OktaUserFactory.create(email=f"member-{i:03d}@example.com") for i in range(60)]
-    owner = OktaUserFactory.create(email="owner@example.com")
+    members = [OktaUserFactory.build(email=f"member-{i:03d}@example.com") for i in range(60)]
+    owner = OktaUserFactory.build(email="owner@example.com")
     for u in members + [owner]:
         db.session.add(u)
     await db.session.commit()
@@ -1889,9 +1889,9 @@ async def test_group_member_details_counts_users_not_rows(client: AsyncClient, d
     """A user holding both a direct and a role-granted membership in a group is a
     single member: member-details pages by distinct user, so total counts the
     user once and both of their rows land on the same page."""
-    group = OktaGroupFactory.create()
-    role = RoleGroupFactory.create()
-    user = OktaUserFactory.create()
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    user = OktaUserFactory.build()
     db.session.add_all([group, role, user])
     await db.session.commit()
 
@@ -1923,7 +1923,7 @@ async def test_get_group_member_details_paginates_in_email_order(client: AsyncCl
     email, not by the opaque user id."""
     group = await OktaGroupFactory.create_async()
 
-    members = [OktaUserFactory.create(id=f"id-{59 - i:03d}", email=f"member-{i:03d}@example.com") for i in range(60)]
+    members = [OktaUserFactory.build(id=f"id-{59 - i:03d}", email=f"member-{i:03d}@example.com") for i in range(60)]
     for u in members:
         db.session.add(u)
     await db.session.commit()

--- a/tests/test_group_request.py
+++ b/tests/test_group_request.py
@@ -13,7 +13,6 @@ from api.extensions import Db
 from api.models import (
     AccessRequestStatus,
     AppGroup,
-    AppTagMap,
     GroupRequest,
     OktaGroup,
     OktaUser,
@@ -26,10 +25,12 @@ from api.operations import CreateGroupRequest, ApproveGroupRequest, RejectGroupR
 from api.plugins import get_notification_hook
 from api.services import okta
 from tests.factories import (
-    OktaUserFactory,
     AppFactory,
     AppGroupFactory,
+    AppTagMapFactory,
     OktaGroupFactory,
+    OktaUserFactory,
+    OktaUserGroupMemberFactory,
     RoleGroupFactory,
     TagFactory,
 )
@@ -79,9 +80,7 @@ async def test_create_app_group_request(
     db.session.add(user)
     await db.session.commit()
 
-    app_obj = AppFactory.create()
-    db.session.add(app_obj)
-    await db.session.commit()
+    app_obj = await AppFactory.create_async()
 
     group_request = await CreateGroupRequest(
         requester_user=user,
@@ -615,10 +614,9 @@ async def test_approve_group_request_sets_type(
     admin = (
         await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
     ).first()
-    app_obj = AppFactory.create()
+    app_obj = await AppFactory.create_async()
 
     db.session.add(user)
-    db.session.add(app_obj)
     await db.session.commit()
 
     mocker.patch.object(
@@ -717,12 +715,10 @@ async def test_app_owner_can_approve_request(
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    app_owner = OktaUserFactory.create()
-    app_obj = AppFactory.create()
+    app_owner = await OktaUserFactory.create_async()
+    app_obj = await AppFactory.create_async()
 
     db.session.add(user)
-    db.session.add(app_owner)
-    db.session.add(app_obj)
     await db.session.commit()
 
     mocker.patch.object(
@@ -734,24 +730,18 @@ async def test_app_owner_can_approve_request(
     mocker.patch.object(okta, "add_owner_to_group")
 
     # Owner group for the app
-    owner_group = AppGroupFactory.create(
+    owner_group = await AppGroupFactory.create_async(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
         app_id=app_obj.id,
         is_owner=True,
     )
 
-    db.session.add(owner_group)
-    await db.session.commit()
-
     # Add app_owner to owner group
-    db.session.add(
-        OktaUserGroupMember(
-            user_id=app_owner.id,
-            group_id=owner_group.id,
-            is_owner=True,
-        )
+    await OktaUserGroupMemberFactory.create_async(
+        user_id=app_owner.id,
+        group_id=owner_group.id,
+        is_owner=True,
     )
-    await db.session.commit()
 
     group_request = await CreateGroupRequest(
         requester_user=user,
@@ -782,33 +772,25 @@ async def test_app_owner_can_reject_request(
     db: Db,
     user: OktaUser,
 ) -> None:
-    app_owner = OktaUserFactory.create()
-    app_obj = AppFactory.create()
+    app_owner = await OktaUserFactory.create_async()
+    app_obj = await AppFactory.create_async()
 
     db.session.add(user)
-    db.session.add(app_owner)
-    db.session.add(app_obj)
     await db.session.commit()
 
     # Create owner group for the app
-    owner_group = AppGroupFactory.create(
+    owner_group = await AppGroupFactory.create_async(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
         app_id=app_obj.id,
         is_owner=True,
     )
 
-    db.session.add(owner_group)
-    await db.session.commit()
-
     # Make app_owner an owner of the app via its owner group
-    db.session.add(
-        OktaUserGroupMember(
-            user_id=app_owner.id,
-            group_id=owner_group.id,
-            is_owner=True,
-        )
+    await OktaUserGroupMemberFactory.create_async(
+        user_id=app_owner.id,
+        group_id=owner_group.id,
+        is_owner=True,
     )
-    await db.session.commit()
 
     group_request = await CreateGroupRequest(
         requester_user=user,
@@ -842,14 +824,11 @@ async def test_wrong_app_owner_cannot_approve_request(
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    app_owner = OktaUserFactory.create()
-    app_obj = AppFactory.create()
-    other_app = AppFactory.create()
+    app_owner = await OktaUserFactory.create_async()
+    app_obj = await AppFactory.create_async()
+    other_app = await AppFactory.create_async()
 
     db.session.add(user)
-    db.session.add(app_owner)
-    db.session.add(app_obj)
-    db.session.add(other_app)
     await db.session.commit()
 
     mocker.patch.object(
@@ -861,30 +840,23 @@ async def test_wrong_app_owner_cannot_approve_request(
     mocker.patch.object(okta, "add_owner_to_group")
 
     # Create owner groups for both apps
-    owner_group = AppGroupFactory.create(
+    owner_group = await AppGroupFactory.create_async(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
         app_id=app_obj.id,
         is_owner=True,
     )
-    other_owner_group = AppGroupFactory.create(
+    await AppGroupFactory.create_async(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{other_app.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
         app_id=other_app.id,
         is_owner=True,
     )
 
-    db.session.add(owner_group)
-    db.session.add(other_owner_group)
-    await db.session.commit()
-
     # Make app_owner an owner of 'app' but not 'other_app'
-    db.session.add(
-        OktaUserGroupMember(
-            user_id=app_owner.id,
-            group_id=owner_group.id,
-            is_owner=True,
-        )
+    await OktaUserGroupMemberFactory.create_async(
+        user_id=app_owner.id,
+        group_id=owner_group.id,
+        is_owner=True,
     )
-    await db.session.commit()
 
     # Create request for other_app
     group_request = await CreateGroupRequest(
@@ -957,10 +929,9 @@ async def test_any_user_cannot_reject_request(
     db: Db,
     user: OktaUser,
 ) -> None:
-    other_user = OktaUserFactory.create()
+    other_user = await OktaUserFactory.create_async()
 
     db.session.add(user)
-    db.session.add(other_user)
     await db.session.commit()
 
     group_request = await CreateGroupRequest(
@@ -1060,11 +1031,10 @@ async def test_approver_can_modify_group_details(
         await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
     ).first()
     tag = TagFactory.create(enabled=True)
-    other_tag = TagFactory.create(enabled=True)
+    other_tag = await TagFactory.create_async(enabled=True)
 
     db.session.add(user)
     db.session.add(tag)
-    db.session.add(other_tag)
     await db.session.commit()
 
     mocker.patch.object(
@@ -1132,10 +1102,9 @@ async def test_cannot_approve_already_resolved_request(
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    approver_user = OktaUserFactory.create()
+    approver_user = await OktaUserFactory.create_async()
 
     db.session.add(user)
-    db.session.add(approver_user)
     await db.session.commit()
 
     mocker.patch.object(
@@ -1188,10 +1157,9 @@ async def test_cannot_approve_deleted_requester(
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    approver_user = OktaUserFactory.create()
+    approver_user = await OktaUserFactory.create_async()
 
     db.session.add(user)
-    db.session.add(approver_user)
     await db.session.commit()
 
     mocker.patch.object(
@@ -1236,12 +1204,8 @@ async def test_app_owner_auto_approves_own_app_group_request(
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
 ) -> None:
-    app_owner = OktaUserFactory.create()
-    app_obj = AppFactory.create()
-
-    db.session.add(app_owner)
-    db.session.add(app_obj)
-    await db.session.commit()
+    app_owner = await OktaUserFactory.create_async()
+    app_obj = await AppFactory.create_async()
 
     mocker.patch.object(
         okta,
@@ -1252,24 +1216,18 @@ async def test_app_owner_auto_approves_own_app_group_request(
     mocker.patch.object(okta, "add_owner_to_group")
 
     # Create owner group for the app
-    owner_group = AppGroupFactory.create(
+    owner_group = await AppGroupFactory.create_async(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
         app_id=app_obj.id,
         is_owner=True,
     )
 
-    db.session.add(owner_group)
-    await db.session.commit()
-
     # Make app_owner an owner of the app via its owner group
-    db.session.add(
-        OktaUserGroupMember(
-            user_id=app_owner.id,
-            group_id=owner_group.id,
-            is_owner=True,
-        )
+    await OktaUserGroupMemberFactory.create_async(
+        user_id=app_owner.id,
+        group_id=owner_group.id,
+        is_owner=True,
     )
-    await db.session.commit()
 
     # App owner creates a group request for their own app
     group_request = await CreateGroupRequest(
@@ -1320,19 +1278,15 @@ async def test_app_owner_auto_approves_own_app_group_request_tagged(
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
 ) -> None:
-    app_owner = OktaUserFactory.create()
-    app_obj = AppFactory.create()
+    app_owner = await OktaUserFactory.create_async()
+    app_obj = await AppFactory.create_async()
     tag = TagFactory.create(enabled=True, constraints={Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY: True})
 
-    db.session.add(app_owner)
-    db.session.add(app_obj)
     db.session.add(tag)
     await db.session.commit()
 
     # Apply tag to the app so it cascades to groups created for this app
-    app_tag_map = AppTagMap(app_id=app_obj.id, tag_id=tag.id)
-    db.session.add(app_tag_map)
-    await db.session.commit()
+    await AppTagMapFactory.create_async(app_id=app_obj.id, tag_id=tag.id)
 
     mocker.patch.object(
         okta,
@@ -1343,24 +1297,18 @@ async def test_app_owner_auto_approves_own_app_group_request_tagged(
     mocker.patch.object(okta, "add_owner_to_group")
 
     # Create owner group for the app
-    owner_group = AppGroupFactory.create(
+    owner_group = await AppGroupFactory.create_async(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
         app_id=app_obj.id,
         is_owner=True,
     )
 
-    db.session.add(owner_group)
-    await db.session.commit()
-
     # Make app_owner an owner of the app via its owner group
-    db.session.add(
-        OktaUserGroupMember(
-            user_id=app_owner.id,
-            group_id=owner_group.id,
-            is_owner=True,
-        )
+    await OktaUserGroupMemberFactory.create_async(
+        user_id=app_owner.id,
+        group_id=owner_group.id,
+        is_owner=True,
     )
-    await db.session.commit()
 
     # App owner creates a group request for their own app
     # Include the tag in the request
@@ -1435,10 +1383,9 @@ async def test_random_user_cannot_approve_group_request(
     mocker: MockerFixture,
     faker: Faker,  # type: ignore[type-arg]
 ) -> None:
-    random_user = OktaUserFactory.create()
+    random_user = await OktaUserFactory.create_async()
 
     db.session.add(user)
-    db.session.add(random_user)
     await db.session.commit()
 
     mocker.patch.object(
@@ -1479,14 +1426,11 @@ async def test_app_owner_cannot_hijack_cross_app_group_via_resolved_name(
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    app_owner = OktaUserFactory.create()
-    app_a = AppFactory.create()
-    app_b = AppFactory.create()
+    app_owner = await OktaUserFactory.create_async()
+    app_a = await AppFactory.create_async()
+    app_b = await AppFactory.create_async()
 
     db.session.add(user)
-    db.session.add(app_owner)
-    db.session.add(app_a)
-    db.session.add(app_b)
     await db.session.commit()
 
     mocker.patch.object(
@@ -1497,20 +1441,15 @@ async def test_app_owner_cannot_hijack_cross_app_group_via_resolved_name(
     mocker.patch.object(okta, "add_user_to_group")
     mocker.patch.object(okta, "add_owner_to_group")
 
-    owner_group = AppGroupFactory.create(
+    owner_group = await AppGroupFactory.create_async(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_a.name}"
         f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
         app_id=app_a.id,
         is_owner=True,
     )
-    db.session.add(owner_group)
-    await db.session.commit()
-    db.session.add(OktaUserGroupMember(user_id=app_owner.id, group_id=owner_group.id, is_owner=True))
-    await db.session.commit()
+    await OktaUserGroupMemberFactory.create_async(user_id=app_owner.id, group_id=owner_group.id, is_owner=True)
 
-    sensitive_group = AppGroupFactory.create(name="App-Finance-Sensitive", app_id=app_b.id)
-    db.session.add(sensitive_group)
-    await db.session.commit()
+    sensitive_group = await AppGroupFactory.create_async(name="App-Finance-Sensitive", app_id=app_b.id)
 
     group_request = await CreateGroupRequest(
         requester_user=user,
@@ -1558,12 +1497,10 @@ async def test_app_owner_cannot_hijack_okta_group_via_resolved_name(
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    app_owner = OktaUserFactory.create()
-    app_obj = AppFactory.create()
+    app_owner = await OktaUserFactory.create_async()
+    app_obj = await AppFactory.create_async()
 
     db.session.add(user)
-    db.session.add(app_owner)
-    db.session.add(app_obj)
     await db.session.commit()
 
     mocker.patch.object(
@@ -1574,20 +1511,15 @@ async def test_app_owner_cannot_hijack_okta_group_via_resolved_name(
     mocker.patch.object(okta, "add_user_to_group")
     mocker.patch.object(okta, "add_owner_to_group")
 
-    owner_group = AppGroupFactory.create(
+    owner_group = await AppGroupFactory.create_async(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}"
         f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
         app_id=app_obj.id,
         is_owner=True,
     )
-    db.session.add(owner_group)
-    await db.session.commit()
-    db.session.add(OktaUserGroupMember(user_id=app_owner.id, group_id=owner_group.id, is_owner=True))
-    await db.session.commit()
+    await OktaUserGroupMemberFactory.create_async(user_id=app_owner.id, group_id=owner_group.id, is_owner=True)
 
-    existing_okta_group = OktaGroupFactory.create(name="Okta-Platform-Admins")
-    db.session.add(existing_okta_group)
-    await db.session.commit()
+    existing_okta_group = await OktaGroupFactory.create_async(name="Okta-Platform-Admins")
 
     group_request = await CreateGroupRequest(
         requester_user=user,
@@ -1634,12 +1566,10 @@ async def test_app_owner_cannot_hijack_role_group_via_resolved_name(
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    app_owner = OktaUserFactory.create()
-    app_obj = AppFactory.create()
+    app_owner = await OktaUserFactory.create_async()
+    app_obj = await AppFactory.create_async()
 
     db.session.add(user)
-    db.session.add(app_owner)
-    db.session.add(app_obj)
     await db.session.commit()
 
     mocker.patch.object(
@@ -1650,20 +1580,15 @@ async def test_app_owner_cannot_hijack_role_group_via_resolved_name(
     mocker.patch.object(okta, "add_user_to_group")
     mocker.patch.object(okta, "add_owner_to_group")
 
-    owner_group = AppGroupFactory.create(
+    owner_group = await AppGroupFactory.create_async(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}"
         f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
         app_id=app_obj.id,
         is_owner=True,
     )
-    db.session.add(owner_group)
-    await db.session.commit()
-    db.session.add(OktaUserGroupMember(user_id=app_owner.id, group_id=owner_group.id, is_owner=True))
-    await db.session.commit()
+    await OktaUserGroupMemberFactory.create_async(user_id=app_owner.id, group_id=owner_group.id, is_owner=True)
 
-    existing_role_group = RoleGroupFactory.create(name="Role-Security-Engineers")
-    db.session.add(existing_role_group)
-    await db.session.commit()
+    existing_role_group = await RoleGroupFactory.create_async(name="Role-Security-Engineers")
 
     group_request = await CreateGroupRequest(
         requester_user=user,
@@ -1710,14 +1635,11 @@ async def test_app_owner_cannot_hijack_group_via_resolved_name_case_insensitive(
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    app_owner = OktaUserFactory.create()
-    app_a = AppFactory.create()
-    app_b = AppFactory.create()
+    app_owner = await OktaUserFactory.create_async()
+    app_a = await AppFactory.create_async()
+    app_b = await AppFactory.create_async()
 
     db.session.add(user)
-    db.session.add(app_owner)
-    db.session.add(app_a)
-    db.session.add(app_b)
     await db.session.commit()
 
     mocker.patch.object(
@@ -1728,20 +1650,15 @@ async def test_app_owner_cannot_hijack_group_via_resolved_name_case_insensitive(
     mocker.patch.object(okta, "add_user_to_group")
     mocker.patch.object(okta, "add_owner_to_group")
 
-    owner_group = AppGroupFactory.create(
+    owner_group = await AppGroupFactory.create_async(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_a.name}"
         f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
         app_id=app_a.id,
         is_owner=True,
     )
-    db.session.add(owner_group)
-    await db.session.commit()
-    db.session.add(OktaUserGroupMember(user_id=app_owner.id, group_id=owner_group.id, is_owner=True))
-    await db.session.commit()
+    await OktaUserGroupMemberFactory.create_async(user_id=app_owner.id, group_id=owner_group.id, is_owner=True)
 
-    sensitive_group = AppGroupFactory.create(name="App-Finance-Sensitive", app_id=app_b.id)
-    db.session.add(sensitive_group)
-    await db.session.commit()
+    sensitive_group = await AppGroupFactory.create_async(name="App-Finance-Sensitive", app_id=app_b.id)
 
     group_request = await CreateGroupRequest(
         requester_user=user,
@@ -1787,12 +1704,10 @@ async def test_cannot_approve_okta_group_with_reserved_app_owners_name(
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    app_owner = OktaUserFactory.create()
-    app_obj = AppFactory.create()
+    app_owner = await OktaUserFactory.create_async()
+    app_obj = await AppFactory.create_async()
 
     db.session.add(user)
-    db.session.add(app_owner)
-    db.session.add(app_obj)
     await db.session.commit()
 
     mocker.patch.object(
@@ -1803,16 +1718,13 @@ async def test_cannot_approve_okta_group_with_reserved_app_owners_name(
     mocker.patch.object(okta, "add_user_to_group")
     mocker.patch.object(okta, "add_owner_to_group")
 
-    owner_group = AppGroupFactory.create(
+    owner_group = await AppGroupFactory.create_async(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}"
         f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
         app_id=app_obj.id,
         is_owner=True,
     )
-    db.session.add(owner_group)
-    await db.session.commit()
-    db.session.add(OktaUserGroupMember(user_id=app_owner.id, group_id=owner_group.id, is_owner=True))
-    await db.session.commit()
+    await OktaUserGroupMemberFactory.create_async(user_id=app_owner.id, group_id=owner_group.id, is_owner=True)
 
     group_request = await CreateGroupRequest(
         requester_user=user,
@@ -1855,12 +1767,10 @@ async def test_cannot_approve_role_group_with_reserved_app_owners_name(
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    app_owner = OktaUserFactory.create()
-    app_obj = AppFactory.create()
+    app_owner = await OktaUserFactory.create_async()
+    app_obj = await AppFactory.create_async()
 
     db.session.add(user)
-    db.session.add(app_owner)
-    db.session.add(app_obj)
     await db.session.commit()
 
     mocker.patch.object(
@@ -1871,16 +1781,13 @@ async def test_cannot_approve_role_group_with_reserved_app_owners_name(
     mocker.patch.object(okta, "add_user_to_group")
     mocker.patch.object(okta, "add_owner_to_group")
 
-    owner_group = AppGroupFactory.create(
+    owner_group = await AppGroupFactory.create_async(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}"
         f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
         app_id=app_obj.id,
         is_owner=True,
     )
-    db.session.add(owner_group)
-    await db.session.commit()
-    db.session.add(OktaUserGroupMember(user_id=app_owner.id, group_id=owner_group.id, is_owner=True))
-    await db.session.commit()
+    await OktaUserGroupMemberFactory.create_async(user_id=app_owner.id, group_id=owner_group.id, is_owner=True)
 
     group_request = await CreateGroupRequest(
         requester_user=user,
@@ -1923,12 +1830,10 @@ async def test_cannot_approve_okta_group_with_any_reserved_app_prefix(
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    app_owner = OktaUserFactory.create()
-    app_obj = AppFactory.create()
+    app_owner = await OktaUserFactory.create_async()
+    app_obj = await AppFactory.create_async()
 
     db.session.add(user)
-    db.session.add(app_owner)
-    db.session.add(app_obj)
     await db.session.commit()
 
     mocker.patch.object(
@@ -1939,16 +1844,13 @@ async def test_cannot_approve_okta_group_with_any_reserved_app_prefix(
     mocker.patch.object(okta, "add_user_to_group")
     mocker.patch.object(okta, "add_owner_to_group")
 
-    owner_group = AppGroupFactory.create(
+    owner_group = await AppGroupFactory.create_async(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}"
         f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
         app_id=app_obj.id,
         is_owner=True,
     )
-    db.session.add(owner_group)
-    await db.session.commit()
-    db.session.add(OktaUserGroupMember(user_id=app_owner.id, group_id=owner_group.id, is_owner=True))
-    await db.session.commit()
+    await OktaUserGroupMemberFactory.create_async(user_id=app_owner.id, group_id=owner_group.id, is_owner=True)
 
     group_request = await CreateGroupRequest(
         requester_user=user,
@@ -1992,12 +1894,10 @@ async def test_cannot_approve_app_group_request_with_owners_group_name(
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    app_owner = OktaUserFactory.create()
-    app_obj = AppFactory.create()
+    app_owner = await OktaUserFactory.create_async()
+    app_obj = await AppFactory.create_async()
 
     db.session.add(user)
-    db.session.add(app_owner)
-    db.session.add(app_obj)
     await db.session.commit()
 
     mocker.patch.object(
@@ -2008,16 +1908,13 @@ async def test_cannot_approve_app_group_request_with_owners_group_name(
     mocker.patch.object(okta, "add_user_to_group")
     mocker.patch.object(okta, "add_owner_to_group")
 
-    owner_group = AppGroupFactory.create(
+    owner_group = await AppGroupFactory.create_async(
         name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}"
         f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
         app_id=app_obj.id,
         is_owner=True,
     )
-    db.session.add(owner_group)
-    await db.session.commit()
-    db.session.add(OktaUserGroupMember(user_id=app_owner.id, group_id=owner_group.id, is_owner=True))
-    await db.session.commit()
+    await OktaUserGroupMemberFactory.create_async(user_id=app_owner.id, group_id=owner_group.id, is_owner=True)
 
     group_request = await CreateGroupRequest(
         requester_user=user,
@@ -2067,9 +1964,8 @@ async def test_cannot_approve_non_role_group_request_with_role_prefix(
     faker: Faker,  # type: ignore[type-arg]
     user: OktaUser,
 ) -> None:
-    admin = OktaUserFactory.create()
+    admin = await OktaUserFactory.create_async()
     db.session.add(user)
-    db.session.add(admin)
     await db.session.commit()
 
     mocker.patch.object(
@@ -2080,11 +1976,8 @@ async def test_cannot_approve_non_role_group_request_with_role_prefix(
     mocker.patch.object(okta, "add_user_to_group")
     mocker.patch.object(okta, "add_owner_to_group")
 
-    access_admin_group = RoleGroupFactory.create(name="App-Access-Owners")
-    db.session.add(access_admin_group)
-    await db.session.commit()
-    db.session.add(OktaUserGroupMember(user_id=admin.id, group_id=access_admin_group.id, is_owner=False))
-    await db.session.commit()
+    access_admin_group = await RoleGroupFactory.create_async(name="App-Access-Owners")
+    await OktaUserGroupMemberFactory.create_async(user_id=admin.id, group_id=access_admin_group.id, is_owner=False)
 
     group_request = await CreateGroupRequest(
         requester_user=user,
@@ -2190,9 +2083,7 @@ async def test_post_group_request_validation_via_http(
     create_url = url_for("api-group-requests.group_requests_create")
 
     # (a) Deleted requester → 403
-    deleted = OktaUserFactory.create(deleted_at=datetime.now(timezone.utc))
-    db.session.add(deleted)
-    await db.session.commit()
+    deleted = await OktaUserFactory.create_async(deleted_at=datetime.now(timezone.utc))
     mock_user(deleted.id)
     rep = await client.post(
         create_url,
@@ -2262,8 +2153,7 @@ async def test_post_group_request_app_id_must_exist_deleted(
     """`requested_app_id` pointing at a soft-deleted App → 404 (the resource
     queries `App.deleted_at.is_(None)` before accepting the request)."""
     db.session.add(user)
-    deleted_app = AppFactory.create(name="DeletedApp", deleted_at=datetime.now(timezone.utc))
-    db.session.add(deleted_app)
+    deleted_app = await AppFactory.create_async(name="DeletedApp", deleted_at=datetime.now(timezone.utc))
     await db.session.commit()
     mock_user(user.id)
     rep = await client.post(
@@ -2285,8 +2175,7 @@ async def test_post_group_request_tag_ids_must_be_undeleted(
     from tests.factories import TagFactory
 
     db.session.add(user)
-    deleted_tag = TagFactory.create(name="DeletedTag", deleted_at=datetime.now(timezone.utc))
-    db.session.add(deleted_tag)
+    deleted_tag = await TagFactory.create_async(name="DeletedTag", deleted_at=datetime.now(timezone.utc))
     await db.session.commit()
     mock_user(user.id)
     rep = await client.post(
@@ -2384,14 +2273,12 @@ async def test_put_group_request_app_owner_cannot_escalate_to_role_group(
     mocker.patch.object(okta, "add_owner_to_group")
 
     # Alice is the app owner of Foo. She is NOT an Access admin.
-    alice = OktaUserFactory.create()
-    foo_app = AppFactory.create()
+    alice = await OktaUserFactory.create_async()
+    foo_app = await AppFactory.create_async()
     db.session.add(user)
-    db.session.add(alice)
-    db.session.add(foo_app)
     await db.session.commit()
 
-    owner_group = AppGroupFactory.create(
+    owner_group = await AppGroupFactory.create_async(
         name=(
             f"{AppGroup.APP_GROUP_NAME_PREFIX}{foo_app.name}"
             f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
@@ -2399,11 +2286,8 @@ async def test_put_group_request_app_owner_cannot_escalate_to_role_group(
         app_id=foo_app.id,
         is_owner=True,
     )
-    db.session.add(owner_group)
-    await db.session.commit()
     # is_owner=True makes Alice a *manager* of app Foo
-    db.session.add(OktaUserGroupMember(user_id=alice.id, group_id=owner_group.id, is_owner=True))
-    await db.session.commit()
+    await OktaUserGroupMemberFactory.create_async(user_id=alice.id, group_id=owner_group.id, is_owner=True)
 
     # Regular user files an app_group request against Foo. Alice is a valid
     # approver for this request because she owns Foo.
@@ -2469,16 +2353,13 @@ async def test_put_group_request_app_owner_cannot_escalate_to_other_app(
     mocker.patch.object(okta, "add_user_to_group")
     mocker.patch.object(okta, "add_owner_to_group")
 
-    alice = OktaUserFactory.create()
-    foo_app = AppFactory.create()
-    bar_app = AppFactory.create()
+    alice = await OktaUserFactory.create_async()
+    foo_app = await AppFactory.create_async()
+    bar_app = await AppFactory.create_async()
     db.session.add(user)
-    db.session.add(alice)
-    db.session.add(foo_app)
-    db.session.add(bar_app)
     await db.session.commit()
 
-    foo_owner_group = AppGroupFactory.create(
+    foo_owner_group = await AppGroupFactory.create_async(
         name=(
             f"{AppGroup.APP_GROUP_NAME_PREFIX}{foo_app.name}"
             f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
@@ -2486,10 +2367,7 @@ async def test_put_group_request_app_owner_cannot_escalate_to_other_app(
         app_id=foo_app.id,
         is_owner=True,
     )
-    db.session.add(foo_owner_group)
-    await db.session.commit()
-    db.session.add(OktaUserGroupMember(user_id=alice.id, group_id=foo_owner_group.id, is_owner=True))
-    await db.session.commit()
+    await OktaUserGroupMemberFactory.create_async(user_id=alice.id, group_id=foo_owner_group.id, is_owner=True)
 
     group_request = await CreateGroupRequest(
         requester_user=user,
@@ -2549,14 +2427,12 @@ async def test_approve_group_request_op_blocks_type_mismatch_for_non_admin(
     mocker.patch.object(okta, "add_user_to_group")
     mocker.patch.object(okta, "add_owner_to_group")
 
-    alice = OktaUserFactory.create()
-    foo_app = AppFactory.create()
+    alice = await OktaUserFactory.create_async()
+    foo_app = await AppFactory.create_async()
     db.session.add(user)
-    db.session.add(alice)
-    db.session.add(foo_app)
     await db.session.commit()
 
-    foo_owner_group = AppGroupFactory.create(
+    foo_owner_group = await AppGroupFactory.create_async(
         name=(
             f"{AppGroup.APP_GROUP_NAME_PREFIX}{foo_app.name}"
             f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
@@ -2564,10 +2440,7 @@ async def test_approve_group_request_op_blocks_type_mismatch_for_non_admin(
         app_id=foo_app.id,
         is_owner=True,
     )
-    db.session.add(foo_owner_group)
-    await db.session.commit()
-    db.session.add(OktaUserGroupMember(user_id=alice.id, group_id=foo_owner_group.id, is_owner=True))
-    await db.session.commit()
+    await OktaUserGroupMemberFactory.create_async(user_id=alice.id, group_id=foo_owner_group.id, is_owner=True)
 
     group_request = await CreateGroupRequest(
         requester_user=user,

--- a/tests/test_group_request.py
+++ b/tests/test_group_request.py
@@ -182,7 +182,7 @@ async def test_create_group_request_tag_limits_ownership_time(
     user: OktaUser,
 ) -> None:
     # Create a tag that limits ownership to 90 days
-    tag = TagFactory.create(
+    tag = TagFactory.build(
         enabled=True,
         constraints={
             Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: 7776000  # in seconds
@@ -226,7 +226,7 @@ async def test_create_group_request_tag_reduces_requested_ownership_time(
     user: OktaUser,
 ) -> None:
     # Create a tag that limits ownership to 30 days
-    tag = TagFactory.create(
+    tag = TagFactory.build(
         enabled=True,
         constraints={
             Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: 2592000  # in seconds
@@ -420,7 +420,7 @@ async def test_approve_group_request_tag_limits_owner_ending_time(
     mocker.patch.object(okta, "add_owner_to_group")
 
     # Create a tag that limits ownership to 30 days
-    tag = TagFactory.create(
+    tag = TagFactory.build(
         enabled=True,
         constraints={
             Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: 2592000  # in seconds
@@ -1030,7 +1030,7 @@ async def test_approver_can_modify_group_details(
     admin = (
         await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
     ).first()
-    tag = TagFactory.create(enabled=True)
+    tag = TagFactory.build(enabled=True)
     other_tag = await TagFactory.create_async(enabled=True)
 
     db.session.add(user)
@@ -1280,7 +1280,7 @@ async def test_app_owner_auto_approves_own_app_group_request_tagged(
 ) -> None:
     app_owner = await OktaUserFactory.create_async()
     app_obj = await AppFactory.create_async()
-    tag = TagFactory.create(enabled=True, constraints={Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY: True})
+    tag = TagFactory.build(enabled=True, constraints={Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY: True})
 
     db.session.add(tag)
     await db.session.commit()
@@ -2014,9 +2014,9 @@ async def test_group_request_list_filters_via_http(client: AsyncClient, db: Db, 
     would still match by ID."""
     from api.operations import CreateGroupRequest
 
-    target_user = OktaUserFactory.create()
-    other_user = OktaUserFactory.create()
-    target_app = AppFactory.create()
+    target_user = OktaUserFactory.build()
+    other_user = OktaUserFactory.build()
+    target_app = AppFactory.build()
     db.session.add_all([target_user, other_user, target_app])
     await db.session.commit()
 
@@ -2483,7 +2483,7 @@ async def test_approve_app_group_request_with_non_conforming_resolved_name_is_re
 ) -> None:
     """Approving an app group request whose resolved name lacks the
     "App-{app name}-" prefix is a 400 and leaves the request pending."""
-    app_obj = AppFactory.create()
+    app_obj = AppFactory.build()
     db.session.add_all([user, app_obj])
     await db.session.commit()
     app_name = app_obj.name

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -352,7 +352,7 @@ async def test_get_group_tool_role_grants_do_not_reload_own_group(
     await db.session.commit()
 
     for _ in range(5):
-        granting_role = RoleGroupFactory.create()
+        granting_role = RoleGroupFactory.build()
         db.session.add(granting_role)
         await db.session.commit()
         await ModifyRoleGroups(

--- a/tests/test_require_reason_constraint.py
+++ b/tests/test_require_reason_constraint.py
@@ -46,7 +46,7 @@ async def test_require_reason_modify_group_users(
     user: OktaUser,
     url_for: Any,
 ) -> None:
-    tags = TagFactory.create_batch(
+    tags = TagFactory.batch(
         3,
         constraints={
             Tag.REQUIRE_MEMBER_REASON_CONSTRAINT_KEY: True,
@@ -568,7 +568,7 @@ async def test_require_reason_modify_role_groups(
     user: OktaUser,
     url_for: Any,
 ) -> None:
-    tags = TagFactory.create_batch(
+    tags = TagFactory.batch(
         3,
         constraints={
             Tag.REQUIRE_MEMBER_REASON_CONSTRAINT_KEY: True,
@@ -1237,7 +1237,7 @@ async def test_require_reason_approve_access_request(
     user: OktaUser,
     url_for: Any,
 ) -> None:
-    tags = TagFactory.create_batch(
+    tags = TagFactory.batch(
         3,
         constraints={
             Tag.REQUIRE_MEMBER_REASON_CONSTRAINT_KEY: True,

--- a/tests/test_require_reason_constraint.py
+++ b/tests/test_require_reason_constraint.py
@@ -8,9 +8,7 @@ from api.extensions import Db
 from api.models import (
     App,
     AppGroup,
-    AppTagMap,
     OktaGroup,
-    OktaGroupTagMap,
     OktaUser,
     OktaUserGroupMember,
     RoleGroup,
@@ -19,7 +17,7 @@ from api.models import (
 )
 from api.operations import CreateAccessRequest, ModifyGroupUsers, ModifyRoleGroups
 from api.services import okta
-from tests.factories import TagFactory
+from tests.factories import AppTagMapFactory, OktaGroupTagMapFactory, TagFactory
 from tests.helpers import db_count
 
 
@@ -87,17 +85,13 @@ async def test_require_reason_modify_group_users(
         sync_to_okta=False,
     ).execute()
 
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tags[0].id))
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tags[2].id))
-    db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[2].id))
-    app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tags[1].id)
-    db.session.add(app_tag_map)
-    app_tag_map2 = AppTagMap(app_id=access_app.id, tag_id=tags[2].id)
-    db.session.add(app_tag_map2)
-    await db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[1].id, app_tag_map_id=app_tag_map.id))
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tags[0].id)
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tags[2].id)
+    await OktaGroupTagMapFactory.create_async(group_id=role_group.id, tag_id=tags[2].id)
+    app_tag_map = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tags[1].id)
+    app_tag_map2 = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tags[2].id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tags[1].id, app_tag_map_id=app_tag_map.id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id)
 
     # Store IDs before requests — constraint-rejection (400) paths roll the
     # shared session back, expiring instances; expired attributes cannot
@@ -602,17 +596,13 @@ async def test_require_reason_modify_role_groups(
 
     await ModifyGroupUsers(group=role_group, members_to_add=[user.id], owners_to_add=[], sync_to_okta=False).execute()
 
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tags[0].id))
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tags[2].id))
-    db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[2].id))
-    app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tags[1].id)
-    db.session.add(app_tag_map)
-    app_tag_map2 = AppTagMap(app_id=access_app.id, tag_id=tags[2].id)
-    db.session.add(app_tag_map2)
-    await db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[1].id, app_tag_map_id=app_tag_map.id))
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tags[0].id)
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tags[2].id)
+    await OktaGroupTagMapFactory.create_async(group_id=role_group.id, tag_id=tags[2].id)
+    app_tag_map = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tags[1].id)
+    app_tag_map2 = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tags[2].id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tags[1].id, app_tag_map_id=app_tag_map.id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id)
 
     # Store IDs before requests — constraint-rejection (400) paths roll the
     # shared session back, expiring instances; expired attributes cannot
@@ -1286,17 +1276,13 @@ async def test_require_reason_approve_access_request(
         sync_to_okta=False,
     ).execute()
 
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tags[0].id))
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tags[2].id))
-    db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[2].id))
-    app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tags[1].id)
-    db.session.add(app_tag_map)
-    app_tag_map2 = AppTagMap(app_id=access_app.id, tag_id=tags[2].id)
-    db.session.add(app_tag_map2)
-    await db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[1].id, app_tag_map_id=app_tag_map.id))
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tags[0].id)
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tags[2].id)
+    await OktaGroupTagMapFactory.create_async(group_id=role_group.id, tag_id=tags[2].id)
+    app_tag_map = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tags[1].id)
+    app_tag_map2 = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tags[2].id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tags[1].id, app_tag_map_id=app_tag_map.id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id)
 
     add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
     remove_user_from_group_spy = mocker.patch.object(okta, "remove_user_from_group")

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -22,7 +22,12 @@ from api.auth import permissions as AuthorizationHelpers
 from api.operations import CreateAccessRequest, CreateRoleRequest, ModifyGroupUsers, ModifyRoleGroups
 from api.plugins import get_notification_hook
 from api.services import okta
-from tests.factories import OktaUserFactory, RoleGroupFactory
+from tests.factories import (
+    OktaUserFactory,
+    OktaUserGroupMemberFactory,
+    RoleGroupFactory,
+    RoleGroupMapFactory,
+)
 from tests.helpers import db_count
 from tests.request_factories import RoleMemberFactory
 
@@ -108,9 +113,7 @@ async def test_get_role_prefers_active_after_name_reuse(
     role_group.deleted_at = datetime.now(UTC).replace(tzinfo=None)
     await db.session.commit()
 
-    new_role = RoleGroupFactory.create(name=role_name)
-    db.session.add(new_role)
-    await db.session.commit()
+    new_role = await RoleGroupFactory.create_async(name=role_name)
     active_id = new_role.id
     assert active_id != soft_deleted_id
 
@@ -125,8 +128,7 @@ async def test_get_role_members_404_when_role_soft_deleted(
     db.session.add(role_group)
     db.session.add(okta_group)
     await db.session.commit()
-    db.session.add(RoleGroupMap(group_id=okta_group.id, role_group_id=role_group.id))
-    await db.session.commit()
+    await RoleGroupMapFactory.create_async(group_id=okta_group.id, role_group_id=role_group.id)
     role_id = role_group.id
 
     role_group.deleted_at = datetime.now(UTC).replace(tzinfo=None)
@@ -157,8 +159,7 @@ async def test_get_role_members(
     assert len(data["groups_in_role"]) == 0
     assert len(data["groups_owned_by_role"]) == 0
 
-    db.session.add(RoleGroupMap(group_id=okta_group.id, role_group_id=role_group.id))
-    await db.session.commit()
+    await RoleGroupMapFactory.create_async(group_id=okta_group.id, role_group_id=role_group.id)
 
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group.id)
     rep = await client.get(role_url)
@@ -169,8 +170,7 @@ async def test_get_role_members(
     assert data["groups_in_role"][0] == okta_group.id
     assert len(data["groups_owned_by_role"]) == 0
 
-    db.session.add(RoleGroupMap(group_id=okta_group.id, role_group_id=role_group.id, is_owner=True))
-    await db.session.commit()
+    await RoleGroupMapFactory.create_async(group_id=okta_group.id, role_group_id=role_group.id, is_owner=True)
 
     role_url = url_for("api-roles.role_members_by_id", role_id=role_group.id)
     rep = await client.get(role_url)
@@ -1575,7 +1575,7 @@ async def test_do_not_renew(
 async def test_do_not_renew_scoped_to_route_role(
     db: Db, client: AsyncClient, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser, url_for: Any
 ) -> None:
-    victim_role = RoleGroupFactory.create()
+    victim_role = await RoleGroupFactory.create_async()
     victim_okta_group = OktaGroup(
         id="victim-group-id",
         name="Victim-Group",
@@ -1584,7 +1584,6 @@ async def test_do_not_renew_scoped_to_route_role(
 
     db.session.add(role_group)
     db.session.add(okta_group)
-    db.session.add(victim_role)
     db.session.add(victim_okta_group)
     db.session.add(user)
     await db.session.commit()
@@ -1685,8 +1684,6 @@ async def test_role_list_owner_id_filter(client: AsyncClient, db: Db, url_for: A
     only honored `q`."""
     from datetime import datetime, timedelta, timezone
 
-    from api.models import OktaUserGroupMember as _OUGM
-
     owner = OktaUserFactory.create()
     other = OktaUserFactory.create()
     role_a = RoleGroupFactory.create()
@@ -1694,9 +1691,8 @@ async def test_role_list_owner_id_filter(client: AsyncClient, db: Db, url_for: A
     db.session.add_all([owner, other, role_a, role_b])
     await db.session.commit()
     end = datetime.now(timezone.utc) + timedelta(days=30)
-    db.session.add(_OUGM(user_id=owner.id, group_id=role_a.id, is_owner=True, ended_at=end))
-    db.session.add(_OUGM(user_id=other.id, group_id=role_b.id, is_owner=True, ended_at=end))
-    await db.session.commit()
+    await OktaUserGroupMemberFactory.create_async(user_id=owner.id, group_id=role_a.id, is_owner=True, ended_at=end)
+    await OktaUserGroupMemberFactory.create_async(user_id=other.id, group_id=role_b.id, is_owner=True, ended_at=end)
 
     list_url = url_for("api-roles.roles")
     rep = await client.get(list_url, params={"owner_id": owner.id})
@@ -1713,9 +1709,8 @@ async def test_put_role_members_rejects_role_in_role(
     url_for: Any,
 ) -> None:
     """Adding a RoleGroup as a member of another RoleGroup is rejected with 400."""
-    inner_role = RoleGroupFactory.create()
+    inner_role = await RoleGroupFactory.create_async()
     db.session.add(role_group)
-    db.session.add(inner_role)
     await db.session.commit()
 
     # Store the ID before requests — the 400 response path rolls back the

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -464,7 +464,7 @@ async def test_role_group_add_with_notify_false_suppresses_completion_notificati
 
 async def test_get_all_role(client: AsyncClient, db: Db, url_for: Any) -> None:
     groups_url = url_for("api-roles.roles")
-    groups = RoleGroupFactory.create_batch(10)
+    groups = RoleGroupFactory.batch(10)
 
     db.session.add_all(groups)
     await db.session.commit()
@@ -1684,10 +1684,10 @@ async def test_role_list_owner_id_filter(client: AsyncClient, db: Db, url_for: A
     only honored `q`."""
     from datetime import datetime, timedelta, timezone
 
-    owner = OktaUserFactory.create()
-    other = OktaUserFactory.create()
-    role_a = RoleGroupFactory.create()
-    role_b = RoleGroupFactory.create()
+    owner = OktaUserFactory.build()
+    other = OktaUserFactory.build()
+    role_a = RoleGroupFactory.build()
+    role_b = RoleGroupFactory.build()
     db.session.add_all([owner, other, role_a, role_b])
     await db.session.commit()
     end = datetime.now(timezone.utc) + timedelta(days=30)

--- a/tests/test_role_memberships_fix.py
+++ b/tests/test_role_memberships_fix.py
@@ -5,8 +5,9 @@ from sqlalchemy import select
 
 from api.integrity import verify_and_fix_role_memberships
 from api.extensions import Db
-from api.models import OktaGroup, OktaUser, OktaUserGroupMember, RoleGroup, RoleGroupMap
+from api.models import OktaGroup, OktaUser, OktaUserGroupMember, RoleGroup
 from api.services import okta
+from tests.factories import OktaUserGroupMemberFactory, RoleGroupMapFactory
 from tests.helpers import db_count
 
 
@@ -16,11 +17,13 @@ async def test_missing_user_from_group_membership(
     db.session.add(user)
     db.session.add(role_group)
     db.session.add(okta_group)
-    db.session.add(OktaUserGroupMember(user_id=user.id, group_id=role_group.id))
-    member_role_group_map = RoleGroupMap(role_group_id=role_group.id, group_id=okta_group.id, is_owner=False)
-    db.session.add(member_role_group_map)
-    owner_role_group_map = RoleGroupMap(role_group_id=role_group.id, group_id=okta_group.id, is_owner=True)
-    db.session.add(owner_role_group_map)
+    await OktaUserGroupMemberFactory.create_async(user_id=user.id, group_id=role_group.id)
+    member_role_group_map = await RoleGroupMapFactory.create_async(
+        role_group_id=role_group.id, group_id=okta_group.id, is_owner=False
+    )
+    owner_role_group_map = await RoleGroupMapFactory.create_async(
+        role_group_id=role_group.id, group_id=okta_group.id, is_owner=True
+    )
     await db.session.commit()
 
     add_membership_spy = mocker.patch.object(okta, "add_user_to_group")
@@ -57,13 +60,15 @@ async def test_missing_user_from_group_membership_with_expiring_role_membership(
     db.session.add(user)
     db.session.add(role_group)
     db.session.add(okta_group)
-    db.session.add(
-        OktaUserGroupMember(user_id=user.id, group_id=role_group.id, ended_at=datetime.now(UTC) + timedelta(days=2))
+    await OktaUserGroupMemberFactory.create_async(
+        user_id=user.id, group_id=role_group.id, ended_at=datetime.now(UTC) + timedelta(days=2)
     )
-    member_role_group_map = RoleGroupMap(role_group_id=role_group.id, group_id=okta_group.id, is_owner=False)
-    db.session.add(member_role_group_map)
-    owner_role_group_map = RoleGroupMap(role_group_id=role_group.id, group_id=okta_group.id, is_owner=True)
-    db.session.add(owner_role_group_map)
+    member_role_group_map = await RoleGroupMapFactory.create_async(
+        role_group_id=role_group.id, group_id=okta_group.id, is_owner=False
+    )
+    owner_role_group_map = await RoleGroupMapFactory.create_async(
+        role_group_id=role_group.id, group_id=okta_group.id, is_owner=True
+    )
     await db.session.commit()
 
     add_membership_spy = mocker.patch.object(okta, "add_user_to_group")
@@ -124,23 +129,21 @@ async def test_missing_user_from_group_membership_with_expiring_role_assignment(
     db.session.add(user)
     db.session.add(role_group)
     db.session.add(okta_group)
-    db.session.add(
-        OktaUserGroupMember(user_id=user.id, group_id=role_group.id, ended_at=datetime.now(UTC) + timedelta(days=4))
+    await OktaUserGroupMemberFactory.create_async(
+        user_id=user.id, group_id=role_group.id, ended_at=datetime.now(UTC) + timedelta(days=4)
     )
-    member_role_group_map = RoleGroupMap(
+    member_role_group_map = await RoleGroupMapFactory.create_async(
         role_group_id=role_group.id,
         group_id=okta_group.id,
         is_owner=False,
         ended_at=datetime.now(UTC) + timedelta(days=2),
     )
-    db.session.add(member_role_group_map)
-    owner_role_group_map = RoleGroupMap(
+    owner_role_group_map = await RoleGroupMapFactory.create_async(
         role_group_id=role_group.id,
         group_id=okta_group.id,
         is_owner=True,
         ended_at=datetime.now(UTC) + timedelta(days=6),
     )
-    db.session.add(owner_role_group_map)
     await db.session.commit()
 
     # drop identity-map state staled by the ops above (expire_on_commit=False)
@@ -204,21 +207,19 @@ async def test_missing_user_from_group_membership_with_both_expiring(
     db.session.add(user)
     db.session.add(role_group)
     db.session.add(okta_group)
-    db.session.add(OktaUserGroupMember(user_id=user.id, group_id=role_group.id))
-    member_role_group_map = RoleGroupMap(
+    await OktaUserGroupMemberFactory.create_async(user_id=user.id, group_id=role_group.id)
+    member_role_group_map = await RoleGroupMapFactory.create_async(
         role_group_id=role_group.id,
         group_id=okta_group.id,
         is_owner=False,
         ended_at=datetime.now(UTC) + timedelta(days=2),
     )
-    db.session.add(member_role_group_map)
-    owner_role_group_map = RoleGroupMap(
+    owner_role_group_map = await RoleGroupMapFactory.create_async(
         role_group_id=role_group.id,
         group_id=okta_group.id,
         is_owner=True,
         ended_at=datetime.now(UTC) + timedelta(days=4),
     )
-    db.session.add(owner_role_group_map)
     await db.session.commit()
 
     add_membership_spy = mocker.patch.object(okta, "add_user_to_group")
@@ -280,27 +281,24 @@ async def test_extra_user_from_role_membership(
     db.session.add(role_group)
     db.session.add(okta_group)
 
-    member_role_group_map = RoleGroupMap(role_group_id=role_group.id, group_id=okta_group.id, is_owner=False)
-    db.session.add(member_role_group_map)
-    owner_role_group_map = RoleGroupMap(role_group_id=role_group.id, group_id=okta_group.id, is_owner=True)
-    db.session.add(owner_role_group_map)
-    await db.session.commit()
-    db.session.add(
-        OktaUserGroupMember(
-            user_id=user.id,
-            group_id=okta_group.id,
-            role_group_map_id=member_role_group_map.id,
-        )
+    member_role_group_map = await RoleGroupMapFactory.create_async(
+        role_group_id=role_group.id, group_id=okta_group.id, is_owner=False
     )
-    db.session.add(
-        OktaUserGroupMember(
-            user_id=user.id,
-            group_id=okta_group.id,
-            role_group_map_id=owner_role_group_map.id,
-            is_owner=True,
-        )
+    owner_role_group_map = await RoleGroupMapFactory.create_async(
+        role_group_id=role_group.id, group_id=okta_group.id, is_owner=True
     )
     await db.session.commit()
+    await OktaUserGroupMemberFactory.create_async(
+        user_id=user.id,
+        group_id=okta_group.id,
+        role_group_map_id=member_role_group_map.id,
+    )
+    await OktaUserGroupMemberFactory.create_async(
+        user_id=user.id,
+        group_id=okta_group.id,
+        role_group_map_id=owner_role_group_map.id,
+        is_owner=True,
+    )
 
     remove_membership_spy = mocker.patch.object(okta, "remove_user_from_group")
     remove_ownership_spy = mocker.patch.object(okta, "remove_owner_from_group")
@@ -346,40 +344,33 @@ async def test_extra_user_from_role_membership_with_direct(
     db.session.add(role_group)
     db.session.add(okta_group)
 
-    member_role_group_map = RoleGroupMap(role_group_id=role_group.id, group_id=okta_group.id, is_owner=False)
-    db.session.add(member_role_group_map)
-    owner_role_group_map = RoleGroupMap(role_group_id=role_group.id, group_id=okta_group.id, is_owner=True)
-    db.session.add(owner_role_group_map)
-    await db.session.commit()
-    db.session.add(
-        OktaUserGroupMember(
-            user_id=user.id,
-            group_id=okta_group.id,
-            role_group_map_id=member_role_group_map.id,
-        )
+    member_role_group_map = await RoleGroupMapFactory.create_async(
+        role_group_id=role_group.id, group_id=okta_group.id, is_owner=False
     )
-    db.session.add(
-        OktaUserGroupMember(
-            user_id=user.id,
-            group_id=okta_group.id,
-            role_group_map_id=owner_role_group_map.id,
-            is_owner=True,
-        )
-    )
-    db.session.add(
-        OktaUserGroupMember(
-            user_id=user.id,
-            group_id=okta_group.id,
-        )
-    )
-    db.session.add(
-        OktaUserGroupMember(
-            user_id=user.id,
-            group_id=okta_group.id,
-            is_owner=True,
-        )
+    owner_role_group_map = await RoleGroupMapFactory.create_async(
+        role_group_id=role_group.id, group_id=okta_group.id, is_owner=True
     )
     await db.session.commit()
+    await OktaUserGroupMemberFactory.create_async(
+        user_id=user.id,
+        group_id=okta_group.id,
+        role_group_map_id=member_role_group_map.id,
+    )
+    await OktaUserGroupMemberFactory.create_async(
+        user_id=user.id,
+        group_id=okta_group.id,
+        role_group_map_id=owner_role_group_map.id,
+        is_owner=True,
+    )
+    await OktaUserGroupMemberFactory.create_async(
+        user_id=user.id,
+        group_id=okta_group.id,
+    )
+    await OktaUserGroupMemberFactory.create_async(
+        user_id=user.id,
+        group_id=okta_group.id,
+        is_owner=True,
+    )
 
     remove_membership_spy = mocker.patch.object(okta, "remove_user_from_group")
     remove_ownership_spy = mocker.patch.object(okta, "remove_owner_from_group")

--- a/tests/test_role_request.py
+++ b/tests/test_role_request.py
@@ -13,7 +13,6 @@ from api.models import (
     App,
     AppGroup,
     OktaGroup,
-    OktaGroupTagMap,
     OktaUser,
     OktaUserGroupMember,
     RoleGroup,
@@ -31,7 +30,14 @@ from api.operations import (
 )
 from api.plugins import ConditionalAccessResponse, get_notification_hook
 from api.services import okta
-from tests.factories import AppGroupFactory, OktaGroupFactory, OktaUserFactory, RoleGroupFactory, RoleRequestFactory
+from tests.factories import (
+    AppGroupFactory,
+    OktaGroupFactory,
+    OktaGroupTagMapFactory,
+    OktaUserFactory,
+    RoleGroupFactory,
+    RoleRequestFactory,
+)
 from tests.helpers import db_count
 from tests.request_factories import CreateRoleRequestBodyFactory, ResolveRoleRequestBodyFactory
 
@@ -55,12 +61,11 @@ async def test_get_role_request(
     rep = await client.get(role_request_url)
     assert rep.status_code == 404
 
-    role_group2 = RoleGroupFactory.create()
+    role_group2 = await RoleGroupFactory.create_async()
 
     db.session.add(user)
     db.session.add(okta_group)
     db.session.add(role_group)
-    db.session.add(role_group2)
     await db.session.commit()
 
     await ModifyGroupUsers(
@@ -151,10 +156,9 @@ async def test_get_role_request_includes_nested_role_and_group_data(
     tag: Tag,
     url_for: Any,
 ) -> None:
-    role_member = OktaUserFactory.create()
+    role_member = await OktaUserFactory.create_async()
 
     db.session.add(user)
-    db.session.add(role_member)
     db.session.add(okta_group)
     db.session.add(role_group)
     db.session.add(tag)
@@ -167,8 +171,7 @@ async def test_get_role_request_includes_nested_role_and_group_data(
         sync_to_okta=False,
     ).execute()
 
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tag.id)
 
     role_request = await CreateRoleRequest(
         requester_user=user,
@@ -617,14 +620,13 @@ async def test_create_app_role_request_notification(
     mocker: MockerFixture,
 ) -> None:
     # test bad data
-    app_owner_user = OktaUserFactory.create()
+    app_owner_user = await OktaUserFactory.create_async()
     app_owner_group = AppGroupFactory.create()
 
     # Add App
     db.session.add(access_app)
 
     # Add Users
-    db.session.add(app_owner_user)
     db.session.add(user)
 
     await db.session.commit()
@@ -748,11 +750,9 @@ async def test_role_request_approvers_tagged(
     tag: Tag,
     mocker: MockerFixture,
 ) -> None:
-    user2 = OktaUserFactory.create()
-    user3 = OktaUserFactory.create()
+    user2 = await OktaUserFactory.create_async()
+    user3 = await OktaUserFactory.create_async()
     db.session.add(user)
-    db.session.add(user2)
-    db.session.add(user3)
     db.session.add(okta_group)
     await db.session.commit()
 
@@ -772,8 +772,7 @@ async def test_role_request_approvers_tagged(
     db.session.add(tag)
     await db.session.commit()
 
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tag.id)
 
     # drop identity-map state staled by the ops above (expire_on_commit=False)
     db.session.expire_all()
@@ -936,8 +935,7 @@ async def test_auto_resolve_create_role_request(
     db.session.add(tag)
     await db.session.commit()
 
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tag.id)
 
     await ModifyGroupUsers(
         group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
@@ -1073,8 +1071,7 @@ async def test_auto_resolve_create_role_request_with_time_limit_constraint_tag(
     db.session.add(tag)
     await db.session.commit()
 
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tag.id)
 
     await ModifyGroupUsers(
         group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
@@ -1167,8 +1164,7 @@ async def test_time_limit_constraint_tag(
     db.session.add(tag)
     await db.session.commit()
 
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tag.id)
 
     hook = get_notification_hook()
     request_created_notification_spy = mocker.patch.object(hook, "access_role_request_created")
@@ -1225,9 +1221,8 @@ async def test_owner_cant_add_self_constraint_tag(
     db.session.add(access_app)
 
     # Add Users
-    user2 = OktaUserFactory.create()
+    user2 = await OktaUserFactory.create_async()
     db.session.add(user)
-    db.session.add(user2)
     await db.session.commit()
 
     # Add app group that no one owns
@@ -1253,8 +1248,7 @@ async def test_owner_cant_add_self_constraint_tag(
     db.session.add(tag)
     await db.session.commit()
 
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tag.id)
 
     db.session.expire_all()
     # ... then reload the objects the operations below read in this task context.
@@ -1319,12 +1313,11 @@ async def test_role_request_approval_via_direct_add(
     mocker: MockerFixture,
     url_for: Any,
 ) -> None:
-    okta_group2 = OktaGroupFactory.create()
+    okta_group2 = await OktaGroupFactory.create_async()
 
     db.session.add(user)
     db.session.add(role_group)
     db.session.add(okta_group)
-    db.session.add(okta_group2)
     await db.session.commit()
 
     await ModifyGroupUsers(
@@ -1502,8 +1495,7 @@ async def test_get_role_request_detail_requested_group_for_app_group(
     db.session.add(app_group)
     db.session.add(tag)
     await db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tag.id)
     await ModifyGroupUsers(
         group=role_group,
         members_to_add=[user.id],

--- a/tests/test_role_request.py
+++ b/tests/test_role_request.py
@@ -526,7 +526,7 @@ async def test_get_all_role_request(
     db.session.add(okta_group)
     await db.session.commit()
 
-    role_requests = RoleRequestFactory.create_batch(
+    role_requests = RoleRequestFactory.batch(
         10, requester_user_id=user.id, requester_role_id=role_group.id, requested_group_id=okta_group.id
     )
     db.session.add_all(role_requests)
@@ -621,7 +621,7 @@ async def test_create_app_role_request_notification(
 ) -> None:
     # test bad data
     app_owner_user = await OktaUserFactory.create_async()
-    app_owner_group = AppGroupFactory.create()
+    app_owner_group = AppGroupFactory.build()
 
     # Add App
     db.session.add(access_app)
@@ -714,7 +714,7 @@ async def test_get_all_possible_role_request_approvers(app: FastAPI, mocker: Moc
         await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
     ).first()
 
-    users = OktaUserFactory.build_batch(3)
+    users = OktaUserFactory.batch(3)
     db.session.add_all(users)
     await db.session.commit()
 
@@ -729,7 +729,7 @@ async def test_get_all_possible_role_request_approvers(app: FastAPI, mocker: Moc
     )
 
     req = RoleRequest()
-    req.requested_group = AppGroupFactory.create()
+    req.requested_group = AppGroupFactory.build()
 
     approvers = await get_all_possible_request_approvers(req)
 
@@ -1410,12 +1410,12 @@ async def test_role_request_list_filters_via_http(client: AsyncClient, db: Db, u
     requests across two users / two roles / two target groups so each
     filter must *exclude* the other to pass — otherwise a regression that
     returns everything would still match by ID."""
-    target_user = OktaUserFactory.create()
-    other_user = OktaUserFactory.create()
-    target_role = RoleGroupFactory.create()
-    other_role = RoleGroupFactory.create()
-    target_group = OktaGroupFactory.create()
-    other_group = OktaGroupFactory.create()
+    target_user = OktaUserFactory.build()
+    other_user = OktaUserFactory.build()
+    target_role = RoleGroupFactory.build()
+    other_role = RoleGroupFactory.build()
+    target_group = OktaGroupFactory.build()
+    other_group = OktaGroupFactory.build()
     db.session.add_all([target_user, other_user, target_role, other_role, target_group, other_group])
     await db.session.commit()
     await ModifyGroupUsers(

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -10,8 +10,8 @@ from fastapi import FastAPI
 
 from api.config import settings
 from api.extensions import Db
-from api.models import App, AppGroup, AppTagMap, OktaGroup, OktaGroupTagMap, Tag
-from tests.factories import TagFactory
+from api.models import App, AppGroup, OktaGroup, Tag
+from tests.factories import AppTagMapFactory, OktaGroupTagMapFactory, TagFactory
 from tests.request_factories import CreateTagBodyFactory, UpdateTagBodyFactory
 
 
@@ -31,12 +31,9 @@ async def test_get_tag(
     db.session.add(app_group)
     await db.session.commit()
 
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tag.id)
-    db.session.add(app_tag_map)
-    await db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag.id, app_tag_map_id=app_tag_map.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tag.id)
+    app_tag_map = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tag.id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tag.id, app_tag_map_id=app_tag_map.id)
 
     # test get tag
     tag_url = url_for("api-tags.tag_by_id", tag_id=tag.id)
@@ -64,12 +61,9 @@ async def test_put_tag(
     db.session.add(app_group)
     await db.session.commit()
 
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tag.id)
-    db.session.add(app_tag_map)
-    await db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag.id, app_tag_map_id=app_tag_map.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tag.id)
+    app_tag_map = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tag.id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tag.id, app_tag_map_id=app_tag_map.id)
 
     data = UpdateTagBodyFactory.json(
         name="Updated",
@@ -134,12 +128,9 @@ async def test_delete_tag(
     db.session.add(app_group)
     await db.session.commit()
 
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tag.id)
-    db.session.add(app_tag_map)
-    await db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tag.id, app_tag_map_id=app_tag_map.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tag.id)
+    app_tag_map = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tag.id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tag.id, app_tag_map_id=app_tag_map.id)
 
     tag_id = tag.id
     tag_url = url_for("api-tags.tag_by_id", tag_id=tag_id)
@@ -188,9 +179,7 @@ async def test_create_tag(client: AsyncClient, db: Db, mocker: MockerFixture, ur
 async def test_get_all_tag(client: AsyncClient, db: Db, url_for: Any) -> None:
     tags_url = url_for("api-tags.tags")
 
-    tags = TagFactory.create_batch(3)
-    db.session.add_all(tags)
-    await db.session.commit()
+    tags = await TagFactory.create_batch_async(3)
 
     rep = await client.get(tags_url)
     assert rep.status_code == 200
@@ -354,10 +343,8 @@ async def test_post_tag_duplicate_name_blocked(client: AsyncClient, db: Db, url_
 
 async def test_put_tag_rename_collision_blocked(client: AsyncClient, db: Db, url_for: Any) -> None:
     """Renaming a tag onto another tag's name is rejected with 400."""
-    tag_a = TagFactory.create(name="OneTag")
-    tag_b = TagFactory.create(name="OtherTag")
-    db.session.add_all([tag_a, tag_b])
-    await db.session.commit()
+    await TagFactory.create_async(name="OneTag")
+    tag_b = await TagFactory.create_async(name="OtherTag")
 
     put_url = url_for("api-tags.tag_by_id_put", tag_id=tag_b.id)
     rep = await client.put(put_url, json={"name": "onetag"})  # case-insensitive
@@ -367,8 +354,8 @@ async def test_put_tag_rename_collision_blocked(client: AsyncClient, db: Db, url
 
 async def test_get_tags_q_via_http(client: AsyncClient, db: Db, url_for: Any) -> None:
     """Q — `q` query param honored on /api/tags."""
-    db.session.add_all([TagFactory.create(name="ZelaTagOne"), TagFactory.create(name="OtherTag")])
-    await db.session.commit()
+    await TagFactory.create_async(name="ZelaTagOne")
+    await TagFactory.create_async(name="OtherTag")
     tags_url = url_for("api-tags.tags")
     rep = await client.get(tags_url, params={"q": "ZelaTag"})
     assert rep.status_code == 200
@@ -435,10 +422,8 @@ async def test_put_tag_emits_tag_modify_audit_log(
 
 async def test_list_tags_search_matches_description(client: AsyncClient, db: Db, url_for: Any) -> None:
     """`q` matches against Tag.description as well as Tag.name."""
-    name_only = TagFactory.create(name="HaystackTag", description="generic")
-    desc_only = TagFactory.create(name="OtherName", description="contains needle here")
-    db.session.add_all([name_only, desc_only])
-    await db.session.commit()
+    name_only = await TagFactory.create_async(name="HaystackTag", description="generic")
+    desc_only = await TagFactory.create_async(name="OtherName", description="contains needle here")
 
     tags_url = url_for("api-tags.tags")
     rep = await client.get(tags_url, params={"q": "needle"})
@@ -459,8 +444,7 @@ async def test_list_tags_response_is_summary_shape(
     db.session.add(tag)
     db.session.add(okta_group)
     await db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tag.id)
 
     tags_url = url_for("api-tags.tags")
     rep = await client.get(tags_url)
@@ -522,9 +506,7 @@ async def test_get_tag_detail_includes_active_app_tags(
     db.session.add(tag)
     db.session.add(access_app)
     await db.session.commit()
-    app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tag.id)
-    db.session.add(app_tag_map)
-    await db.session.commit()
+    await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tag.id)
 
     tag_url = url_for("api-tags.tag_by_id", tag_id=tag.id)
     rep = await client.get(tag_url)
@@ -548,8 +530,7 @@ async def test_get_tag_detail_active_group_tags_carries_group_description(
     db.session.add(okta_group)
     db.session.add(tag)
     await db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=okta_group.id, tag_id=tag.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=okta_group.id, tag_id=tag.id)
 
     tag_url = url_for("api-tags.tag_by_id", tag_id=tag.id)
     rep = await client.get(tag_url)

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -463,10 +463,10 @@ async def test_get_tag_prefers_active_over_deleted_with_same_name(client: AsyncC
     """When two tags share the same name (one soft-deleted, one active),
     GET /api/tags/{name} must return the active one. The router uses
     `nullsfirst(deleted_at.desc())` to enforce that ordering."""
-    deleted = TagFactory.create(name="DupName", description="old")
+    deleted = TagFactory.build(name="DupName", description="old")
     deleted.deleted_at = datetime.now(timezone.utc)
     db.session.add(deleted)
-    active = TagFactory.create(name="DupName", description="new")
+    active = TagFactory.build(name="DupName", description="new")
     db.session.add(active)
     await db.session.commit()
 
@@ -482,7 +482,7 @@ async def test_get_tag_returns_deleted_when_no_active_match(client: AsyncClient,
     """If only a soft-deleted tag with that name exists, GET still returns
     it (the `nullsfirst(deleted_at.desc())` ordering falls through to the
     deleted row when no active row exists)."""
-    deleted = TagFactory.create(name="OnlyDeleted")
+    deleted = TagFactory.build(name="OnlyDeleted")
     deleted.deleted_at = datetime.now(timezone.utc)
     db.session.add(deleted)
     await db.session.commit()

--- a/tests/test_time_limit_constraint.py
+++ b/tests/test_time_limit_constraint.py
@@ -20,7 +20,7 @@ from api.models import (
 )
 from api.operations import ModifyGroupUsers, ModifyRoleGroups
 from api.services import okta
-from tests.factories import TagFactory
+from tests.factories import AppTagMapFactory, OktaGroupTagMapFactory, TagFactory
 from tests.helpers import db_count
 
 SEVEN_DAYS_IN_SECONDS = 7 * 24 * 60 * 60
@@ -66,16 +66,12 @@ async def test_time_limit_modify_group_users(
     db.session.add(app_group)
     await db.session.commit()
 
-    db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[0].id))
-    db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[1].id))
-    app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tags[0].id)
-    db.session.add(app_tag_map)
-    app_tag_map2 = AppTagMap(app_id=access_app.id, tag_id=tags[2].id)
-    db.session.add(app_tag_map2)
-    await db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[0].id, app_tag_map_id=app_tag_map.id))
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=role_group.id, tag_id=tags[0].id)
+    await OktaGroupTagMapFactory.create_async(group_id=role_group.id, tag_id=tags[1].id)
+    app_tag_map = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tags[0].id)
+    app_tag_map2 = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tags[2].id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tags[0].id, app_tag_map_id=app_tag_map.id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id)
 
     add_user_to_group_spy = mocker.patch.object(okta, "add_user_to_group")
     remove_user_from_group_spy = mocker.patch.object(okta, "remove_user_from_group")
@@ -358,16 +354,12 @@ async def test_time_limit_modify_role_groups(
     db.session.add(app_group)
     await db.session.commit()
 
-    db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[0].id))
-    db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[1].id))
-    app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tags[0].id)
-    db.session.add(app_tag_map)
-    app_tag_map2 = AppTagMap(app_id=access_app.id, tag_id=tags[2].id)
-    db.session.add(app_tag_map2)
-    await db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[0].id, app_tag_map_id=app_tag_map.id))
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=role_group.id, tag_id=tags[0].id)
+    await OktaGroupTagMapFactory.create_async(group_id=role_group.id, tag_id=tags[1].id)
+    app_tag_map = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tags[0].id)
+    app_tag_map2 = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tags[2].id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tags[0].id, app_tag_map_id=app_tag_map.id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id)
 
     await ModifyGroupUsers(
         group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
@@ -514,8 +506,8 @@ async def test_time_limit_modify_group_type(
     db.session.add(user)
     await db.session.commit()
 
-    db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[0].id))
-    db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[2].id))
+    await OktaGroupTagMapFactory.create_async(group_id=role_group.id, tag_id=tags[0].id)
+    await OktaGroupTagMapFactory.create_async(group_id=role_group.id, tag_id=tags[2].id)
     db.session.add_all([AppTagMap(app_id=access_app.id, tag_id=tag.id) for tag in tags])
     await db.session.commit()
 
@@ -668,17 +660,13 @@ async def test_time_limit_modify_group_tags(
     db.session.add(app_group)
     await db.session.commit()
 
-    db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[0].id))
-    db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[1].id))
-    db.session.add(OktaGroupTagMap(group_id=role_group.id, tag_id=tags[2].id))
-    app_tag_map = AppTagMap(app_id=access_app.id, tag_id=tags[0].id)
-    db.session.add(app_tag_map)
-    app_tag_map2 = AppTagMap(app_id=access_app.id, tag_id=tags[2].id)
-    db.session.add(app_tag_map2)
-    await db.session.commit()
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[0].id, app_tag_map_id=app_tag_map.id))
-    db.session.add(OktaGroupTagMap(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id))
-    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=role_group.id, tag_id=tags[0].id)
+    await OktaGroupTagMapFactory.create_async(group_id=role_group.id, tag_id=tags[1].id)
+    await OktaGroupTagMapFactory.create_async(group_id=role_group.id, tag_id=tags[2].id)
+    app_tag_map = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tags[0].id)
+    app_tag_map2 = await AppTagMapFactory.create_async(app_id=access_app.id, tag_id=tags[2].id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tags[0].id, app_tag_map_id=app_tag_map.id)
+    await OktaGroupTagMapFactory.create_async(group_id=app_group.id, tag_id=tags[2].id, app_tag_map_id=app_tag_map2.id)
 
     await ModifyGroupUsers(
         group=okta_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False

--- a/tests/test_time_limit_constraint.py
+++ b/tests/test_time_limit_constraint.py
@@ -40,7 +40,7 @@ async def test_time_limit_modify_group_users(
     url_for: Any,
 ) -> None:
     # Set primary tag constraint time limit to 3 days
-    tags = TagFactory.create_batch(
+    tags = TagFactory.batch(
         3,
         constraints={
             Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: THREE_DAYS_IN_SECONDS,
@@ -328,7 +328,7 @@ async def test_time_limit_modify_role_groups(
     url_for: Any,
 ) -> None:
     # Set primary tag constraint time limit to 3 days
-    tags = TagFactory.create_batch(
+    tags = TagFactory.batch(
         3,
         constraints={
             Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: THREE_DAYS_IN_SECONDS,
@@ -483,7 +483,7 @@ async def test_time_limit_modify_group_type(
     url_for: Any,
 ) -> None:
     # Set primary tag constraint time limit to 3 days
-    tags = TagFactory.create_batch(
+    tags = TagFactory.batch(
         3,
         constraints={
             Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: THREE_DAYS_IN_SECONDS,
@@ -638,7 +638,7 @@ async def test_time_limit_modify_group_tags(
     url_for: Any,
 ) -> None:
     # Set primary tag constraint time limit to 7 days initially
-    tags = TagFactory.create_batch(
+    tags = TagFactory.batch(
         3,
         constraints={
             Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: SEVEN_DAYS_IN_SECONDS,
@@ -917,7 +917,7 @@ async def test_time_limit_add_group_tags(
     url_for: Any,
 ) -> None:
     # Set primary tag constraint time limit to 3 days
-    tags = TagFactory.create_batch(
+    tags = TagFactory.batch(
         3,
         constraints={
             Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: THREE_DAYS_IN_SECONDS,
@@ -1143,7 +1143,7 @@ async def test_time_limit_add_app_tags(
     url_for: Any,
 ) -> None:
     # Set primary tag constraint time limit to 3 days
-    tags = TagFactory.create_batch(
+    tags = TagFactory.batch(
         3,
         constraints={
             Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: THREE_DAYS_IN_SECONDS,

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -172,7 +172,7 @@ async def test_user_email_uniqueness(client: AsyncClient, db: Db) -> None:
     known_email = "test@email.com"
 
     # Create a user with a unique email
-    user1 = OktaUserFactory.create()
+    user1 = OktaUserFactory.build()
 
     user1.email = known_email
 
@@ -180,7 +180,7 @@ async def test_user_email_uniqueness(client: AsyncClient, db: Db) -> None:
     await db.session.commit()
 
     # Trying to insert a user with the same email should fail
-    user2 = OktaUserFactory.create()
+    user2 = OktaUserFactory.build()
     user2.email = known_email
     try:
         db.session.add(user2)
@@ -219,7 +219,7 @@ async def test_get_user_manager_includes_profile(client: AsyncClient, db: Db, us
     `USER_DISPLAY_CUSTOM_ATTRIBUTES`). The FastAPI `OktaUserDetail.manager`
     must expose the same dict so the React user-detail page can render the
     manager's title alongside their name."""
-    manager = OktaUserFactory.create()
+    manager = OktaUserFactory.build()
     manager.profile = {"Title": "Director", "Manager": "ceo@example.com"}
     db.session.add(manager)
     await db.session.commit()

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -151,10 +151,7 @@ async def test_create_user(client: AsyncClient, db: Db, user: OktaUser, url_for:
 
 async def test_get_all_user(client: AsyncClient, db: Db, url_for: Any) -> None:
     users_url = url_for("api-users.users")
-    users = OktaUserFactory.create_batch(10)
-
-    db.session.add_all(users)
-    await db.session.commit()
+    users = await OktaUserFactory.create_batch_async(10)
 
     rep = await client.get(users_url)
     assert rep.status_code == 200


### PR DESCRIPTION
Follow-up to #555, acting on the remaining half of Matthew's #542 review — the ORM factories themselves (the request-body half shipped in #555). The theme is making the factories use polyfactory's real API instead of the factory_boy-shaped shim the migration left behind.

**`create_async` persistence.** `_ORMFactory` now sets `__async_session__` to the active request-scoped `db.session` (resolved lazily — the scope changes per test), so `await Factory.create_async(...)` / `create_batch_async(...)` add + commit + refresh in one call. This collapses the `X = Factory.create(); db.session.add(X); await db.session.commit()` triad. It's what makes `SQLAlchemyFactory` earn its keep (Matthew's point) rather than dropping to plain builders.

**Missing factories.**
- `GroupRequestFactory` — completes the request trio alongside `AccessRequestFactory`/`RoleRequestFactory`, plus a parallel `group_request` conftest fixture.
- `OktaUserGroupMemberFactory` / `RoleGroupMapFactory` / `OktaGroupTagMapFactory` / `AppTagMapFactory` for the temporal association tables — they generate nothing on their own (defaults + caller-supplied FKs) and exist for the `create_async` path.

**Suite-wide adoption.** The construct+add+commit triads are converted to `create_async` across the suite — inline association-row seeding and entity create+add+commit both collapse to one `await` call.

**Dropped the factory_boy-style aliases.** The ORM factories carried `create`/`create_batch`/`build_batch` as thin aliases over polyfactory's `build`/`batch` — a compat shim to avoid churning call sites during the migration. Those are removed and the ~95 call sites now use `build()`/`batch()` directly. This also kills a real footgun: `create()` (built, no DB write) next to the new `create_async()` (persists) read as if `create()` persisted too. The hand-rolled Okta SDK builders (`GroupFactory`/`UserFactory`/`UserSchemaFactory`) keep their own `create`/`create_batch` — unrelated to the polyfactory API, they mock external Okta responses.

**Not done — persisting fixtures.** Making the conftest fixtures themselves persist was considered and rejected: `AccessRequest`/`RoleRequest`/`GroupRequest`/`AppGroup` require NOT-NULL FKs that tests set in the body (so those fixtures can't be pre-persisted), and pre-persisting the rest would change baseline DB state and break the suite's many count/existence assertions.

Test-only change; no runtime code touched. Full suite green on sqlite.