### PR TITLE
Syncer bugfix: skip mid-run-deleted groups without an ERROR

### DIFF
--- a/api/services/okta_service.py
+++ b/api/services/okta_service.py
@@ -32,6 +32,10 @@ REQUEST_TIMEOUT = 30
 # may swallow them and let the next reconcile retry. Covers rate limiting (429)
 # and upstream/gateway blips (5xx, e.g. a 502 Bad Gateway from the load balancer).
 TRANSIENT_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+# The status a list endpoint returns when the resource it lists no longer exists —
+# chiefly a group deleted after the syncer took its group snapshot. See
+# ``OktaResourceNotFoundError``.
+NOT_FOUND_STATUS_CODE = 404
 # Page size for cursor-paginated list endpoints. Okta caps most list endpoints
 # at 200 per page; the facade drives the ``after`` cursor to walk pages.
 LIST_PAGE_LIMIT = 200
@@ -78,6 +82,23 @@ class OktaTransientError(Exception):
         self.retryable = retryable
 
 
+class OktaResourceNotFoundError(Exception):
+    """Raised when a list endpoint 404s because the resource it lists is gone.
+
+    The syncer takes one group snapshot per run (``api/cli.py``) and reuses it for
+    the whole membership and ownership fan-out, which can take tens of minutes. A
+    group deleted — usually *through Access itself*, whose ``DeleteGroup`` removes
+    it from Okta — after that snapshot was taken is still in the list being walked
+    but already absent from Okta, so its member/owner fetch 404s. That race is
+    expected and self-healing: the next run's snapshot won't contain the group and
+    ``sync_groups`` reconciles it as deleted locally. Callers in the fan-out skip
+    it at WARNING rather than ERROR so it doesn't alert.
+
+    Distinct from ``OktaTransientError``: nothing was flaky and a retry would not
+    help — the resource is genuinely gone.
+    """
+
+
 # On a gateway failure that yields no response object, the SDK returns
 # ``(None, None, error)`` from the request executor, then dereferences
 # ``response.status`` before checking the error on its list/get endpoints. That
@@ -107,6 +128,16 @@ def _is_transient_okta_error(error: Any) -> bool:
     if isinstance(error, AttributeError) and str(error) == _NONE_RESPONSE_ATTRIBUTE_ERROR:
         return True
     return str(error) == "Request Timeout exceeded."
+
+
+def _is_not_found_okta_error(error: Any) -> bool:
+    """Whether an SDK error is a 404 for a resource that no longer exists.
+
+    Both ``OktaAPIError`` (JSON error bodies) and ``HTTPError`` expose ``.status``.
+    Classified only for list endpoints (see ``_paginate``), where a 404 means the
+    parent resource being listed is gone rather than that a single lookup missed.
+    """
+    return error is not None and getattr(error, "status", None) == NOT_FOUND_STATUS_CODE
 
 
 def _is_retryable_okta_error(error: Any) -> bool:
@@ -292,6 +323,11 @@ class OktaService:
         carries the ``after`` cursor for the next page. ``*args`` carries any
         positional argument the endpoint requires (e.g. the group id for group
         listings).
