### PR TITLE
Return users to the page they asked for after OIDC login

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,14 @@ OIDC_OVERWRITE_REDIRECT_URI=https://<YOUR_ACCESS_DEPLOYMENT_DOMAIN_NAME>/oidc/au
 ALLOWED_HOSTS=<YOUR_ACCESS_DEPLOYMENT_DOMAIN_NAME>
 ```
 
+Signed-out users who follow a link into Access — say a group page you sent
+someone so they can request membership — are sent through the IdP and returned
+to the page they asked for, query string and all, rather than dropped on the
+home page. The same holds when a session expires while the app is open: the
+browser is handed to the IdP and comes back to whatever page the user was on.
+Only same-origin paths are accepted as a return target, so the flow can't be
+used to bounce anyone to a third-party host.
+
 #### Cloudflare Access
 
 To use Cloudflare Access authentication, set up a

--- a/api/auth/dependencies.py
+++ b/api/auth/dependencies.py
@@ -57,6 +57,17 @@ class OIDCRedirectRequired(Exception):
         super().__init__(f"OIDC login required (next={next_path!r})")
 
 
+def _requested_path(request: Request) -> str:
+    """The path the caller asked for, query string included.
+
+    The SPA keeps list filters, search terms, sort order and pagination in the
+    query string, so those are the shareable part of a deep link — dropping
+    them lands the user on an unfiltered page after login.
+    """
+    query = request.url.query
+    return f"{request.url.path}?{query}" if query else request.url.path
+
+
 async def get_current_user_id(request: Request, db: DbSession) -> str:
     """Resolve the current user id, raising 403 if unauthenticated."""
     if settings.ENV in ("development", "test"):
@@ -94,9 +105,11 @@ async def get_current_user_id(request: Request, db: DbSession) -> str:
     if settings.OIDC_CLIENT_SECRETS:
         userinfo = request.session.get("userinfo") if hasattr(request, "session") else None
         if not userinfo or "email" not in userinfo:
-            # Browser flow: the SPA should follow the 307 to the OIDC login
-            # endpoint, which kicks off the authorization-code redirect.
-            raise OIDCRedirectRequired(next_path=request.url.path)
+            # Browser navigation gets a 307 to the OIDC login endpoint, which
+            # kicks off the authorization-code redirect and returns the user to
+            # `next_path` afterwards. `/api/*` callers get a 401 instead — see
+            # `oidc_redirect_handler`.
+            raise OIDCRedirectRequired(next_path=_requested_path(request))
         user = await _lookup_user_by_email(db, userinfo["email"])
         request.state.current_user_id = user.id
         if settings.FASTAPI_SENTRY_DSN:

--- a/api/auth/oidc.py
+++ b/api/auth/oidc.py
@@ -67,13 +67,19 @@ _router = APIRouter(prefix="/oidc", tags=["oidc"])
 
 def _is_safe_next(next_url: Optional[str]) -> bool:
     # Reject absolute URLs and protocol-relative paths so `next` cannot bounce
-    # the post-auth redirect to a third-party host.
+    # the post-auth redirect to a third-party host. A query string and fragment
+    # are fine — the SPA keeps deep-link state (filters, search, pagination)
+    # there, so they have to survive the round trip.
     if not next_url or not next_url.startswith("/"):
         return False
     if next_url.startswith("//") or next_url.startswith("/\\"):
         return False
     parsed = urlparse(next_url)
-    return not parsed.scheme and not parsed.netloc
+    if parsed.scheme or parsed.netloc:
+        return False
+    # Landing back on an auth endpoint is never what the user meant: `/logout`
+    # would undo the login they just completed and `/login` would loop.
+    return not parsed.path.startswith(_router.prefix + "/")
 
 
 @_router.get("/login", name="oidc_login")

--- a/api/exception_handlers.py
+++ b/api/exception_handlers.py
@@ -2,9 +2,10 @@
 
 All HTTP errors cross the wire as
 `{"type": "about:blank", "title": "<reason>", "status": <code>, "detail": "<message>"}`
-with `Content-Type: application/problem+json`. Validation errors include a
-non-standard `errors:` extension with the full FastAPI/Pydantic error list
-for clients that want it.
+with `Content-Type: application/problem+json`. Two RFC 9457 extension members
+are in use: validation errors carry `errors:` (the full FastAPI/Pydantic error
+list) and the OIDC 401 carries `login_url:` (where the client should send the
+browser to sign in).
 
 `PluginNotFoundError` is the lone outlier: it emits `{"error": ...}` because
 the React plugin-admin page reads `error` (not `detail`). Migrating that page
@@ -27,6 +28,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from pydantic import ValidationError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.requests import Request
+from starlette.responses import Response
 
 from api.auth.dependencies import OIDCRedirectRequired
 from api.exceptions import AccessException
@@ -38,6 +40,9 @@ logger = logging.getLogger(__name__)
 INDEX_HTML = Path(__file__).resolve().parent.parent / "build" / "index.html"
 
 PROBLEM_JSON = "application/problem+json"
+
+# `api.auth.oidc` mounts the login endpoint here.
+LOGIN_PATH = "/oidc/login"
 
 
 def _is_api(request: Request) -> bool:
@@ -156,9 +161,34 @@ async def pydantic_validation_handler(request: Request, exc: ValidationError) ->
     )
 
 
-async def oidc_redirect_handler(request: Request, exc: OIDCRedirectRequired) -> RedirectResponse:
+def _is_document_navigation(request: Request) -> bool:
+    """Whether this request is a browser navigating to a page.
+
+    Only a top-level navigation can carry a user through an interactive IdP
+    round trip. `fetch`/XHR cannot: it would follow the redirect into the IdP's
+    cross-origin HTML, fail CORS, and surface as a generic network error rather
+    than a login prompt.
+    """
+    # Every browser that would follow the redirect sends Sec-Fetch-Mode; the
+    # Accept sniff is the fallback for clients that omit it.
+    sec_fetch_mode = request.headers.get("sec-fetch-mode")
+    if sec_fetch_mode is not None:
+        return sec_fetch_mode == "navigate"
+    return "text/html" in request.headers.get("accept", "")
+
+
+async def oidc_redirect_handler(request: Request, exc: OIDCRedirectRequired) -> Response:
+    if not _is_document_navigation(request):
+        # Hand XHR callers a 401 carrying the login endpoint instead, so the SPA
+        # can navigate the whole window there with its own location as `next`
+        # — see `redirectToLogin` in `src/api/apiFetcher.ts`.
+        return _problem(
+            status_code=401,
+            detail="Authentication required",
+            extras={"login_url": LOGIN_PATH},
+        )
     query = urlencode({"next": exc.next_path})
-    return RedirectResponse(url=f"/oidc/login?{query}", status_code=307)
+    return RedirectResponse(url=f"{LOGIN_PATH}?{query}", status_code=307)
 
 
 async def plugin_not_found_handler(request: Request, exc: PluginNotFoundError) -> JSONResponse:

--- a/src/api/apiFetcher.test.ts
+++ b/src/api/apiFetcher.test.ts
@@ -1,0 +1,59 @@
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {apiFetch} from './apiFetcher';
+
+const assign = vi.fn();
+
+const setLocation = (pathname: string, search = '', hash = '') => {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: {pathname, search, hash, assign},
+  });
+};
+
+const respondWith = (status: number, body: unknown) => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response(JSON.stringify(body), {status, headers: {'Content-Type': 'application/json'}})),
+  );
+};
+
+// `apiFetch` deliberately never settles once it starts a login navigation, so
+// race it against a timer rather than awaiting it.
+const settles = (promise: Promise<unknown>) =>
+  Promise.race([promise.then(() => true).catch(() => true), new Promise((r) => setTimeout(() => r(false), 20))]);
+
+describe('apiFetch on 401', () => {
+  beforeEach(() => {
+    assign.mockClear();
+    setLocation('/groups/acme-painter');
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('sends the browser to the login endpoint from the problem body', async () => {
+    respondWith(401, {status: 401, detail: 'Authentication required', login_url: '/oidc/login'});
+    const pending = apiFetch({url: '/api/users/@me', method: 'get'});
+    expect(await settles(pending)).toBe(false);
+    expect(assign).toHaveBeenCalledWith('/oidc/login?next=%2Fgroups%2Facme-painter');
+  });
+
+  it('asks to return to the current page, query string and fragment included', async () => {
+    setLocation('/roles', '?q=painter&page=2', '#members');
+    respondWith(401, {status: 401, detail: 'Authentication required', login_url: '/oidc/login'});
+    expect(await settles(apiFetch({url: '/api/roles', method: 'get'}))).toBe(false);
+    expect(assign).toHaveBeenCalledWith('/oidc/login?next=%2Froles%3Fq%3Dpainter%26page%3D2%23members');
+  });
+
+  it('falls back to the default login path when the body omits one', async () => {
+    respondWith(401, {status: 401, detail: 'Authentication required'});
+    expect(await settles(apiFetch({url: '/api/users/@me', method: 'get'}))).toBe(false);
+    expect(assign).toHaveBeenCalledWith('/oidc/login?next=%2Fgroups%2Facme-painter');
+  });
+
+  it('leaves other error statuses to the caller', async () => {
+    respondWith(403, {status: 403, detail: 'Forbidden'});
+    await expect(apiFetch({url: '/api/users/@me', method: 'get'})).rejects.toMatchObject({payload: 'Forbidden'});
+    expect(assign).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/apiFetcher.ts
+++ b/src/api/apiFetcher.ts
@@ -13,12 +13,33 @@ export type ErrorMessage = {
   title?: string;
   status?: number;
   detail?: string;
+  // Non-standard extension on 401s from an OIDC deployment: the endpoint that
+  // starts the login flow.
+  login_url?: string;
   errors?: Array<{
     type?: string;
     loc?: Array<string | number>;
     msg?: string;
     ctx?: Record<string, unknown>;
   }>;
+};
+
+const DEFAULT_LOGIN_PATH = '/oidc/login';
+
+/**
+ * Hand the whole window to the login endpoint, asking to be returned to the
+ * page the user is currently on.
+ *
+ * The backend answers an unauthenticated `/api/*` request with a 401 rather
+ * than the 307-to-the-IdP a document navigation gets, because `fetch` can't
+ * complete an interactive login: it would follow the redirect to the IdP's
+ * cross-origin HTML and fail CORS. So the session-expiry case has to be
+ * escalated to a real navigation here, otherwise the user is stuck looking at
+ * an error on a page they can't reload their way out of.
+ */
+export const redirectToLogin = (loginUrl: string = DEFAULT_LOGIN_PATH) => {
+  const {pathname, search, hash} = window.location;
+  window.location.assign(`${loginUrl}?next=${encodeURIComponent(`${pathname}${search}${hash}`)}`);
 };
 
 export type ApiFetcherOptions<TBody, THeaders, TQueryParams, TPathParams> = {
@@ -74,11 +95,19 @@ export async function apiFetch<
       // React client renders directly via `error.payload`. `detail` is the
       // human-readable summary; fall back to `title`.
       let payload: string;
+      let problem: ErrorMessage = {};
       try {
-        const problem = (await response.json()) as ErrorMessage;
+        problem = (await response.json()) as ErrorMessage;
         payload = problem.detail ?? problem.title ?? 'Unexpected error';
       } catch (e) {
         payload = e instanceof Error ? `Unexpected error (${e.message})` : 'Unexpected error';
+      }
+      if (response.status === 401) {
+        // The OIDC session expired or was never established. Log back in and
+        // come back to this page; the returned promise never settles because
+        // the navigation is already underway.
+        redirectToLogin(problem.login_url);
+        return await new Promise<TData>(() => {});
       }
       throw {status: 'unknown' as const, payload};
     }

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -13,6 +13,7 @@ import json
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, AsyncGenerator, Generator
+from urllib.parse import parse_qs, urlparse
 
 import httpx
 import itsdangerous
