### PR TITLE
feat: search group/role members by name or email

### DIFF
--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -498,6 +498,7 @@ async def get_group_member_details(
     db: DbSession,
     current_user_id: CurrentUserId,
     owner: Annotated[Optional[bool], Query()] = None,
+    q: Annotated[Optional[str], Query()] = None,
 ) -> Page[OktaUserGroupMemberDetail]:
     """Paginated, fully-hydrated active membership rows for a group. `owner=true`
     returns ownerships, `owner=false` memberships, omitted returns both. Lets the
@@ -510,7 +511,11 @@ async def get_group_member_details(
     with the de-duplicated list the UI shows and keeps all of a user's rows on
     the same page. Note `total` and `size` count users, so a page can contain
     more than `size` items (rows) when users hold multiple rows; consumers must
-    not assume ``len(items) == size``."""
+    not assume ``len(items) == size``.
+
+    `q` is the group page's member search: it filters to users whose name or
+    email matches the query, computed in SQL so a large paginated group can be
+    searched without loading every member client-side."""
     resolved_group_id = (
         await db.scalars(
             select(OktaGroup.id)
@@ -540,6 +545,16 @@ async def get_group_member_details(
     )
     if owner is not None:
         user_stmt = user_stmt.where(OktaUserGroupMember.is_owner.is_(owner))
+    if q:
+        like = f"%{q}%"
+        user_stmt = user_stmt.where(
+            or_(
+                OktaUser.email.ilike(like),
+                OktaUser.display_name.ilike(like),
+                OktaUser.first_name.ilike(like),
+                OktaUser.last_name.ilike(like),
+            )
+        )
     user_stmt = user_stmt.distinct().order_by(OktaUser.email, OktaUserGroupMember.user_id)
 
     async def _load_rows(user_rows: Any) -> list[Any]:

--- a/src/api/apiComponents.ts
+++ b/src/api/apiComponents.ts
@@ -1752,6 +1752,7 @@ export type GroupMemberDetailsByIdPathParams = {
 
 export type GroupMemberDetailsByIdQueryParams = {
   owner?: boolean | null;
+  q?: string | null;
   /**
    * Page number
    *
@@ -1792,6 +1793,10 @@ export type GroupMemberDetailsByIdVariables = {
  * the same page. Note `total` and `size` count users, so a page can contain
  * more than `size` items (rows) when users hold multiple rows; consumers must
  * not assume ``len(items) == size``.
+ *
+ * `q` is the group page's member search: it filters to users whose name or
+ * email matches the query, computed in SQL so a large paginated group can be
+ * searched without loading every member client-side.
  */
 export const fetchGroupMemberDetailsById = (variables: GroupMemberDetailsByIdVariables, signal?: AbortSignal) =>
   apiFetch<
@@ -1821,6 +1826,10 @@ export const fetchGroupMemberDetailsById = (variables: GroupMemberDetailsByIdVar
  * the same page. Note `total` and `size` count users, so a page can contain
  * more than `size` items (rows) when users hold multiple rows; consumers must
  * not assume ``len(items) == size``.
+ *
+ * `q` is the group page's member search: it filters to users whose name or
+ * email matches the query, computed in SQL so a large paginated group can be
+ * searched without loading every member client-side.
  */
 export function groupMemberDetailsByIdQuery(variables: GroupMemberDetailsByIdVariables): {
   queryKey: reactQuery.QueryKey;
@@ -1861,6 +1870,10 @@ export function groupMemberDetailsByIdQuery(variables: GroupMemberDetailsByIdVar
  * the same page. Note `total` and `size` count users, so a page can contain
  * more than `size` items (rows) when users hold multiple rows; consumers must
  * not assume ``len(items) == size``.
+ *
+ * `q` is the group page's member search: it filters to users whose name or
+ * email matches the query, computed in SQL so a large paginated group can be
+ * searched without loading every member client-side.
  */
 export const useSuspenseGroupMemberDetailsById = <TData = Schemas.PageTypeVarCustomizedOktaUserGroupMemberDetail>(
   variables: GroupMemberDetailsByIdVariables,
@@ -1898,6 +1911,10 @@ export const useSuspenseGroupMemberDetailsById = <TData = Schemas.PageTypeVarCus
  * the same page. Note `total` and `size` count users, so a page can contain
  * more than `size` items (rows) when users hold multiple rows; consumers must
  * not assume ``len(items) == size``.
+ *
+ * `q` is the group page's member search: it filters to users whose name or
+ * email matches the query, computed in SQL so a large paginated group can be
+ * searched without loading every member client-side.
  */
 export const useGroupMemberDetailsById = <TData = Schemas.PageTypeVarCustomizedOktaUserGroupMemberDetail>(
   variables: GroupMemberDetailsByIdVariables | reactQuery.SkipToken,

--- a/src/components/DebouncedSearchField.tsx
+++ b/src/components/DebouncedSearchField.tsx
@@ -1,0 +1,65 @@
+import Autocomplete from '@mui/material/Autocomplete';
+import TextField from '@mui/material/TextField';
+import {SxProps, Theme} from '@mui/material/styles';
+import React from 'react';
+
+// How long to wait after the last keystroke before firing the search query.
+const SEARCH_DEBOUNCE_MS = 200;
+
+interface DebouncedSearchFieldProps {
+  label: string;
+  // Emits the trimmed query, debounced, once the user stops typing — so callers
+  // filter server-side without a request per keystroke.
+  onSearchChange: (q: string) => void;
+  debounceMs?: number;
+  sx?: SxProps<Theme>;
+  autoFocus?: boolean;
+}
+
+// Search-as-you-type field: a free-solo Autocomplete (no suggestion list) that
+// debounces input and emits the trimmed query. Used wherever a list is paged
+// server-side and can't be filtered client-side (app groups, group members).
+export default function DebouncedSearchField({
+  label,
+  onSearchChange,
+  debounceMs = SEARCH_DEBOUNCE_MS,
+  sx,
+  autoFocus,
+}: DebouncedSearchFieldProps) {
+  const onSearchChangeRef = React.useRef(onSearchChange);
+  onSearchChangeRef.current = onSearchChange;
+
+  const debounceRef = React.useRef<ReturnType<typeof setTimeout>>();
+  const handleInputChange = React.useCallback(
+    (_: unknown, newValue: string | null) => {
+      const q = newValue?.trim() ?? '';
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+      debounceRef.current = setTimeout(() => onSearchChangeRef.current?.(q), debounceMs);
+    },
+    [debounceMs],
+  );
+
+  React.useEffect(
+    () => () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    },
+    [],
+  );
+
+  return (
+    <Autocomplete
+      size="small"
+      sx={sx}
+      renderInput={(params) => <TextField {...params} label={label} />}
+      options={[]}
+      onInputChange={handleInputChange}
+      clearOnEscape
+      freeSolo
+      autoFocus={autoFocus}
+    />
+  );
+}

--- a/src/pages/apps/components/AppsAdminActionGroup.tsx
+++ b/src/pages/apps/components/AppsAdminActionGroup.tsx
@@ -1,12 +1,10 @@
-import {Autocomplete, Button, Grid, Paper, TextField, Box} from '@mui/material';
+import {Button, Grid, Paper, Box} from '@mui/material';
 import UnfoldLessIcon from '@mui/icons-material/UnfoldLess';
 import UnfoldMoreIcon from '@mui/icons-material/UnfoldMore';
 import CreateUpdateGroup from '../../groups/CreateUpdate';
+import DebouncedSearchField from '../../../components/DebouncedSearchField';
 import {OktaUserDetail, AppDetail} from '../../../api/apiSchemas';
 import React from 'react';
-
-// How long to wait after the last keystroke before firing the search query.
-const SEARCH_DEBOUNCE_MS = 200;
 
 interface AppsAdminActionGroupProps {
   currentUser: OktaUserDetail;
@@ -24,26 +22,9 @@ export const AppsAdminActionGroup: React.FC<AppsAdminActionGroupProps> = React.m
     const onSearchChangeRef = React.useRef(onSearchChange);
     onSearchChangeRef.current = onSearchChange;
 
-    // Search as you type, debounced: fire the query shortly after the user stops
-    // typing rather than per keystroke (or only on Enter), so it stays responsive
-    // without a request per character.
-    const debounceRef = React.useRef<ReturnType<typeof setTimeout>>();
-    const handleSearchChange = React.useCallback((_: unknown, newValue: string | null) => {
-      const q = newValue?.trim() ?? '';
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-      }
-      debounceRef.current = setTimeout(() => onSearchChangeRef.current?.(q), SEARCH_DEBOUNCE_MS);
+    const handleSearchChange = React.useCallback((q: string) => {
+      onSearchChangeRef.current?.(q);
     }, []);
-
-    React.useEffect(
-      () => () => {
-        if (debounceRef.current) {
-          clearTimeout(debounceRef.current);
-        }
-      },
-      [],
-    );
 
     const onToggleExpandRef = React.useRef(onToggleExpand);
     const isExpandedRef = React.useRef(isExpanded);
@@ -81,14 +62,10 @@ export const AppsAdminActionGroup: React.FC<AppsAdminActionGroupProps> = React.m
                 marginLeft: 'auto',
                 justifyContent: 'flex-end',
               }}>
-              <Autocomplete
-                size="small"
+              <DebouncedSearchField
+                label="Search groups or users"
+                onSearchChange={handleSearchChange}
                 sx={{flex: '1 1 220px', minWidth: 0, maxWidth: 320}}
-                renderInput={(params) => <TextField {...params} label="Search groups or users" />}
-                options={[]}
-                onInputChange={handleSearchChange}
-                clearOnEscape
-                freeSolo
                 autoFocus
               />
               <Button

--- a/src/pages/groups/Read.tsx
+++ b/src/pages/groups/Read.tsx
@@ -770,7 +770,16 @@ export default function ReadGroup() {
                           </Typography>
                         </Stack>
                         <Stack direction="row" spacing={1} alignItems="center" sx={{flexWrap: 'nowrap'}}>
+                          {/*
+                           * The field is an uncontrolled Autocomplete, so MUI owns its text.
+                           * /groups/:id and /roles/:id render the same ReadGroup element, so
+                           * navigating between groups re-renders rather than remounts — keying
+                           * on id remounts the field so its text clears in lockstep with the
+                           * memberSearchQuery reset above (otherwise stale text desyncs from the
+                           * results). The apps page keys its search group the same way.
+                           */}
                           <DebouncedSearchField
+                            key={id}
                             label="Search members"
                             onSearchChange={handleMemberSearchChange}
                             sx={{width: 220}}

--- a/src/pages/groups/Read.tsx
+++ b/src/pages/groups/Read.tsx
@@ -71,6 +71,7 @@ import AppLinkButton from './AppLinkButton';
 import AvatarButton from '../../components/AvatarButton';
 import MembershipChip from '../../components/MembershipChip';
 import AppGroupLifecyclePluginData from '../../components/AppGroupLifecyclePluginData';
+import DebouncedSearchField from '../../components/DebouncedSearchField';
 
 function sortGroupMembers(
   [aUserId, aUsers]: [string, Array<OktaUserGroupMemberDetail>],
@@ -167,13 +168,31 @@ export default function ReadGroup() {
 
   // Members page MEMBER_PAGE_SIZE at a time via the page-number control below.
   const [memberPage, setMemberPage] = React.useState(1);
-  // Reset to page 1 when the group changes (component is reused across
+  // Member search is computed server-side (member-details `q` param) so a large
+  // paginated group can be searched by name/email without loading every row.
+  const [memberSearchQuery, setMemberSearchQuery] = React.useState('');
+  // Reset page and search when the group changes (component is reused across
   // /groups/:id and /roles/:id).
   React.useEffect(() => {
     setMemberPage(1);
+    setMemberSearchQuery('');
   }, [id]);
+  // A new search returns a different, usually smaller result set, so jump back
+  // to the first page rather than stranding the user on a now-empty page. The
+  // search field is uncontrolled and only emits on keystrokes, so this can't
+  // reset the page out from under someone paging through results.
+  const handleMemberSearchChange = React.useCallback((q: string) => {
+    setMemberSearchQuery(q);
+    setMemberPage(1);
+  }, []);
   const {data: groupMemberData} = useGroupMemberDetailsById(
-    {pathParams: {groupId: id ?? ''}, queryParams: {owner: false, page: memberPage, size: 100}},
+    {
+      pathParams: {groupId: id ?? ''},
+      queryParams: Object.assign(
+        {owner: false, page: memberPage, size: 100},
+        memberSearchQuery ? {q: memberSearchQuery} : null,
+      ),
+    },
     {enabled: id != null},
   );
 
@@ -735,21 +754,31 @@ export default function ReadGroup() {
               <Table sx={{minWidth: 650}} size="small" aria-label="group members">
                 <TableHead>
                   <TableRow>
-                    <TableCell colSpan={3}>
-                      <Stack direction="row" spacing={1} sx={{display: 'flex', alignItems: 'center'}}>
-                        <Typography variant="h6" color="text.accent">
-                          {group.type == 'role_group' ? 'Role Members' : 'Group Members'}
-                        </Typography>
-                        <Typography variant="body1" color="text.secondary">
-                          {group.type == 'role_group' ? 'Members of Okta Group for Role' : 'Members of Okta Group'}
-                        </Typography>
-                      </Stack>
-                    </TableCell>
-                    <TableCell align="right">
-                      <Stack direction="row" spacing={1} justifyContent={'flex-end'}>
-                        <CreateRequest currentUser={currentUser} group={group} owner={false}></CreateRequest>
-                        <AddUsers currentUser={currentUser} group={group} />
-                        <AddRoles currentUser={currentUser} group={group} />
+                    <TableCell colSpan={4}>
+                      <Stack
+                        direction="row"
+                        spacing={2}
+                        alignItems="center"
+                        justifyContent="space-between"
+                        sx={{flexWrap: 'wrap', rowGap: 1}}>
+                        <Stack direction="row" spacing={1} alignItems="center" sx={{flexWrap: 'wrap'}}>
+                          <Typography variant="h6" color="text.accent">
+                            {group.type == 'role_group' ? 'Role Members' : 'Group Members'}
+                          </Typography>
+                          <Typography variant="body1" color="text.secondary">
+                            {group.type == 'role_group' ? 'Members of Okta Group for Role' : 'Members of Okta Group'}
+                          </Typography>
+                        </Stack>
+                        <Stack direction="row" spacing={1} alignItems="center" sx={{flexWrap: 'nowrap'}}>
+                          <DebouncedSearchField
+                            label="Search members"
+                            onSearchChange={handleMemberSearchChange}
+                            sx={{width: 220}}
+                          />
+                          <CreateRequest currentUser={currentUser} group={group} owner={false}></CreateRequest>
+                          <AddUsers currentUser={currentUser} group={group} />
+                          <AddRoles currentUser={currentUser} group={group} />
+                        </Stack>
                       </Stack>
                     </TableCell>
                   </TableRow>
@@ -878,7 +907,7 @@ export default function ReadGroup() {
                     <TableRow key="member">
                       <TableCell>
                         <Typography variant="body2" color="text.secondary">
-                          None
+                          {memberSearchQuery ? 'No matching members' : 'None'}
                         </Typography>
                       </TableCell>
                     </TableRow>

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -1942,3 +1942,101 @@ async def test_get_group_member_details_paginates_in_email_order(client: AsyncCl
     assert emails == sorted(emails)
     assert emails[0] == "member-000@example.com"
     assert emails[-1] == "member-059@example.com"
+
+
+async def test_get_group_member_details_search_by_q(client: AsyncClient, db: Db, url_for: Any) -> None:
+    """`q` filters members server-side by name or email so a large paginated
+    group can be searched without loading every row client-side. Matching is a
+    case-insensitive substring against first/last name, display name, and email."""
+    group = await OktaGroupFactory.create_async()
+
+    alice = OktaUserFactory.build(first_name="Alice", last_name="Anderson", email="alice.anderson@example.com")
+    bob = OktaUserFactory.build(first_name="Bob", last_name="Baker", email="bob.baker@example.com")
+    carol = OktaUserFactory.build(first_name="Carol", last_name="Carter", email="carol.carter@example.com")
+    for u in (alice, bob, carol):
+        db.session.add(u)
+    await db.session.commit()
+
+    await ModifyGroupUsers(
+        group=group,
+        members_to_add=[alice.id, bob.id, carol.id],
+        sync_to_okta=False,
+    ).execute()
+
+    group_id = group.id
+    alice_id, bob_id, carol_id = alice.id, bob.id, carol.id
+    db.session.expunge_all()
+
+    url = url_for("api-groups.group_member_details_by_id", group_id=group_id)
+
+    def user_ids(payload: Any) -> set[str]:
+        return {r["active_user"]["id"] for r in payload["items"]}
+
+    # Last name (also a substring of the email).
+    rep = await client.get(url, params={"owner": "false", "q": "anderson"})
+    assert rep.status_code == 200, rep.text
+    data = rep.json()
+    assert data["total"] == 1
+    assert user_ids(data) == {alice_id}
+
+    # First name, case-insensitive.
+    data = (await client.get(url, params={"owner": "false", "q": "BOB"})).json()
+    assert data["total"] == 1
+    assert user_ids(data) == {bob_id}
+
+    # Email fragment.
+    data = (await client.get(url, params={"owner": "false", "q": "carol.carter@"})).json()
+    assert data["total"] == 1
+    assert user_ids(data) == {carol_id}
+
+    # Shared email domain matches everyone.
+    data = (await client.get(url, params={"owner": "false", "q": "@example.com"})).json()
+    assert data["total"] == 3
+    assert user_ids(data) == {alice_id, bob_id, carol_id}
+
+    # No match.
+    data = (await client.get(url, params={"owner": "false", "q": "nobody"})).json()
+    assert data["total"] == 0
+    assert data["items"] == []
+
+
+async def test_get_group_member_details_search_paginates(client: AsyncClient, db: Db, url_for: Any) -> None:
+    """`q` composes with pagination: `total`/`pages` reflect the filtered set
+    (not the whole group), and paging through filtered results yields disjoint,
+    complete pages. This is what lets the group page search a large member list
+    and still page through the matches."""
+    group = await OktaGroupFactory.create_async()
+
+    # 15 users match the query, 10 don't. Distinct lowercase emails keep both the
+    # match set and the email ordering deterministic across pages.
+    matching = [OktaUserFactory.build(email=f"match-{i:02d}@example.com") for i in range(15)]
+    other = [OktaUserFactory.build(email=f"zzz-{i:02d}@example.com") for i in range(10)]
+    for u in matching + other:
+        db.session.add(u)
+    await db.session.commit()
+
+    await ModifyGroupUsers(
+        group=group,
+        members_to_add=[u.id for u in matching + other],
+        sync_to_okta=False,
+    ).execute()
+
+    group_id = group.id
+    db.session.expunge_all()
+
+    url = url_for("api-groups.group_member_details_by_id", group_id=group_id)
+
+    page1 = (await client.get(url, params={"owner": "false", "q": "match-", "size": 10, "page": 1})).json()
+    page2 = (await client.get(url, params={"owner": "false", "q": "match-", "size": 10, "page": 2})).json()
+
+    # total/pages count only the 15 matching users, not all 25 members.
+    assert page1["total"] == 15
+    assert page1["pages"] == 2
+    assert page2["total"] == 15
+
+    emails1 = [r["active_user"]["email"] for r in page1["items"]]
+    emails2 = [r["active_user"]["email"] for r in page2["items"]]
+    # Pages are disjoint and together cover exactly the matching set.
+    assert set(emails1).isdisjoint(emails2)
+    assert all(e.startswith("match-") for e in emails1 + emails2)
+    assert sorted(emails1 + emails2) == [f"match-{i:02d}@example.com" for i in range(15)]


### PR DESCRIPTION


https://github.com/user-attachments/assets/6b2ab415-5c4d-476d-a26e-ec8019e58fe6



## What & why

[PR #500](https://github.com/discord/access/pull/500) added pagination to the member list on the group/role Read page. For large groups that span several pages, that made it hard to find a specific user — you'd have to page through to spot them. This adds a member search so you can filter the whole group by name or email, mirroring the search the apps page already has.

Because the member list is paginated server-side, the search is computed server-side too: `GET /api/groups/{id}/member-details` gains an optional `q` that filters the paginated set by name/email in SQL. Client-side filtering wouldn't work — it would only ever see the current page. Searching resets to page 1, and the page control reflects the filtered result count, so search and pagination compose (paging through filtered results keeps the query, and totals/pages track the filter).

The debounced search field is factored into a shared `DebouncedSearchField` component and reused by the apps page, which previously carried the same debounce logic inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)