+
+        A 404 here means the resource being listed is gone, so it surfaces as
+        ``OktaResourceNotFoundError`` for callers that treat that as benign. Every
+        other error keeps raising the generic ``Exception`` so genuine failures stay
+        loud.
         """
         results: list[Any] = []
         after: Optional[str] = None
@@ -302,6 +338,8 @@ class OktaService:
             # List endpoints are data-returning, so the tuple is (data, resp, error).
             page, response, error = result
             if error is not None:
+                if _is_not_found_okta_error(error):
+                    raise OktaResourceNotFoundError(str(error))
                 raise Exception(error)
             assert page is not None and response is not None
             results.extend(page)

--- a/api/services/okta_service.py
+++ b/api/services/okta_service.py
@@ -298,10 +298,17 @@ class OktaService:
         and retries 429s internally, returning errors rather than raising them.
         A transient outcome — a request timeout, a 429 that outlived the SDK's
         rate-limit retries, or a 5xx upstream/gateway error — is surfaced as
-        ``OktaTransientError`` so callers can choose to swallow it; every other
-        error passes through in the returned tuple for the caller to raise. A
-        gateway blip can also make the SDK *raise* (rather than return) a transient
-        failure, so raised exceptions are routed through the same check.
+        ``OktaTransientError`` so callers can choose to swallow it, and a 404 as
+        ``OktaResourceNotFoundError``; every other error passes through in the
+        returned tuple for the caller to raise. A gateway blip can also make the SDK
+        *raise* (rather than return) a transient failure, so raised exceptions are
+        routed through the same checks.
+
+        Classifying here rather than at each call site makes it uniform and
+        impossible to forget when a facade method is added. The corollary is that a
+        facade method can no longer inspect a 404 in the returned tuple — it never
+        gets one — so a method that treats "already gone" as success must catch
+        ``OktaResourceNotFoundError`` instead (see ``delete_group_push_mapping``).
         """
         try:
             result = await coro
@@ -310,10 +317,14 @@ class OktaService:
                 raise OktaTransientError(
                     str(exc) or "Okta request timed out", retryable=_is_retryable_okta_error(exc)
                 ) from exc
+            if _is_not_found_okta_error(exc):
+                raise OktaResourceNotFoundError(str(exc)) from exc
             raise
         error = result[-1] if isinstance(result, tuple) and result else None
         if _is_transient_okta_error(error):
             raise OktaTransientError(str(error) or "Okta request timed out", retryable=_is_retryable_okta_error(error))
+        if _is_not_found_okta_error(error):
+            raise OktaResourceNotFoundError(str(error))
         return result
 
     async def _paginate(self, list_method: Callable[..., Any], *args: Any, **kwargs: Any) -> list[Any]:
@@ -324,10 +335,9 @@ class OktaService:
         positional argument the endpoint requires (e.g. the group id for group
         listings).
 
