### PR TITLE
Fix broken release image build; add a CI check that the image builds with every plugin flag on

### DIFF
--- a/.github/scripts/verify_plugin_entry_points.py
+++ b/.github/scripts/verify_plugin_entry_points.py
@@ -1,0 +1,54 @@
+"""Assert the example plugins registered inside a built Access image.
+
+Run *inside* the image (see .github/workflows/docker-build.yml), which is the
+point: `uv pip install` targeting the wrong interpreter is a silent failure that
+surfaces only at runtime as "Registered 0 plugins", so the entry points have to
+be queried by the image's own Python rather than inferred from a zero exit code
+on the build. Uses importlib.metadata only — no DB, Okta, or config needed.
+
+Expects every INSTALL_*_PLUGIN build arg to have been set to "true". Locally:
+
+    uv run python .github/scripts/verify_plugin_entry_points.py
+
+(which exits 1 against a normal dev venv, where only the audit logger is
+installed — that is the intended negative result, not a bug.)
+"""
+
+import importlib.metadata as md
+import sys
+
+# Entry point group -> names expected once every INSTALL_* arg is on.
+#
+# Note examples/plugins/notifications and notifications_slack both publish the
+# distribution "access-notifications" with an entry point named "notifications",
+# so enabling both build args yields one, not two: the later install (slack)
+# replaces the earlier one. Both install branches still run, which is what the
+# image build is covering here.
+EXPECTED = {
+    "access_app_group_lifecycle": {"audit_logger", "google_group_manager"},
+    "access_conditional_access": {"conditional_access"},
+    "access_metrics_reporter": {"metrics_reporter"},
+    "access_notifications": {"notifications"},
+    "access.commands": {"health"},
+}
+
+
+def main() -> int:
+    missing_any = False
+    for group, expected in EXPECTED.items():
+        found = {ep.name for ep in md.entry_points(group=group)}
+        print(f"{group}: {sorted(found)}")
+        if missing := expected - found:
+            print(f"  MISSING from {group}: {sorted(missing)}", file=sys.stderr)
+            missing_any = True
+
+    if missing_any:
+        print("\nFAILED: expected plugin entry points are not registered", file=sys.stderr)
+        return 1
+
+    print(f"\nOK: all expected entry points registered across {len(EXPECTED)} groups")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -70,36 +70,19 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Verify plugin entry points are registered
-        # `uv pip install` targeting the wrong interpreter is a silent failure
-        # that only shows up at runtime as "Registered 0 plugins", so assert the
-        # entry points are visible to the image's own Python rather than
-        # trusting the build's exit code. Uses importlib.metadata only — no DB,
-        # no Okta, no config required.
+        # Runs the script inside the built image, so the entry points are queried
+        # by the image's own Python. See the script's docstring for why a green
+        # build alone isn't sufficient.
+        #
+        # Mount the script rather than piping it to `python -` on stdin: without
+        # `docker run -i` the container's stdin is empty, so `python -` reads an
+        # EOF, runs nothing, and exits 0 — a check that always passes. Grepping
+        # for the script's success line is the backstop against that whole class
+        # of silent no-op.
         run: |
