### PR TITLE
Add a hidden confetti cannon, revealed by the theme toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@mui/x-date-pickers": "^6.18.4",
         "@sentry/react": "^8.34.0",
         "@tanstack/react-query": "^5.101.0",
+        "confetti-cannon": "^2.3.2",
         "dayjs": "^1.11.10",
         "env-cmd": "^10.1.0",
         "react": "^18.0.0",
@@ -3636,6 +3637,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -3814,6 +3822,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/confetti-cannon": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/confetti-cannon/-/confetti-cannon-2.3.2.tgz",
+      "integrity": "sha512-PZLtESiOZhbBt40O07S4SjGkK12LUwfm7zKBovjloZDw4j4tT1L9rl2drGnSjp0MTRNFcknBPgukx7Wgna7JlA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "classnames": "^2.3.2",
+        "invariant": "^2.2.4",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "uuid": "^9.0.0"
       }
     },
     "node_modules/convert-source-map": {
@@ -4880,6 +4901,16 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
       "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
       "license": "MIT"
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -8550,6 +8581,21 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vfile": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8584,10 +8584,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.2.tgz",
+      "integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -8595,7 +8594,7 @@
       "license": "MIT",
       "peer": true,
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@mui/x-date-pickers": "^6.18.4",
     "@sentry/react": "^8.34.0",
     "@tanstack/react-query": "^5.101.0",
+    "confetti-cannon": "^2.3.2",
     "dayjs": "^1.11.10",
     "env-cmd": "^10.1.0",
     "react": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "*.{js,ts,jsx,tsx}": "prettier --write"
   },
   "overrides": {
-    "esbuild": "^0.28.1"
+    "esbuild": "^0.28.1",
+    "uuid": "^14.0.2"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,8 @@ import ReadUser from './pages/users/Read';
 import {useCurrentUser} from './authentication';
 import ReadRequest from './pages/requests/Read';
 import ReadRoleRequest from './pages/role_requests/Read';
+import ConfettiToggleButton from './components/confetti/ConfettiToggleButton';
+import {ConfettiProvider, useConfetti} from './components/confetti/ConfettiContext';
 
 import {appName} from './config/accessConfig';
 
@@ -120,14 +122,17 @@ function ThemeToggle({setThemeMode, condensed}: {setThemeMode: (theme: PaletteMo
   );
   const currentTheme = useTheme();
   const systemTheme = useMediaQuery('(prefers-color-scheme: dark)') ? 'dark' : 'light';
+  const {registerThemeToggleClick} = useConfetti();
 
   const handleThemeOverride = (theme: PaletteMode) => {
+    registerThemeToggleClick();
     setThemeMode(theme);
     localStorage.setItem('user-set-color-scheme', theme);
     setStoredTheme(theme);
   };
 
   const handleSystemDefault = () => {
+    registerThemeToggleClick();
     setThemeMode(systemTheme);
     localStorage.removeItem('user-set-color-scheme');
     setStoredTheme(null);
@@ -287,8 +292,9 @@ function Dashboard({setThemeMode}: {setThemeMode: (theme: PaletteMode) => void})
         <List component="nav">
           <NavItems open={open} />
         </List>
-        <Stack marginTop="auto" p={2}>
+        <Stack marginTop="auto" p={2} direction={open ? 'row' : 'column'} spacing={1} alignItems="center">
           <ThemeToggle setThemeMode={setThemeMode} condensed={!open} />
+          <ConfettiToggleButton />
         </Stack>
       </Drawer>
       <Box
@@ -461,7 +467,9 @@ function AppState({source, theme, setMode}: AppStateProps) {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <Dashboard setThemeMode={setMode} />
+      <ConfettiProvider>
+        <Dashboard setThemeMode={setMode} />
+      </ConfettiProvider>
     </ThemeProvider>
   );
 }

--- a/src/components/confetti/ConfettiContext.test.tsx
+++ b/src/components/confetti/ConfettiContext.test.tsx
@@ -1,0 +1,146 @@
+import * as React from 'react';
+import {describe, it, expect, afterEach, beforeEach, vi} from 'vitest';
+import {act, render, screen} from '@testing-library/react';
+
+// The overlay draws to a canvas and observes its size, neither of which jsdom
+// has; stand in a marker so tests can still see when it is mounted.
+vi.mock('./ConfettiOverlay', async () => {
+  const react = await import('react');
+  return {default: () => react.createElement('div', {'data-testid': 'overlay'})};
+});
+
+// MUI's useMediaQuery reaches for the styled engine, which the test environment
+// doesn't have. Stub the one query the provider asks about.
+const media = vi.hoisted(() => ({prefersReducedMotion: false}));
+vi.mock('@mui/material/useMediaQuery', () => ({default: () => media.prefersReducedMotion}));
+
+import {ConfettiProvider, CLICKS_TO_UNLOCK, CLICK_WINDOW_MS, useConfetti} from './ConfettiContext';
+
+// A stand-in for the drawer footer: reports what the user would see, and lets a
+// test click the theme buttons as quickly or as slowly as it likes.
+let clickTheme: () => void;
+let setEnabled: (enabled: boolean) => void;
+
+function DrawerFooterProbe() {
+  const context = useConfetti();
+  clickTheme = context.registerThemeToggleClick;
+  setEnabled = context.setEnabled;
+  return (
+    <>
+      <div data-testid="unlocked">{String(context.unlocked)}</div>
+      <div data-testid="enabled">{String(context.enabled)}</div>
+    </>
+  );
+}
+
+const renderProbe = () =>
+  render(
+    <ConfettiProvider>
+      <DrawerFooterProbe />
+    </ConfettiProvider>,
+  );
+
+const shows = (testId: string) => screen.getByTestId(testId).textContent === 'true';
+
+const clickThemeTimes = (times: number, gapMs = 100) =>
+  act(() => {
+    for (let i = 0; i < times; i++) {
+      vi.advanceTimersByTime(gapMs);
+      clickTheme();
+    }
+  });
+
+// The lazily-loaded overlay lands a microtask after the switch is flipped.
+const settle = () => act(async () => {});
+
+beforeEach(() => {
+  localStorage.clear();
+  media.prefersReducedMotion = false;
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('revealing the confetti button', () => {
+  it('stays hidden until the theme toggle is clicked enough times in a row', () => {
+    renderProbe();
+    expect(shows('unlocked')).toBe(false);
+
+    clickThemeTimes(CLICKS_TO_UNLOCK - 1);
+    expect(shows('unlocked')).toBe(false);
+
+    clickThemeTimes(1);
+    expect(shows('unlocked')).toBe(true);
+  });
+
+  it('starts the count over when the clicks are too far apart', () => {
+    renderProbe();
+
+    // One click short of the reveal, and then one that lands too late to count
+    // towards it: it starts a fresh streak of its own instead.
+    clickThemeTimes(CLICKS_TO_UNLOCK - 1);
+    clickThemeTimes(1, CLICK_WINDOW_MS + 1);
+    expect(shows('unlocked')).toBe(false);
+
+    // So the reveal is still one click away, not already behind us.
+    clickThemeTimes(CLICKS_TO_UNLOCK - 2);
+    expect(shows('unlocked')).toBe(false);
+    clickThemeTimes(1);
+    expect(shows('unlocked')).toBe(true);
+  });
+
+  it('stays revealed on the next visit', () => {
+    const {unmount} = renderProbe();
+    clickThemeTimes(CLICKS_TO_UNLOCK);
+    expect(shows('unlocked')).toBe(true);
+    unmount();
+
+    renderProbe();
+    expect(shows('unlocked')).toBe(true);
+  });
+});
+
+describe('the cannon switch', () => {
+  it('starts off and remembers being left on', async () => {
+    const {unmount} = renderProbe();
+    expect(shows('enabled')).toBe(false);
+    expect(screen.queryByTestId('overlay')).toBeNull();
+
+    act(() => setEnabled(true));
+    await settle();
+    expect(shows('enabled')).toBe(true);
+    expect(screen.queryByTestId('overlay')).not.toBeNull();
+    unmount();
+
+    renderProbe();
+    await settle();
+    expect(shows('enabled')).toBe(true);
+    expect(screen.queryByTestId('overlay')).not.toBeNull();
+  });
+
+  it('remembers being switched back off', async () => {
+    const {unmount} = renderProbe();
+    act(() => setEnabled(true));
+    await settle();
+    act(() => setEnabled(false));
+    unmount();
+
+    renderProbe();
+    await settle();
+    expect(shows('enabled')).toBe(false);
+    expect(screen.queryByTestId('overlay')).toBeNull();
+  });
+
+  it('keeps the confetti grounded when the system asks for reduced motion', async () => {
+    media.prefersReducedMotion = true;
+    renderProbe();
+
+    act(() => setEnabled(true));
+    await settle();
+    // The switch still reads as on, so it holds the preference for later.
+    expect(shows('enabled')).toBe(true);
+    expect(screen.queryByTestId('overlay')).toBeNull();
+  });
+});

--- a/src/components/confetti/ConfettiContext.tsx
+++ b/src/components/confetti/ConfettiContext.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import useMediaQuery from '@mui/material/useMediaQuery';
+
+import {Point} from './typingTargets';
+
+// The confetti machinery — and confetti-cannon itself — is only worth
+// downloading once someone has found the switch.
+const ConfettiOverlay = React.lazy(() => import('./ConfettiOverlay'));
+
+/** Consecutive theme-toggle clicks that reveal the confetti button. */
+export const CLICKS_TO_UNLOCK = 3;
+/** A click this long after the previous one starts the count over. */
+export const CLICK_WINDOW_MS = 3000;
+
+const UNLOCKED_STORAGE_KEY = 'confetti-cannon-unlocked';
+const ENABLED_STORAGE_KEY = 'confetti-cannon-enabled';
+
+interface ConfettiContextValue {
+  /** Whether the toggle has been discovered, and so is rendered at all. */
+  unlocked: boolean;
+  enabled: boolean;
+  /** The user's system asks for less motion, so confetti stays in its box. */
+  reducedMotion: boolean;
+  /** Counts a theme-toggle click towards revealing the confetti button. */
+  registerThemeToggleClick: () => void;
+  /** Turns the cannon on or off; `origin` gets a burst when turning it on. */
+  setEnabled: (enabled: boolean, origin?: Point) => void;
+}
+
+// Defaults keep the theme toggle usable in isolation (tests, storybooks).
+const ConfettiContext = React.createContext<ConfettiContextValue>({
+  unlocked: false,
+  enabled: false,
+  reducedMotion: false,
+  registerThemeToggleClick: () => {},
+  setEnabled: () => {},
+});
+
+export function useConfetti() {
+  return React.useContext(ConfettiContext);
+}
+
+export function ConfettiProvider({children}: {children: React.ReactNode}) {
+  const [unlocked, setUnlocked] = React.useState(() => localStorage.getItem(UNLOCKED_STORAGE_KEY) === 'true');
+  const [enabled, setEnabledState] = React.useState(() => localStorage.getItem(ENABLED_STORAGE_KEY) === 'true');
+  // Only set when the user flips the switch, so a reload doesn't fire a burst.
+  const [launchFrom, setLaunchFrom] = React.useState<Point | null>(null);
+  const reducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
+
+  const clickCount = React.useRef(0);
+  const lastClickAt = React.useRef(0);
+
+  const registerThemeToggleClick = React.useCallback(() => {
+    const now = Date.now();
+    clickCount.current = now - lastClickAt.current > CLICK_WINDOW_MS ? 1 : clickCount.current + 1;
+    lastClickAt.current = now;
+
+    if (clickCount.current >= CLICKS_TO_UNLOCK) {
+      clickCount.current = 0;
+      setUnlocked(true);
+      localStorage.setItem(UNLOCKED_STORAGE_KEY, 'true');
+    }
+  }, []);
+
+  const setEnabled = React.useCallback((next: boolean, origin?: Point) => {
+    setEnabledState(next);
+    localStorage.setItem(ENABLED_STORAGE_KEY, String(next));
+    setLaunchFrom(next ? origin ?? null : null);
+  }, []);
+
+  const value = React.useMemo(
+    () => ({unlocked, enabled, reducedMotion, registerThemeToggleClick, setEnabled}),
+    [unlocked, enabled, reducedMotion, registerThemeToggleClick, setEnabled],
+  );
+
+  return (
+    <ConfettiContext.Provider value={value}>
+      {children}
+      {enabled && !reducedMotion && (
+        <React.Suspense fallback={null}>
+          <ConfettiOverlay launchFrom={launchFrom} />
+        </React.Suspense>
+      )}
+    </ConfettiContext.Provider>
+  );
+}

--- a/src/components/confetti/ConfettiOverlay.tsx
+++ b/src/components/confetti/ConfettiOverlay.tsx
@@ -1,0 +1,170 @@
+import * as React from 'react';
+import {rgbToHex, useTheme} from '@mui/material/styles';
+import {
+  ConfettiCanvas,
+  ConfettiCanvasHandle,
+  CreateConfettiArgs,
+  Environment,
+  SpriteCanvas,
+  SpriteCanvasHandle,
+  SpriteProp,
+  useConfettiCannon,
+} from 'confetti-cannon';
+
+import {getTypingOrigin, isTypingTarget, Point} from './typingTargets';
+
+// confetti-cannon scales its drawing by `global.devicePixelRatio` — a Node-ism
+// its own webpack build shimmed away, and one Vite does not provide. Point
+// `global` at the browser's global object before any confetti is drawn. This
+// module is only loaded once the cannon is switched on, so nothing else in the
+// app is touched.
+(globalThis as {global?: typeof globalThis}).global ??= globalThis;
+
+// confetti-cannon pre-renders its confetti onto an offscreen sprite sheet, one
+// row per shape and one column per color, so every shape has to arrive as an
+// image. Inline SVG data URIs keep them in the bundle. The shapes are solid
+// black because colorizing rewrites every pixel's color and keeps only the
+// alpha channel, which is where the shape actually lives.
+const spriteDataUri = (shape: string) =>
+  `data:image/svg+xml;utf8,${encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" fill="none" width="8" height="8" viewBox="0 0 8 8">${shape}</svg>`,
+  )}`;
+
+const SPRITES: SpriteProp[] = [
+  spriteDataUri('<rect width="8" height="8" fill="#000"/>'),
+  spriteDataUri('<circle cx="4" cy="4" r="4" fill="#000"/>'),
+  spriteDataUri('<rect y="2" width="8" height="4" rx="2" fill="#000"/>'),
+  spriteDataUri('<polygon points="4,0 8,8 0,8" fill="#000"/>'),
+];
+
+const MIN_CONFETTI_SIZE = 6;
+const MAX_CONFETTI_SIZE = 14;
+// A keystroke is a small puff at the caret; switching the cannon on is a real
+// celebration around the button. `SPREAD` is how far from that point, in
+// pixels, a piece can start out.
+const CONFETTI_PER_KEYSTROKE = 4;
+const KEYSTROKE_SPREAD = 6;
+const CONFETTI_PER_CELEBRATION = 45;
+const CELEBRATION_SPREAD = 12;
+// Fast typists outrun the animation otherwise, and the screen turns to soup.
+const KEYSTROKE_THROTTLE_MS = 70;
+
+export default function ConfettiOverlay({launchFrom}: {launchFrom: Point | null}) {
+  const theme = useTheme();
+  const [confettiCanvas, setConfettiCanvas] = React.useState<ConfettiCanvasHandle | null>(null);
+  const [spriteCanvas, setSpriteCanvas] = React.useState<SpriteCanvasHandle | null>(null);
+  const environment = React.useMemo(() => new Environment(), []);
+  const cannon = useConfettiCannon(confettiCanvas, spriteCanvas);
+
+  // Confetti wears the app's own palette. The sprite sheet colorizes from hex
+  // only, so normalize through rgbToHex and drop any alpha an 8-digit result
+  // carries — sprite transparency comes from the shape, not the color.
+  const colors = React.useMemo(
+    () =>
+      [
+        theme.palette.primary.main,
+        theme.palette.primary.light,
+        theme.palette.secondary.main,
+        theme.palette.success.main,
+        theme.palette.warning.main,
+        theme.palette.error.main,
+        theme.palette.info.main,
+      ].map((color) => rgbToHex(color).slice(0, 7)),
+    [theme],
+  );
+
+  const fire = React.useCallback(
+    (origin: Point, count: number, spread: number) => {
+      const args: CreateConfettiArgs = {
+        position: {
+          type: 'static-random',
+          minValue: {x: origin.x - spread, y: origin.y - spread},
+          maxValue: {x: origin.x + spread, y: origin.y + spread},
+        },
+        velocity: {
+          type: 'static-random',
+          minValue: {x: -18, y: -25},
+          maxValue: {x: 18, y: -50},
+        },
+        rotation: {
+          type: 'linear-random',
+          minValue: 0,
+          maxValue: 360,
+          minAddValue: -25,
+          maxAddValue: 25,
+        },
+        size: {
+          type: 'static-random',
+          minValue: MIN_CONFETTI_SIZE,
+          maxValue: MAX_CONFETTI_SIZE,
+          // Keep each piece's aspect ratio so circles stay round.
+          uniformVectorValues: true,
+        },
+        opacity: {type: 'linear', value: 1, addValue: -0.07},
+      };
+      cannon.createMultipleConfetti(args, count);
+    },
+    [cannon],
+  );
+
+  // Fire from the button that switched the cannon on, once the canvases are up.
+  const celebrated = React.useRef(false);
+  React.useEffect(() => {
+    if (launchFrom == null || !cannon.isReady || celebrated.current) {
+      return;
+    }
+    celebrated.current = true;
+    fire(launchFrom, CONFETTI_PER_CELEBRATION, CELEBRATION_SPREAD);
+  }, [cannon.isReady, fire, launchFrom]);
+
+  React.useEffect(() => {
+    if (!cannon.isReady) {
+      return;
+    }
+
+    let lastFiredAt = 0;
+    const handleInput = (event: Event) => {
+      if (!isTypingTarget(event.target)) {
+        return;
+      }
+      const now = Date.now();
+      if (now - lastFiredAt < KEYSTROKE_THROTTLE_MS) {
+        return;
+      }
+      lastFiredAt = now;
+      fire(getTypingOrigin(event.target), CONFETTI_PER_KEYSTROKE, KEYSTROKE_SPREAD);
+    };
+
+    // Capture phase so a field that stops propagation still gets its confetti.
+    document.addEventListener('input', handleInput, true);
+    return () => document.removeEventListener('input', handleInput, true);
+  }, [cannon.isReady, fire]);
+
+  const canvasStyle = React.useMemo<React.CSSProperties>(
+    () => ({
+      position: 'fixed',
+      inset: 0,
+      // A canvas has an intrinsic size, so inset alone won't stretch it.
+      width: '100%',
+      height: '100%',
+      // Confetti is never in the way: the canvas covers dialogs and the app
+      // bar, but every click passes straight through it.
+      pointerEvents: 'none',
+      zIndex: theme.zIndex.tooltip + 1,
+    }),
+    [theme.zIndex.tooltip],
+  );
+
+  return (
+    <>
+      <SpriteCanvas
+        ref={setSpriteCanvas}
+        sprites={SPRITES}
+        colors={colors}
+        spriteWidth={MAX_CONFETTI_SIZE}
+        spriteHeight={MAX_CONFETTI_SIZE}
+      />
+      <ConfettiCanvas ref={setConfettiCanvas} environment={environment} style={canvasStyle} aria-hidden />
+    </>
+  );
+}

--- a/src/components/confetti/ConfettiToggleButton.tsx
+++ b/src/components/confetti/ConfettiToggleButton.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import CelebrationIcon from '@mui/icons-material/Celebration';
+import ToggleButton from '@mui/material/ToggleButton';
+import Tooltip from '@mui/material/Tooltip';
+import Zoom from '@mui/material/Zoom';
+
+import {useConfetti} from './ConfettiContext';
+
+export default function ConfettiToggleButton() {
+  const {unlocked, enabled, reducedMotion, setEnabled} = useConfetti();
+
+  if (!unlocked) {
+    return null;
+  }
+
+  const label = reducedMotion
+    ? "Confetti cannon (held back by your system's reduced motion setting)"
+    : enabled
+      ? 'Stop the confetti'
+      : 'Confetti cannon: confetti as you type';
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    // Launch the celebratory burst from the button the user just hit.
+    const rect = event.currentTarget.getBoundingClientRect();
+    setEnabled(!enabled, {x: rect.left + rect.width / 2, y: rect.top + rect.height / 2});
+  };
+
+  return (
+    // Zoom has to sit outside Tooltip: it hands the transition style down to
+    // its child, and only Tooltip forwards that on to the button.
+    <Zoom in>
+      <Tooltip title={label}>
+        <ToggleButton value="confetti" size="small" selected={enabled} onClick={handleClick} aria-label={label}>
+          <CelebrationIcon />
+        </ToggleButton>
+      </Tooltip>
+    </Zoom>
+  );
+}

--- a/src/components/confetti/typingTargets.test.ts
+++ b/src/components/confetti/typingTargets.test.ts
@@ -1,0 +1,91 @@
+import {describe, it, expect, beforeAll, afterAll, vi} from 'vitest';
+
+import {getTypingOrigin, isTypingTarget} from './typingTargets';
+
+// jsdom has no 2d canvas, so stand in a context whose text measurement is
+// predictable: 10px per character.
+beforeAll(() => {
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+    font: '',
+    measureText: (text: string) => ({width: text.length * 10}),
+  } as unknown as CanvasRenderingContext2D);
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+const RECT = {left: 100, top: 50, width: 200, height: 40, right: 300, bottom: 90, x: 100, y: 50};
+
+function placeInDocument<T extends HTMLElement>(element: T): T {
+  // jsdom lays nothing out, so every field gets the same stated geometry.
+  element.getBoundingClientRect = () => ({...RECT, toJSON: () => RECT});
+  document.body.appendChild(element);
+  return element;
+}
+
+function textInput(value: string, caretIndex = value.length) {
+  const input = document.createElement('input');
+  input.style.fontSize = '10px';
+  input.style.fontFamily = 'monospace';
+  // Pinned so the expected caret offsets don't depend on jsdom's UA styles.
+  input.style.borderLeftWidth = '1px';
+  input.style.paddingLeft = '4px';
+  input.value = value;
+  placeInDocument(input);
+  input.setSelectionRange(caretIndex, caretIndex);
+  return input;
+}
+
+describe('isTypingTarget', () => {
+  it('accepts free-text inputs and textareas', () => {
+    const untyped = document.createElement('input');
+    expect(isTypingTarget(untyped)).toBe(true);
+
+    for (const type of ['text', 'search', 'url', 'email', 'tel', 'number']) {
+      const input = document.createElement('input');
+      input.type = type;
+      expect(isTypingTarget(input)).toBe(true);
+    }
+
+    expect(isTypingTarget(document.createElement('textarea'))).toBe(true);
+  });
+
+  it('leaves password fields alone', () => {
+    const password = document.createElement('input');
+    password.type = 'password';
+    expect(isTypingTarget(password)).toBe(false);
+  });
+
+  it('ignores inputs that are not typed into, and non-inputs', () => {
+    for (const type of ['checkbox', 'radio', 'range', 'file', 'color', 'submit']) {
+      const input = document.createElement('input');
+      input.type = type;
+      expect(isTypingTarget(input)).toBe(false);
+    }
+
+    expect(isTypingTarget(document.createElement('div'))).toBe(false);
+    expect(isTypingTarget(document.createElement('button'))).toBe(false);
+    expect(isTypingTarget(null)).toBe(false);
+  });
+});
+
+describe('getTypingOrigin', () => {
+  it('follows the caret across an input', () => {
+    // Field at x=100 with 5px of border and padding, 4 characters at 10px each.
+    expect(getTypingOrigin(textInput('abcd'))).toEqual({x: 145, y: 70});
+    // Same value, caret parked after the first character.
+    expect(getTypingOrigin(textInput('abcd', 1))).toEqual({x: 115, y: 70});
+  });
+
+  it('keeps confetti inside a field the text has overflowed', () => {
+    // 40 characters measure 400px in a 200px-wide field.
+    expect(getTypingOrigin(textInput('a'.repeat(40)))).toEqual({x: RECT.right, y: 70});
+  });
+
+  it('falls back to the middle of a textarea, whose caret needs a text layout', () => {
+    const textarea = placeInDocument(document.createElement('textarea'));
+    textarea.value = 'a wrapped\nreason';
+    expect(getTypingOrigin(textarea)).toEqual({x: 200, y: 70});
+  });
+});

--- a/src/components/confetti/typingTargets.ts
+++ b/src/components/confetti/typingTargets.ts
@@ -1,0 +1,81 @@
+// Where a keystroke should launch its confetti from. Kept free of React and of
+// confetti-cannon itself so the target and caret rules can be unit tested.
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+// Free-text input types only. Confetti follows typed characters, so pickers,
+// checkboxes, and — deliberately — password fields are left alone.
+const TEXT_INPUT_TYPES = new Set(['text', 'search', 'url', 'email', 'tel', 'number']);
+
+export function isTypingTarget(target: EventTarget | null): target is HTMLInputElement | HTMLTextAreaElement {
+  if (target instanceof HTMLTextAreaElement) {
+    return true;
+  }
+  if (target instanceof HTMLInputElement) {
+    return TEXT_INPUT_TYPES.has(target.type);
+  }
+  return false;
+}
+
+// One offscreen canvas measures text for every field on the page.
+let measureContext: CanvasRenderingContext2D | null | undefined;
+
+function getMeasureContext() {
+  if (measureContext === undefined) {
+    measureContext = document.createElement('canvas').getContext('2d');
+  }
+  return measureContext;
+}
+
+// Width of `text` as `element` would render it, or null when it can't be measured.
+function measureTextWidth(element: Element, text: string): number | null {
+  const context = getMeasureContext();
+  if (context == null) {
+    return null;
+  }
+
+  const style = window.getComputedStyle(element);
+  if (!style.fontSize || !style.fontFamily) {
+    return null;
+  }
+
+  context.font = `${style.fontStyle} ${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
+  return context.measureText(text).width;
+}
+
+function toNumber(value: string) {
+  const parsed = parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/**
+ * Viewport point to launch a keystroke's confetti from: the caret itself in a
+ * single-line input, or the middle of the field when the caret can't be located
+ * (a textarea wraps, so its caret needs a full text layout to find).
+ */
+export function getTypingOrigin(element: HTMLInputElement | HTMLTextAreaElement): Point {
+  const rect = element.getBoundingClientRect();
+  const middle = {x: rect.left + rect.width / 2, y: rect.top + rect.height / 2};
+
+  if (element instanceof HTMLTextAreaElement) {
+    return middle;
+  }
+
+  // selectionStart is null on input types that don't support selection
+  // (number, email), where the caret always sits after the last character.
+  const caretIndex = element.selectionStart ?? element.value.length;
+  const textWidth = measureTextWidth(element, element.value.slice(0, caretIndex));
+  if (textWidth == null) {
+    return middle;
+  }
+
+  const style = window.getComputedStyle(element);
+  const textStart = rect.left + toNumber(style.borderLeftWidth) + toNumber(style.paddingLeft);
+  const caretX = textStart + textWidth - element.scrollLeft;
+  // A caret scrolled out of view, or a long value in a narrow field, would
+  // otherwise fire confetti outside the input.
+  return {x: Math.min(Math.max(caretX, rect.left), rect.right), y: middle.y};
+}


### PR DESCRIPTION
## What

https://github.com/user-attachments/assets/9e71c307-fd4b-4ce5-afa4-62255c2288da


Clicking any of the light/dark/system theme buttons three times in a row — each click within three seconds of the last — reveals a confetti button beside the toggle in the lower left of the drawer. Switching it on fires a burst from the button, and from then on every keystroke in a text field puffs a few pieces of confetti from the caret. Both the reveal and the on/off state persist in `localStorage`, so the switch stays found once discovered.

Built on [discord/confetti-cannon](https://github.com/discord/confetti-cannon) (MIT, no runtime dependencies of its own).

## Why

Surprise and delight. Access is a tool people use to ask for things and wait, and a small hidden reward costs nothing when it stays out of the way — which is the constraint that shaped most of the decisions below.

## Notes for reviewers

- **Nobody pays for it until they find it.** The overlay sits behind `React.lazy`, so `confetti-cannon` and its canvases only download once the switch is flipped; it builds as its own ~23kB (7.7kB gzipped) chunk rather than joining the main bundle.
- **`global` shim.** `confetti-cannon` scales its drawing by `global.devicePixelRatio`, a Node-ism its own webpack build shimmed away. Vite provides no `global`, so the overlay module aliases it to `globalThis` before any confetti is drawn — nothing renders at all without this. It lives in the lazy module so the rest of the app is untouched.
- **Never in the way.** The canvas is fixed, `aria-hidden`, and `pointer-events: none`, above the app bar and dialogs, so clicks pass straight through it.
- **Deliberate omissions.** Password fields and non-text inputs get no confetti, bursts are throttled so fast typing can't flood the screen, and `prefers-reduced-motion: reduce` keeps the overlay unmounted while the switch still remembers the preference for later.
- **Colors come from the MUI palette**, so it matches light and dark without hardcoding hexes.
- **One layout consequence:** with the drawer collapsed the two buttons stack, making its footer ~46px taller. The drawer paper is content-sized today, so on windows under ~595px tall the page scrolls slightly further to reach it. Happy to cap the paper at `100vh` so the drawer scrolls internally instead, if you'd prefer that here rather than as a follow-up.
- **`uuid` override.** `confetti-cannon` peer-depends on `uuid` ^9, which npm auto-installs and which carries a moderate advisory (missing buffer bounds check in v3/v5/v6 when `buf` is passed — the library only calls v4 and never passes a buffer, so it was never reachable). There is no fix inside the peer range, so the second commit pins it forward with an `overrides` entry; `npm audit` is clean again.
- **Not in the README** — documenting the gesture would spoil it. Say the word if operators should have a line anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
