### PR TITLE
Bug fix: Cap role-derived ownerships by the membership that confers them

### DIFF
--- a/api/operations/constraints/check_for_self_add.py
+++ b/api/operations/constraints/check_for_self_add.py
@@ -73,8 +73,8 @@ class CheckForSelfAdd:
             if group.is_managed and disallow_self_add_ownership is True:
                 return (
                     False,
-                    "Current user is an group owner who is restricted "
-                    + f"from readding themself as owner to {group.name} due to group tags",
+                    "Current user is a group owner who is restricted "
+                    + f"from re-adding themself as owner to {group.name} due to group tags",
                 )
         if len(self.members_to_add) > 0 and current_user.id in self.members_to_add:
             disallow_self_add_membership = coalesce_constraints(
@@ -194,7 +194,7 @@ class CheckForSelfAdd:
                         return (
                             False,
                             "Current user is a role member who is restricted from adding "
-                            + f"{group.name} as a member to {member_group.name} because that group  "
+                            + f"{group.name} as a member to {member_group.name} because that group "
                             + "has tags which restricts self-adding membership",
                         )
 
@@ -217,7 +217,7 @@ class CheckForSelfAdd:
                         return (
                             False,
                             "Current user is a role member who is restricted from adding "
-                            + f"{group.name} as an owner to {owner_group.name} because that group  "
+                            + f"{group.name} as an owner to {owner_group.name} because that group "
                             + "has tags which restricts self-adding ownership",
                         )
         return True, ""

--- a/api/operations/constraints/check_for_self_add.py
+++ b/api/operations/constraints/check_for_self_add.py
@@ -114,7 +114,7 @@ class CheckForSelfAdd:
                         return (
                             False,
                             "Current user is a role owner who is restricted from adding themself as "
-                            + f"member to {group.name} because the associated group {member_group.name} "
+                            + f"member to {group.name} because the associated group {owner_group.name} "
                             + "has group tags which restricts self-adding ownership",
                         )
         return True, ""

--- a/api/operations/modify_groups_time_limit.py
+++ b/api/operations/modify_groups_time_limit.py
@@ -101,6 +101,38 @@ class ModifyGroupsTimeLimit:
                 .values({OktaUserGroupMember.ended_at: membership_time_limit_from_now})
                 .execution_options(synchronize_session="fetch")
             )
+            # A role confers its access on its MEMBERS, so the ownerships a
+            # role grants in the groups it owns are held by those members and
+            # are bounded by the same membership limit. They are materialized
+            # as min(role membership, role-group map), so capping the
+            # membership without capping these would leave them outliving the
+            # membership they exist because of.
+            role_owner_map_associations = (
+                await db.session.scalars(
+                    select(RoleGroupMap)
+                    .where(RoleGroupMap.role_group_id.in_([g.id for g in role_groups]))
+                    .where(RoleGroupMap.is_owner.is_(True))
+                    .where(
+                        or_(
+                            RoleGroupMap.ended_at.is_(None),
+                            RoleGroupMap.ended_at > func.now(),
+                        )
+                    )
+                )
+            ).all()
+            await db.session.execute(
+                update(OktaUserGroupMember)
+                .where(OktaUserGroupMember.role_group_map_id.in_([m.id for m in role_owner_map_associations]))
+                .where(OktaUserGroupMember.is_owner.is_(True))
+                .where(
+                    or_(
+                        OktaUserGroupMember.ended_at.is_(None),
+                        OktaUserGroupMember.ended_at > membership_time_limit_from_now,
+                    )
+                )
+                .values({OktaUserGroupMember.ended_at: membership_time_limit_from_now})
+                .execution_options(synchronize_session="fetch")
+            )
             await db.session.commit()
         if ownership_seconds_limit is not None:
             ownership_time_limit_from_now = datetime.now(UTC) + timedelta(seconds=ownership_seconds_limit)
@@ -130,34 +162,6 @@ class ModifyGroupsTimeLimit:
                     )
                 )
                 .values({RoleGroupMap.ended_at: ownership_time_limit_from_now})
