### PR TITLE
Add an example Kubernetes CronJob for sync-app-groups

### DIFF
--- a/.claude/access-dev-sync.md
+++ b/.claude/access-dev-sync.md
@@ -28,6 +28,10 @@ plugins, where a plugin's own loop swallowing failures lets the job exit 0 havin
 and would let advisory locks accumulate across a batch, which overlapping runs iterating in different
 orders can deadlock on.
 
+`examples/kubernetes/cron-job-sync-app-groups.yaml` is the reference deployment, and its comments
+carry the operator-facing version of the reasoning below (why `concurrencyPolicy: Forbid`, why
+`backoffLimit: 0`, why the sweep is hourly). Keep the two in step when this behavior changes.
+
 Note the loop holds plain column values and re-loads each group inside the iteration. That is
 deliberate, not incidental: a rolled-back group expires the entire identity map, so anything held
 across an iteration boundary is unusable — the same hazard described under `lazy="raise_on_sql"` in

--- a/examples/kubernetes/cron-job-sync-app-groups.yaml
+++ b/examples/kubernetes/cron-job-sync-app-groups.yaml
@@ -1,0 +1,68 @@
+---
+# Drives the app-group-lifecycle plugin hooks: invokes each configured plugin's `sync_group`
+# hook once per active app group, reconciling Access groups against the external system the
+# plugin backs them with (see "App Group Lifecycle Plugins" in the README).
+#
+# Only useful when an app group lifecycle plugin is installed. Plugins are baked into the image
+# at build time -- see the INSTALL_*_PLUGIN build args in the Dockerfile -- so the image this
+# CronJob runs must be one built with yours. Without a plugin the command finds no configured
+# apps and exits 0, so it is safe but pointless to schedule.
+#
+# The job attempts every group regardless of individual failures, and exits non-zero if any
+# group failed to sync, so a run that left groups unreconciled shows up as a failed job rather
+# than only in the logs. Each group is its own transaction, so a failure strands nothing behind
+# it and the next run retries it.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  labels:
+    app: access
+    owner: security
+  name: access-cronjob-sync-app-groups
+  namespace: access
+spec:
+  # Reconciliation is idempotent, but overlapping runs would contend on the per-group advisory
+  # locks the plugins take, so let a long run finish rather than stacking another on top of it.
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      # No retries: the next scheduled run is the retry, and a failed job is the signal that
+      # some groups did not reconcile.
+      backoffLimit: 0
+      template:
+        spec:
+          containers:
+            - command:
+                - access
+                - sync-app-groups
+              env: # See "Production Setup" in the README for more details on configuring these environment variables
+                - name: ENV
+                  value: production
+                - name: OKTA_DOMAIN
+                  value: mydomain.okta.com # Replace with your Okta domain
+                - name: DATABASE_URI
+                  value: postgresql:// # Replace with your database URI
+                - name: OKTA_API_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      key: OKTA_API_TOKEN
+                      name: access-secrets
+                # Any configuration your app group lifecycle plugin reads from the environment
+                # goes here too. The example Google Workspace plugin
+                # (examples/plugins/app_group_lifecycle_google) reads these two, and picks up
+                # Google credentials from the ambient application-default credentials -- via
+                # Workload Identity on the service account below, rather than a mounted key.
+                # - name: GOOGLE_WORKSPACE_OKTA_APP_ID
+                #   value: 0oa1example2app3id4 # Replace with the Okta app that pushes groups downstream
+                # - name: GOOGLE_WORKSPACE_DOMAIN
+                #   value: mydomain.com # Replace with your Google Workspace domain
+              image: access # Replace with reference to a Docker image build of access in your container registry
+              name: access-cronjob-sync-app-groups
+          restartPolicy: Never
+          serviceAccountName: access
+      ttlSecondsAfterFinished: 1800
+  # Hourly. Event-driven hooks already reconcile on create, update, delete, and membership
+  # change, so this sweep exists to catch drift and to retry groups whose external system was
+  # unreachable -- not to be the primary path. Tighten it if your plugin defers work (e.g.
+  # waiting on Okta to import a pushed group) and you want those groups to settle sooner.
+  schedule: 0 * * * *


### PR DESCRIPTION
# Summary

Adds `examples/kubernetes/cron-job-sync-app-groups.yaml`, the missing reference deployment for the `access sync-app-groups` cronjob, and points `.claude/access-dev-sync.md` at it.

**Urgency**: 3 days
**Expected review effort**: LOW (~5 min)

> **Stacked on #577.** Base is `brynna/google-group-manager-refactor-cf8e89`, so this diff shows only the manifest. GitHub retargets it to `main` once #577 merges.

# Motivation

Review comment on #577:

> Let's add an example Kubernetes deployment of this cronjob in https://github.com/discord/access/blob/main/examples/kubernetes

`examples/kubernetes` already covers the web deployment plus the `sync` and `notify` cronjobs. An operator adopting an app group lifecycle plugin has no reference for scheduling the sweep that drives it.

<details>
<summary><h1>Description of Changes</h1></summary>

Modeled on `cron-job-syncer.yaml` — same labels, namespace, service account, env block, and `ttlSecondsAfterFinished`. The comments carry the three settings whose reasoning isn't obvious from the manifest:

- **`concurrencyPolicy: Forbid`** — overlapping runs contend on the per-group advisory locks plugins take through `ctx.lock`.
- **`backoffLimit: 0`** — the next scheduled run is the retry, and the command's non-zero exit is the signal that some groups went unreconciled.
- **`schedule: 0 * * * *`** — the event-driven hooks already reconcile on create, update, delete, and membership change, so this sweep is for drift and for retrying an unreachable external system, not the primary path.

It also states that plugins are baked into the image at build time (the `INSTALL_*_PLUGIN` build args in the Dockerfile), because the manifest alone gives no hint that the stock image makes this command a no-op. The Google Workspace plugin's two environment variables are included commented-out as a worked example of where plugin config goes.

The `.claude/access-dev-sync.md` section on this cronjob now names the manifest, so the operator-facing rationale and the contributor-facing one stay in step.

</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

- Parses as valid YAML; `kind`, `schedule`, and `command` are as intended.
- Diffed field-by-field against `cron-job-syncer.yaml` and `cron-job-notify-owners.yaml` for consistency.
- **Not done:** applied to a real cluster. No code changes, so the suite is unaffected.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)