-        A 404 here means the resource being listed is gone, so it surfaces as
-        ``OktaResourceNotFoundError`` for callers that treat that as benign. Every
-        other error keeps raising the generic ``Exception`` so genuine failures stay
-        loud.
+        A 404 — the resource being listed is gone — is already surfaced as
+        ``OktaResourceNotFoundError`` by ``_call``, so it never reaches the check
+        below; every other error keeps raising the generic ``Exception``.
         """
         results: list[Any] = []
         after: Optional[str] = None
@@ -338,8 +348,6 @@ class OktaService:
             # List endpoints are data-returning, so the tuple is (data, resp, error).
             page, response, error = result
             if error is not None:
-                if _is_not_found_okta_error(error):
-                    raise OktaResourceNotFoundError(str(error))
                 raise Exception(error)
             assert page is not None and response is not None
             results.extend(page)
@@ -639,25 +647,28 @@ class OktaService:
         async with self._okta_client() as client:
             # The SDK returns HTTP errors in the result tuple rather than raising; ``_call``
             # (via the client proxy) already converts transient ones (429/5xx) to
-            # OktaTransientError, so any error we see here is definitive. A 404 at either step
-            # means the mapping is already gone -- deletion is idempotent, so treat it as success
-            # (safe for a retry/replay after a partial earlier attempt). Read the trailing error
-            # element without a fixed-arity unpack: delete returns a 2-tuple on error but a
-            # 3-tuple on success, while update returns a 3-tuple either way.
-            # Okta rejects deleting an ACTIVE mapping, so deactivate it first.
-            deactivate = await client.update_group_push_mapping(
-                appId, mappingId, UpdateGroupPushMappingRequest(status="INACTIVE")
-            )
-            error = deactivate[-1] if isinstance(deactivate, tuple) else None
-            if error is not None:
-                if getattr(error, "status", None) == 404:
-                    return
-                raise Exception(error)
+            # OktaTransientError and a 404 to OktaResourceNotFoundError, so any error left in
+            # the tuple here is definitive. A 404 at either step means the mapping is already
+            # gone -- deletion is idempotent, so treat it as success (safe for a retry/replay
+            # after a partial earlier attempt); catching it also skips the delete when the
+            # mapping vanished at the deactivate step. Read the trailing error element without
+            # a fixed-arity unpack: delete returns a 2-tuple on error but a 3-tuple on success,
+            # while update returns a 3-tuple either way.
+            try:
+                # Okta rejects deleting an ACTIVE mapping, so deactivate it first.
+                deactivate = await client.update_group_push_mapping(
+                    appId, mappingId, UpdateGroupPushMappingRequest(status="INACTIVE")
+                )
+                error = deactivate[-1] if isinstance(deactivate, tuple) else None
+                if error is not None:
+                    raise Exception(error)
 
-            deletion = await client.delete_group_push_mapping(appId, mappingId, deleteTargetGroup)
-            error = deletion[-1] if isinstance(deletion, tuple) else None
-            if error is not None and getattr(error, "status", None) != 404:
-                raise Exception(error)
+                deletion = await client.delete_group_push_mapping(appId, mappingId, deleteTargetGroup)
+                error = deletion[-1] if isinstance(deletion, tuple) else None
+                if error is not None:
+                    raise Exception(error)
+            except OktaResourceNotFoundError:
+                return
 
     # https://developer.okta.com/docs/api/openapi/okta-management/management/tag/GroupPushMapping/#tag/GroupPushMapping/operation/listGroupPushMappings
     async def list_group_push_mappings(self, appId: str, sourceGroupId: str | None = None) -> list[dict[str, Any]]:

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -38,7 +38,13 @@ from api.operations import (
 )
 from api.plugins import NotificationHook, send_notification
 from api.services import okta
-from api.services.okta_service import Group, OktaTransientError, User, is_managed_group
+from api.services.okta_service import (
+    Group,
+    OktaResourceNotFoundError,
+    OktaTransientError,
+    User,
+    is_managed_group,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -277,6 +283,12 @@ async def sync_group_memberships(
         if isinstance(members, OktaTransientError):
             logger.warning(f"Transient Okta error listing members for group {group.id}, skipping.", exc_info=members)
             continue
+        if isinstance(members, OktaResourceNotFoundError):
+            logger.warning(
+                f"Group {group.id} no longer exists in Okta (deleted after this run's group "
+                f"snapshot was taken), skipping membership sync."
+            )
+            continue
         if isinstance(members, Exception):
             logger.error(f"Failed to list members for group {group.id}, skipping.", exc_info=members)
             continue
@@ -381,6 +393,12 @@ async def sync_group_ownerships(
     async for group, owners in _prefetch_group_okta_lists(groups, okta.list_owners_for_group, concurrency):
         if isinstance(owners, OktaTransientError):
             logger.warning(f"Transient Okta error listing owners for group {group.id}, skipping.", exc_info=owners)
+            continue
+        if isinstance(owners, OktaResourceNotFoundError):
+            logger.warning(
+                f"Group {group.id} no longer exists in Okta (deleted after this run's group "
+                f"snapshot was taken), skipping ownership sync."
+            )
             continue
         if isinstance(owners, Exception):
             logger.error(f"Failed to list owners for group {group.id}, skipping.", exc_info=owners)

--- a/tests/test_group_membership_sync.py
+++ b/tests/test_group_membership_sync.py
@@ -1,7 +1,9 @@
+import logging
 from collections import namedtuple
 from datetime import datetime, timedelta
 from typing import Callable, Tuple
 
+import pytest
 from pytest_mock import MockerFixture
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -9,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.models import OktaGroup, OktaUser, OktaUserGroupMember
 from api.extensions import Db
 from api.services import okta
-from api.services.okta_service import Group, User
+from api.services.okta_service import Group, OktaResourceNotFoundError, User
 from api.syncer import sync_group_memberships
 from tests.factories import GroupFactory, UserFactory
 
@@ -327,6 +329,45 @@ async def test_membership_sync_continues_after_group_failure(db: Db, mocker: Moc
     # Verify the failing group has no members
     failed_members = await _get_group_members(db, initial_okta_groups[0].id)
     assert len(failed_members) == 0
+
+
+async def test_membership_sync_skips_group_deleted_mid_run_at_warning(
+    db: Db, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A group deleted from Okta after this run took its group snapshot 404s when the
+    membership pass reaches it. That race is expected and self-healing — the next run's
+    snapshot won't contain the group, and ``sync_groups`` soft-deletes it locally — so it
+    is logged at WARNING and skipped rather than raising an ERROR that pages someone."""
+    initial_okta_users = UserFactory.create_batch(3)
+    initial_okta_groups = GroupFactory.create_batch(3)
+    _, _ = await seed_db(db, initial_okta_users, initial_okta_groups)
+
+    deleted_group_id = initial_okta_groups[0].id
+
+    def fake_list_users_for_group(group_id: str) -> list[User]:
+        if group_id == deleted_group_id:
+            raise OktaResourceNotFoundError(
+                f"Okta HTTP 404 E0000007 Not found: Resource not found: {group_id} (UserGroup)"
+            )
+        if group_id == initial_okta_groups[1].id:
+            return initial_okta_users
+        return []
+
+    with caplog.at_level(logging.WARNING):
+        _ = await run_sync(db, mocker, initial_okta_groups, fake_list_users_for_group, False)
+
+    # The other groups still reconcile — one group vanishing does not stop the pass.
+    assert len(await _get_group_members(db, initial_okta_groups[1].id)) == 3
+    assert len(await _get_group_members(db, deleted_group_id)) == 0
+
+    # Skipped quietly: a WARNING naming the group, and nothing at ERROR to alert on.
+    # Scoped to the syncer's own logger — unrelated fan-out noise from Okta mutation
+    # calls the test doesn't stub is not what's under test here.
+    syncer_records = [record for record in caplog.records if record.name == "api.syncer"]
+    assert not any(record.levelno >= logging.ERROR for record in syncer_records)
+    assert any(
+        record.levelno == logging.WARNING and deleted_group_id in record.getMessage() for record in syncer_records
+    )
 
 
 async def seed_db(db: Db, users: list[OktaUser], groups: list[OktaGroup]) -> Tuple[list[OktaUser], list[OktaGroup]]:

--- a/tests/test_group_ownership_sync.py
+++ b/tests/test_group_ownership_sync.py
@@ -1,7 +1,9 @@
+import logging
 from collections import namedtuple
 from datetime import datetime, timedelta
 from typing import Callable, Tuple
 
+import pytest
 from pytest_mock import MockerFixture
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -9,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.models import AppGroup, OktaGroup, OktaUser, OktaUserGroupMember
 from api.extensions import Db
 from api.services import okta
-from api.services.okta_service import Group, User
+from api.services.okta_service import Group, OktaResourceNotFoundError, User
 from api.syncer import sync_group_ownerships
 from tests.factories import AppFactory, AppGroupFactory, GroupFactory, UserFactory
 
@@ -394,6 +396,41 @@ async def seed_db(db: Db, users: list[OktaUser], groups: list[OktaGroup]) -> Tup
             list((await session.scalars(select(OktaUser))).all()),
             list((await session.scalars(select(OktaGroup))).all()),
         )
+
+
+async def test_ownership_sync_skips_group_deleted_mid_run_at_warning(
+    db: Db, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The ownership pass shares the membership pass's stale group snapshot, so it hits
+    the same benign 404 for a group deleted mid-run. Skip it at WARNING, not ERROR."""
+    initial_okta_users = UserFactory.create_batch(3)
+    initial_okta_groups = GroupFactory.create_batch(3)
+    _, _ = await seed_db(db, initial_okta_users, initial_okta_groups)
+
+    deleted_group_id = initial_okta_groups[0].id
+
+    def fake_list_owners_for_group(group_id: str) -> list[User]:
+        if group_id == deleted_group_id:
+            raise OktaResourceNotFoundError(
+                f"Okta HTTP 404 E0000007 Not found: Resource not found: {group_id} (UserGroup)"
+            )
+        if group_id == initial_okta_groups[1].id:
+            return initial_okta_users
+        return []
+
+    with caplog.at_level(logging.WARNING):
+        _ = await run_sync(db, mocker, initial_okta_groups, fake_list_owners_for_group, False)
+
+    assert len(await _get_group_owners(db, initial_okta_groups[1].id)) == 3
+    assert len(await _get_group_owners(db, deleted_group_id)) == 0
+
+    # Scoped to the syncer's own logger — unrelated fan-out noise from Okta mutation
+    # calls the test doesn't stub is not what's under test here.
+    syncer_records = [record for record in caplog.records if record.name == "api.syncer"]
+    assert not any(record.levelno >= logging.ERROR for record in syncer_records)
+    assert any(
+        record.levelno == logging.WARNING and deleted_group_id in record.getMessage() for record in syncer_records
+    )
 
 
 async def run_sync(

--- a/tests/test_okta_service.py
+++ b/tests/test_okta_service.py
@@ -19,6 +19,7 @@ from api.services.okta_service import (
     OktaService,
     OktaTransientError,
     UserSchema,
+    _WrapperClient,
     is_managed_group,
 )
 from tests.factories import UserFactory
@@ -306,12 +307,19 @@ def _fake_okta_client(mocker, svc):
     ``Client``), which returns ``(data, ApiResponse, error)`` tuples and reports HTTP errors
     in the trailing ``error`` element (it does NOT raise) — delete even returns a 2-tuple
     ``(response, error)`` on error. Tests script those methods directly rather than the
-    low-level request executor."""
+    low-level request executor.
+
+    The mock is yielded wrapped in ``_WrapperClient``, exactly as the real
+    ``_okta_client`` does, so calls route through ``OktaService._call`` and its error
+    classification. Yielding the bare mock would bypass ``_call``, letting a facade
+    method's own error handling be tested against errors that in production never
+    reach it — the classification would have already raised.
+    """
     client = MagicMock()
 
     @asynccontextmanager
     async def fake_client():
-        yield client
+        yield _WrapperClient(client)
 
     mocker.patch.object(svc, "_okta_client", fake_client)
     return client
@@ -513,7 +521,7 @@ async def test_list_group_push_mappings_requires_app_id():
         await svc.list_group_push_mappings("")
 
 
-async def test_paginate_404_surfaces_as_resource_not_found() -> None:
+async def test_call_404_on_list_endpoint_surfaces_as_resource_not_found() -> None:
     """A list endpoint that 404s because its parent resource is gone is surfaced as
     ``OktaResourceNotFoundError`` so the syncer fan-out can skip it quietly rather
     than logging an ERROR for an expected, benign race."""
@@ -532,9 +540,9 @@ async def test_paginate_404_surfaces_as_resource_not_found() -> None:
             await service.list_users_for_group("deleted_group")
 
 
-async def test_paginate_non_404_error_is_not_resource_not_found() -> None:
-    """A list-endpoint error that isn't a 404 keeps raising the generic Exception, so
-    genuine failures stay loud instead of being downgraded to the benign path."""
+async def test_call_non_404_error_is_not_resource_not_found() -> None:
+    """An error that isn't a 404 keeps raising the generic Exception, so genuine
+    failures stay loud instead of being downgraded to the benign path."""
     service = OktaService()
     service.initialize("fake.domain", "fake.token")
 
@@ -550,3 +558,34 @@ async def test_paginate_non_404_error_is_not_resource_not_found() -> None:
             await service.list_users_for_group("some_group")
 
     assert not isinstance(exc_info.value, OktaResourceNotFoundError)
+
+
+async def test_call_404_on_single_resource_endpoint_surfaces_as_resource_not_found() -> None:
+    """Classification lives in ``_call``, not ``_paginate``, so it covers every proxied
+    SDK method — not just the paginated list endpoints the syncer fan-out uses."""
+    service = OktaService()
+    service.initialize("fake.domain", "fake.token")
+
+    response_details = MagicMock(status=404, headers={})
+    not_found = OktaAPIError(
+        "https://fake.domain/api/v1/users/gone",
+        response_details,
+        {"errorCode": "E0000007", "errorSummary": "Not found: Resource not found: gone (User)"},
+    )
+
+    with patch("okta.client.Client.get_user", AsyncMock(return_value=(None, MagicMock(), not_found))):
+        with pytest.raises(OktaResourceNotFoundError):
+            await service.get_user("gone")
+
+
+async def test_delete_group_push_mapping_tolerance_survives_call_level_classification(mocker) -> None:
+    """Regression guard for the classification move: ``_call`` now raises on a 404 before
+    the facade method can inspect it, so ``delete_group_push_mapping`` must catch
+    ``OktaResourceNotFoundError`` to keep deletion idempotent. Exercised through
+    ``_WrapperClient`` — mocking the bare client would bypass ``_call`` and pass either way."""
+    svc = OktaService()
+    client = _fake_okta_client(mocker, svc)
+    client.update_group_push_mapping = AsyncMock(return_value=(_mapping(id="map-1"), MagicMock(), None))
+    client.delete_group_push_mapping = AsyncMock(return_value=(MagicMock(), MagicMock(status=404)))
+
+    await svc.delete_group_push_mapping("app-1", "map-1")  # must not raise

--- a/tests/test_okta_service.py
+++ b/tests/test_okta_service.py
@@ -11,8 +11,11 @@ from okta.models.group_push_mapping import GroupPushMapping
 from okta.models.group_rule import GroupRule as OktaGroupRuleType
 from okta.models.user_schema import UserSchema as OktaUserSchemaType
 
+from okta.errors.okta_api_error import OktaAPIError
+
 from api.services.okta_service import (
     OKTA_TRANSIENT_RETRIES,
+    OktaResourceNotFoundError,
     OktaService,
     OktaTransientError,
     UserSchema,
@@ -508,3 +511,42 @@ async def test_list_group_push_mappings_requires_app_id():
     svc = OktaService()
     with pytest.raises(ValueError):
         await svc.list_group_push_mappings("")
+
+
+async def test_paginate_404_surfaces_as_resource_not_found() -> None:
+    """A list endpoint that 404s because its parent resource is gone is surfaced as
+    ``OktaResourceNotFoundError`` so the syncer fan-out can skip it quietly rather
+    than logging an ERROR for an expected, benign race."""
+    service = OktaService()
+    service.initialize("fake.domain", "fake.token")
+
+    response_details = MagicMock(status=404, headers={})
+    not_found = OktaAPIError(
+        "https://fake.domain/api/v1/groups/deleted_group/users",
+        response_details,
+        {"errorCode": "E0000007", "errorSummary": "Not found: Resource not found: deleted_group (UserGroup)"},
+    )
+
+    with patch("okta.client.Client.list_group_users", AsyncMock(return_value=(None, MagicMock(), not_found))):
+        with pytest.raises(OktaResourceNotFoundError):
+            await service.list_users_for_group("deleted_group")
+
+
+async def test_paginate_non_404_error_is_not_resource_not_found() -> None:
+    """A list-endpoint error that isn't a 404 keeps raising the generic Exception, so
+    genuine failures stay loud instead of being downgraded to the benign path."""
+    service = OktaService()
+    service.initialize("fake.domain", "fake.token")
+
+    response_details = MagicMock(status=403, headers={})
+    forbidden = OktaAPIError(
+        "https://fake.domain/api/v1/groups/some_group/users",
+        response_details,
+        {"errorCode": "E0000006", "errorSummary": "You do not have permission"},
+    )
+
+    with patch("okta.client.Client.list_group_users", AsyncMock(return_value=(None, MagicMock(), forbidden))):
+        with pytest.raises(Exception) as exc_info:
+            await service.list_users_for_group("some_group")
+
+    assert not isinstance(exc_info.value, OktaResourceNotFoundError)

--- a/tests/test_okta_transient_errors.py
+++ b/tests/test_okta_transient_errors.py
@@ -73,8 +73,11 @@ async def test_transient_5xx_surfaces_as_okta_timeout(
 
 
 async def test_non_transient_http_error_not_mapped(mocker: MockerFixture, okta_service: OktaService) -> None:
-    """A non-transient HTTP error (e.g. 404) passes through and is not mapped to OktaTransientError."""
-    mocker.patch("okta.client.Client.get_user", return_value=(None, MagicMock(), _http_error(404)))
+    """A non-transient HTTP error (e.g. 403) passes through and is not mapped to
+    OktaTransientError. Uses 403 rather than 404: a 404 is separately classified as
+    ``OktaResourceNotFoundError`` (see tests/test_okta_service.py), which would make this
+    assertion pass for the wrong reason."""
+    mocker.patch("okta.client.Client.get_user", return_value=(None, MagicMock(), _http_error(403)))
     with pytest.raises(Exception) as exc_info:
         await okta_service.get_user("okta_id")
     assert not isinstance(exc_info.value, OktaTransientError)


### PR DESCRIPTION
# Summary

The syncer logs an ERROR (and pages) when a group is deleted from Okta partway through a sync run, even though the situation is expected, harmless, and self-healing. Classify that 404 as `OktaResourceNotFoundError` and skip it at WARNING, alongside the existing `OktaTransientError` branch.

**Urgency**: 5 days
**Expected review effort**: MEDIUM

# Motivation

Fixes 24 occurrences of a Sentry error over ~11 weeks, 0 users impacted, every one benign.

The syncer takes one Okta group snapshot per run (`api/cli.py:295`) and reuses it for the whole membership and ownership fan-out. In production those passes run 20–68 minutes, so the snapshot ages substantially before the fan-out reaches the tail of the list. A group deleted after the snapshot was taken is still in the list being walked but already gone from Okta, so its member/owner fetch 404s. The facade raised a bare `Exception`, which the fan-out logged at ERROR.

I confirmed the diagnosis against production rather than assuming it. All 24 group IDs from Sentry are present in the Access DB with `deleted_at` set, and in **24 out of 24 cases the deletion landed during the run that 404'd, after that run's snapshot was taken** (decoding each event's cronjob pod name to recover the run's start time). No group ever 404'd twice, which rules out a stale/dangling DB reference — that failure mode would repeat on every run forever.

The deletions came from Access itself: `DeleteGroup` soft-deletes the row and removes the group from Okta, and `DeleteApp` cascades across an app's groups — which is why the 404s arrive in bursts of same-app groups.

Nothing is lost by skipping: the next run's snapshot won't contain the group, and `sync_groups` reconciles it as deleted locally.

<details>
<summary><h1>Description of Changes</h1></summary>

Two commits, described in order.

### `fix(syncer)` — the alert-noise fix

**`api/services/okta_service.py`**
- New `OktaResourceNotFoundError`, documenting the snapshot-vs-authoritative-read skew that produces it. Deliberately distinct from `OktaTransientError`: nothing was flaky and a retry would not help, so it should not map to a 503 on the request path.
- New `_is_not_found_okta_error` plus a `NOT_FOUND_STATUS_CODE` constant next to the existing `TRANSIENT_STATUS_CODES`.

**`api/syncer.py`**
- A WARNING-level skip branch in both `sync_group_memberships` and `sync_group_ownerships`, ordered ahead of the generic `isinstance(..., Exception)` branch (both new and existing types are `Exception` subclasses, so order matters).

### `refactor(okta)` — uniform classification

- Classification moved from `_paginate` up into `_call`, so it covers every proxied SDK method rather than only paginated list endpoints. This mirrors the existing `OktaTransientError` handling and matches the rationale `_WrapperClient` already gives for centralizing dispatch in `_call`.
- **`delete_group_push_mapping` had to change as a direct consequence.** It treats a 404 at either the deactivate or the delete step as success, so deletion stays idempotent across a retry or replay of a partial attempt — and it did that by reading the 404 out of the returned tuple. Once `_call` raises first, that tuple never arrives. It now catches `OktaResourceNotFoundError` around both steps, which also preserves skipping the delete when the mapping already vanished at deactivate.
- **`_fake_okta_client` fidelity fix.** The fixture yielded a bare `MagicMock` where the real `_okta_client` yields `_WrapperClient(client)`, so every test using it bypassed `_call` entirely. See the reviewer callout below.
</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

- Full suite green: 769 passed. `ruff check`, `ruff format --check`, and `ty check` all clean.
- New tests in `tests/test_okta_service.py`: a 404 surfaces as `OktaResourceNotFoundError` on both a list endpoint and a single-resource endpoint (pinning that classification lives in `_call`, not `_paginate`); a 403 does not, so genuine failures stay loud.
- New tests in `tests/test_group_membership_sync.py` and `tests/test_group_ownership_sync.py`: the affected group is skipped with a WARNING naming it, nothing is logged at ERROR from the `api.syncer` logger, and the *other* groups in the run still reconcile. Confirmed to fail before the fix and pass after (verified by reverting `api/syncer.py` and re-running — both failed on exactly the ERROR-level assertion).
- The push-mapping regression was demonstrated, not argued: with the fixture corrected, the two idempotency tests passed on the old code, failed the moment classification moved into `_call`, and passed again once the method caught `OktaResourceNotFoundError`.
- Audited every other place a 404 could leak differently — all ~15 remaining `raise Exception(error)` sites (type change only; `Exception` subclass, message preserved), `.args[]` and error-object introspection (none in `api/`), `exception_handlers.py` (no handler for the new type, so it falls to the `Exception` catch-all → 500, unchanged), `_WrapperClient`'s retry (catches `OktaTransientError` only), the syncer's mutation-path catchers, and `add_owner_to_group`'s "already assigned" tolerance (message on a 400/409, not a 404).
- `tests/test_okta_transient_errors.py::test_non_transient_http_error_not_mapped` retargeted from 404 to 403: its point is that non-transient errors pass through unmapped, and a 404 is now classified, so it would have passed for the wrong reason.
</details>

# Guidance for Reviewers

Best to review file-by-file; the second commit reverses a scoping decision made in the first, so the combined diff reads as though `_paginate` was never involved.

The callout that most merits attention is in `refactor(okta)`:

**`_fake_okta_client` was yielding a bare `MagicMock` where production yields `_WrapperClient(client)`, so every test using it bypassed `_call`.** That is why the push-mapping idempotency tests would have stayed green through a real regression: they were exercising error handling against errors that in production never reach the code under test. The fixture now yields the wrapper. It is shared by 11 tests — all still pass, but it is a fidelity change with reach beyond this PR and worth a look on its own.

Two smaller ones:

1. **Centralizing in `_call` revokes each facade method's ability to *see* a 404.** `delete_group_push_mapping` was the only call site that depended on that (checked for `== 404`/`!= 404` and error-object introspection across `api/`), but it is the kind of thing no type checker will catch, so a second pair of eyes on that grep is worthwhile.
2. **Only 404 is reclassified.** A 403 or any other error still raises loudly, with a test pinning it so it can't be widened by accident.

Also worth confirming WARNING is the level you want. It matches the neighbouring `OktaTransientError` branch and keeps the event out of Sentry's alerting, but INFO would be quieter still if this is considered fully routine.

Out of scope, noted for the record: `group_ids_with_group_rules` is fetched once per run (`api/cli.py:285`) and reused across all three passes, so `is_managed` — which gates authoritative membership deletes — is decided on a snapshot that ages the same way. Real but separate, and a behavior change rather than alert-noise cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
