### PR TITLE
Ownership constraint request membership button

### DIFF
--- a/src/pages/groups/AddRoles.tsx
+++ b/src/pages/groups/AddRoles.tsx
@@ -60,7 +60,7 @@ interface AddRolesButtonProps {
 function AddRolesButton(props: AddRolesButtonProps) {
   return (
     <Button variant="contained" onClick={() => props.setOpen(true)} endIcon={<RoleAddIcon />}>
-      {'Add ' + (props.owner ? 'Roles as Owners' : 'Roles as Members')}
+      {'Add ' + (props.owner ? 'Roles as Owners' : 'Roles')}
     </Button>
   );
 }

--- a/src/pages/groups/AddUsers.tsx
+++ b/src/pages/groups/AddUsers.tsx
@@ -236,6 +236,7 @@ function AddUsersDialog(props: AddUsersDialogProps) {
   };
 
   const addUsersText = props.owner ? 'Owners' : 'Members';
+  const ownerOrMember = props.owner ? 'owner' : 'member';
 
   return (
     <Dialog open fullWidth onClose={() => props.setOpen(false)}>
@@ -253,9 +254,13 @@ function AddUsersDialog(props: AddUsersDialogProps) {
               : null}
           </Typography>
           <Typography variant="subtitle1" color="text.accent">
-            {disallow_owner_add && !isAccessAdmin(props.currentUser)
-              ? 'Owners may not add themselves as ' + (props.owner ? 'owners' : 'members') + ' of this group.'
-              : null}
+            {disallow_owner_add && !isAccessAdmin(props.currentUser) ? (
+              <>
+                You cannot add yourself to this group due to the{' '}
+                <strong>owner can't add themselves as {ownerOrMember}</strong> tag constraint. Please get another owner
+                to add you or make an access request instead.
+              </>
+            ) : null}
           </Typography>
           {requestError != '' ? <Alert severity="error">{requestError}</Alert> : null}
           <FormControl size="small" margin="normal" fullWidth>

--- a/src/pages/requests/Create.tsx
+++ b/src/pages/requests/Create.tsx
@@ -46,8 +46,8 @@ import {
   RoleGroupDetail,
   RoleGroupMapDetail,
 } from '../../api/apiSchemas';
-import {canManageGroup} from '../../authorization';
-import {minTagTime, minTagTimeGroups} from '../../helpers';
+import {canManageGroup, isAccessAdmin} from '../../authorization';
+import {minTagTime, minTagTimeGroups, ownerCantAddSelf} from '../../helpers';
 import accessConfig from '../../config/accessConfig';
 
 dayjs.extend(IsSameOrBefore);
@@ -525,9 +525,20 @@ export default function CreateRequest(props: CreateRequestProps) {
   const open = props.open ?? internalOpen;
   const setOpen = props.setOpen ?? setInternalOpen;
 
+  // Managers of a group normally have no need to request access — they can add themselves
+  // directly — so the button is hidden for them. The exception is a group tagged to disallow
+  // owner self-add, where a request is their only path. Access admins are exempt from tag
+  // constraints, so they never see it.
+  const blockedFromSelfAdd =
+    !isAccessAdmin(props.currentUser) &&
+    ownerCantAddSelf(
+      props.group?.active_group_tags?.map((tagMap) => tagMap.active_tag!),
+      props.owner ?? false,
+    );
+
   if (
     props.group?.deleted_at != null ||
-    (props.group != null && canManageGroup(props.currentUser, props.group)) ||
+    (props.group != null && canManageGroup(props.currentUser, props.group) && !blockedFromSelfAdd) ||
     props.group?.is_managed == false
   ) {
     return null;


### PR DESCRIPTION
If a group has a tag that prevents owners adding themselves as owners/members, they will not be able to add themselves to a group via the 'Add owners/members' or 'Add roles as owners/members' dialogs but the 'Request ownership/membership' button was not visible. Updating the UI so the request button is visible in that case. Also updated the direct ownership/membership dialog to have a more descriptive message.

Since 3 buttons couldn't fit on the same row in the membership case as-is, I shortened the 'Add roles as members' button to say 'Add roles'. In the owners case, since there isn't a search bar, I left the full button title as-is


**Closed then reopened the PR due to the GH outage yesterday**

Before:
<img width="1721" height="866" alt="Screenshot 2026-08-06 at 12 24 34 PM" src="https://github.com/user-attachments/assets/f1bde770-7303-42ca-9804-f0996271638b" />
<img width="1727" height="865" alt="Screenshot 2026-08-06 at 12 15 02 PM" src="https://github.com/user-attachments/assets/3f09a613-c4e1-4942-93f2-049ec71cdec6" />

After:
<img width="1725" height="866" alt="Screenshot 2026-08-06 at 12 18 00 PM" src="https://github.com/user-attachments/assets/7a07217d-b9bc-4639-9ff5-4a7d55b4d17a" />
<img width="1725" height="861" alt="Screenshot 2026-08-06 at 12 18 12 PM" src="https://github.com/user-attachments/assets/4934b220-fbe0-4b15-8542-174ce4104ae8" />