-                .execution_options(synchronize_session="fetch")
-            )
-            # Reduce all user ownerships for groups associated with any given role groups
-            # to the minimum allowed time limit
-            role_group_map_associations = (
-                await db.session.scalars(
-                    select(RoleGroupMap)
-                    .where(RoleGroupMap.role_group_id.in_([g.id for g in role_groups]))
-                    .where(RoleGroupMap.is_owner.is_(True))
-                    .where(
-                        or_(
-                            RoleGroupMap.ended_at.is_(None),
-                            RoleGroupMap.ended_at > func.now(),
-                        )
-                    )
-                )
-            ).all()
-            await db.session.execute(
-                update(OktaUserGroupMember)
-                .where(OktaUserGroupMember.role_group_map_id.in_([m.id for m in role_group_map_associations]))
-                .where(OktaUserGroupMember.is_owner.is_(True))
-                .where(
-                    or_(
-                        OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > ownership_time_limit_from_now,
-                    )
-                )
-                .values({OktaUserGroupMember.ended_at: ownership_time_limit_from_now})
                 .execution_options(synchronize_session="fetch")
             )
             await db.session.commit()

--- a/api/operations/modify_groups_time_limit.py
+++ b/api/operations/modify_groups_time_limit.py
@@ -154,10 +154,10 @@ class ModifyGroupsTimeLimit:
                 .where(
                     or_(
                         OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > membership_time_limit_from_now,
+                        OktaUserGroupMember.ended_at > ownership_time_limit_from_now,
                     )
                 )
-                .values({OktaUserGroupMember.ended_at: membership_time_limit_from_now})
+                .values({OktaUserGroupMember.ended_at: ownership_time_limit_from_now})
                 .execution_options(synchronize_session="fetch")
             )
             await db.session.commit()

--- a/tests/test_time_limit_constraint.py
+++ b/tests/test_time_limit_constraint.py
@@ -1276,15 +1276,11 @@ async def test_owner_only_time_limit_caps_role_derived_ownership(
     user: OktaUser,
     url_for: Any,
 ) -> None:
-    """A tag setting only an owner time limit still caps role-derived ownerships.
+    """A tag setting only an owner time limit caps the ownerships a role grants.
 
-    The ownership branch of `ModifyGroupsTimeLimit` used to reach for
-    `membership_time_limit_from_now` when capping the ownerships a role grants
-    to its associated groups. That name is only bound by the membership branch,
-    so an owner-only tag raised `UnboundLocalError` here.
+    Memberships are left alone, since the tag carries no member limit.
     """
-    # Deliberately no MEMBER_TIME_LIMIT_CONSTRAINT_KEY -- an owner-only tag is
-    # the case that leaves the membership limit unset.
+    # Owner limit only -- the member limit is deliberately left unset.
     tag = TagFactory.build(constraints={Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: THREE_DAYS_IN_SECONDS})
     db.session.add_all([tag, okta_group, role_group, user])
     await db.session.commit()
@@ -1304,7 +1300,6 @@ async def test_owner_only_time_limit_caps_role_derived_ownership(
     )
     assert role_owner_map_id is not None
 
-    # Baseline: nothing is time-bounded before the tag is applied.
     assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_not(None))) == 0
 
     update_group_spy = mocker.patch.object(okta, "update_group")
@@ -1322,7 +1317,6 @@ async def test_owner_only_time_limit_caps_role_derived_ownership(
     assert rep.status_code == 200
     assert update_group_spy.call_count == 1
 
-    # The ownership the role grants `okta_group` is capped at the owner limit.
     assert (
         await db_count(
             db.session,
@@ -1336,7 +1330,6 @@ async def test_owner_only_time_limit_caps_role_derived_ownership(
         == 1
     )
 
-    # The tag sets no member limit, so the user's role membership stays indefinite.
     assert (
         await db_count(
             db.session,
@@ -1362,9 +1355,8 @@ async def test_differing_time_limits_cap_role_derived_ownership_at_owner_limit(
 ) -> None:
     """Role-derived ownerships are capped at the owner limit, not the member one.
 