-          docker run --rm --entrypoint python access:ci - <<'PY'
-          import importlib.metadata as md
-          import sys
-
-          # Group -> entry point names expected once every INSTALL_* arg is on.
-          # examples/plugins/notifications and notifications_slack both publish
-          # the distribution "access-notifications" with an entry point named
-          # "notifications", so enabling both yields one, not two: the later
-          # install (slack) replaces the earlier one.
-          expected = {
-              "access_app_group_lifecycle": {"audit_logger", "google_group_manager"},
-              "access_conditional_access": {"conditional_access"},
-              "access_metrics_reporter": {"metrics_reporter"},
-              "access_notifications": {"notifications"},
-              "access.commands": {"health"},
-          }
-
-          failed = False
-          for group, want in expected.items():
-              got = {ep.name for ep in md.entry_points(group=group)}
-              print(f"{group}: {sorted(got)}")
-              if missing := want - got:
-                  print(f"  MISSING from {group}: {sorted(missing)}", file=sys.stderr)
-                  failed = True
-
-          sys.exit(1 if failed else 0)
-          PY
+          output=$(docker run --rm \
+            -v "$PWD/.github/scripts:/verify:ro" \
+            --entrypoint python \
+            access:ci /verify/verify_plugin_entry_points.py 2>&1)
+          echo "$output"
+          grep -q "^OK: all expected entry points registered" <<<"$output"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,105 @@
+name: Build Docker Image
+
+# Verifies the Access image builds from a clean checkout. This is the
+# merge-requirement counterpart to docker-image.yml, which only builds on pushes
+# to main (after merge) and needs registry credentials to push.
+#
+# Deliberately secret-free so it runs on forked-PR builds too:
+#   - PUSH_SENTRY_RELEASE stays "false", so the Dockerfile's `sentry` stage is
+#     never in the build graph and the SENTRY_* secret mounts are never reached.
+#   - ACCESS_CONFIG_OVERRIDE is not mounted, so the frontend builds against
+#     config/config.default.json — the same path an open-source `docker build`
+#     takes.
+# Nothing here needs a dummy value; if a future build step does require a
+# secret, mount a fake one rather than wiring a real repository secret in.
+#
+# No `paths:` filter on purpose: a required check that is skipped never reports a
+# status, which would block every PR that doesn't touch the filtered paths.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+# A superseded commit's image build is worth cancelling; this is the most
+# expensive job in CI.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker-build:
+    name: Build Access image with all example plugins
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          # Load into the local Docker daemon so the next step can run the
+          # image and confirm the plugins actually landed in /app/.venv.
+          load: true
+          tags: access:ci
+          # Enable every INSTALL_*_PLUGIN arg in the Dockerfile so all of the
+          # optional-plugin install branches are exercised, not just the one
+          # the release build happens to use. Keep in sync with the arg list in
+          # the Dockerfile and the table in examples/plugins/README.md.
+          build-args: |
+            INSTALL_AUDIT_LOGGER_PLUGIN=true
+            INSTALL_CONDITIONAL_ACCESS_PLUGIN=true
+            INSTALL_DATADOG_METRICS_PLUGIN=true
+            INSTALL_GOOGLE_GROUP_LIFECYCLE_PLUGIN=true
+            INSTALL_HEALTH_CHECK_PLUGIN=true
+            INSTALL_NOTIFICATIONS_PLUGIN=true
+            INSTALL_SLACK_NOTIFICATIONS_PLUGIN=true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify plugin entry points are registered
+        # `uv pip install` targeting the wrong interpreter is a silent failure
+        # that only shows up at runtime as "Registered 0 plugins", so assert the
+        # entry points are visible to the image's own Python rather than
+        # trusting the build's exit code. Uses importlib.metadata only — no DB,
+        # no Okta, no config required.
+        run: |
+          docker run --rm --entrypoint python access:ci - <<'PY'
+          import importlib.metadata as md
+          import sys
+
+          # Group -> entry point names expected once every INSTALL_* arg is on.
+          # examples/plugins/notifications and notifications_slack both publish
+          # the distribution "access-notifications" with an entry point named
+          # "notifications", so enabling both yields one, not two: the later
+          # install (slack) replaces the earlier one.
+          expected = {
+              "access_app_group_lifecycle": {"audit_logger", "google_group_manager"},
+              "access_conditional_access": {"conditional_access"},
+              "access_metrics_reporter": {"metrics_reporter"},
+              "access_notifications": {"notifications"},
+              "access.commands": {"health"},
+          }
+
+          failed = False
+          for group, want in expected.items():
+              got = {ep.name for ep in md.entry_points(group=group)}
+              print(f"{group}: {sorted(got)}")
+              if missing := want - got:
+                  print(f"  MISSING from {group}: {sorted(missing)}", file=sys.stderr)
+                  failed = True
+
+          sys.exit(1 if failed else 0)
+          PY

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,12 @@ ARG INSTALL_SLACK_NOTIFICATIONS_PLUGIN="false"
 # Bind-mount the plugin sources for the length of this RUN only: enabled plugins
 # are installed (non-editable) into /app/.venv, so nothing needs to persist in
 # the final image and the default (all-false) build stays byte-identical.
