### PR TITLE
Serve the confetti sprites from the app's own origin

### DIFF
--- a/public/confetti/circle.svg
+++ b/public/confetti/circle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" width="8" height="8" viewBox="0 0 8 8">
+  <circle cx="4" cy="4" r="4" fill="#000" />
+</svg>

--- a/public/confetti/ribbon.svg
+++ b/public/confetti/ribbon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" width="8" height="8" viewBox="0 0 8 8">
+  <rect y="2" width="8" height="4" rx="2" fill="#000" />
+</svg>

--- a/public/confetti/square.svg
+++ b/public/confetti/square.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" width="8" height="8" viewBox="0 0 8 8">
+  <rect width="8" height="8" fill="#000" />
+</svg>

--- a/public/confetti/triangle.svg
+++ b/public/confetti/triangle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" width="8" height="8" viewBox="0 0 8 8">
+  <polygon points="4,0 8,8 0,8" fill="#000" />
+</svg>

--- a/src/components/confetti/ConfettiOverlay.tsx
+++ b/src/components/confetti/ConfettiOverlay.tsx
@@ -7,10 +7,10 @@ import {
   Environment,
   SpriteCanvas,
   SpriteCanvasHandle,
-  SpriteProp,
   useConfettiCannon,
 } from 'confetti-cannon';
 
+import SPRITES from './sprites';
 import {getTypingOrigin, isTypingTarget, Point} from './typingTargets';
 
 // confetti-cannon scales its drawing by `global.devicePixelRatio` — a Node-ism
@@ -19,23 +19,6 @@ import {getTypingOrigin, isTypingTarget, Point} from './typingTargets';
 // module is only loaded once the cannon is switched on, so nothing else in the
 // app is touched.
 (globalThis as {global?: typeof globalThis}).global ??= globalThis;
-
-// confetti-cannon pre-renders its confetti onto an offscreen sprite sheet, one
-// row per shape and one column per color, so every shape has to arrive as an
-// image. Inline SVG data URIs keep them in the bundle. The shapes are solid
-// black because colorizing rewrites every pixel's color and keeps only the
-// alpha channel, which is where the shape actually lives.
-const spriteDataUri = (shape: string) =>
-  `data:image/svg+xml;utf8,${encodeURIComponent(
-    `<svg xmlns="http://www.w3.org/2000/svg" fill="none" width="8" height="8" viewBox="0 0 8 8">${shape}</svg>`,
-  )}`;
-
-const SPRITES: SpriteProp[] = [
-  spriteDataUri('<rect width="8" height="8" fill="#000"/>'),
-  spriteDataUri('<circle cx="4" cy="4" r="4" fill="#000"/>'),
-  spriteDataUri('<rect y="2" width="8" height="4" rx="2" fill="#000"/>'),
-  spriteDataUri('<polygon points="4,0 8,8 0,8" fill="#000"/>'),
-];
 
 const MIN_CONFETTI_SIZE = 6;
 const MAX_CONFETTI_SIZE = 14;

--- a/src/components/confetti/sprites.test.ts
+++ b/src/components/confetti/sprites.test.ts
@@ -1,0 +1,16 @@
+import {describe, it, expect} from 'vitest';
+
+import SPRITES from './sprites';
+
+describe('confetti sprites', () => {
+  // Regression guard: inlined `data:` sprites are blocked by the app's CSP,
+  // which has no `img-src` and so falls back to `default-src 'self'`. A blocked
+  // sprite never fires `onload`, and the cannon then sits at not-ready without
+  // reporting anything — so this failure mode is invisible at runtime.
+  it('are same-origin paths the app CSP allows', () => {
+    expect(SPRITES.length).toBeGreaterThan(0);
+    for (const sprite of SPRITES) {
+      expect(sprite).toMatch(/^\/[\w/-]+\.svg$/);
+    }
+  });
+});

--- a/src/components/confetti/sprites.ts
+++ b/src/components/confetti/sprites.ts
@@ -1,0 +1,21 @@
+// The shapes confetti-cannon pre-renders onto its offscreen sprite sheet, one
+// row per shape and one column per color.
+//
+// These must stay same-origin URLs, not inlined `data:` URIs. The app's CSP
+// (api/middleware.py, `build_csp`) declares no `img-src`, so images fall back to
+// `default-src 'self'` and a `data:` URI is blocked outright. SpriteCanvas only
+// ever resolves its load promise on `image.onload` — there is no `onerror`
+// path — so a blocked sprite leaves the cannon silently stuck at not-ready
+// rather than failing loudly. Files under `public/` are served from the app's
+// own origin by the SPA catch-all, which `'self'` covers.
+//
+// Each file draws its shape in solid black: colorizing rewrites every pixel's
+// color and keeps only the alpha channel, which is where the shape lives.
+const SPRITES: string[] = [
+  '/confetti/square.svg',
+  '/confetti/circle.svg',
+  '/confetti/ribbon.svg',
+  '/confetti/triangle.svg',
+];
+
+export default SPRITES;


### PR DESCRIPTION
## What

The confetti cannon added in #591 does nothing once deployed. Its four sprite shapes were inlined as `data:image/svg+xml` URIs; the app's CSP declares no `img-src`, so images fall back to `default-src 'self'` and every sprite is blocked:

```
Loading the image 'data:image/svg+xml;utf8,...' violates the following Content
Security Policy directive: "default-src 'self'". Note that 'img-src' was not
explicitly set, so 'default-src' is used as a fallback. The action has been blocked.
```

This ships the shapes as files under `public/confetti/` instead, which the SPA catch-all serves from the app's own origin — already covered by `'self'`, so the policy does not need widening for an easter egg.

## Why it failed silently

Worth knowing, because it's the reason this reached staging looking fine: `SpriteCanvas` resolves its per-image load promise only from `image.onload` and has no `onerror` path. A blocked sprite leaves `Promise.all` pending forever, so the sprite canvas never reports ready and `useConfettiCannon` sits at `isReady: false`. Every `createConfetti` call then no-ops. The button still appears and still toggles; nothing ever fires, and the library says nothing.

Locally there was no signal either: Vite's dev server sends no CSP at all, and `_csp_for` hands out the relaxed `DEBUG_CSP`, which *does* allow `data:`. Only the production `build_csp` policy blocks it.

## Notes for reviewers

- **Verified against the real policy**, not by reasoning about it: I built the exact string `build_csp()` emits into a probe page and confirmed three things — the `data:` URI is blocked, all four files load, and drawing one into a canvas leaves it `getImageData`-readable. That last one matters: SpriteCanvas colorizes each piece by reading pixels back, so a tainted canvas would have broken the feature a second way. Same-origin SVGs don't taint.
- **No CSP change.** Adding `img-src 'self' data:` would also have worked, but the policy in `api/middleware.py` is deliberately tight (its docstring turns down two benign violations rather than loosen anything), and static files get the same result without touching it.
- **The sprite list moved to its own module** with a test pinning entries to same-origin paths. Re-inlining them would reintroduce a failure mode with no runtime symptom, which is exactly how this shipped.
- **The `style-src` noise in staging's console is unrelated** — that's Sentry Session Replay's rrweb calling `setAttribute("style", …)` on detached nodes, already documented as expected in `build_csp`. It predates the confetti and is not affected by this change.
- The files land at `build/confetti/*.svg`, outside `assets/`, so they get no immutable caching — correct, since they aren't content-hashed. `FileResponse` serves them as `image/svg+xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)