-    The companion to the owner-only case above: when both limits are set but
-    differ, using `membership_time_limit_from_now` here silently capped
-    role-derived ownerships at the wrong limit instead of raising.
+    When a tag sets the two limits to different values, each side of the role's
+    grant takes its own: ownerships the owner limit, memberships the member one.
     """
     tag = TagFactory.build(
         constraints={
@@ -1412,19 +1404,18 @@ async def test_differing_time_limits_cap_role_derived_ownership_at_owner_limit(
     assert rep.status_code == 200
     assert update_group_spy.call_count == 1
 
-    # Ownership derived from the role is capped at the 1-day owner limit...
     assert (
         await db_count(
             db.session,
             select(OktaUserGroupMember).where(
                 OktaUserGroupMember.role_group_map_id == role_owner_map_id,
                 OktaUserGroupMember.is_owner.is_(True),
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(hours=12)),
                 OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=2)),
             ),
         )
         == 1
     )
-    # ...while membership derived from the role keeps the 7-day member limit.
     assert (
         await db_count(
             db.session,

--- a/tests/test_time_limit_constraint.py
+++ b/tests/test_time_limit_constraint.py
@@ -1265,3 +1265,175 @@ async def test_time_limit_add_app_tags(
         == 2
     )
     assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at.is_(None))) == 0
+
+
+async def test_owner_only_time_limit_caps_role_derived_ownership(
+    client: AsyncClient,
+    db: Db,
+    mocker: MockerFixture,
+    okta_group: OktaGroup,
+    role_group: RoleGroup,
+    user: OktaUser,
+    url_for: Any,
+) -> None:
+    """A tag setting only an owner time limit still caps role-derived ownerships.
+
+    The ownership branch of `ModifyGroupsTimeLimit` used to reach for
+    `membership_time_limit_from_now` when capping the ownerships a role grants
+    to its associated groups. That name is only bound by the membership branch,
+    so an owner-only tag raised `UnboundLocalError` here.
+    """
+    # Deliberately no MEMBER_TIME_LIMIT_CONSTRAINT_KEY -- an owner-only tag is
+    # the case that leaves the membership limit unset.
+    tag = TagFactory.build(constraints={Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: THREE_DAYS_IN_SECONDS})
+    db.session.add_all([tag, okta_group, role_group, user])
+    await db.session.commit()
+
+    # A role propagates its *members* outward, so the ownership `okta_group`
+    # receives from the role is derived from the user's role membership.
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyRoleGroups(role_group=role_group, owner_groups_to_add=[okta_group.id], sync_to_okta=False).execute()
+
+    role_owner_map_id = await db.session.scalar(
+        select(RoleGroupMap.id)
+        .where(RoleGroupMap.role_group_id == role_group.id)
+        .where(RoleGroupMap.group_id == okta_group.id)
+        .where(RoleGroupMap.is_owner.is_(True))
+    )
+    assert role_owner_map_id is not None
+
+    # Baseline: nothing is time-bounded before the tag is applied.
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_not(None))) == 0
+
+    update_group_spy = mocker.patch.object(okta, "update_group")
+
+    # Capture values before the PUT -- it expires the fixture-loaded objects
+    # on the shared session.
+    role_group_id, user_id = role_group.id, user.id
+    data: dict[str, Any] = {
+        "type": role_group.type,
+        "name": role_group.name,
+        "description": role_group.description,
+        "tags_to_add": [tag.id],
+    }
+    rep = await client.put(url_for("api-groups.group_by_id", group_id=role_group_id), json=data)
+    assert rep.status_code == 200
+    assert update_group_spy.call_count == 1
+
+    # The ownership the role grants `okta_group` is capped at the owner limit.
+    assert (
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.role_group_map_id == role_owner_map_id,
+                OktaUserGroupMember.is_owner.is_(True),
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+            ),
+        )
+        == 1
+    )
+
+    # The tag sets no member limit, so the user's role membership stays indefinite.
+    assert (
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.group_id == role_group_id,
+                OktaUserGroupMember.user_id == user_id,
+                OktaUserGroupMember.is_owner.is_(False),
+                OktaUserGroupMember.ended_at.is_(None),
+            ),
+        )
+        == 1
+    )
+
+
+async def test_differing_time_limits_cap_role_derived_ownership_at_owner_limit(
+    client: AsyncClient,
+    db: Db,
+    mocker: MockerFixture,
+    okta_group: OktaGroup,
+    role_group: RoleGroup,
+    user: OktaUser,
+    url_for: Any,
+) -> None:
+    """Role-derived ownerships are capped at the owner limit, not the member one.
+
+    The companion to the owner-only case above: when both limits are set but
+    differ, using `membership_time_limit_from_now` here silently capped
+    role-derived ownerships at the wrong limit instead of raising.
+    """
+    tag = TagFactory.build(
+        constraints={
+            Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: SEVEN_DAYS_IN_SECONDS,
+            Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: ONE_DAY_IN_SECONDS,
+        }
+    )
+    db.session.add_all([tag, okta_group, role_group, user])
+    await db.session.commit()
+
+    await ModifyGroupUsers(
+        group=role_group, members_to_add=[user.id], owners_to_add=[user.id], sync_to_okta=False
+    ).execute()
+    await ModifyRoleGroups(
+        role_group=role_group,
+        groups_to_add=[okta_group.id],
+        owner_groups_to_add=[okta_group.id],
+        sync_to_okta=False,
+    ).execute()
+
+    role_owner_map_id = await db.session.scalar(
+        select(RoleGroupMap.id)
+        .where(RoleGroupMap.role_group_id == role_group.id)
+        .where(RoleGroupMap.group_id == okta_group.id)
+        .where(RoleGroupMap.is_owner.is_(True))
+    )
+    role_member_map_id = await db.session.scalar(
+        select(RoleGroupMap.id)
+        .where(RoleGroupMap.role_group_id == role_group.id)
+        .where(RoleGroupMap.group_id == okta_group.id)
+        .where(RoleGroupMap.is_owner.is_(False))
+    )
+    assert role_owner_map_id is not None
+    assert role_member_map_id is not None
+
+    update_group_spy = mocker.patch.object(okta, "update_group")
+
+    data: dict[str, Any] = {
+        "type": role_group.type,
+        "name": role_group.name,
+        "description": role_group.description,
+        "tags_to_add": [tag.id],
+    }
+    rep = await client.put(url_for("api-groups.group_by_id", group_id=role_group.id), json=data)
+    assert rep.status_code == 200
+    assert update_group_spy.call_count == 1
+
+    # Ownership derived from the role is capped at the 1-day owner limit...
+    assert (
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.role_group_map_id == role_owner_map_id,
+                OktaUserGroupMember.is_owner.is_(True),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=2)),
+            ),
+        )
+        == 1
+    )
+    # ...while membership derived from the role keeps the 7-day member limit.
+    assert (
+        await db_count(
+            db.session,
+            select(OktaUserGroupMember).where(
+                OktaUserGroupMember.role_group_map_id == role_member_map_id,
+                OktaUserGroupMember.is_owner.is_(False),
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
+            ),
+        )
+        == 1
+    )

--- a/tests/test_time_limit_constraint.py
+++ b/tests/test_time_limit_constraint.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+import pytest
 from httpx import AsyncClient
 from pytest_mock import MockerFixture
 
@@ -18,9 +19,15 @@ from api.models import (
     RoleGroupMap,
     Tag,
 )
-from api.operations import ModifyGroupUsers, ModifyRoleGroups
+from api.operations import ModifyGroupsTimeLimit, ModifyGroupUsers, ModifyRoleGroups
 from api.services import okta
-from tests.factories import AppTagMapFactory, OktaGroupTagMapFactory, TagFactory
+from tests.factories import (
+    AppTagMapFactory,
+    OktaGroupFactory,
+    OktaGroupTagMapFactory,
+    RoleGroupFactory,
+    TagFactory,
+)
 from tests.helpers import db_count
 
 SEVEN_DAYS_IN_SECONDS = 7 * 24 * 60 * 60
@@ -1267,7 +1274,7 @@ async def test_time_limit_add_app_tags(
     assert await db_count(db.session, select(RoleGroupMap).where(RoleGroupMap.ended_at.is_(None))) == 0
 
 
-async def test_owner_only_time_limit_caps_role_derived_ownership(
+async def test_owner_only_time_limit_leaves_role_derived_ownership_alone(
     client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
@@ -1276,9 +1283,13 @@ async def test_owner_only_time_limit_caps_role_derived_ownership(
     user: OktaUser,
     url_for: Any,
 ) -> None:
-    """A tag setting only an owner time limit caps the ownerships a role grants.
+    """A tag setting only an owner time limit does not cap what the role grants.
 
-    Memberships are left alone, since the tag carries no member limit.
+    The owner limit governs who may own the role, and owning a role confers
+    none of its access. The ownerships the role grants are held by its
+    *members*, so with no member limit set there is nothing to cap -- and
+    capping them here would shorten access whose source membership is still
+    indefinite, which `verify_and_fix_role_memberships` would then restore.
     """
     # Owner limit only -- the member limit is deliberately left unset.
     tag = TagFactory.build(constraints={Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: THREE_DAYS_IN_SECONDS})