-RUN --mount=type=bind,source=examples/plugins,target=examples/plugins \
+# `rw` is required, not incidental: every example uses a legacy setup.py, and
+# setuptools' build_wheel writes <name>.egg-info/ into the source directory, so
+# a read-only mount fails the build with "could not create '<name>.egg-info':
+# Read-only file system". BuildKit discards writes to an `rw` bind mount, so the
+# scratch egg-info still never reaches the image.
+RUN --mount=type=bind,source=examples/plugins,target=examples/plugins,rw \
     set -eu; \
     install_plugin() { \
         if [ -f "$1/requirements.txt" ]; then uv pip install -r "$1/requirements.txt"; fi; \

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ help:
 	@echo ""
 	@echo "Docker:"
 	@echo "  make build              docker build"
+	@echo "  make build-all-plugins  docker build with every INSTALL_*_PLUGIN arg on (mirrors CI)"
 	@echo "  make run-docker         docker compose up --build"
 	@echo "  make compose-down       docker compose down"
 	@echo ""
@@ -179,6 +180,21 @@ sync-app-groups: .env dev
 .PHONY: build
 build:
 	docker build -t access .
+
+# Same build the "Build Docker Image" CI check runs: every optional-plugin
+# install branch in the Dockerfile enabled, no secrets. Use this to reproduce a
+# CI image-build failure locally.
+.PHONY: build-all-plugins
+build-all-plugins:
+	docker build -t access:all-plugins \
+	  --build-arg INSTALL_AUDIT_LOGGER_PLUGIN=true \
+	  --build-arg INSTALL_CONDITIONAL_ACCESS_PLUGIN=true \
+	  --build-arg INSTALL_DATADOG_METRICS_PLUGIN=true \
+	  --build-arg INSTALL_GOOGLE_GROUP_LIFECYCLE_PLUGIN=true \
+	  --build-arg INSTALL_HEALTH_CHECK_PLUGIN=true \
+	  --build-arg INSTALL_NOTIFICATIONS_PLUGIN=true \
+	  --build-arg INSTALL_SLACK_NOTIFICATIONS_PLUGIN=true \
+	  .
 
 .PHONY: run-docker
 run-docker:

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -79,6 +79,14 @@ venv has no `pip`, and plain `pip` installs into the base image's system
 interpreter, where the running app never looks — the classic
 "Registered 0 plugins" symptom.
 
+The `Build Docker Image` CI check
+([docker-build.yml](../../.github/workflows/docker-build.yml)) builds the image
+with **every** arg in the table set to `true` and then asserts each plugin's
+entry point is visible to the image's own Python, so a broken install branch
+fails the PR rather than a deploy. Adding a new example plugin means adding its
+arg to that workflow's `build-args` (and to `make build-all-plugins`) alongside
+the `ARG` in the Dockerfile.
+
 ### Baking in your own plugin
 
 Suppose your plugin lives in your own repo, not this one. Add it to a Dockerfile that


### PR DESCRIPTION
# Summary

Adds a `Build Docker Image` GitHub Actions check that builds the Access image on every PR with all seven `INSTALL_*_PLUGIN` build args enabled, then asserts the plugins actually registered in the image. It uses no secrets, so it works on forked PRs too. Intended to be marked as a required check for merge.

**On its first run the new check failed, surfacing a live outage: the release image build has been broken on `main` since #532 and nothing has been published to the registry since 2026-07-23.** Commit 2 fixes that.

**Urgency**: 1 day — `main` currently cannot produce a deployable image.
**Expected review effort**: LOW

# Motivation

The image build is only exercised by [docker-image.yml](.github/workflows/docker-image.yml), which runs on pushes to `main` — i.e. *after* merge — and needs registry credentials to push. A PR that breaks the Dockerfile isn't caught until the release build fails post-merge, and because that failure is invisible on the PR, it went unnoticed for five consecutive pushes to `main`. This adds a pre-merge signal that can be enforced via branch protection.

<details>
<summary><h1>Description of Changes</h1></summary>

Three commits, reviewable independently.

## 1. Add the CI check — [.github/workflows/docker-build.yml](.github/workflows/docker-build.yml)

On `pull_request` + `push: main`.

- **All plugin flags on.** The release build only sets `INSTALL_GOOGLE_GROUP_LIFECYCLE_PLUGIN`, so the other six install branches have never been exercised in CI. This sets all seven.
- **No secrets.** `PUSH_SENTRY_RELEASE` stays `false`, so `FROM ${PUSH_SENTRY_RELEASE}` resolves to the `false` stage and the `sentry` stage — the only consumer of the `SENTRY_*` secret mounts — never enters the build graph. `ACCESS_CONFIG_OVERRIDE` is left unmounted, so the frontend builds against `config/config.default.json` via the Dockerfile's existing `if [ -s /run/secrets/... ]` guard. No dummy values were needed; a comment notes that a future secret-requiring step should get a fake value here rather than a real repository secret.
- **Verifies the plugins registered, not just that the build exited 0.** Installing a plugin against the wrong interpreter is a silent failure that only surfaces at runtime as "Registered 0 plugins" (called out in [examples/plugins/README.md](examples/plugins/README.md)). The job `load`s the image and runs [.github/scripts/verify_plugin_entry_points.py](.github/scripts/verify_plugin_entry_points.py) inside it, asserting each plugin's entry point is visible to the image's own Python. No DB, Okta, or config needed.
- **`type=gha` build cache** and `concurrency`/`cancel-in-progress`, since this is now the most expensive job in CI. Running on `push: main` too seeds the cache PR builds read from.
- **No `paths:` filter, on purpose** — a required check that is skipped never reports a status, which would block every PR that doesn't touch the filtered paths.

Plus `make build-all-plugins` to reproduce the build locally (following the CI-job-plus-make-target convention from #564), and a README note on the maintenance coupling: a new example plugin needs its arg added in three places (Dockerfile `ARG`, the workflow's `build-args`, the make target).

## 2. Fix the release build — [Dockerfile](Dockerfile)

`RUN --mount=type=bind` is **read-only**. Every example plugin ships a legacy `setup.py`, and setuptools' `build_wheel` writes `<name>.egg-info/` into the source directory, so any enabled plugin fails the build:

```
error: could not create 'app_group_lifecycle_google.egg-info': Read-only file system
```

#552 introduced the bind mount when no build set an `INSTALL_*_PLUGIN` arg, so the broken path was never taken and the build stayed green. #532 then set `INSTALL_GOOGLE_GROUP_LIFECYCLE_PLUGIN=true` in the release workflow, which took it — and the release build has failed on every push to `main` since (5/5: #532, #568, #502, #564, #567).

The fix marks the mount `rw`. BuildKit discards writes to an `rw` bind mount, so the scratch egg-info still never reaches the final image and the "nothing persists" property the existing comment describes is preserved.

## 3. Fix the verification step passing without running

Worth reading even though it's this PR's own bug, because the failure mode generalizes. The step originally piped its script to `python -` on the container's stdin — but `docker run` without `-i` leaves stdin empty, so Python read an EOF, ran nothing, and exited 0. It reported success in two seconds with no output, on a build where the assertions had never been evaluated. A green check that cannot fail is worse than no check.

The script now lives in a file that is bind-mounted read-only, removing the stdin dependency entirely and making it runnable locally. The step additionally greps for the script's success line: the specific stdin bug is fixed, but "produced no output" is indistinguishable from "passed" for any silent no-op, so the step asserts on evidence rather than on the exit code alone.
</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

**The check demonstrably fails when the image is broken.** Its first run ([30859738581](https://github.com/discord/access/actions/runs/30859738581)) failed at the same Dockerfile line and with the same error as the five failed release builds on `main`.

**The verification step demonstrably runs and asserts.** After commit 3, the step's output is present in the log with every group populated:

```
access_app_group_lifecycle: ['audit_logger', 'google_group_manager']
access_conditional_access: ['conditional_access']
access_metrics_reporter: ['metrics_reporter']
access_notifications: ['notifications']
access.commands: ['health']
OK: all expected entry points registered across 5 groups
```

Compare the run before that fix, where the same step "passed" in 2s having printed nothing.

Also checked:
- The script's negative path: run against a dev venv (only the audit logger installed) it exits 1 and names each missing entry point. `ruff check`, `ruff format --check`, and `ty check` are clean on it.
- The grep backstop: simulated a no-op command in the step's shell logic and confirmed the step fails rather than passes.
- Entry-point names were read from each `setup.py` rather than inferred from directory names — note the Google plugin's is `google_group_manager`.
- `make -n build-all-plugins` expands correctly.
- All 8 checks green on `98dff60`, image build in 1m2s warm / 3m21s cold.
</details>

# Guidance for Reviewers

Commit-by-commit: commit 1 adds the check (and fails), commit 2 fixes the bug it found, commit 3 fixes a false-pass in commit 1's own verification step.

**The Dockerfile fix could be split out and landed on its own to unblock releases immediately** — say the word and I'll extract it into a standalone PR. It's independent of the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
