### PR TITLE
Report unresolvable and dangling Okta push mappings as status, not hook failures

### DIFF
--- a/api/plugins/app_group_lifecycle.py
+++ b/api/plugins/app_group_lifecycle.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import InstrumentedAttribute, joinedload
 from api.models import App, AppGroup, OktaUser, OktaUserGroupMember
 from api.plugins._async_dispatch import run_hooks_to_completion, verify_async_impls
 from api.services import okta
+from api.services.okta_service import OktaResourceNotFoundError
 
 app_group_lifecycle_plugin_name = "access_app_group_lifecycle"
 hookspec = pluggy.HookspecMarker(app_group_lifecycle_plugin_name)
@@ -54,6 +55,50 @@ class AmbiguousOktaTargetError(Exception):
 
 class MissingOktaTargetError(Exception):
     """Okta is not aware of a target group from an external app and so cannot create a push mapping."""
+
+
+class UnresolvableOktaTargetError(ValueError):
+    """A push mapping's target group exists in Okta but carries no external id, so the downstream
+    group it represents cannot be identified.
+
+    Okta populates external-id profile attributes only when it IMPORTS a group from the downstream
+    app. A target group Okta created itself via group push has only name/description, and a later
+    import does not backfill it -- so unlike `MissingOktaTargetError` this never self-heals and must
+    not be deferred. How a caller surfaces it depends on whether the Access group already carries
+    enough configuration to identify the downstream group by another route: if it does, the link is
+    genuinely broken; if it does not, the group is simply not configured yet.
+
+    Subclasses ValueError because that is what this condition raised before the typed errors
+    existed, so plugins already catching ValueError here keep working.
+
+    Attributes:
+        mapping_id: The push mapping that was found. A caller may record it to avoid creating a
+            duplicate on a later pass, but only once it has confirmed the mapping targets the group
+            the Access group is configured for -- this error means that link could not be verified.
+        target_group_name: The Okta target group's profile name, the only identifying attribute it
+            carries. Okta names a group it creates via push after the name it was pushed with, so
+            this is what lets a caller tell an operator which downstream group the mapping points
+            at, and check a later configuration against it."""
+
+    def __init__(self, message: str, mapping_id: str, target_group_name: str | None) -> None:
+        super().__init__(message)
+        self.mapping_id = mapping_id
+        self.target_group_name = target_group_name
+
+
+class DanglingPushMappingError(Exception):
+    """A push mapping still references a target group that Okta no longer has.
+
+    The link is broken at the Okta end: the target group was deleted out of band, so nothing
+    downstream can be resolved through it. Like `UnresolvableOktaTargetError` this does not
+    self-heal, and unlike it the mapping itself is unusable -- a caller must not record the
+    mapping id as this group's link, or a later pass will believe the group is already linked
+    and skip re-creating it. Repair needs the stale mapping removed and the group re-pushed."""
+
+    def __init__(self, message: str, mapping_id: str, target_group_id: str) -> None:
+        super().__init__(message)
+        self.mapping_id = mapping_id
+        self.target_group_id = target_group_id
 
 
 logger = logging.getLogger(__name__)
@@ -703,7 +748,9 @@ class AppGroupLifecycleContext:
 
         Raises:
             Exception: If the mapping exists but has no id or no target group id.
-            ValueError: If the target group's profile does not carry the external id field.
+            DanglingPushMappingError: If the mapped target group no longer exists in Okta.
+            UnresolvableOktaTargetError: If the target group's profile does not carry the external
+                id field, which is the case for any target group Okta created via group push.
         """
         mappings = await okta.list_group_push_mappings(okta_app_id, sourceGroupId=group.id)
         # Okta allows at most one mapping per app, source, and target.
@@ -722,7 +769,19 @@ class AppGroupLifecycleContext:
         # Custom Okta attributes live in the profile union's actual_instance.additional_properties;
         # both the profile and its actual_instance are Optional on the SDK model, so guard before
         # dereferencing them.
-        profile = (await okta.get_group(target_group_id)).group.profile
+        try:
+            profile = (await okta.get_group(target_group_id)).group.profile
+        except OktaResourceNotFoundError as e:
+            # The mapping outlived its target group. Surfaced as a typed error rather than letting
+            # the raw SDK 404 escape, so callers can tell "this link is broken" from a real fault.
+            raise DanglingPushMappingError(
+                f"The Okta push mapping for {group.name} references target group {target_group_id}, "
+                "which no longer exists in Okta. The link is broken and will not recover on its own: "
+                "remove the stale mapping and re-push the group, or re-create the mapping against "
+                "the correct target group.",
+                mapping_id=mapping_id,
+                target_group_id=target_group_id,
+            ) from e
         actual_instance = profile.actual_instance if profile is not None else None
         external_id = (
             (actual_instance.additional_properties or {}).get(target_group_external_id_field)
@@ -730,9 +789,27 @@ class AppGroupLifecycleContext:
             else None
         )
         if not external_id:
-            raise ValueError(
-                f"ID '{target_group_external_id_field}' could not be resolved for target group mapped to "
-                f"{group.name}.\nTarget group {target_group_id} has profile:\n{profile}"
+            # The profile is dumped here rather than folded into the exception message: the message
+            # reaches operators as the group's sync status detail, where a raw SDK profile is noise.
+            # DEBUG rather than WARNING because this repeats on every sync for as long as the group
+            # stays unresolved, which for a push-created target group is indefinitely. It is also
+            # not the actionable line -- the caller reports the condition and what to do about it.
+            # This layer logs it only because it is the one that has the profile, which is what a
+            # maintainer needs when the attribute is missing for an unexpected reason.
+            logger.debug(
+                f"Target group {target_group_id} mapped to {group.name} has no "
+                f"'{target_group_external_id_field}'. Profile:\n{profile}"
+            )
+            target_group_name = getattr(actual_instance, "name", None) if actual_instance is not None else None
+            raise UnresolvableOktaTargetError(
+                f"Okta target group {target_group_id} ({target_group_name or 'unnamed'}) mapped to "
+                f"{group.name} has no '{target_group_external_id_field}' in its profile. Okta sets that "
+                "attribute only when it imports a group from the downstream app; a target group Okta "
+                "created via group push never receives it, and re-running an import does not backfill it. "
+                "Identify the downstream group by the target group's name, or re-link this group to a "
+                "target group that Okta imported.",
+                mapping_id=mapping_id,
+                target_group_name=target_group_name,
             )
         return mapping_id, external_id
 

--- a/examples/plugins/app_group_lifecycle_google/plugin.py
+++ b/examples/plugins/app_group_lifecycle_google/plugin.py
@@ -22,7 +22,9 @@ from api.plugins.app_group_lifecycle import (
     AppGroupLifecyclePluginConfigProperty,
     AppGroupLifecyclePluginMetadata,
     AppGroupLifecyclePluginStatusProperty,
+    DanglingPushMappingError,
     MissingOktaTargetError,
+    UnresolvableOktaTargetError,
     hookimpl,
 )
 
@@ -49,10 +51,16 @@ STATUS_LAST_SYNCED_AT = "last_synced_at"
 SYNC_SYNCED = "synced"
 SYNC_PENDING = "pending"
 SYNC_ERROR = "error"
-# Terminal, like SYNC_ERROR: this group is deliberately not managed by the plugin (disabled
-# for the app, or missing the config needed to resolve a Google group). Recorded rather than
-# left blank because a group with no status at all reads as "the hook has not run yet" -- see
-# `pending_values` on AppGroupLifecyclePluginStatusProperty.
+# Terminal, like SYNC_ERROR: this group has not converged and the next move belongs to an Access
+# *user*, not to an admin. Covers the app having the plugin disabled, and every condition a group's
+# owner can resolve by editing its plugin configuration -- a missing email, a prefix violating the
+# app's pattern, an address already claimed by another Access group, a push mapping whose target
+# cannot be identified. Note this does not always mean nothing is linked: the plugin may still hold
+# a push mapping id or a claimed Google group id for a skipped group. Deliberately NOT SYNC_ERROR,
+# which is reserved for what only an Access admin can fix, so a misconfigured group reaches its
+# owners instead of paging admins. Recorded rather than left blank because a group with no status
+# at all reads as "the hook has not run yet" -- see `pending_values` on
+# AppGroupLifecyclePluginStatusProperty.
 SYNC_SKIPPED = "skipped"
 
 OKTA_GOOGLE_GROUP_PROFILE_FIELD_EMAIL = "googleGroupEmail"
@@ -62,6 +70,16 @@ OKTA_GOOGLE_GROUP_PROFILE_FIELD_EMAIL = "googleGroupEmail"
 GOOGLE_LOCAL_PART_RE = re.compile(r"^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$")
 
 logger = logging.getLogger(__name__)
+
+
+class GoogleGroupSyncError(Exception):
+    """Raised by sync_group when a reconcile finished in SYNC_ERROR.
+
+    _reconcile records an admin-actionable failure and returns rather than raising, so its status
+    and explanation survive the host's commit. The batch sync still has to count the group as
+    failed: `api/cli.py` tallies a failure only when the hook returns an exception, so without this
+    a run that left groups in SYNC_ERROR would exit 0 and look clean. Conditions the plugin does
+    not consider failures -- SYNC_SKIPPED and SYNC_PENDING -- deliberately do not raise."""
 
 
 def _is_group_absent_error(error: HttpError) -> bool:
@@ -245,14 +263,14 @@ class GoogleGroupManagerPlugin:
             STATUS_GOOGLE_GROUP_ID: AppGroupLifecyclePluginStatusProperty(display_name="Google Group ID", type="text"),
             STATUS_SYNC_STATUS: AppGroupLifecyclePluginStatusProperty(
                 display_name="Sync Status",
-                help_text="synced, pending, or error",
+                help_text="synced, pending, skipped, or error",
                 type="text",
                 # SYNC_PENDING is this plugin's "not converged yet" state -- it is waiting on Okta
                 # to import or push a group -- so the UI keeps refreshing while a group sits on it.
                 # SYNC_ERROR is deliberately absent: it is terminal until the next reconcile.
                 pending_values=(SYNC_PENDING,),
             ),
-            STATUS_SYNC_ERROR: AppGroupLifecyclePluginStatusProperty(display_name="Sync Error", type="text"),
+            STATUS_SYNC_ERROR: AppGroupLifecyclePluginStatusProperty(display_name="Sync Status Details", type="text"),
             STATUS_LAST_SYNCED_AT: AppGroupLifecyclePluginStatusProperty(display_name="Last Synced", type="date"),
         }
 
@@ -390,8 +408,10 @@ class GoogleGroupManagerPlugin:
 
     # ---- Status setters ----
 
-    def _mark(self, ctx: AppGroupLifecycleContext, group: AppGroup, status: str, error: str | None = None) -> None:
-        """Record this reconcile's outcome on the group.
+    def _write_sync_status(
+        self, ctx: AppGroupLifecycleContext, group: AppGroup, status: str, detail: str | None
+    ) -> None:
+        """Persist this reconcile's outcome. Use one of the _mark_* helpers rather than this.
 
         Synchronous: the context mutates plugin_data in memory and marks the group for persistence,
         and the host commits after the hook returns.
@@ -405,29 +425,88 @@ class GoogleGroupManagerPlugin:
             ctx: The plugin capability context.
             group: The group being reconciled.
             status: One of the SYNC_* values.
-            error: The failure detail to surface in the UI, or None on success.
+            detail: The explanation to surface in the UI, or None when there is nothing to explain.
         """