@@ -1323,8 +1334,7 @@ async def test_owner_only_time_limit_caps_role_derived_ownership(
             select(OktaUserGroupMember).where(
                 OktaUserGroupMember.role_group_map_id == role_owner_map_id,
                 OktaUserGroupMember.is_owner.is_(True),
-                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=2)),
-                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
+                OktaUserGroupMember.ended_at.is_(None),
             ),
         )
         == 1
@@ -1344,7 +1354,7 @@ async def test_owner_only_time_limit_caps_role_derived_ownership(
     )
 
 
-async def test_differing_time_limits_cap_role_derived_ownership_at_owner_limit(
+async def test_differing_time_limits_cap_role_derived_ownership_at_member_limit(
     client: AsyncClient,
     db: Db,
     mocker: MockerFixture,
@@ -1353,10 +1363,11 @@ async def test_differing_time_limits_cap_role_derived_ownership_at_owner_limit(
     user: OktaUser,
     url_for: Any,
 ) -> None:
-    """Role-derived ownerships are capped at the owner limit, not the member one.
+    """Role-derived ownerships are capped at the member limit, not the owner one.
 
-    When a tag sets the two limits to different values, each side of the role's
-    grant takes its own: ownerships the owner limit, memberships the member one.
+    Both sides of what a role grants are held by its members, so both follow
+    the member limit. The owner limit applies to ownership *of the role*, which
+    confers nothing.
     """
     tag = TagFactory.build(
         constraints={
@@ -1410,8 +1421,8 @@ async def test_differing_time_limits_cap_role_derived_ownership_at_owner_limit(
             select(OktaUserGroupMember).where(
                 OktaUserGroupMember.role_group_map_id == role_owner_map_id,
                 OktaUserGroupMember.is_owner.is_(True),
-                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(hours=12)),
-                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=2)),
+                OktaUserGroupMember.ended_at > (datetime.now(UTC) + timedelta(days=6)),
+                OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
             ),
         )
         == 1
@@ -1428,3 +1439,97 @@ async def test_differing_time_limits_cap_role_derived_ownership_at_owner_limit(
         )
         == 1
     )
+
+
+# --- A role's conferred access is bounded by the membership conferring it ----
+#
+# A user's rows in the groups a role is associated with are materialized as
+# `min(role_membership.ended_at, role_group_map.ended_at)`, so they exist by
+# virtue of that membership and must not outlive it. Both are governed by the
+# role's MEMBER limit: being a member of the role is what confers the access,
+# on either association axis. The role's OWNER limit governs who may own the
+# role, which confers nothing.
+
+
+async def _role_associated_with(db: Db, user: OktaUser, *, role_owns_group: bool, constraints: dict):
+    """A tagged role R associated with group G, and a user who is an indefinite
+    MEMBER of R and therefore holds a derived grant in G."""
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(constraints=constraints)
+    db.session.add_all([group, role, tag, user])
+    await db.session.commit()
+    mapping = RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=role_owns_group)
+    db.session.add(mapping)
+    await db.session.commit()
+    db.session.add(OktaUserGroupMember(group_id=role.id, user_id=user.id, is_owner=False))
+    db.session.add(
+        OktaUserGroupMember(group_id=group.id, user_id=user.id, is_owner=role_owns_group, role_group_map_id=mapping.id)
+    )
+    db.session.add(OktaGroupTagMapFactory.build(group_id=role.id, tag_id=tag.id))
+    await db.session.commit()
+    return role.id, group.id, user.id, tag.id
+
+
+async def _membership_and_conferred(db: Db, role_id: str, group_id: str, user_id: str):
+    membership = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role_id)
+            .where(OktaUserGroupMember.user_id == user_id)
+            .where(OktaUserGroupMember.role_group_map_id.is_(None))
+        )
+    ).one()
+    conferred = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == group_id)
+            .where(OktaUserGroupMember.user_id == user_id)
+            .where(OktaUserGroupMember.role_group_map_id.is_not(None))
+        )
+    ).one()
+    return membership, conferred
+
+
+@pytest.mark.parametrize("role_owns_group", [False, True], ids=["role_is_member", "role_is_owner"])
+async def test_member_limit_on_a_role_reaches_the_access_it_confers(
+    db: Db, mocker: MockerFixture, user: OktaUser, role_owns_group: bool
+) -> None:
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
+    role_id, group_id, user_id, tag_id = await _role_associated_with(
+        db,
+        user,
+        role_owns_group=role_owns_group,
+        constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: ONE_DAY_IN_SECONDS},
+    )
+
+    await ModifyGroupsTimeLimit(groups=[role_id], tags=[tag_id]).execute()
+
+    db.session.expire_all()
+    membership, conferred = await _membership_and_conferred(db, role_id, group_id, user_id)
+    assert membership.ended_at is not None
+    assert conferred.ended_at is not None, "conferred access outlives the membership conferring it"
+    assert conferred.ended_at <= membership.ended_at
+
+
+@pytest.mark.parametrize("role_owns_group", [False, True], ids=["role_is_member", "role_is_owner"])
+async def test_owner_limit_on_a_role_does_not_reach_the_access_it_confers(
+    db: Db, mocker: MockerFixture, user: OktaUser, role_owns_group: bool
+) -> None:
+    """Owning a role confers none of its grants, so the owner limit governs
+    only who may own the role. Capping conferred access by it would shorten
+    access whose source membership nothing has capped -- and the next
+    `fix-role-memberships` run would restore it indefinitely anyway."""
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
+    role_id, group_id, user_id, tag_id = await _role_associated_with(
+        db, user, role_owns_group=role_owns_group, constraints={Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: ONE_DAY_IN_SECONDS}
+    )
+
+    await ModifyGroupsTimeLimit(groups=[role_id], tags=[tag_id]).execute()
+
+    db.session.expire_all()
+    membership, conferred = await _membership_and_conferred(db, role_id, group_id, user_id)
+    assert membership.ended_at is None
+    assert conferred.ended_at is None


### PR DESCRIPTION
# Summary

`ModifyGroupsTimeLimit.execute()` caps the ownerships a role confers using the wrong limit and under the wrong condition. Both come from one statement sitting in the ownership branch when it belongs in the membership branch. Moves it, and adds regression coverage that varies the two limits independently.

**Urgency**: 3 days
**Expected review effort**: MEDIUM — the diff is small, but it settles *which* limit governs access a role confers, and this branch contains an earlier commit that answered that question the other way.

> [!IMPORTANT]
> **The thesis of this PR changed mid-review.** The first commit fixed the crash below by switching the statement to the *ownership* limit. That is the wrong value — see Motivation — and the final commit reverses it. If you reviewed the earlier version, the disagreement is the thing worth your attention.

# Motivation

The final bulk `update(OktaUserGroupMember)` in the `if ownership_seconds_limit is not None:` branch referenced `membership_time_limit_from_now`. That value was right; its placement was not, and it bit two ways:

- **A tag setting `owner_time_limit` without `member_time_limit`** never enters the membership branch, so the name is unbound and applying the tag raises `UnboundLocalError` → HTTP 500. The statement is built unconditionally, so this fired for *any* owner-limit-only tag, not just ones on role groups.
- **A tag setting `member_time_limit` without `owner_time_limit`** never enters the ownership branch, so the statement never runs. The role's members are capped while the ownerships those memberships confer keep their old end dates — access outliving the membership it exists because of. Silent, and it returns 200.

Capping those ownerships by the owner limit instead does not hold either: The ownerships a role grants in the groups it owns are held by the role's **members**, not its owners.

The bug survived because every tag in `tests/test_time_limit_constraint.py` sets `MEMBER_TIME_LIMIT` and `OWNER_TIME_LIMIT` to the *same* value. That binds the name (no crash), makes the wrong branch indistinguishable from the right one, and makes a swap between the two values invisible — a fixture matrix that moves two knobs in lockstep is structurally blind to all three failures.

<details>
<summary><h1>Description of Changes</h1></summary>

**`api/operations/modify_groups_time_limit.py`** — the derived-ownership update moves from the ownership branch to the membership branch, keyed on `membership_time_limit_from_now`. It still follows the role's *owner*-side associations, because those are the ones producing owner-side rows; what changes is which limit bounds them and when the update runs.

**`tests/test_time_limit_constraint.py`** — four tests that vary the two limits independently, which the existing suite never does:

- `test_owner_only_time_limit_leaves_role_derived_ownership_alone` — owner-limit-only tag on a role that owns another group; asserts nothing is capped, since no member limit is set. Fails pre-fix with `UnboundLocalError`.
- `test_differing_time_limits_cap_role_derived_ownership_at_member_limit` — member 7 days / owner 1 day; asserts both the derived ownership and the derived membership land at 7.
- `test_member_limit_on_a_role_reaches_the_access_it_confers` — parametrized over both association axes; asserts conferred access never outlives the membership conferring it. The member-limit-only case is the one neither `main` nor the first commit covered.
- `test_owner_limit_on_a_role_does_not_reach_the_access_it_confers` — parametrized likewise; asserts the owner limit reaches neither the role's members nor what they confer.

**`api/operations/constraints/check_for_self_add.py`** — an unrelated copy-paste slip in the same area, in its own commit:

- The owner loop's rejection message interpolated `member_group.name`, the *preceding* loop's variable. Beyond naming the wrong group, this leaked a function-scoped loop variable: a role with owner-associated groups but no member-associated ones leaves `member_group` unbound, turning a clean rejection into an `UnboundLocalError`.
- Grammar in the same message set: "is an group owner" → "a group owner", "readding" → "re-adding", and a stray double space before "has tags which restricts …" in both of `execute_for_role`'s messages.

</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

- Each new test was confirmed to fail against the code it guards, for the predicted reason — `UnboundLocalError` for the owner-only case, and an uncapped `ended_at` for the member-only case. A regression test that passes pre-fix would prove nothing here.
- `make test` green: ruff, ty, 875 backend tests, 38 frontend tests.
- No existing test asserted on the reworded strings (`grep` over `tests/` and `src/`), so the wording commit is behavior-neutral.
- Not exercised against Postgres (`make pytest-postgres`); the change moves an existing statement between branches, so there is no dialect-specific surface.

</details>

# Guidance for Reviewers

Read just the final state (file by file).

A refactor extracting these bulk updates into composable helpers is planned to stack on top of this branch, so the structure here is not the long-term shape.
