### PR TITLE
Stop copying node_modules into new worktrees

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -15,8 +15,16 @@ config/config.test.json
 # worktrees skips re-running `make db-init` for each new worktree.
 instance/access.db
 
-# Installed dependencies. Copying these avoids re-running `npm install` /
-# `make dev` in every new worktree. uv re-validates the copied .venv on the
-# next `uv run`/`uv sync`, rebuilding it if the interpreter path drifted.
-node_modules/
+# Python virtualenv. Copying it skips re-running `uv sync` in every new
+# worktree, and the copy is self-repairing: uv re-validates the .venv on the
+# next `uv run`/`uv sync`, rebuilding it if the interpreter path drifted,
+# which it always does across worktrees.
 .venv/
+
+# node_modules/ is deliberately absent. npm has no equivalent re-validation
+# pass: packages already present at the locked version count as satisfied, so
+# whatever is wrong with a copied tree survives `npm install`. If the copy drops
+# file modes, every bin/ entry lands non-executable and the install then dies in
+# esbuild's install script with EACCES, a failure that names the wrong package
+# and that npm cannot repair. Installing from the committed lockfile against a
+# warm cache takes ~4s, which is cheaper than that class of bug.


### PR DESCRIPTION
# Summary

Removes `node_modules/` from `.worktreeinclude` so new worktrees run `npm install` instead of inheriting a copied dependency tree. `.venv/` stays.

**Urgency**: 5 days (not blocking; the tooling bug that exposed this appears already fixed)
**Expected review effort**: LOW

# Motivation

Copying `node_modules/` into a new worktree saves about 4 seconds against a warm npm cache with `package-lock.json` committed. In exchange it introduces a failure mode npm cannot recover from.

npm treats packages already present at the locked version as satisfied and never revisits them, so whatever is wrong with a copied tree survives `npm install`. When the copy dropped file modes, every `bin/` entry arrived non-executable and `make run-frontend` died with:

```
npm error command sh -c node install.js
npm error Error: spawnSync .../node_modules/esbuild/bin/esbuild EACCES
```

The trace names esbuild, but esbuild is only the first package to try *executing* something; all 28 files under a `bin/` directory were affected, and the crashed install left `node_modules/.bin/` empty. `rm -rf node_modules && npm install` was the only thing that cleared it.

The copier defect was transient and is not this repo's: worktrees created Jun 27 / Jul 17 / Jul 29 have correct modes, Aug 3 and Aug 4 do not, and Aug 7 is correct again. This PR is not a fix for that bug. It removes the repo's exposure to that class of bug, for a saving that turned out to be four seconds.

<details>
<summary><h1>Description of Changes</h1></summary>

One entry removed, and the surrounding comments rewritten to explain the split.

`.venv/` is deliberately kept. uv re-validates a copied venv and rebuilds it whenever the interpreter path has drifted, which it always has across worktrees, so that copy repairs itself. That difference is the whole basis for the change: **keep the entries that self-heal, drop the one that cannot.**

Most of the added lines document why `node_modules/` is now absent. A config file gives no signal about why an obvious entry is missing, so without that note the next person re-adds it and rediscovers the failure.
</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

- Reproduced the failure in an affected worktree and confirmed the scope: 28 of 28 files under `bin/` directories non-executable, versus `-rwxr-xr-x` for the same files in the main checkout.
- Confirmed the mode bit was the sole cause: the binary ran correctly (`0.28.1`) after a `chmod +x`, with no other change.
- Exercised the path this PR creates (no copied tree, install from lockfile): `added 595 packages ... in 4s`, `node_modules/.bin/` repopulated with 34 entries, `esbuild --version` → `0.28.1`, and `vite` came up `ready in 250 ms` and served `HTTP 200`.
- Confirmed the retained `.venv/` path self-heals: `.venv/bin` is `24 exec / 9 non-exec` in every worktree where uv has run, including one whose `node_modules` was broken.
- Note: `vite/bin/openChrome.js` is legitimately `644` after a clean install and is not a bin entry, so a healthy tree surveys as 27 exec / 1 non-exec, not 28 / 0.
</details>

# Guidance for Reviewers

The judgment call worth checking is keeping `.venv/` while dropping `node_modules/`, rather than treating both dependency trees the same. The argument rests on uv's rebuild-on-interpreter-drift behaviour making the venv copy self-correcting; if you don't buy that, the consistent alternative is dropping both.

Worth knowing that this is now insurance rather than a live fix, since the copier is behaving correctly again. Reasonable to close if you'd rather not carry it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