-        if error:
-            logger.error(f"Google group reconciliation failed for group {group.name}: {error}")
-
         ctx.set_status(group, STATUS_SYNC_STATUS, status, durable_on_failure=True)
-        ctx.set_status(group, STATUS_SYNC_ERROR, error, durable_on_failure=True)
-        if status == SYNC_SYNCED:
-            ctx.set_status(
-                group, STATUS_LAST_SYNCED_AT, datetime.now(timezone.utc).isoformat(), durable_on_failure=True
-            )
+        ctx.set_status(group, STATUS_SYNC_ERROR, detail, durable_on_failure=True)
 
-    def _mark_skipped(self, ctx: AppGroupLifecycleContext, group: AppGroup, reason: str) -> None:
-        """Record that this reconcile deliberately did nothing.
+    # One helper per outcome, each owning its own log level. The level is a routing decision, not a
+    # formatting one: only _mark_error means "an Access admin has to do something", so only it logs
+    # at ERROR. Deriving the level from whether a detail string was passed -- as a single combined
+    # helper must -- inevitably miscategorises, because pending and skipped carry a detail too.
+
+    def _mark_synced(self, ctx: AppGroupLifecycleContext, group: AppGroup) -> None:
+        """Record a successful reconcile. Carries no detail: there is nothing to explain, and any
+        stale explanation from a previous pass must be cleared. Logs at DEBUG: a converged group is
+        the outcome this loop exists to produce, so it is not news.
+
+        Args:
+            ctx: The plugin capability context.
+            group: The group being reconciled.
+        """
+        logger.debug(f"Reconciled {group.name}.")
+        self._write_sync_status(ctx, group, SYNC_SYNCED, None)
+        ctx.set_status(group, STATUS_LAST_SYNCED_AT, datetime.now(timezone.utc).isoformat(), durable_on_failure=True)
+
+    def _mark_pending(self, ctx: AppGroupLifecycleContext, group: AppGroup, reason: str) -> None:
+        """Record that this reconcile is waiting on Okta or Google to converge.
+
+        Transient and self-healing -- a later pass picks it up -- so it is progress, not a fault,
+        and logs at INFO. SYNC_PENDING is the one status the UI treats as "keep refreshing"; see
+        `pending_values` in get_plugin_group_status_properties.
+
+        Args:
+            ctx: The plugin capability context.
+            group: The group being reconciled.
+            reason: What is being waited on, surfaced in the UI.
+        """
+        logger.info(f"Deferring {group.name}: {reason}")
+        self._write_sync_status(ctx, group, SYNC_PENDING, reason)
+
+    def _mark_skipped(self, ctx: AppGroupLifecycleContext, group: AppGroup, reason: str | None = None) -> None:
+        """Record that this group is not being managed, and why if there is anything to say.
 
         A bare return would leave the group's status empty, which the UI cannot tell apart from a
         hook that has not run yet -- so it would poll the group on every page view for the whole
-        refresh window. The detailed reason goes to the log; the status just says the group is not
-        being managed.
+        refresh window.
+
+        Used for every condition an Access *user* can resolve by editing this group's plugin
+        configuration, and the reason is always recorded for those: it is the only place the
+        responsible group owner sees what to fix. Such a condition is deliberately not SYNC_ERROR
+        -- that state means the plugin hit something only an Access admin can fix -- and a
+        misconfigured group is not an operational failure of the plugin, so it logs at INFO.
+
+        Omit the reason when nothing is wrong and nobody needs to act: a group whose app does not
+        use this plugin is skipped permanently and by design. It logs at DEBUG and leaves the
+        details field empty rather than restating a non-event at INFO on every pass.
+
+        Args:
+            ctx: The plugin capability context.
+            group: The group being reconciled.
+            reason: Operator-facing explanation, surfaced to the group's owners in the UI. Write it
+                as a standalone sentence naming the fix. None when there is nothing to act on.
         """
-        logger.info(f"Skipping {group.name}: {reason}")
-        ctx.set_status(group, STATUS_SYNC_STATUS, SYNC_SKIPPED, durable_on_failure=True)
-        ctx.set_status(group, STATUS_SYNC_ERROR, None, durable_on_failure=True)
+        if reason:
+            logger.info(f"Skipping {group.name}: {reason}")
+        else:
+            logger.debug(f"Skipping {group.name}: not managed by this plugin.")
+        self._write_sync_status(ctx, group, SYNC_SKIPPED, reason)
+
+    def _mark_error(self, ctx: AppGroupLifecycleContext, group: AppGroup, error: str) -> None:
+        """Record a reconcile failure that only an Access admin can resolve.
+
+        The one helper that logs at ERROR, keeping this plugin's ERROR output to the conditions
+        someone with Okta/infrastructure access has to act on: a broken Okta link, a duplicate
+        import, an unexpected fault. Anything an Access user can fix by editing the group's
+        configuration belongs in _mark_skipped instead.
+
+        Args:
+            ctx: The plugin capability context.
+            group: The group being reconciled.
+            error: Operator-facing failure detail, surfaced in the UI.
+        """
+        logger.error(f"Google group reconciliation failed for group {group.name}: {error}")
+        self._write_sync_status(ctx, group, SYNC_ERROR, error)
 
     # ---- Reconcile ----
 
@@ -466,7 +545,7 @@ class GoogleGroupManagerPlugin:
         self, ctx: AppGroupLifecycleContext, group: AppGroup, candidate_id: str, email: str | None = None
     ) -> str | None:
         """Record candidate_id as this group's owned Google group, but ONLY after confirming no
