### PR TITLE
Make the pre-commit hook work from git worktrees

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,9 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+# Deliberately no `_/husky.sh` bootstrap: it resolves through $0, i.e.
+# core.hooksPath, which in a git worktree may point at a different checkout's
+# .husky -- and `_/` is gitignored, so it exists only where `npm install` last
+# ran. git runs hooks with cwd at the current worktree root, so lint-staged
+# already sees the right files. Keep this hook free of $0-relative paths.
+[ "$HUSKY" = "0" ] && exit 0
 
 npx lint-staged


### PR DESCRIPTION
# Summary

Makes `.husky/pre-commit` work when committing from a git worktree, by removing the `_/husky.sh` bootstrap line that resolves through `$0` (and therefore through `core.hooksPath`, the main repo) instead of through the worktree being committed from.

**Urgency**: 5 days — dev tooling only, no runtime or API surface, and `--no-verify` is a workaround in the meantime.
**Expected review effort**: LOW

# Motivation

`core.hooksPath` is repo-wide state, so in a multi-worktree checkout it can point at a different worktree's `.husky` than the one you are committing from. The bootstrap line resolved `_/husky.sh` relative to `$0` — i.e. relative to `core.hooksPath` — and `.husky/.gitignore` excludes `_`, so that file exists only in whichever checkout `npm install` last ran in.

Committing from a worktree then aborts with:

```
.husky/pre-commit: line 2: /path/to/other/checkout/.husky/_/husky.sh: No such file or directory
```

That is a hard failure rather than a skipped hook, so the commit never lands. When the file *does* happen to exist elsewhere, the hook silently appears to work, so the breakage comes and goes with wherever `npm install` last ran.

Git runs hooks with the working directory set to the **current worktree root** even when `core.hooksPath` points somewhere else. So `npx lint-staged` was never the worktree-sensitive part — it already resolves the right project and the right staged files on its own. Only husky's bootstrap was position-dependent.

<details>
<summary><h1>Description of Changes</h1></summary>

Drops `. "$(dirname "$0")/_/husky.sh"` from `.husky/pre-commit`, leaving `npx lint-staged` to resolve from the cwd.

`HUSKY=0` was the only `husky.sh` feature this repo relied on, so it is reimplemented inline (`[ "$HUSKY" = "0" ] && exit 0`) to keep that documented escape hatch working. The change is therefore behavior-neutral outside the worktree case.

The comment block is deliberately longer than the code: the deleted line reads like missing husky setup, and is likely to be restored by a future reader unless the reason it is absent is recorded next to it.

</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

Tested by pointing `core.hooksPath` at a directory containing only a `pre-commit` and **no** `_/husky.sh`, reproducing the broken state exactly:

| Case | Result |
|---|---|
| Old hook, broken `hooksPath` | fails with `_/husky.sh: No such file or directory` — reproduces the bug |
| New hook, same broken `hooksPath` | lint-staged runs; prettier reformats the staged file |
| `HUSKY=0`, new hook | skips, no lint-staged output |
| New hook, ordinary in-worktree `hooksPath` | unaffected |

The second case is the load-bearing one: a deliberately mis-formatted `.ts` file was staged and prettier rewrote it, confirming lint-staged still resolves the *correct* worktree's staged files via the cwd rather than via `$0`. The probe file was removed afterwards; no application code is touched.

Not applicable: the backend/frontend test suites, since this is a git hook and no test covers it.

</details>

# Guidance for Reviewers

Single commit; the diff is small enough to read directly.

The one judgment call worth a second opinion is reimplementing `HUSKY=0` inline rather than dropping it. It keeps parity with husky's documented behavior for one line, but it does mean the hook now hardcodes a convention husky owns. Dropping it and relying on `git commit --no-verify` instead is a defensible alternative if you would rather this file stay minimal.
