### PR TITLE
Wider search bar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -216,8 +216,6 @@ function Dashboard({setThemeMode}: {setThemeMode: (theme: PaletteMode) => void})
             <MenuIcon />
           </IconButton>
           <Box sx={{flexGrow: 1}} />
-          {/* Search plus the account icon line up with the table search fields below: the Container
-              gutter and the Toolbar's right padding match, so we only add back TableTopBar's paddingX. */}
           <Box
             sx={(theme) => ({
               display: 'flex',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,7 @@ import ListTags from './pages/tags/List';
 import ListUsers from './pages/users/List';
 import NavItems from './components/NavItems';
 import QuickSwitcher from './components/QuickSwitcher';
+import {TABLE_SEARCH_WIDTH, TABLE_TOP_BAR_PADDING_X} from './components/TableTopBar';
 import NotFound from './pages/NotFound';
 import ReadApp from './pages/apps/Read';
 import ReadGroup from './pages/groups/Read';
@@ -215,38 +216,48 @@ function Dashboard({setThemeMode}: {setThemeMode: (theme: PaletteMode) => void})
             <MenuIcon />
           </IconButton>
           <Box sx={{flexGrow: 1}} />
-          <Tooltip title="Search (users, groups, roles, apps)">
-            <Button
-              color="inherit"
-              onClick={() => setQuickSwitcherOpen(true)}
-              startIcon={<SearchIcon />}
-              sx={{
-                mr: 1,
-                textTransform: 'none',
-                borderColor: alpha('#fff', 0.4),
-                color: 'inherit',
-              }}
-              variant="outlined"
-              size="small">
-              Search
-              <Box
-                component="span"
+          {/* Search plus the account icon line up with the table search fields below: the Container
+              gutter and the Toolbar's right padding match, so we only add back TableTopBar's paddingX. */}
+          <Box
+            sx={(theme) => ({
+              display: 'flex',
+              alignItems: 'center',
+              width: `calc(${TABLE_SEARCH_WIDTH}px + ${theme.spacing(TABLE_TOP_BAR_PADDING_X)})`,
+            })}>
+            <Tooltip title="Search (users, groups, roles, apps)">
+              <Button
+                color="inherit"
+                onClick={() => setQuickSwitcherOpen(true)}
+                startIcon={<SearchIcon />}
                 sx={{
-                  ml: 1.5,
-                  px: 0.75,
-                  py: 0.1,
-                  borderRadius: 1,
-                  fontSize: '0.7rem',
-                  lineHeight: 1.6,
-                  backgroundColor: alpha('#fff', 0.15),
-                }}>
-                {isMacPlatform ? '⌘K' : 'Ctrl K'}
-              </Box>
-            </Button>
-          </Tooltip>
-          <IconButton color="inherit" component={RouterLink} to="/users/@me">
-            <AccountIcon />
-          </IconButton>
+                  flexGrow: 1,
+                  mr: 1,
+                  textTransform: 'none',
+                  borderColor: alpha('#fff', 0.4),
+                  color: 'inherit',
+                }}
+                variant="outlined"
+                size="small">
+                Search
+                <Box
+                  component="span"
+                  sx={{
+                    ml: 'auto',
+                    px: 0.75,
+                    py: 0.1,
+                    borderRadius: 1,
+                    fontSize: '0.7rem',
+                    lineHeight: 1.6,
+                    backgroundColor: alpha('#fff', 0.15),
+                  }}>
+                  {isMacPlatform ? '⌘K' : 'Ctrl K'}
+                </Box>
+              </Button>
+            </Tooltip>
+            <IconButton color="inherit" component={RouterLink} to="/users/@me">
+              <AccountIcon />
+            </IconButton>
+          </Box>
         </Toolbar>
       </AppBar>
       <QuickSwitcher open={quickSwitcherOpen} onClose={() => setQuickSwitcherOpen(false)} />

--- a/src/components/TableTopBar.tsx
+++ b/src/components/TableTopBar.tsx
@@ -20,6 +20,12 @@ export function renderUserOption(props: React.HTMLAttributes<HTMLLIElement>, opt
   );
 }
 
+// Width of the table search fields, also matched by the global search in the topbar.
+export const TABLE_SEARCH_WIDTH = 320;
+
+// Horizontal padding (in theme spacing units) of the top bar the search field sits in.
+export const TABLE_TOP_BAR_PADDING_X = 2;
+
 export function TableTopBarAutocomplete({
   defaultValue,
   filterOptions = (x) => x,
@@ -30,7 +36,7 @@ export function TableTopBarAutocomplete({
       key={defaultValue}
       defaultValue={defaultValue}
       size="small"
-      sx={{width: 320}}
+      sx={{width: TABLE_SEARCH_WIDTH}}
       freeSolo
       filterOptions={filterOptions}
       renderInput={(params) => <TextField {...params} label="Search" autoFocus />}
@@ -52,7 +58,7 @@ export default function TableTopBar({title, link, children}: TableTopBarProps) {
       direction="row"
       paddingTop={2}
       paddingBottom={1}
-      paddingX={2}
+      paddingX={TABLE_TOP_BAR_PADDING_X}
       gap={4}
       justifyContent="space-between"
       flexWrap="wrap"


### PR DESCRIPTION
Lining up the topbar search with the other search bars

Before:
<img width="1417" height="869" alt="Screenshot 2026-08-21 at 4 54 18 PM" src="https://github.com/user-attachments/assets/4b967c6f-f037-473e-b98c-4687047da153" />

After:
<img width="1424" height="868" alt="Screenshot 2026-08-21 at 4 54 09 PM" src="https://github.com/user-attachments/assets/35ef4761-5fc4-4e75-a48f-dbf84e312f0c" />