@@ -31,6 +32,14 @@ from tests.factories import OktaUserFactory
 
 TEST_SECRET_KEY = "test-oidc-secret-key-min-32-bytes-long!!"
 TEST_OIDC_USER_EMAIL = "oidc-user@example.com"
+# The OIDC login bounce is only served to top-level browser navigation —
+# `fetch` cannot complete an interactive IdP round trip. These mirror what a
+# browser sends for each case; see `_is_document_navigation`.
+NAVIGATION_HEADERS = {
+    "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "sec-fetch-mode": "navigate",
+}
+XHR_HEADERS = {"accept": "*/*", "sec-fetch-mode": "cors"}
 STUB_OIDC_CLIENT_SECRETS = {
     "web": {
         "client_id": "test-client",
@@ -343,14 +352,24 @@ async def test_staging_app_exposes_api_docs_when_enabled(oidc_app_with_docs: Fas
     assert oidc_app_with_docs.openapi_url == "/api/openapi.json"
 
 
-async def test_unauthenticated_protected_endpoint_redirects_to_oidc_login(
-    oidc_client: httpx.AsyncClient,
-) -> None:
-    response = await oidc_client.get("/api/users")
+async def test_unauthenticated_xhr_returns_401(oidc_client: httpx.AsyncClient) -> None:
+    # `fetch` can't complete an interactive IdP round trip, so it gets a 401
+    # pointing at the login endpoint and navigates the window there itself.
+    response = await oidc_client.get("/api/users", headers=XHR_HEADERS)
+    assert response.status_code == 401
+    assert response.headers["content-type"].startswith("application/problem+json")
+    body = response.json()
+    assert body["status"] == 401
+    assert body["login_url"] == "/oidc/login"
+    assert "location" not in response.headers
+
+
+async def test_unauthenticated_api_navigation_redirects_to_oidc_login(oidc_client: httpx.AsyncClient) -> None:
+    # A browser pointed at an `/api/*` page — `/api/docs` when ENABLE_API_DOCS
+    # is on — is still a navigation, so it gets the login bounce.
+    response = await oidc_client.get("/api/users", headers=NAVIGATION_HEADERS)
     assert response.status_code == 307
-    location = response.headers["location"]
-    assert location.startswith("/oidc/login?next=")
-    assert "next=%2Fapi%2Fusers" in location
+    assert "next=%2Fapi%2Fusers" in response.headers["location"]
 
 
 async def test_oidc_login_is_in_allowlist(oidc_client: httpx.AsyncClient) -> None:
@@ -371,18 +390,26 @@ async def test_oidc_logout_is_in_allowlist(oidc_client: httpx.AsyncClient) -> No
     assert not response.headers["location"].startswith("/oidc/login")
 
 
-async def test_unmapped_api_path_redirects_through_auth_gate(oidc_client: httpx.AsyncClient) -> None:
-    response = await oidc_client.get("/api/this-endpoint-does-not-exist")
-    assert response.status_code == 307
-    assert response.headers["location"].startswith("/oidc/login?next=")
+async def test_unmapped_api_path_goes_through_auth_gate(oidc_client: httpx.AsyncClient) -> None:
+    response = await oidc_client.get("/api/this-endpoint-does-not-exist", headers=XHR_HEADERS)
+    assert response.status_code == 401
 
 
 async def test_unauthenticated_spa_path_redirects_to_oidc_login(oidc_client: httpx.AsyncClient) -> None:
-    response = await oidc_client.get("/groups/foo")
+    response = await oidc_client.get("/groups/foo", headers=NAVIGATION_HEADERS)
     assert response.status_code == 307
     location = response.headers["location"]
     assert location.startswith("/oidc/login?next=")
     assert "next=%2Fgroups%2Ffoo" in location
+
+
+async def test_unauthenticated_spa_path_keeps_query_string(oidc_client: httpx.AsyncClient) -> None:
+    # Filters, search and pagination live in the query string, so a shared deep
+    # link is only half preserved without it.
+    response = await oidc_client.get("/roles", params={"q": "painter", "page": "2"}, headers=NAVIGATION_HEADERS)
+    assert response.status_code == 307
+    next_value = parse_qs(urlparse(response.headers["location"]).query)["next"][0]
+    assert next_value == "/roles?q=painter&page=2"
 
 
 # ---------------------------------------------------------------------------
@@ -392,10 +419,12 @@ async def test_unauthenticated_spa_path_redirects_to_oidc_login(oidc_client: htt
 
 @pytest.mark.parametrize(
     "next_value",
-    ["/dashboard", "/groups/foo", "/api/users/me", "/"],
+    ["/dashboard", "/groups/foo", "/api/users/me", "/", "/roles?q=painter&page=2", "/groups/foo#members"],
 )
 async def test_oidc_login_stores_safe_next(oidc_client: httpx.AsyncClient, next_value: str) -> None:
-    response = await oidc_client.get(f"/oidc/login?next={next_value}")
+    # `params=` so `next` is percent-encoded — an unencoded `&` or `#` would be
+    # parsed as part of the login URL rather than as part of `next`.
+    response = await oidc_client.get("/oidc/login", params={"next": next_value})
     assert response.status_code == 302
     session = _read_session_from_set_cookie(response.headers.get("set-cookie", ""))
     assert session is not None
@@ -415,6 +444,9 @@ async def test_oidc_login_stores_safe_next(oidc_client: httpx.AsyncClient, next_
         "data:text/html,<script>alert(1)</script>",
         "",
         "relative/path",
+        # Bouncing back into the auth endpoints undoes or loops the login.
+        "/oidc/logout",
+        "/oidc/login?next=%2F",
     ],
 )
 async def test_oidc_login_drops_unsafe_next(oidc_client: httpx.AsyncClient, next_value: str) -> None:
@@ -442,13 +474,23 @@ async def test_oidc_authorize_defaults_to_root_when_no_next(oidc_client: httpx.A
     assert response.headers["location"] == "/"
 
 
+async def test_oidc_authorize_restores_next_with_query_string(oidc_client: httpx.AsyncClient) -> None:
+    _set_session(oidc_client, {"oidc_next": "/roles?q=painter&page=2"})
+    response = await oidc_client.get("/oidc/authorize")
+    assert response.status_code in (302, 307)
+    assert response.headers["location"] == "/roles?q=painter&page=2"
+
+
 # ---------------------------------------------------------------------------
 # Happy-path login
 # ---------------------------------------------------------------------------
 
 
 async def test_full_login_flow(oidc_client: httpx.AsyncClient, seed_oidc_user: OktaUser) -> None:
-    initial = await oidc_client.get("/api/users")
+    # The scenario from issue #566: someone follows a link to a deep page while
+    # signed out and should land on that same page once the IdP is done.
+    deep_link = "/roles?q=painter&page=2"
+    initial = await oidc_client.get(deep_link, headers=NAVIGATION_HEADERS)
     assert initial.status_code == 307
     redirect_target = initial.headers["location"]
     assert redirect_target.startswith("/oidc/login?next=")
@@ -459,9 +501,9 @@ async def test_full_login_flow(oidc_client: httpx.AsyncClient, seed_oidc_user: O
 
     callback = await oidc_client.get("/oidc/authorize")
     assert callback.status_code in (302, 307)
-    assert callback.headers["location"] == "/api/users"
+    assert callback.headers["location"] == deep_link
 
-    final = await oidc_client.get("/api/users")
+    final = await oidc_client.get(deep_link, headers=NAVIGATION_HEADERS)
     assert final.status_code == 200
 
 
@@ -546,7 +588,7 @@ async def test_post_logout_request_redirects_back_to_login(oidc_client: httpx.As
     assert logout.status_code in (302, 307)
 
     oidc_client.cookies.clear()
-    response = await oidc_client.get("/api/users")
+    response = await oidc_client.get("/groups/foo", headers=NAVIGATION_HEADERS)
     assert response.status_code == 307
     assert response.headers["location"].startswith("/oidc/login?next=")
 


### PR DESCRIPTION
Closes #566.

A signed-out user following a link to a group page should land on that group page once the IdP is done with them, not on the home page. Two gaps kept that from happening.

**The query string was dropped.** The `next` captured on the login bounce was `request.url.path`. The SPA keeps list filters, search terms, sort order and pagination in the query string, so that's the shareable part of a deep link — without it the user arrives at an unfiltered page.

**XHR was bounced to the IdP.** An unauthenticated `/api/*` request got the same 307 a browser navigation gets. `fetch` can't complete an interactive login: it follows the redirect into the IdP's cross-origin HTML, fails CORS, and the SPA surfaces a generic "unexpected error". Someone whose session expired while the app was open was stuck there with no way back short of a manual reload. Requests that aren't a top-level navigation now get a `401` carrying a `login_url` extension member, and the client escalates to a real navigation with its own location (query string and fragment included) as `next`.

Navigation is detected from `Sec-Fetch-Mode`, falling back to sniffing `Accept` for clients that omit it, rather than from the request path. Path-based detection would have been simpler but would have broken browsing to `/api/docs` on deployments that enable it.

While in here, `next` now also rejects paths under `/oidc/` — a crafted link could otherwise return the user to `/oidc/logout` (undoing the login they just completed) or `/oidc/login` (looping). Third-party hosts were already rejected.

Note this is partly pre-existing behaviour the reporter hasn't seen yet: the `next` round trip itself landed with the FastAPI migration (#425) and isn't in a release, so on v1.6.1 the redirect always goes to `/`. This PR closes the remaining gaps on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)