### PR TITLE
Tell group_deleted who was in the group

### DIFF
--- a/api/operations/delete_group.py
+++ b/api/operations/delete_group.py
@@ -24,7 +24,11 @@ from api.models import (
 )
 from api.operations.reject_access_request import RejectAccessRequest
 from api.operations.reject_role_request import RejectRoleRequest
-from api.plugins.app_group_lifecycle import AppGroupLifecycleHook, invoke_app_group_lifecycle_hook
+from api.plugins.app_group_lifecycle import (
+    AppGroupLifecycleHook,
+    get_active_group_members,
+    invoke_app_group_lifecycle_hook,
+)
 from api.services import okta
 from api.schemas import AuditLogSchema, EventType
 
@@ -104,6 +108,13 @@ class DeleteGroup:
             )
             .where(OktaUserGroupMember.group_id == group.id)
         )
+
+        # Capture the membership the group_deleted hook receives, before the bulk UPDATE below
+        # ends it. A plugin that provisions users individually needs to know who it provisioned in
+        # order to deprovision them, and cannot recover it afterwards. Distinct from
+        # `direct_members_to_remove_ids`, which drops role-granted members -- those hold the access
+        # too, so the hook has to see them.
+        lifecycle_hook_members = await get_active_group_members(db.session, group.id)
 
         direct_members_to_remove_ids = [
             m.user_id
@@ -314,6 +325,8 @@ class DeleteGroup:
         await db.session.commit()
 
         # Invoke app group lifecycle plugin hook, if configured
-        await invoke_app_group_lifecycle_hook(AppGroupLifecycleHook.GROUP_DELETED, group=group)
+        await invoke_app_group_lifecycle_hook(
+            AppGroupLifecycleHook.GROUP_DELETED, group=group, members=lifecycle_hook_members
+        )
 
         await defer_or_drain_fan_out(okta_tasks, f"DeleteGroup for group {self.group_id}")

--- a/api/operations/modify_group_type.py
+++ b/api/operations/modify_group_type.py
@@ -20,7 +20,11 @@ from api.models import (
 from api.operations.modify_group_users import ModifyGroupUsers
 from api.operations.modify_groups_time_limit import ModifyGroupsTimeLimit
 from api.operations.modify_role_groups import ModifyRoleGroups
-from api.plugins.app_group_lifecycle import AppGroupLifecycleHook, invoke_app_group_lifecycle_hook
+from api.plugins.app_group_lifecycle import (
+    AppGroupLifecycleHook,
+    get_active_group_members,
+    invoke_app_group_lifecycle_hook,
+)
 from api.schemas import AuditLogSchema, EventType
 
 
@@ -120,7 +124,17 @@ class ModifyGroupType:
                 # Invoke group_deleted hook before the AppGroup row is removed so the
                 # plugin can still access group.app and status values (e.g. to delete
                 # the linked external group).
-                await invoke_app_group_lifecycle_hook(AppGroupLifecycleHook.GROUP_DELETED, group=group)
+                #
+                # The memberships survive a type change, unlike a delete, so these users keep their
+                # Access membership -- but the group stops being this plugin's to manage and its
+                # external group goes away, so the hook is told who was in it. Passed explicitly
+                # for the same reason as on the delete path: it makes the payload identical on both,
+                # rather than something a plugin could read off the group here and not there.
+                await invoke_app_group_lifecycle_hook(
+                    AppGroupLifecycleHook.GROUP_DELETED,
+                    group=group,
+                    members=await get_active_group_members(db.session, group.id),
+                )
 
                 # Remove app tag map for this group that is no longer attached to an app
                 await db.session.execute(

--- a/api/plugins/app_group_lifecycle.py
+++ b/api/plugins/app_group_lifecycle.py
@@ -162,6 +162,42 @@ def _active_membership(keyed_column: InstrumentedAttribute[str]) -> Select[tuple
     )
 
 
+async def get_active_group_members(session: AsyncSession, group_id: str) -> list[OktaUser]:
+    """The users who currently hold membership in a group.
+
+    The single definition of "this group's membership" that the plugin interface exposes, shared by
+    ``AppGroupLifecycleContext.list_group_members`` and by the ``members`` payload the operations
+    hand to ``group_deleted``. Keep it shared: a hook that reads membership one way during a sync
+    and is handed it another way during a delete would silently disagree with itself.
+
+    Takes the session explicitly rather than reaching for `db.session`, because a context holds its
+    own captured session -- see ``AppGroupLifecycleContext.__init__``.
+
+    Args:
+        session: The session to query on.
+        group_id: The group whose membership to read.
+
+    Returns:
+        Active, non-owner members, ordered by email. Owners are excluded: they administer the group
+        rather than hold the access it grants. A user holding membership both directly and through
+        a role appears once. Soft-deleted users are excluded.
+    """
+    return list(
+        (
+            await session.scalars(
+                select(OktaUser)
+                .where(
+                    OktaUser.id.in_(
+                        _active_membership(OktaUserGroupMember.user_id).where(OktaUserGroupMember.group_id == group_id)
+                    )
+                )
+                .where(OktaUser.deleted_at.is_(None))
+                .order_by(OktaUser.email)
+            )
+        ).all()
+    )
+
+
 class AppGroupLifecycleContext:
     """The capability surface an app group lifecycle hook may use to talk to Access.
 
@@ -325,22 +361,7 @@ class AppGroupLifecycleContext:
                 capability inside the apps the plugin is responsible for.
         """
         await self._require_own_group(group)
-        return list(
-            (
-                await self._session.scalars(
-                    select(OktaUser)
-                    .where(
-                        OktaUser.id.in_(
-                            _active_membership(OktaUserGroupMember.user_id).where(
-                                OktaUserGroupMember.group_id == group.id
-                            )
-                        )
-                    )
-                    .where(OktaUser.deleted_at.is_(None))
-                    .order_by(OktaUser.email)
-                )
-            ).all()
-        )
+        return await get_active_group_members(self._session, group.id)
 
     async def find_user_groups(self, user: OktaUser, *, app: App | None = None) -> list[AppGroup]:
         """The app groups ``user`` currently holds membership in, among this plugin's apps.
@@ -911,7 +932,13 @@ class AppGroupLifecyclePluginSpec:
         """
 
     @hookspec
-    async def group_deleted(self, ctx: AppGroupLifecycleContext, group: AppGroup, plugin_id: str | None) -> None:
+    async def group_deleted(
+        self,
+        ctx: AppGroupLifecycleContext,
+        group: AppGroup,
+        members: list[OktaUser],
+        plugin_id: str | None,
+    ) -> None:
         """
         Handle group deletion.
 
@@ -921,6 +948,15 @@ class AppGroupLifecyclePluginSpec:
                  writes, Okta group push. Mutations are only persisted through `ctx`, and a
                  hook must not commit or roll back: the host owns the transaction.
             group: The app group that was deleted.
+            members: The users who held membership when the group stopped being this plugin's to
+                     manage, captured before the deletion ended those memberships. Passed rather
+                     than looked up because by the time this fires `ctx.list_group_members(group)`
+                     is empty on the delete path -- and, worse, is *not* empty on the type-change
+                     path, so a hook reading it would behave differently depending on why the
+                     group went away. Where the external system attaches one combined permission
+                     set to a user rather than one per group, recompute each member's union over
+                     `ctx.find_user_groups(user)` and write the reduced set, rather than deleting
+                     the user outright.
             plugin_id: If provided, only the plugin matching this ID should respond.
                        If None, all plugins may respond.
         """

--- a/examples/plugins/app_group_lifecycle_audit_logger/plugin.py
+++ b/examples/plugins/app_group_lifecycle_audit_logger/plugin.py
@@ -217,7 +217,13 @@ class AuditLoggerPlugin:
         self._increment_event_count(ctx, group)
 
     @hookimpl
-    async def group_deleted(self, ctx: AppGroupLifecycleContext, group: AppGroup, plugin_id: str | None) -> None:
+    async def group_deleted(
+        self,
+        ctx: AppGroupLifecycleContext,
+        group: AppGroup,
+        members: list[OktaUser],
+        plugin_id: str | None,
+    ) -> None:
         """Handle group deletion."""
         if plugin_id is not None and plugin_id != PLUGIN_ID:
             return
@@ -225,7 +231,10 @@ class AuditLoggerPlugin:
         if not self._is_enabled(ctx, group):
             return
 
-        self._log(ctx, f"Group deleted: {group.name} (app: {group.app.name})", group=group)
+        # `members` is who held membership when the group stopped being this plugin's. Reading it
+        # back off the group here would log nobody: the deletion already ended those memberships.
+        who = ", ".join(m.email for m in members) or "no members"
+        self._log(ctx, f"Group deleted: {group.name} (app: {group.app.name}), held by {who}", group=group)
 
         # Update status
         self._increment_event_count(ctx, group)

--- a/tests/test_app_group_lifecycle_plugin.py
+++ b/tests/test_app_group_lifecycle_plugin.py
@@ -23,7 +23,15 @@ from sqlalchemy.orm import joinedload
 
 from api.config import settings
 from api.extensions import Db
-from api.models import App, AppGroup, OktaUser, OktaUserGroupMember, RoleGroupMap
+from api.models import (
+    AccessRequestStatus,
+    App,
+    AppGroup,
+    OktaUser,
+    OktaUserGroupMember,
+    RoleGroupMap,
+)
+from api.operations import DeleteGroup
 from api.plugins.app_group_lifecycle import (
     AmbiguousOktaTargetError,
     AppGroupLifecycleContext,
@@ -46,7 +54,14 @@ from api.plugins.app_group_lifecycle import (
     validate_app_group_lifecycle_plugin_group_config,
 )
 from api.services import okta
-from tests.factories import AppFactory, AppGroupFactory, OktaGroupFactory, OktaUserFactory, RoleGroupFactory
+from tests.factories import (
+    AccessRequestFactory,
+    AppFactory,
+    AppGroupFactory,
+    OktaGroupFactory,
+    OktaUserFactory,
+    RoleGroupFactory,
+)
 
 
 class DummyPlugin:
@@ -61,6 +76,10 @@ class DummyPlugin:
         self.group_created_configs: list[dict[str, Any]] = []
         self.group_updated_calls: list[tuple[str, str, str]] = []
         self.group_deleted_calls: list[str] = []
+        # (group id, member emails) and the membership the context reports at hook time, so a test
+        # can tell the passed-in snapshot apart from what the hook could look up for itself.
+        self.group_deleted_members: list[tuple[str, list[str]]] = []
+        self.group_deleted_ctx_members: list[tuple[str, list[str]]] = []
         self.members_added_calls: list[tuple[str, list[str]]] = []
         self.members_removed_calls: list[tuple[str, list[str]]] = []
         # (group id, "owning app name") per sync_group call.
@@ -236,7 +255,9 @@ class DummyPlugin:
         self.group_updated_calls.append((group.id, old_name, old_description))
 
     @hookimpl
-    async def group_deleted(self, ctx: AppGroupLifecycleContext, group: AppGroup, plugin_id: str | None) -> None:
+    async def group_deleted(
+        self, ctx: AppGroupLifecycleContext, group: AppGroup, members: list[OktaUser], plugin_id: str | None
+    ) -> None:
         if plugin_id is not None and plugin_id != self.ID:
             return
         await ctx.find_groups_by_status("probe", "unset")  # exercise the context (see group_created)
@@ -244,6 +265,8 @@ class DummyPlugin:
         if group.id in self.group_deleted_failures:
             raise RuntimeError(f"group_deleted failed for {group.id}")
         self.group_deleted_calls.append(group.id)
+        self.group_deleted_members.append((group.id, [m.email for m in members]))
+        self.group_deleted_ctx_members.append((group.id, [m.email for m in await ctx.list_group_members(group)]))
 
     @hookimpl
     async def group_members_added(
@@ -3355,6 +3378,157 @@ class TestSyncGroupHook:
         await sync_app_groups.callback.__wrapped__()
 
         assert test_plugin.sync_group_calls == [(groups["One"], "SyncExitOk")]
+
+
+class TestGroupDeletedMembers:
+    """`group_deleted` receives the membership the group had when it stopped being the plugin's to
+    manage. A plugin that provisions users individually needs it to deprovision them, and cannot
+    recover it after the fact -- on the delete path the memberships are already ended, and on the
+    type-change path they are not, so a hook looking it up itself would behave differently
+    depending on why the group went away.
+    """
+
+    async def _app_group(self, db: Db, app_name: str, group_suffix: str = "G") -> AppGroup:
+        test_app = AppFactory.build(
+            name=app_name,
+            app_group_lifecycle_plugin=DummyPlugin.ID,
+            plugin_data={DummyPlugin.ID: {"configuration": {"enabled": True}}},
+        )
+        prefix = f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}"
+        group = AppGroupFactory.build(app_id=test_app.id, is_managed=True, name=f"{prefix}{group_suffix}")
+        db.session.add_all([test_app, group])
+        await db.session.commit()
+        return group
+
+    async def _member(
+        self, db: Db, email: str, group: AppGroup, *, is_owner: bool = False, role_group_map_id: str | None = None
+    ) -> OktaUser:
+        user = OktaUserFactory.build(email=email)
+        db.session.add(user)
+        await db.session.commit()
+        db.session.add(
+            OktaUserGroupMember(
+                user_id=user.id, group_id=group.id, is_owner=is_owner, role_group_map_id=role_group_map_id
+            )
+        )
+        await db.session.commit()
+        return user
+
+    async def _convert_to_okta_group(self, client: AsyncClient, url_for: Any, group: AppGroup, name: str) -> None:
+        response = await client.put(
+            url_for("api-groups.group_by_id", group_id=group.id),
+            json={"type": "okta_group", "name": name, "description": "Converted"},
+        )
+        assert response.status_code == 200, response.text
+
+    async def test_delete_hands_the_hook_the_members_it_can_no_longer_look_up(
+        self, db: Db, test_plugin: DummyPlugin, mocker: MockerFixture
+    ) -> None:
+        """The point of the argument: by the time the hook fires, DeleteGroup has already end-dated
+        every membership, so a hook that asked the context would deprovision nobody."""
+        group = await self._app_group(db, "DeletedMembersApp")
+        await self._member(db, "held@example.com", group)
+
+        await DeleteGroup(group=group, sync_to_okta=False).execute()
+
+        assert test_plugin.group_deleted_members == [(group.id, ["held@example.com"])]
+        # ...and the same hook asking for itself sees nothing, which is why this is passed.
+        assert test_plugin.group_deleted_ctx_members == [(group.id, [])]
+
+    async def test_includes_role_granted_members_and_excludes_owners(
+        self, db: Db, test_plugin: DummyPlugin, mocker: MockerFixture
+    ) -> None:
+        """Role-granted members hold the access the external system provisioned just as directly
+        as a direct grant, so deprovisioning has to see them. Owners administer the group instead
+        of holding its access, so they are not provisioned and must not be."""
+        group = await self._app_group(db, "DeletedRoleMembersApp")
+        role = RoleGroupFactory.build()
+        db.session.add(role)
+        await db.session.commit()
+        mapping = RoleGroupMap(role_group_id=role.id, group_id=group.id, is_owner=False)
+        db.session.add(mapping)
+        await db.session.commit()
+
+        await self._member(db, "direct@example.com", group)
+        await self._member(db, "via-role@example.com", group, role_group_map_id=mapping.id)
+        await self._member(db, "owner@example.com", group, is_owner=True)
+
+        await DeleteGroup(group=group, sync_to_okta=False).execute()
+
+        assert test_plugin.group_deleted_members == [(group.id, ["direct@example.com", "via-role@example.com"])]
+
+    async def test_members_survive_the_operations_intervening_commits(
+        self, db: Db, test_plugin: DummyPlugin, mocker: MockerFixture
+    ) -> None:
+        """DeleteGroup captures the members early, then commits several more times before the hook
+        fires -- rejecting pending requests, ending tag mappings. The snapshot has to still be
+        readable at the end; an expired instance would raise MissingGreenlet inside the hook, where
+        the failure is logged and swallowed and the notification silently lost."""
+        group = await self._app_group(db, "DeletedPendingApp")
+        requester = await self._member(db, "requester@example.com", group)
+        db.session.add(
+            AccessRequestFactory.build(
+                requester_user_id=requester.id,
+                requested_group_id=group.id,
+                request_ownership=False,
+                request_reason="pending at deletion",
+                status=AccessRequestStatus.PENDING,
+            )
+        )
+        await db.session.commit()
+        group_id = group.id
+
+        await DeleteGroup(group=group, sync_to_okta=False).execute()
+
+        assert test_plugin.group_deleted_members == [(group_id, ["requester@example.com"])]
+
+    async def test_type_change_hands_the_hook_the_same_members(
+        self, client: AsyncClient, db: Db, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
+    ) -> None:
+        """Converting away from an AppGroup keeps the memberships in Access, but the group stops
+        being this plugin's and its external group goes away, so the hook is still told who was in
+        it."""
+        mocker.patch.object(okta, "update_group")
+        group = await self._app_group(db, "ConvertedMembersApp")
+        await self._member(db, "kept@example.com", group)
+
+        await self._convert_to_okta_group(client, url_for, group, "ConvertedKeepsMembers")
+
+        assert test_plugin.group_deleted_members == [(group.id, ["kept@example.com"])]
+
+    async def test_both_paths_agree_for_identical_membership(
+        self, client: AsyncClient, db: Db, test_plugin: DummyPlugin, mocker: MockerFixture, url_for: Any
+    ) -> None:
+        """The reason this is an argument rather than a lookup. The two fire sites end membership at
+        different points, so a hook reading it off the group would see one thing on delete and
+        another on type change. Pin that the payload does not depend on which happened.
+        """
+        mocker.patch.object(okta, "update_group")
+        deleted = await self._app_group(db, "AgreeDeleteApp")
+        converted = await self._app_group(db, "AgreeConvertApp")
+        # Captured up front: ModifyGroupType expunges the session, so `converted` is detached by
+        # the time the assertions run.
+        deleted_id, converted_id = deleted.id, converted.id
+        for label, group in (("del", deleted), ("conv", converted)):
+            await self._member(db, f"a-{label}@example.com", group)
+            await self._member(db, f"b-{label}@example.com", group)
+            await self._member(db, f"owner-{label}@example.com", group, is_owner=True)
+
+        await DeleteGroup(group=deleted, sync_to_okta=False).execute()
+        await self._convert_to_okta_group(client, url_for, converted, "AgreeConverted")
+
+        by_group = dict(test_plugin.group_deleted_members)
+        assert by_group[deleted_id] == ["a-del@example.com", "b-del@example.com"]
+        assert by_group[converted_id] == ["a-conv@example.com", "b-conv@example.com"]
+
+    async def test_group_with_no_members_gets_an_empty_list(
+        self, db: Db, test_plugin: DummyPlugin, mocker: MockerFixture
+    ) -> None:
+        group = await self._app_group(db, "DeletedEmptyApp")
+
+        await DeleteGroup(group=group, sync_to_okta=False).execute()
+
+        assert test_plugin.group_deleted_members == [(group.id, [])]
 
 
 class TestPluginAuditLogging:


### PR DESCRIPTION
# Summary

`group_deleted` now receives `members`: the users who held membership when the group stopped being the plugin's to manage. Closes the gap @somethingnew2-0 raised on #577, and fixes a path-dependence in the hook that turned up while investigating it.

**Urgency**: 3 days
**Expected review effort**: LOW (~15 min)

> **Stacked on #587**, which is stacked on #577. GitHub retargets each as its parent merges.

# Motivation

From [#577](https://github.com/discord/access/pull/577#issuecomment-5332695682):

> Where that bites is `group_deleted`. `delete_group` end-dates every membership before invoking the hook, so `list_group_members(group)` returns empty there — which is why a plugin that has to clean up after itself keeps its own record of who it provisioned in group status.

That's correct, and the proposed fix was a way to resolve those recorded emails back to `OktaUser`s. This takes the other branch: rather than support the shadow record, remove the need for it. Access already knows who was in the group.

**The record is the fragile part.** It goes stale if a user's email changes in Okta (shouldn't happen ideally); a crash between provisioning a user and writing the status orphans someone the plugin will never clean up; and `group_deleted` is precisely where `_reapply_durable_status` returns early, so on the one path where the record matters most a failed hook can't repair it.

## The path-dependence

Probing both fire sites turned up something not in the original report:

```
DeleteGroup     -> members visible at group_deleted: []
ModifyGroupType -> members visible at group_deleted: ['probeconvert@example.com']
```

`DeleteGroup` end-dates memberships before firing; `ModifyGroupType` fires with them still live. So a hook reading membership off the group behaved differently depending on *why* the group went away, and the hookspec said nothing about it. Passing the payload explicitly fixes that by construction — there's now one value, computed the same way on both paths.

<details>
<summary><h1>Description of Changes</h1></summary>

**`members: list[OktaUser]` on the `group_deleted` hookspec.** Backwards compatible: pluggy passes an implementation only the arguments it declares, so an existing plugin that doesn't want members keeps working untouched — verified by the Google example plugin, which is unchanged and still green.

**`get_active_group_members(session, group_id)`** is now the single definition of a group's membership, shared by `ctx.list_group_members` and by both fire sites. Deliberately shared: a hook handed one thing on delete and reading another during a sync would silently disagree with itself. It takes the session explicitly because a context holds its own captured one.

**`DeleteGroup`** captures the members alongside `direct_members_to_remove_ids`, before the bulk `UPDATE`. Note it can't reuse that list — it filters `role_group_map_id.is_(None)`, so it misses role-granted members, who hold the access just as directly.

**`ModifyGroupType`** captures them immediately before the fire. The memberships survive a type change, so these users keep their Access membership; what goes away is the external group.

**The audit logger example** logs who held the group, as the reference for the new argument.

</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

- Full suite green: 835 passed. `ruff check`, `ruff format --check`, `ty check` clean.
- **6 new tests**, including that `members` is populated where `ctx.list_group_members(group)` is empty in the same hook call — which pins *why* the argument exists, so a later "the plugin can just look it up" simplification fails rather than silently deprovisioning nobody.
- Both paths asserted to deliver the same payload for identically-populated groups.
- Covers role-granted members included, owners excluded, empty group, and survival across `DeleteGroup`'s intervening commits (a deletion with a pending access request, which routes through `RejectAccessRequest`).
- Mutation-checked: moving the capture to after the bulk `UPDATE` — the realistic reordering regression — breaks 4 of the 6.
- **Not done:** an end-to-end run against a real external system. Needs credentials I don't have.

</details>

# Guidance for Reviewers

The semantics of `members` on the `ModifyGroupType` path is the judgment call: nobody loses Access membership there, so "members" reads slightly oddly. I've defined it as *"who held membership when the group stopped being this plugin's to manage"*, which is true on both paths and is what a plugin needs to tear down its external group either way. Say if you'd rather the type-change path passed something else, or nothing.

It also seems a bit odd that the plugin defines the concept/logic of `get_active_group_members` rather than Access itself, but I'm not familiar with a better hope for such helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)