-        other Access group already owns it -- refusing (and marking SYNC_ERROR) rather than
+        other Access group already owns it -- refusing (and marking SYNC_SKIPPED) rather than
         clobbering / double-linking a group owned elsewhere. Returns the id on success, or None
         when refused. A no-op confirmation when we already hold this id.
 
@@ -500,12 +579,12 @@ class GoogleGroupManagerPlugin:
         await ctx.lock(candidate_id)
         owners = await ctx.find_groups_by_status(STATUS_GOOGLE_GROUP_ID, candidate_id, exclude_group=group, limit=1)
         if owners:
-            self._mark(
+            self._mark_skipped(
                 ctx,
                 group,
-                SYNC_ERROR,
                 f"Google group {email or candidate_id} is already managed by Access group "
-                f"'{owners[0].name}'; refusing to link it to this one.",
+                f"'{owners[0].name}'. Change this group's '{CONFIG_EMAIL}' configuration to a "
+                "different address to link it.",
             )
             return None
         ctx.set_status(group, STATUS_GOOGLE_GROUP_ID, candidate_id)
@@ -548,10 +627,10 @@ class GoogleGroupManagerPlugin:
             group: The group to reconcile.
 
         The sync status is written with `durable_on_failure`, so the host re-applies it after
-        rolling back a failed hook and an operator still sees why reconcile failed. See _mark.
+        rolling back a failed hook and an operator still sees why reconcile failed. See _write_sync_status.
         """
         if not self._is_enabled(ctx, group):
-            self._mark_skipped(ctx, group, "the Google plugin is not enabled for this app")
+            self._mark_skipped(ctx, group)
             return
 
         try:
@@ -572,9 +651,72 @@ class GoogleGroupManagerPlugin:
 
                 if candidate_group_id is None:
                     # Case 3: Retrieve an existing mapped Google group (linked in Okta out-of-band)
-                    link = await ctx.discover_existing_push_mapping_and_target_group_external_id(
-                        group, self._okta_app_id, OKTA_GOOGLE_GROUP_PROFILE_FIELD_EMAIL
-                    )
+                    try:
+                        link = await ctx.discover_existing_push_mapping_and_target_group_external_id(
+                            group, self._okta_app_id, OKTA_GOOGLE_GROUP_PROFILE_FIELD_EMAIL
+                        )
+                    except DanglingPushMappingError as e:
+                        # The mapping outlived its Okta target group, so there is nothing to resolve
+                        # through it and no amount of retrying helps. Report it and stop. The mapping
+                        # id is deliberately NOT recorded: it is unusable, and storing it would make
+                        # a later reconcile treat this group as already linked.
+                        self._mark_error(
+                            ctx,
+                            group,
+                            f"This group's Okta push mapping points at target group {e.target_group_id}, "
+                            "which no longer exists in Okta, so its Google group cannot be reached. "
+                            "Remove the stale mapping in Okta and re-push this group to relink it.",
+                        )
+                        return
+                    except UnresolvableOktaTargetError as e:
+                        # The mapping exists, but its Okta target group carries no googleGroupEmail
+                        # and never will: Okta writes that attribute only when it imports a group
+                        # from Google, and does not backfill a target it created via group push.
+                        # Nothing to wait for, so this is reported rather than deferred.
+                        #
+                        # Record the mapping unconditionally. Discovery looks mappings up by THIS
+                        # group's source id, so it is definitively this group's link. Withholding it
+                        # would dead-end the recovery path: once the owner configures the address,
+                        # the mapping-creation step below resolves its target by searching for the
+                        # googleGroupEmail attribute, which is precisely what this target will never
+                        # have, so the group would sit PENDING forever instead of linking.
+                        #
+                        # The residual risk is an owner who configures an address belonging to some
+                        # OTHER Google group: this mapping still pushes members to the target it
+                        # already has, while Access claims and reports the configured one. Naming
+                        # the target group in the message below is the mitigation -- Okta names a
+                        # push-created target after the name it was pushed with, so it tells the
+                        # owner exactly which prefix to use.
+                        ctx.set_status(group, STATUS_PUSH_MAPPING_ID, e.mapping_id)
+
+                        if configured_email is None:
+                            # Nothing configured: the owner has not linked this group yet, and
+                            # naming the target group tells them which address to configure.
+                            target = f" It targets '{e.target_group_name}'." if e.target_group_name else ""
+                            self._mark_skipped(
+                                ctx,
+                                group,
+                                "This group's Okta push mapping points at a target group with no "
+                                f"{OKTA_GOOGLE_GROUP_PROFILE_FIELD_EMAIL}, so its Google group cannot be "
+                                f"identified automatically.{target} Set this group's '{CONFIG_EMAIL}' "
+                                f"configuration to that address prefix (the part before @{self._domain}) "
+                                "to link it.",
+                            )
+                            return
+                        # An email IS configured and still resolved to nothing in Google, so this is
+                        # not a configuration gap: the Google group the config names is missing while
+                        # the mapping points somewhere unidentifiable. Neither the owner nor a retry
+                        # can settle that, so it goes to the admins.
+                        self._mark_error(
+                            ctx,
+                            group,
+                            f"No Google group exists at the configured address {configured_email}, and "
+                            "this group's Okta push mapping points at a target group with no "
+                            f"{OKTA_GOOGLE_GROUP_PROFILE_FIELD_EMAIL}, so the mapped group cannot be "
+                            "identified either. Check whether the Google group was deleted, and whether "
+                            "the Okta push mapping still points where it should.",
+                        )
+                        return
                     if link:
                         mapping_id, resolved_email = link
                     if resolved_email:
@@ -582,13 +724,12 @@ class GoogleGroupManagerPlugin:
                         # email of the linked group doesn't match. This is a conflict that won't self-heal,
                         # so we surface it as an error rather than silently adopting the wrong group.
                         if configured_email is not None and resolved_email != configured_email:
-                            self._mark(
+                            self._mark_skipped(
                                 ctx,
                                 group,
-                                SYNC_ERROR,
                                 f"Existing Okta push mapping targets Google group '{resolved_email}', but this "
-                                f"group is configured for '{configured_email}'. Resolve the conflict in Okta or update the "
-                                "group's configured email.",
+                                f"group is configured for '{configured_email}'. Update this group's "
+                                f"'{CONFIG_EMAIL}' configuration to match, or resolve the conflict in Okta.",
                             )
                             return
 
@@ -600,7 +741,7 @@ class GoogleGroupManagerPlugin:
                         ctx, group, candidate_group_id, configured_email or resolved_email
                     )
                     if claimed_google_group_id is None:
-                        return  # owned by another Access group; _claim_group_id marked the error
+                        return  # owned by another Access group; _claim_group_id recorded the skip
                     if mapping_id:
                         ctx.set_status(group, STATUS_PUSH_MAPPING_ID, mapping_id)
 
@@ -610,13 +751,19 @@ class GoogleGroupManagerPlugin:
                 # step. This avoids waiting for Okta to import a made in Google first (which involves
                 # a manually-triggered fetch). Config is required to create a new group.
                 if not configured_email_prefix or not configured_email:
-                    self._mark_skipped(ctx, group, "missing the email config needed to create a Google group")
+                    self._mark_skipped(
+                        ctx,
+                        group,
+                        f"Set this group's '{CONFIG_EMAIL}' configuration to create and link a Google group.",
+                    )
                     return
 
                 pattern = ctx.get_config(group.app, CONFIG_EMAIL_PATTERN)
                 pattern_error = self._validate_email_against_pattern(configured_email_prefix, pattern)
                 if pattern_error:
-                    self._mark(ctx, group, SYNC_ERROR, pattern_error)
+                    self._mark_skipped(
+                        ctx, group, f"{pattern_error}. Update this group's '{CONFIG_EMAIL}' configuration."
+                    )
                     return
 
                 if not ctx.get_status(group, STATUS_PUSH_MAPPING_ID):
@@ -636,14 +783,14 @@ class GoogleGroupManagerPlugin:
                 # defer if it isn't visible, adopting its Cloud Identity id and patching its
                 # metadata on a later reconcile once it appears.
                 if google_group_id_to_claim is None:
-                    self._mark(ctx, group, SYNC_PENDING, "Awaiting Google group creation via Okta push")
+                    self._mark_pending(ctx, group, "Awaiting Google group creation via Okta push")
                     return
 
                 claimed_google_group_id = await self._claim_group_id(
                     ctx, group, google_group_id_to_claim, configured_email
                 )
                 if claimed_google_group_id is None:
-                    return  # owned by another Access group; _claim_group_id marked the error
+                    return  # owned by another Access group; _claim_group_id recorded the skip
 
             # We hold a live Google group (cached, adopted, or freshly created) -> enforce Access's
             # properties onto it (or backfill from it during adoption). A group Okta just created is
@@ -653,7 +800,7 @@ class GoogleGroupManagerPlugin:
             google_group = await self._get_google_group(claimed_google_group_id)
             reconcile_error = await self._adopt_or_enforce(ctx, group, claimed_google_group_id, google_group)
             if reconcile_error is not None:
-                self._mark(ctx, group, SYNC_ERROR, reconcile_error)
+                self._mark_error(ctx, group, reconcile_error)
                 return
 
             # Ensure the push mapping exists; may defer if Okta hasn't imported yet. An ambiguous
@@ -663,7 +810,17 @@ class GoogleGroupManagerPlugin:
             if not ctx.get_status(group, STATUS_PUSH_MAPPING_ID):
                 resolved_email = configured_email or await self._get_email_from_status(ctx, group)
                 if not resolved_email:
-                    self._mark_skipped(ctx, group, "no resolvable email for the adopted Google group")
+                    # Reached only after a Google group was claimed and reconciled: the re-read to
+                    # recover its address found it gone or without a groupKey. The group IS managed
+                    # and the configuration is not the fix, so this is neither a skip nor an owner's
+                    # problem -- the linked Google group changed underneath us.
+                    self._mark_error(
+                        ctx,
+                        group,
+                        "This group's linked Google group could not be re-read to recover its "
+                        "address, so its Okta push mapping cannot be created. It may have been "
+                        "deleted in Google while this reconcile was running.",
+                    )
                     return
                 try:
                     mapping_id = await ctx.create_push_mapping_for_existing_group(
@@ -671,17 +828,17 @@ class GoogleGroupManagerPlugin:
                     )
                     ctx.set_status(group, STATUS_PUSH_MAPPING_ID, mapping_id)
                 except AmbiguousOktaTargetError as e:
-                    self._mark(ctx, group, SYNC_ERROR, str(e))
+                    self._mark_error(ctx, group, str(e))
                     return
                 except MissingOktaTargetError:
-                    self._mark(ctx, group, SYNC_PENDING, "Awaiting Okta import of the Google group")
+                    self._mark_pending(ctx, group, "Awaiting Okta import of the Google group")
                     return
 
-            self._mark(ctx, group, SYNC_SYNCED)
+            self._mark_synced(ctx, group)
         except Exception as e:
             logger.exception(f"Reconcile failed for group {group.name}")
             try:
-                self._mark(ctx, group, SYNC_ERROR, str(e))
+                self._mark_error(ctx, group, str(e))
             except Exception:
                 logger.exception("Failed to persist error status")
             raise
@@ -794,6 +951,12 @@ class GoogleGroupManagerPlugin:
         if plugin_id is not None and plugin_id != PLUGIN_ID:
             return
         await self._reconcile(ctx, group)
+        # _reconcile reports an admin-actionable failure as status rather than by raising, so that
+        # the explanation survives; re-raise it here so the batch run still counts the group as
+        # failed. The status write is durable, so it outlives the rollback this triggers. Only the
+        # event-driven hooks call _reconcile directly, so a request-path reconcile is unaffected.
+        if ctx.get_status(group, STATUS_SYNC_STATUS) == SYNC_ERROR:
+            raise GoogleGroupSyncError(f"{group.name}: {ctx.get_status(group, STATUS_SYNC_ERROR)}")
 
 
 google_group_manager_plugin = GoogleGroupManagerPlugin()

--- a/examples/plugins/app_group_lifecycle_google/test_plugin.py
+++ b/examples/plugins/app_group_lifecycle_google/test_plugin.py
@@ -1,5 +1,6 @@
 """Tests for the Google Groups Lifecycle Plugin."""
 
+import logging
 import os
 import sys
 from pathlib import Path
@@ -60,6 +61,10 @@ from plugin import (  # noqa: E402
 )
 
 from api.models import App, AppGroup  # noqa: E402
+from api.plugins.app_group_lifecycle import (  # noqa: E402
+    DanglingPushMappingError,
+    UnresolvableOktaTargetError,
+)
 
 
 @pytest.fixture
@@ -192,6 +197,69 @@ def test_validate_group_config_enforces_app_email_pattern(plugin_instance: Googl
         {"email": "sec-platform", "display_name": "X"}, app_config, PLUGIN_ID
     )
     assert errors == {}
+
+
+def test_mark_helpers_route_log_levels_by_who_must_act(
+    plugin_instance: GoogleGroupManagerPlugin, mocker: MockerFixture, ctx_mock: MagicMock, caplog: Any
+) -> None:
+    """The log level is a routing decision: only _mark_error means an Access admin has to act, so
+    only it logs at ERROR. A single combined helper could not do this -- it would have to infer the
+    level from whether a detail was passed, and pending/skipped both carry one."""
+    group = _group(mocker)
+
+    with caplog.at_level(logging.DEBUG, logger="plugin"):
+        plugin_instance._mark_synced(ctx_mock, group)
+        plugin_instance._mark_pending(ctx_mock, group, "waiting on Okta")
+        plugin_instance._mark_skipped(ctx_mock, group, "no email configured")
+        plugin_instance._mark_skipped(ctx_mock, group)  # nothing to act on -> DEBUG, no detail
+        plugin_instance._mark_error(ctx_mock, group, "okta link is broken")
+
+    assert {r.levelno for r in caplog.records} == {logging.DEBUG, logging.INFO, logging.ERROR}
+    # Exactly one ERROR, and it is the admin-actionable one.
+    errors = [r.getMessage() for r in caplog.records if r.levelno == logging.ERROR]
+    assert errors == ["Google group reconciliation failed for group App-Google-Platform-Security: okta link is broken"]
+    # A successful reconcile stays out of an INFO-level log entirely.
+    assert [r.levelno for r in caplog.records if "Reconciled" in r.getMessage()] == [logging.DEBUG]
+    # Pending and skipped are both INFO -- progress and misconfiguration, neither an admin's problem.
+    # A reason-less skip is the exception: nothing to act on, so it drops to DEBUG.
+    assert sorted(r.getMessage() for r in caplog.records if r.levelno == logging.INFO) == [
+        "Deferring App-Google-Platform-Security: waiting on Okta",
+        "Skipping App-Google-Platform-Security: no email configured",
+    ]
+    assert [r.levelno for r in caplog.records if "not managed by this plugin" in r.getMessage()] == [logging.DEBUG]
+    ctx_mock.set_status.assert_any_call(group, STATUS_SYNC_ERROR, None, durable_on_failure=True)
+
+
+async def test_reconcile_clears_a_stale_detail_on_recovery(
+    plugin_instance: GoogleGroupManagerPlugin, mocker: MockerFixture, ctx_mock: MagicMock
+) -> None:
+    # A group that failed and then recovered must not keep showing the old explanation. Starts from
+    # real recorded failure state and asserts against the group's own plugin_data, rather than
+    # asserting a mock was called with None.
+    group = _group(
+        mocker,
+        group_config={"email": "sec", "display_name": "Sec"},
+        status={
+            STATUS_SYNC_STATUS: SYNC_ERROR,
+            STATUS_SYNC_ERROR: "something went wrong on an earlier pass",
+            STATUS_GOOGLE_GROUP_ID: "ggid-1",
+            STATUS_PUSH_MAPPING_ID: "map-1",
+        },
+    )
+    ctx_mock.get_config.side_effect = lambda obj, key, default=None: {
+        "enabled": True,
+        "email": "sec",
+        "display_name": "Sec",
+    }.get(key, default)
+    mocker.patch.object(plugin_instance, "_get_owned_group_id", return_value="ggid-1")
+    mocker.patch.object(plugin_instance, "_get_google_group", return_value={"groupKey": {"id": "sec@test-company.com"}})
+    mocker.patch.object(plugin_instance, "_adopt_or_enforce", return_value=None)
+
+    await plugin_instance._reconcile(ctx_mock, group)
+
+    status = group.plugin_data[PLUGIN_ID]["status"]
+    assert status[STATUS_SYNC_STATUS] == SYNC_SYNCED
+    assert status[STATUS_SYNC_ERROR] is None  # the stale explanation is gone, not merely overwritten
 
 
 def _group(
@@ -609,12 +677,13 @@ async def test_reconcile_flags_error_on_domain_mismatch_adoption(
     set_status.assert_any_call(group, STATUS_SYNC_STATUS, SYNC_ERROR, durable_on_failure=True)
 
 
-async def test_reconcile_errors_when_existing_mapping_email_mismatches_config(
+async def test_reconcile_skips_when_existing_mapping_email_mismatches_config(
     plugin_instance: GoogleGroupManagerPlugin, mocker: MockerFixture, ctx_mock: MagicMock
 ) -> None:
     # An out-of-band push mapping points at a different Google group than the group's configured
-    # email -> a conflict that won't self-heal, so reconcile surfaces a sync error rather than
-    # adopting the wrong group.
+    # email -> a conflict that won't self-heal, so reconcile refuses to adopt the wrong group. The
+    # group's own config is one of the two ways out, so this is SKIPPED (the owner's to fix) rather
+    # than SYNC_ERROR (an admin's), and the reason is recorded for them to read.
     group = _group(mocker, group_config={"email": "platform-security", "display_name": "Platform Security"})
     ctx_mock.get_config.side_effect = lambda obj, key, default=None: {
         "enabled": True,
@@ -633,8 +702,8 @@ async def test_reconcile_errors_when_existing_mapping_email_mismatches_config(
 
     await plugin_instance._reconcile(ctx_mock, group)
 
-    set_status.assert_any_call(group, STATUS_SYNC_STATUS, SYNC_ERROR, durable_on_failure=True)
-    # The error names both the mapped and the configured email.
+    set_status.assert_any_call(group, STATUS_SYNC_STATUS, SYNC_SKIPPED, durable_on_failure=True)
+    # The reason names both the mapped and the configured email.
     error_msgs = [c.args[2] for c in set_status.call_args_list if c.args[1] == STATUS_SYNC_ERROR]
     assert error_msgs
     assert "someone-else@test-company.com" in error_msgs[0]
@@ -642,6 +711,158 @@ async def test_reconcile_errors_when_existing_mapping_email_mismatches_config(
     # It bails before trying to claim/adopt; only the configured-email lookup ran (not the mapped one).
     claim.assert_not_called()
     lookup.assert_called_once()
+
+
+async def test_reconcile_skips_when_mapped_target_group_has_no_email(
+    plugin_instance: GoogleGroupManagerPlugin, mocker: MockerFixture, ctx_mock: MagicMock
+) -> None:
+    # An out-of-band push mapping whose Okta target group Okta created via group push: it carries
+    # no googleGroupEmail and never will, because Okta writes that attribute only on import and
+    # does not backfill push-created targets. Unlike the awaiting-import case this cannot self-heal,
+    # so reconcile records it instead of deferring -- and does NOT re-raise, since there is
+    # nothing for the host to retry. It is SKIPPED, not SYNC_ERROR: setting this group's email
+    # config resolves it, so it belongs to the group's owners rather than to Access admins.
+    group = _group(mocker, group_config={})
+    ctx_mock.get_config.side_effect = lambda obj, key, default=None: {"enabled": True}.get(key, default)
+    ctx_mock.get_status.side_effect = lambda *_a, **_k: None
+    lookup = mocker.patch.object(plugin_instance, "_look_up_google_group_id", return_value=None)
+    ctx_mock.discover_existing_push_mapping_and_target_group_external_id.side_effect = UnresolvableOktaTargetError(
+        "target group has no 'googleGroupEmail'", mapping_id="map-7", target_group_name="platform-sec"
+    )
+    set_status = ctx_mock.set_status
+    claim = mocker.patch.object(plugin_instance, "_claim_group_id")
+
+    await plugin_instance._reconcile(ctx_mock, group)  # must not raise
+
+    set_status.assert_any_call(group, STATUS_SYNC_STATUS, SYNC_SKIPPED, durable_on_failure=True)
+    error_msgs = [c.args[2] for c in set_status.call_args_list if c.args[1] == STATUS_SYNC_ERROR]
+    assert error_msgs
+    # The reason is always recorded in the sync-error field even though the status is SKIPPED --
+    # it is the only place the group's owners see what to fix. And it must name the one action
+    # that fixes this: setting the email config. The host's neutral message is not passed through.
+    assert "googleGroupEmail" in error_msgs[0]
+    assert f"'{CONFIG_EMAIL}'" in error_msgs[0]
+    assert "test-company.com" in error_msgs[0]
+    # It names the target group, which is the only thing telling the owner WHICH address to
+    # configure; without it they could link this group to an unrelated Google group.
+    assert "platform-sec" in error_msgs[0]
+    # The discovered mapping is still recorded, so a later pass doesn't create a duplicate.
+    set_status.assert_any_call(group, STATUS_PUSH_MAPPING_ID, "map-7")
+    # It bails before adopting anything; no Google group was resolved to claim.
+    claim.assert_not_called()
+    lookup.assert_not_called()
+
+
+async def test_reconcile_errors_when_unresolvable_target_and_email_is_configured(
+    plugin_instance: GoogleGroupManagerPlugin, mocker: MockerFixture, ctx_mock: MagicMock
+) -> None:
+    # Case 3 is also reached when an email IS configured and the Google lookup simply found
+    # nothing, e.g. the linked Google group was deleted out of band. That is not a configuration
+    # gap -- the owner already did the one thing a skip would ask of them -- so it must be an
+    # admin-facing error, not the quietest state the plugin has.
+    group = _group(mocker, group_config={"email": "sec", "display_name": "Sec"})
+    ctx_mock.get_config.side_effect = lambda obj, key, default=None: {
+        "enabled": True,
+        "email": "sec",
+        "display_name": "Sec",
+    }.get(key, default)
+    ctx_mock.get_status.side_effect = lambda *_a, **_k: None
+    mocker.patch.object(plugin_instance, "_look_up_google_group_id", return_value=None)
+    ctx_mock.discover_existing_push_mapping_and_target_group_external_id.side_effect = UnresolvableOktaTargetError(
+        "target group has no 'googleGroupEmail'", mapping_id="map-7", target_group_name="platform-sec"
+    )
+    set_status = ctx_mock.set_status
+
+    await plugin_instance._reconcile(ctx_mock, group)
+
+    set_status.assert_any_call(group, STATUS_SYNC_STATUS, SYNC_ERROR, durable_on_failure=True)
+    error_msgs = [c.args[2] for c in set_status.call_args_list if c.args[1] == STATUS_SYNC_ERROR]
+    assert error_msgs
+    # It names the configured address that resolved to nothing, and does NOT tell the owner to set
+    # the email config they have already set.
+    assert "sec@test-company.com" in error_msgs[0]
+    assert "Set this group's" not in error_msgs[0]
+
+
+async def test_recorded_mapping_id_prevents_creating_a_duplicate_on_the_next_pass(
+    plugin_instance: GoogleGroupManagerPlugin, mocker: MockerFixture, ctx_mock: MagicMock
+) -> None:
+    # The follow-on pass after an unresolvable skip, which is the whole point of recording the
+    # mapping id. Once the owner configures the address, Case 2 resolves the Google group and the
+    # recorded mapping must be reused. Without it the mapping step would look the target up by
+    # googleGroupEmail -- the attribute a push-created target never has -- and park the group on
+    # SYNC_PENDING forever instead of linking it.
+    group = _group(mocker, group_config={"email": "platform-sec", "display_name": "Sec"})
+    ctx_mock.get_config.side_effect = lambda obj, key, default=None: {
+        "enabled": True,
+        "email": "platform-sec",
+        "display_name": "Sec",
+    }.get(key, default)
+    ctx_mock.get_status.side_effect = lambda _obj, key, default=None: {
+        STATUS_PUSH_MAPPING_ID: "map-7",  # recorded by the earlier skip
+    }.get(key, default)
+    mocker.patch.object(plugin_instance, "_get_owned_group_id", return_value=None)
+    mocker.patch.object(plugin_instance, "_look_up_google_group_id", return_value="ggid-1")
+    mocker.patch.object(plugin_instance, "_claim_group_id", return_value="ggid-1")
+    mocker.patch.object(plugin_instance, "_get_google_group", return_value={"groupKey": {"id": "x"}})
+    mocker.patch.object(plugin_instance, "_adopt_or_enforce", return_value=None)
+
+    await plugin_instance._reconcile(ctx_mock, group)
+
+    ctx_mock.create_push_mapping_for_existing_group.assert_not_awaited()
+    ctx_mock.create_push_mapping_and_new_group.assert_not_awaited()
+    ctx_mock.set_status.assert_any_call(group, STATUS_SYNC_STATUS, SYNC_SYNCED, durable_on_failure=True)
+
+
+async def test_sync_group_raises_so_a_failed_group_fails_the_batch_run(
+    plugin_instance: GoogleGroupManagerPlugin, mocker: MockerFixture, ctx_mock: MagicMock
+) -> None:
+    # _reconcile records an admin-actionable failure as status instead of raising, so the batch
+    # sync would otherwise count the group as a success and the CLI would exit 0. sync_group
+    # re-raises on SYNC_ERROR specifically; SKIPPED and PENDING must not fail the run.
+    group = _group(mocker)
+    mocker.patch.object(plugin_instance, "_reconcile")
+
+    ctx_mock.get_status.side_effect = lambda _obj, key, default=None: {
+        STATUS_SYNC_STATUS: SYNC_ERROR,
+        STATUS_SYNC_ERROR: "the okta link is broken",
+    }.get(key, default)
+    with pytest.raises(Exception, match="the okta link is broken"):
+        await plugin_instance.sync_group(ctx_mock, group, PLUGIN_ID)
+
+    for quiet in (SYNC_SKIPPED, SYNC_PENDING, SYNC_SYNCED):
+        ctx_mock.get_status.side_effect = lambda _obj, key, default=None, _s=quiet: {
+            STATUS_SYNC_STATUS: _s,
+            STATUS_SYNC_ERROR: "detail",
+        }.get(key, default)
+        await plugin_instance.sync_group(ctx_mock, group, PLUGIN_ID)  # must not raise
+
+
+async def test_reconcile_errors_when_push_mapping_target_group_is_gone(
+    plugin_instance: GoogleGroupManagerPlugin, mocker: MockerFixture, ctx_mock: MagicMock
+) -> None:
+    # The push mapping outlived its Okta target group. Nothing downstream is resolvable through a
+    # broken link and it cannot self-heal, so reconcile reports it instead of re-raising a raw SDK
+    # 404 on every periodic pass. Crucially the mapping id is NOT recorded: it is unusable, and
+    # recording it would make a later pass believe this group is already linked.
+    group = _group(mocker, group_config={})
+    ctx_mock.get_config.side_effect = lambda obj, key, default=None: {"enabled": True}.get(key, default)
+    ctx_mock.get_status.side_effect = lambda *_a, **_k: None
+    mocker.patch.object(plugin_instance, "_look_up_google_group_id", return_value=None)
+    ctx_mock.discover_existing_push_mapping_and_target_group_external_id.side_effect = DanglingPushMappingError(
+        "target group gone", mapping_id="map-7", target_group_id="okta-tgt-gone"
+    )
+    set_status = ctx_mock.set_status
+    claim = mocker.patch.object(plugin_instance, "_claim_group_id")
+
+    await plugin_instance._reconcile(ctx_mock, group)  # must not raise
+
+    set_status.assert_any_call(group, STATUS_SYNC_STATUS, SYNC_ERROR, durable_on_failure=True)
+    error_msgs = [c.args[2] for c in set_status.call_args_list if c.args[1] == STATUS_SYNC_ERROR]
+    assert error_msgs and "okta-tgt-gone" in error_msgs[0]
+    # A broken mapping must never be recorded as this group's link.
+    assert not [c for c in set_status.call_args_list if c.args[1] == STATUS_PUSH_MAPPING_ID]
+    claim.assert_not_called()
 
 
 async def test_reconcile_grandfathers_unchanged_legacy_email(
@@ -686,16 +907,22 @@ async def test_reconcile_grandfathers_unchanged_legacy_email(
 
 
 async def test_reconcile_skips_when_disabled(
-    plugin_instance: GoogleGroupManagerPlugin, mocker: MockerFixture, ctx_mock: MagicMock
+    plugin_instance: GoogleGroupManagerPlugin, mocker: MockerFixture, ctx_mock: MagicMock, caplog: Any
 ) -> None:
     group = _group(mocker)
     ctx_mock.get_config.side_effect = lambda *_a, **_k: False  # enabled = False
     discover = ctx_mock.discover_existing_push_mapping_and_target_group_external_id
-    await plugin_instance._reconcile(ctx_mock, group)
+    with caplog.at_level(logging.DEBUG, logger="plugin"):
+        await plugin_instance._reconcile(ctx_mock, group)
     discover.assert_not_called()
     # Recorded, not silent: an empty status is indistinguishable from "the hook has not run yet",
     # and the group page polls for the whole refresh window on every view when it sees one.
     ctx_mock.set_status.assert_any_call(group, STATUS_SYNC_STATUS, SYNC_SKIPPED, durable_on_failure=True)
+    # An app that does not use this plugin is not something anyone acts on, so this skip carries
+    # no detail and stays out of an INFO-level log. Skips that DO need an owner's attention still
+    # record a reason.
+    ctx_mock.set_status.assert_any_call(group, STATUS_SYNC_ERROR, None, durable_on_failure=True)
+    assert [r.levelno for r in caplog.records] == [logging.DEBUG]
 
 
 async def test_reconcile_marks_skipped_when_config_is_missing(
@@ -713,6 +940,9 @@ async def test_reconcile_marks_skipped_when_config_is_missing(
     await plugin_instance._reconcile(ctx_mock, group)
 
     ctx_mock.set_status.assert_any_call(group, STATUS_SYNC_STATUS, SYNC_SKIPPED, durable_on_failure=True)
+    # The reason names the config the owner has to set, not just that the group was skipped.
+    reasons = [c.args[2] for c in ctx_mock.set_status.call_args_list if c.args[1] == STATUS_SYNC_ERROR]
+    assert reasons and f"'{CONFIG_EMAIL}'" in reasons[0]
     assert (
         SYNC_SKIPPED
         not in (
@@ -817,7 +1047,7 @@ async def test_reconcile_marks_error_and_reraises_on_unexpected_failure(
     set_status.assert_any_call(group, STATUS_SYNC_STATUS, SYNC_ERROR, durable_on_failure=True)
 
 
-async def test_reconcile_create_path_rejects_pattern_violation(
+async def test_reconcile_create_path_skips_on_pattern_violation(
     plugin_instance: GoogleGroupManagerPlugin, mocker: MockerFixture, ctx_mock: MagicMock
 ) -> None:
     group = _group(mocker, group_config={"email": "platform", "display_name": "P"}, description="d")
@@ -836,7 +1066,7 @@ async def test_reconcile_create_path_rejects_pattern_violation(
     await plugin_instance._reconcile(ctx_mock, group)
 
     create.assert_not_called()
-    set_status.assert_any_call(group, STATUS_SYNC_STATUS, SYNC_ERROR, durable_on_failure=True)
+    set_status.assert_any_call(group, STATUS_SYNC_STATUS, SYNC_SKIPPED, durable_on_failure=True)
 
 
 async def test_reconcile_creates_when_no_group_exists(
@@ -925,7 +1155,7 @@ async def test_reconcile_refuses_google_group_owned_by_another_access_group(
     plugin_instance: GoogleGroupManagerPlugin, mocker: MockerFixture, ctx_mock: MagicMock
 ) -> None:
     # A group whose email resolves to a Google group already managed by another Access group --
-    # in a *different* app sharing this plugin -- must be flagged error, not adopted/clobbered.
+    # in a *different* app sharing this plugin -- must be refused, not adopted/clobbered.
     group = _group(mocker, group_config={"email": "shared", "display_name": "Shared"})
     ctx_mock.get_config.side_effect = lambda obj, key, default=None: {
         "enabled": True,
@@ -957,7 +1187,7 @@ async def test_reconcile_refuses_google_group_owned_by_another_access_group(
     enforce.assert_not_called()
     ctx_mock.create_push_mapping_for_existing_group.assert_not_awaited()
     ctx_mock.create_push_mapping_and_new_group.assert_not_awaited()
-    set_status.assert_any_call(group, STATUS_SYNC_STATUS, SYNC_ERROR, durable_on_failure=True)
+    set_status.assert_any_call(group, STATUS_SYNC_STATUS, SYNC_SKIPPED, durable_on_failure=True)
     # The owning group's name is plumbed into the error.
     error_msg = next(c.args[2] for c in set_status.call_args_list if c.args[1] == STATUS_SYNC_ERROR)
     assert "App-Other-Owner" in error_msg
@@ -984,7 +1214,9 @@ async def test_reconcile_does_not_persist_id_when_owned_by_another_group(
 
     status = group.plugin_data[PLUGIN_ID]["status"]
     assert status.get(STATUS_GOOGLE_GROUP_ID) is None  # id of the group we don't own was NOT recorded
-    assert status.get(STATUS_SYNC_STATUS) == SYNC_ERROR
+    assert status.get(STATUS_SYNC_STATUS) == SYNC_SKIPPED
+    # The reason must reach the group's owners, who resolve it by changing their email config.
+    assert "App-Other-Owner" in status.get(STATUS_SYNC_ERROR)
 
 
 async def test_reconcile_runs_owner_check_in_config_absent_adoption(
@@ -1012,7 +1244,7 @@ async def test_reconcile_runs_owner_check_in_config_absent_adoption(
     status = group.plugin_data[PLUGIN_ID]["status"]
     assert status.get(STATUS_GOOGLE_GROUP_ID) is None  # neither the id...
     assert status.get(STATUS_PUSH_MAPPING_ID) is None  # ...nor the link's mapping was adopted
-    assert status.get(STATUS_SYNC_STATUS) == SYNC_ERROR
+    assert status.get(STATUS_SYNC_STATUS) == SYNC_SKIPPED
 
 
 async def test_claim_locks_before_checking_ownership(

--- a/tests/test_app_group_lifecycle_plugin.py
+++ b/tests/test_app_group_lifecycle_plugin.py
@@ -40,7 +40,9 @@ from api.plugins.app_group_lifecycle import (
     AppGroupLifecyclePluginFilteringError,
     AppGroupLifecyclePluginMetadata,
     AppGroupLifecyclePluginStatusProperty,
+    DanglingPushMappingError,
     MissingOktaTargetError,
+    UnresolvableOktaTargetError,
     _StatusWrite,
     get_app_group_lifecycle_plugin_app_config_properties,
     get_app_group_lifecycle_plugin_app_status_properties,
@@ -54,6 +56,7 @@ from api.plugins.app_group_lifecycle import (
     validate_app_group_lifecycle_plugin_group_config,
 )
 from api.services import okta
+from api.services.okta_service import OktaResourceNotFoundError
 from tests.factories import (
     AccessRequestFactory,
     AppFactory,
@@ -4363,6 +4366,114 @@ async def test_discover_existing_push_mapping_returns_mapping_id_and_external_id
     )
 
     assert result == ("map-9", "found@test-company.com")
+
+
+async def test_discover_existing_push_mapping_raises_unresolvable_when_target_has_no_external_id(
+    mocker: MockerFixture,
+) -> None:
+    # Okta writes external-id profile attributes only when it IMPORTS a group from the downstream
+    # app. A target group Okta created itself via group push carries only name/description, and a
+    # later import does not backfill it -- so this never self-heals and must not be conflated with
+    # the not-yet-imported case (which defers). The mapping id rides on the exception so the caller
+    # can still record the link it found and avoid creating a duplicate mapping later.
+    mocker.patch(
+        "api.plugins.app_group_lifecycle.okta.list_group_push_mappings",
+        return_value=[{"id": "map-9", "sourceGroupId": "grp-1", "targetGroupId": "okta-tgt-9"}],
+    )
+    tgt = mocker.Mock()
+    tgt.group.profile.actual_instance.additional_properties = {}  # push-created: no external id
+    tgt.group.profile.actual_instance.name = "platform-sec"
+    mocker.patch("api.plugins.app_group_lifecycle.okta.get_group", return_value=tgt)
+
+    with pytest.raises(UnresolvableOktaTargetError) as exc_info:
+        await _push_ctx().discover_existing_push_mapping_and_target_group_external_id(
+            _push_source_group(mocker), _OKTA_APP_ID, _EXTERNAL_ID_FIELD
+        )
+
+    assert exc_info.value.mapping_id == "map-9"
+    # The target group's name is the only identifying attribute a push-created target carries, so
+    # it rides on the error for the caller to show an operator which downstream group is mapped.
+    assert exc_info.value.target_group_name == "platform-sec"
+    message = str(exc_info.value)
+    assert _EXTERNAL_ID_FIELD in message
+    assert "okta-tgt-9" in message
+    assert "App-Google-Platform-Security" in message
+
+
+async def test_discover_existing_push_mapping_raises_unresolvable_when_profile_is_absent(
+    mocker: MockerFixture,
+) -> None:
+    # Same non-retryable outcome when the profile union has no actual_instance at all, rather
+    # than an instance with empty additional_properties.
+    mocker.patch(
+        "api.plugins.app_group_lifecycle.okta.list_group_push_mappings",
+        return_value=[{"id": "map-9", "sourceGroupId": "grp-1", "targetGroupId": "okta-tgt-9"}],
+    )
+    tgt = mocker.Mock()
+    tgt.group.profile = None
+    mocker.patch("api.plugins.app_group_lifecycle.okta.get_group", return_value=tgt)
+
+    with pytest.raises(UnresolvableOktaTargetError):
+        await _push_ctx().discover_existing_push_mapping_and_target_group_external_id(
+            _push_source_group(mocker), _OKTA_APP_ID, _EXTERNAL_ID_FIELD
+        )
+
+
+async def test_discover_existing_push_mapping_raises_unresolvable_when_actual_instance_is_absent(
+    mocker: MockerFixture,
+) -> None:
+    # Third shape of "no external id": the profile object exists but its anyOf union resolved to
+    # nothing, so there is no actual_instance to read additional_properties off. Distinct from a
+    # None profile, and the guard has to survive both.
+    mocker.patch(
+        "api.plugins.app_group_lifecycle.okta.list_group_push_mappings",
+        return_value=[{"id": "map-9", "sourceGroupId": "grp-1", "targetGroupId": "okta-tgt-9"}],
+    )
+    tgt = mocker.Mock()
+    tgt.group.profile.actual_instance = None
+    mocker.patch("api.plugins.app_group_lifecycle.okta.get_group", return_value=tgt)
+
+    with pytest.raises(UnresolvableOktaTargetError) as exc_info:
+        await _push_ctx().discover_existing_push_mapping_and_target_group_external_id(
+            _push_source_group(mocker), _OKTA_APP_ID, _EXTERNAL_ID_FIELD
+        )
+
+    # Nothing to name the target group with, so the caller gets None rather than a bogus name.
+    assert exc_info.value.target_group_name is None
+
+
+async def test_unresolvable_okta_target_error_is_a_value_error() -> None:
+    # The condition raised a bare ValueError before these typed errors existed, and the helper's
+    # docstring documented that. Operator plugins catching ValueError here must keep working.
+    assert issubclass(UnresolvableOktaTargetError, ValueError)
+
+
+async def test_discover_existing_push_mapping_raises_dangling_when_target_group_is_gone(
+    mocker: MockerFixture,
+) -> None:
+    # The mapping still references a target group that Okta no longer has (deleted out of band).
+    # The 404 arrives as OktaResourceNotFoundError -- classified for every call by the service
+    # wrapper, not just list endpoints -- and is re-raised as a typed, non-retryable error so
+    # callers can say what is actually wrong instead of surfacing a raw SDK 404 string.
+    mocker.patch(
+        "api.plugins.app_group_lifecycle.okta.list_group_push_mappings",
+        return_value=[{"id": "map-9", "sourceGroupId": "grp-1", "targetGroupId": "okta-tgt-gone"}],
+    )
+    mocker.patch(
+        "api.plugins.app_group_lifecycle.okta.get_group",
+        side_effect=OktaResourceNotFoundError("Okta HTTP 404 Not Found"),
+    )
+
+    with pytest.raises(DanglingPushMappingError) as exc_info:
+        await _push_ctx().discover_existing_push_mapping_and_target_group_external_id(
+            _push_source_group(mocker), _OKTA_APP_ID, _EXTERNAL_ID_FIELD
+        )
+
+    assert exc_info.value.mapping_id == "map-9"
+    assert exc_info.value.target_group_id == "okta-tgt-gone"
+    message = str(exc_info.value)
+    assert "okta-tgt-gone" in message
+    assert "App-Google-Platform-Security" in message
 
 
 async def test_discover_existing_push_mapping_returns_none_when_no_mapping(mocker: MockerFixture) -> None:


### PR DESCRIPTION
# Summary

Two conditions in the Google example plugin's out-of-band adoption path raised untyped exceptions that reconcile's catch-all turned into a sync error *and* re-raised, so the host logged a hook failure on every periodic pass for something no retry can fix. This adds typed errors for both, routes conditions by who can actually resolve them, and splits `_mark` into one helper per outcome so each owns its log level.

**Urgency**: 5 days
**Expected review effort**: MEDIUM

# Motivation

An operator linked an Access group to a group in the downstream app by creating the Okta group push mapping by hand. The downstream group was created as expected, but every subsequent reconcile failed with `ID 'googleGroupEmail' could not be resolved for target group mapped to <group>`.

The cause is that Okta populates a target group's external-id profile attributes only when it **imports** that group from the downstream app. A target group Okta created itself via group push carries only `name` and `description`, and a later import does **not** backfill it. So the attribute never appears; the condition is permanent, not a race with the import cycle, and re-running an import does not help.

Because the adoption helper raised a bare `ValueError`, this permanent condition was indistinguishable from a transient fault: it produced a traceback plus a host-level hook failure on every pass, and the message an operator saw was a raw SDK profile dump. The same path also had no typed handling for a mapping whose target group had since been deleted, which surfaced a bare Okta 404.

<details>
<summary><h1>Description of Changes</h1></summary>

**Two typed, non-retryable errors** join the existing `AmbiguousOktaTargetError` / `MissingOktaTargetError` pair, so callers can tell these apart from the not-yet-imported case that legitimately defers:

- `UnresolvableOktaTargetError` — the target group exists but carries no external id. Subclasses `ValueError`, which is what this condition raised before and what the helper's docstring documented, so operator plugins catching `ValueError` here keep working. It **carries its mapping id**, so the caller records the link it found rather than creating a duplicate mapping on a later pass, and the **target group's profile name**, which is the only identifying attribute a push-created target has.
- `DanglingPushMappingError` — the mapping references a target group Okta no longer has. It deliberately **does not** record the mapping id: storing an unusable one would convince a later reconcile the group is already linked and skip re-pushing it.

The shared helper's messages stay provider-neutral, since any lifecycle plugin can use it; the example plugin restates them in its own terms.

**The unresolvable case is routed on whether the group is actually configured.** Case 3 is also reached when an email *is* set and the Google lookup simply found nothing, which is what happens when a linked downstream group is deleted out of band. Treating that as a configuration gap would tell the owner to do the one thing they had already done, and would make a vanished downstream group the quietest state the plugin has; only an unconfigured group is skipped, a configured one is an error.

**A reconcile that ends in `SYNC_ERROR` now fails the batch sync run.** `api/cli.py` counts a group as failed only when the hook returns an exception, so recording an error as status rather than raising would let a run that left groups broken exit 0. `sync_group` re-raises on `SYNC_ERROR` specifically; skipped and pending do not. The error status is written durably, so it survives the rollback that triggers.

**Conditions are routed by who can fix them.** Anything an Access *user* resolves by editing a group's plugin configuration is now `SYNC_SKIPPED`, with the reason recorded in the status details field, since that field is the only place a group's owners see it. `SYNC_ERROR` is reserved for what needs Okta or infrastructure access. Three pre-existing paths move off `SYNC_ERROR` as part of this: an email prefix violating the app's pattern, an address already managed by another Access group, and a mapping whose email conflicts with the configured one.

**`_mark` is split into `_mark_synced` / `_mark_pending` / `_mark_skipped` / `_mark_error`**, sharing a private `_write_sync_status`. The combined helper inferred its log level from whether a detail string was passed, which is why `SYNC_PENDING` logged `Awaiting Google group creation via Okta push` at ERROR. Now only `_mark_error` logs at ERROR; synced is DEBUG, pending and skipped are INFO, and a skip with nothing to act on omits its reason and drops to DEBUG.

On the same principle, the target-group profile for a missing external id is now logged separately at DEBUG instead of being embedded in the raised message (where it reached the log at ERROR). It repeats on every sync for as long as the group stays unresolved, which for a push-created target group is indefinitely, and it is diagnostic rather than actionable; the caller's own line is the one an operator acts on.

**The `sync_error` status property is renamed to "Sync Status Details"** (display name only; the key is unchanged so existing `plugin_data` keeps its value). It now carries pending and skip reasons too, so the old name was misleading.
</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

- Both suites pass: `229 passed` across `tests/test_app_group_lifecycle_plugin.py` and the example plugin's `test_plugin.py`.
- `ruff check`, `ruff format --check`, and `ty check` clean.
- Written test-first; each new error was confirmed to fail for the intended reason before implementing.
- Helper-level tests cover both new errors, including the empty-`additional_properties` and absent-`profile` variants.
- Reconcile-level tests assert each condition marks the right status, does **not** re-raise, and that the mapping id is recorded for the unresolvable case and *not* for the dangling one.
- Covers the follow-on pass: a recorded mapping id is reused rather than producing a duplicate, which is the behaviour the mapping-id recording exists for.
- Covers the unresolvable case both with and without a configured email, since those take different routes.
- A dedicated test pins the log-level routing (exactly one ERROR; synced only at DEBUG; pending and skipped at INFO), and another asserts a successful reconcile clears any stale detail so a recovered group stops showing its old failure.
- The pre-change behaviour was confirmed by a throwaway characterisation test driving reconcile with a 404 target, which showed the raw `Okta HTTP 404 Not Found` string reaching the status field alongside a re-raise. Not kept, since it pinned behaviour this PR removes.
</details>

# Guidance for Reviewers

Single commit; **review file-by-file**.

Three things most worth a second opinion:

1. **Recording `mapping_id` for the unresolvable case.** Discovery looks mappings up by this group's own source id, so the mapping is definitively this group's link, and withholding it would dead-end recovery: the mapping-creation step resolves its target by searching for the external-id attribute, which is exactly what a push-created target never has, so a correctly-configured group would sit on pending forever. The residual risk is an owner configuring an address belonging to a *different* downstream group; naming the target group in the message is the mitigation rather than a hard gate. Worth a second opinion on whether that trade is right.
2. **The `mapping_id` asymmetry** between the two new errors (recorded for unresolvable, deliberately not for dangling). It is the subtlest decision here: `push_mapping_id` is what the create path checks before re-pushing, so getting it backwards would either duplicate mappings or permanently convince the plugin a broken link is healthy. Both directions are pinned by tests.
3. **Which conditions became `SYNC_SKIPPED`.** This changes what operators see for three pre-existing paths. I kept the out-of-domain adoption failure as `SYNC_ERROR` on the grounds that it only runs in the no-config branch, so by construction there is no configuration to be wrong; disagreement there is reasonable.
4. **Whether four `_mark_*` helpers is the right shape**, versus keeping one helper and passing the level explicitly.

Two notes on scope: the `_mark` split is strictly speaking separable, but it exists because the routing change surfaced the pending-logged-at-ERROR bug, and splitting them would leave the first half asserting log behaviour the second half changes. Roughly half the diff is tests and docstrings. Happy to break this into stacked PRs if you would rather review it that way.
