### PR TITLE
Expire role requests and group requests, with an opt-out

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -16,3 +16,13 @@ OIDC_CLIENT_SECRETS=<YOUR_CLIENT_SECRETS>
 OIDC_OVERWRITE_REDIRECT_URI=https://<YOUR_ACCESS_DEPLOYMENT_DOMAIN_NAME>/oidc/authorize
 ALLOWED_HOSTS=<YOUR_ACCESS_DEPLOYMENT_DOMAIN_NAME>
 ACCESS_CONFIG_FILE=<NAME_OF_FILE_IN_CONFIG_DIR>
+
+# How long a pending request may sit before the sync cronjob closes it, in
+# seconds. Both default to one week (604800) and are independent of each other.
+# Set either to "never" to switch off its age-based expiration.
+#
+# "never" does not stop everything: an access or role request whose own
+# requested end date has already passed is still closed, because that is a
+# separate check from the maximum age.
+#MAX_ACCESS_REQUEST_AGE_SECONDS=604800
+#MAX_GROUP_REQUEST_AGE_SECONDS=604800

--- a/.env.production.example
+++ b/.env.production.example
@@ -19,10 +19,15 @@ ACCESS_CONFIG_FILE=<NAME_OF_FILE_IN_CONFIG_DIR>
 
 # How long a pending request may sit before the sync cronjob closes it, in
 # seconds. Both default to one week (604800) and are independent of each other.
-# Set either to "never" to switch off its age-based expiration.
+# MAX_ACCESS_REQUEST_AGE_SECONDS governs access and role requests; the group
+# variable governs group requests only. Set either to "never" to switch off
+# its age-based expiration.
 #
 # "never" does not stop everything: an access or role request whose own
 # requested end date has already passed is still closed, because that is a
 # separate check from the maximum age.
+#
+# A value of 0 or less is rejected at startup rather than silently closing
+# every pending request on the next sync; use "never" to disable expiration.
 #MAX_ACCESS_REQUEST_AGE_SECONDS=604800
 #MAX_GROUP_REQUEST_AGE_SECONDS=604800

--- a/README.md
+++ b/README.md
@@ -288,6 +288,38 @@ the values in the default config.
 To use your custom config file, set the `ACCESS_CONFIG_FILE` environment variable to the name of your config
 override file in the project-level `config` directory.
 
+#### Request expiration
+
+The `access sync` cronjob closes pending requests that have sat too long. Two
+environment variables control it, both in seconds, both defaulting to one week:
+
+| Variable | Governs | Default |
+| --- | --- | --- |
+| `MAX_ACCESS_REQUEST_AGE_SECONDS` | access requests **and** role requests | `604800` |
+| `MAX_GROUP_REQUEST_AGE_SECONDS` | group requests | `604800` |
+
+Set either to `never` to switch off age-based expiration for the request types
+it governs:
+
+```
+MAX_ACCESS_REQUEST_AGE_SECONDS=never
+```
+
+Three things worth knowing:
+
+- **The two are independent.** Raising `MAX_ACCESS_REQUEST_AGE_SECONDS` does not
+  raise the group cutoff; set both if you want both changed.
+- **Access and role requests share one cutoff.** Disabling
+  `MAX_ACCESS_REQUEST_AGE_SECONDS` stops role requests aging out too.
+- **`never` does not mean nothing is ever closed.** Access and role requests are
+  also closed when the end date the requester asked for has already passed,
+  which is a separate check that `never` does not affect. Group requests have no
+  such check, so `never` stops their expiration entirely.
+
+A value of `0` or less is rejected at startup: it would close every pending
+request on the next sync, and is almost always a mistaken attempt to disable
+expiration. Use `never` for that.
+
 ### Sample Usage
 
 To override environment variables, create an override config file in the `config` directory. (You can name

--- a/README.md
+++ b/README.md
@@ -272,23 +272,7 @@ If you are using Cloudflare Access, ensure that you configure `CLOUDFLARE_TEAM_D
 
 Else, if you are using a generic OIDC identity provider (such as Okta), then you should configure `SECRET_KEY` and `OIDC_CLIENT_SECRETS`. `CLOUDFLARE_TEAM_DOMAIN` and `CLOUDFLARE_APPLICATION_AUDIENCE` do not need to be set and can be removed from your env file. Make sure to also mount your `client-secrets.json` file to the container if you don't have it inline.
 
-### Access application configuration
-
-_All front-end and back-end configuration overrides are **optional**._
-
-The default config for the application is at [`config/config.default.json`](config/config.default.json).
-
-The file is structured with two keys, `FRONTEND` and `BACKEND`, which contain the configuration overrides for the
-front-end and back-end respectively.
-
-If you want to override either front-end or back-end values, create your own config file based on 
-[`config/config.default.json`](config/config.default.json). Any values that you don't override will fall back to 
-the values in the default config.
-
-To use your custom config file, set the `ACCESS_CONFIG_FILE` environment variable to the name of your config
-override file in the project-level `config` directory.
-
-#### Request expiration
+##### Request expiration
 
 The `access sync` cronjob closes pending requests that have sat too long. Two
 environment variables control it, both in seconds, both defaulting to one week:
@@ -297,6 +281,9 @@ environment variables control it, both in seconds, both defaulting to one week:
 | --- | --- | --- |
 | `MAX_ACCESS_REQUEST_AGE_SECONDS` | access requests **and** role requests | `604800` |
 | `MAX_GROUP_REQUEST_AGE_SECONDS` | group requests | `604800` |
+
+These are environment variables; setting them in an `ACCESS_CONFIG_FILE` JSON
+config has no effect.
 
 Set either to `never` to switch off age-based expiration for the request types
 it governs:
@@ -319,6 +306,33 @@ Three things worth knowing:
 A value of `0` or less is rejected at startup: it would close every pending
 request on the next sync, and is almost always a mistaken attempt to disable
 expiration. Use `never` for that.
+
+**The requested-window check for role requests is new and is not covered by
+either cutoff.** The first `access sync` run after upgrading to a version with
+this check will, in a single run, close every existing pending role request
+whose requested end date has already passed; each closure notifies the
+requester and every eligible approver, which for a role request includes
+Access admins. Setting `MAX_ACCESS_REQUEST_AGE_SECONDS=never` before that first
+run only suppresses the age-based half of expiration, not this window check.
+Operators with a large backlog of old role requests may want to plan for this
+rather than be surprised by a burst of notifications on the first sync after
+upgrading.
+
+### Access application configuration
+
+_All front-end and back-end configuration overrides are **optional**._
+
+The default config for the application is at [`config/config.default.json`](config/config.default.json).
+
+The file is structured with two keys, `FRONTEND` and `BACKEND`, which contain the configuration overrides for the
+front-end and back-end respectively.
+
+If you want to override either front-end or back-end values, create your own config file based on 
+[`config/config.default.json`](config/config.default.json). Any values that you don't override will fall back to 
+the values in the default config.
+
+To use your custom config file, set the `ACCESS_CONFIG_FILE` environment variable to the name of your config
+override file in the project-level `config` directory.
 
 ### Sample Usage
 

--- a/README.md
+++ b/README.md
@@ -307,16 +307,11 @@ A value of `0` or less is rejected at startup: it would close every pending
 request on the next sync, and is almost always a mistaken attempt to disable
 expiration. Use `never` for that.
 
-**The requested-window check for role requests is new and is not covered by
-either cutoff.** The first `access sync` run after upgrading to a version with
-this check will, in a single run, close every existing pending role request
-whose requested end date has already passed; each closure notifies the
-requester and every eligible approver, which for a role request includes
-Access admins. Setting `MAX_ACCESS_REQUEST_AGE_SECONDS=never` before that first
-run only suppresses the age-based half of expiration, not this window check.
-Operators with a large backlog of old role requests may want to plan for this
-rather than be surprised by a burst of notifications on the first sync after
-upgrading.
+Closing a request notifies its requester and every approver eligible to review
+it; for a role request that includes Access admins. A sync run that closes many
+requests at once sends a correspondingly large number of notifications, so on a
+busy instance it is worth knowing how many requests are pending past a cutoff or
+past their requested end date.
 
 ### Access application configuration
 

--- a/api/cli.py
+++ b/api/cli.py
@@ -267,6 +267,7 @@ async def sync(
     from api.services import okta
     from api.syncer import (
         expire_access_requests,
+        expire_group_requests,
         expire_role_requests,
         sync_group_memberships,
         sync_group_ownerships,
@@ -311,6 +312,7 @@ async def sync(
                 )
             await expire_access_requests()
             await expire_role_requests()
+            await expire_group_requests()
     finally:
         await okta.stop_pooled_client()
 

--- a/api/cli.py
+++ b/api/cli.py
@@ -267,6 +267,7 @@ async def sync(
     from api.services import okta
     from api.syncer import (
         expire_access_requests,
+        expire_role_requests,
         sync_group_memberships,
         sync_group_ownerships,
         sync_groups,
@@ -309,6 +310,7 @@ async def sync(
                     concurrency=group_fetch_concurrency,
                 )
             await expire_access_requests()
+            await expire_role_requests()
     finally:
         await okta.stop_pooled_client()
 

--- a/api/config.py
+++ b/api/config.py
@@ -10,10 +10,18 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Any, Literal, Optional, Union, cast
+from typing import Any, Final, Literal, Optional, Union, cast
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Sentinel for "no maximum age": disables the age-based expiration sweep for a
+# request type. A string rather than None because Settings comes only from env
+# vars and .env, so every value arrives as a string: an omitted variable is
+# indistinguishable from one set to nothing, and "", "None", and "null" all fail
+# int validation. (config.default.json's BACKEND key feeds AccessConfig, a
+# separate object, not this class.)
+NEVER_EXPIRE: Final = "never"
 
 
 def _read_secret_key() -> Optional[str]:
@@ -116,17 +124,32 @@ class Settings(BaseSettings):
     # User attributes
     USER_DISPLAY_CUSTOM_ATTRIBUTES: str = "Title,Manager"
     USER_SEARCH_CUSTOM_ATTRIBUTES: Optional[str] = None
-    MAX_ACCESS_REQUEST_AGE_SECONDS: int = 7 * 24 * 60 * 60
-    # Group requests get their own cutoff: their approver may need to negotiate a
-    # name and pick tags rather than just answer yes/no, which plausibly wants a
-    # longer fuse than a membership request. Unset falls back to
-    # MAX_ACCESS_REQUEST_AGE_SECONDS via `max_group_request_age_seconds`, so
-    # operators who never set it keep the behavior they already had.
-    # Unset falls back to MAX_ACCESS_REQUEST_AGE_SECONDS. An explicit 0 is
-    # honored and means "close every pending group request on each sync run";
-    # ge=0 rejects a negative value, which would otherwise expire future-dated
-    # rows.
-    MAX_GROUP_REQUEST_AGE_SECONDS: Optional[int] = Field(default=None, ge=0)
+    # How long a pending request may sit before the sync cronjob closes it.
+    # Access and role requests share one cutoff: both are a yes/no on granting
+    # access, so they get the same fuse. Group requests get their own because
+    # their approver may need to negotiate a name and pick tags rather than just
+    # answer yes/no. The two are independent; neither inherits the other.
+    #
+    # Set either to NEVER_EXPIRE ("never") to switch its age-based sweep off.
+    # That does NOT stop the separate requested-window sweep: an access or role
+    # request whose own `request_ending_at` has passed is still closed.
+    MAX_ACCESS_REQUEST_AGE_SECONDS: Union[int, Literal["never"]] = 7 * 24 * 60 * 60
+    MAX_GROUP_REQUEST_AGE_SECONDS: Union[int, Literal["never"]] = 7 * 24 * 60 * 60
+
+    @field_validator("MAX_ACCESS_REQUEST_AGE_SECONDS", "MAX_GROUP_REQUEST_AGE_SECONDS")
+    @classmethod
+    def _reject_non_positive_age(cls, v: Union[int, str]) -> Union[int, str]:
+        # Short-circuit on the sentinel: a Field(ge=...) bound cannot be used
+        # here because it is applied to the union rather than to its int branch
+        # and rejects "never" itself.
+        if v == NEVER_EXPIRE:
+            return v
+        if isinstance(v, int) and v < 1:
+            raise ValueError(
+                f"must be a positive number of seconds, or {NEVER_EXPIRE!r} to disable expiration; "
+                "a value of 0 or less would close every pending request on the next sync"
+            )
+        return v
 
     # Cloudflare Access
     CLOUDFLARE_APPLICATION_AUDIENCE: Optional[str] = None
@@ -249,11 +272,25 @@ class Settings(BaseSettings):
         return [s.strip() for s in self.APP_GROUP_DELETER_ID.split(",") if s.strip()]
 
     @property
-    def max_group_request_age_seconds(self) -> int:
-        # Explicit `is None` rather than `or`: an operator setting 0 means "expire
-        # immediately", which `or` would silently replace with the access default.
-        if self.MAX_GROUP_REQUEST_AGE_SECONDS is None:
-            return self.MAX_ACCESS_REQUEST_AGE_SECONDS
+    def max_access_request_age_seconds(self) -> Optional[int]:
+        """Seconds after which a pending access or role request is closed for age.
+
+        None when the operator disabled the age-based sweep. This does not affect
+        the separate requested-window sweep, which always runs.
+        """
+        if self.MAX_ACCESS_REQUEST_AGE_SECONDS == NEVER_EXPIRE:
+            return None
+        return self.MAX_ACCESS_REQUEST_AGE_SECONDS
+
+    @property
+    def max_group_request_age_seconds(self) -> Optional[int]:
+        """Seconds after which a pending group request is closed for age.
+
+        None when the operator disabled the age-based sweep. Independent of
+        MAX_ACCESS_REQUEST_AGE_SECONDS; group requests have no second sweep.
+        """
+        if self.MAX_GROUP_REQUEST_AGE_SECONDS == NEVER_EXPIRE:
+            return None
         return self.MAX_GROUP_REQUEST_AGE_SECONDS
 
 
@@ -359,7 +396,6 @@ DATABASE_NAME = settings.DATABASE_NAME
 DATABASE_USES_PUBLIC_IP = settings.DATABASE_USES_PUBLIC_IP
 USER_DISPLAY_CUSTOM_ATTRIBUTES = settings.USER_DISPLAY_CUSTOM_ATTRIBUTES
 USER_SEARCH_CUSTOM_ATTRIBUTES = settings.USER_SEARCH_CUSTOM_ATTRIBUTES or ",".join(settings.user_search_attrs)
-MAX_ACCESS_REQUEST_AGE_SECONDS = settings.MAX_ACCESS_REQUEST_AGE_SECONDS
 CLOUDFLARE_APPLICATION_AUDIENCE = settings.CLOUDFLARE_APPLICATION_AUDIENCE
 CLOUDFLARE_TEAM_DOMAIN = settings.CLOUDFLARE_TEAM_DOMAIN
 SECRET_KEY = settings.SECRET_KEY

--- a/api/config.py
+++ b/api/config.py
@@ -117,6 +117,12 @@ class Settings(BaseSettings):
     USER_DISPLAY_CUSTOM_ATTRIBUTES: str = "Title,Manager"
     USER_SEARCH_CUSTOM_ATTRIBUTES: Optional[str] = None
     MAX_ACCESS_REQUEST_AGE_SECONDS: int = 7 * 24 * 60 * 60
+    # Group requests get their own cutoff: their approver may need to negotiate a
+    # name and pick tags rather than just answer yes/no, which plausibly wants a
+    # longer fuse than a membership request. Unset falls back to
+    # MAX_ACCESS_REQUEST_AGE_SECONDS via `max_group_request_age_seconds`, so
+    # operators who never set it keep the behavior they already had.
+    MAX_GROUP_REQUEST_AGE_SECONDS: Optional[int] = None
 
     # Cloudflare Access
     CLOUDFLARE_APPLICATION_AUDIENCE: Optional[str] = None
@@ -238,6 +244,14 @@ class Settings(BaseSettings):
             return []
         return [s.strip() for s in self.APP_GROUP_DELETER_ID.split(",") if s.strip()]
 
+    @property
+    def max_group_request_age_seconds(self) -> int:
+        # Explicit `is None` rather than `or`: an operator setting 0 means "expire
+        # immediately", which `or` would silently replace with the access default.
+        if self.MAX_GROUP_REQUEST_AGE_SECONDS is None:
+            return self.MAX_ACCESS_REQUEST_AGE_SECONDS
+        return self.MAX_GROUP_REQUEST_AGE_SECONDS
+
 
 def _build_settings() -> Settings:
     s = Settings()
@@ -342,6 +356,7 @@ DATABASE_USES_PUBLIC_IP = settings.DATABASE_USES_PUBLIC_IP
 USER_DISPLAY_CUSTOM_ATTRIBUTES = settings.USER_DISPLAY_CUSTOM_ATTRIBUTES
 USER_SEARCH_CUSTOM_ATTRIBUTES = settings.USER_SEARCH_CUSTOM_ATTRIBUTES or ",".join(settings.user_search_attrs)
 MAX_ACCESS_REQUEST_AGE_SECONDS = settings.MAX_ACCESS_REQUEST_AGE_SECONDS
+MAX_GROUP_REQUEST_AGE_SECONDS = settings.max_group_request_age_seconds
 CLOUDFLARE_APPLICATION_AUDIENCE = settings.CLOUDFLARE_APPLICATION_AUDIENCE
 CLOUDFLARE_TEAM_DOMAIN = settings.CLOUDFLARE_TEAM_DOMAIN
 SECRET_KEY = settings.SECRET_KEY

--- a/api/config.py
+++ b/api/config.py
@@ -122,7 +122,11 @@ class Settings(BaseSettings):
     # longer fuse than a membership request. Unset falls back to
     # MAX_ACCESS_REQUEST_AGE_SECONDS via `max_group_request_age_seconds`, so
     # operators who never set it keep the behavior they already had.
-    MAX_GROUP_REQUEST_AGE_SECONDS: Optional[int] = None
+    # Unset falls back to MAX_ACCESS_REQUEST_AGE_SECONDS. An explicit 0 is
+    # honored and means "close every pending group request on each sync run";
+    # ge=0 rejects a negative value, which would otherwise expire future-dated
+    # rows.
+    MAX_GROUP_REQUEST_AGE_SECONDS: Optional[int] = Field(default=None, ge=0)
 
     # Cloudflare Access
     CLOUDFLARE_APPLICATION_AUDIENCE: Optional[str] = None
@@ -356,7 +360,6 @@ DATABASE_USES_PUBLIC_IP = settings.DATABASE_USES_PUBLIC_IP
 USER_DISPLAY_CUSTOM_ATTRIBUTES = settings.USER_DISPLAY_CUSTOM_ATTRIBUTES
 USER_SEARCH_CUSTOM_ATTRIBUTES = settings.USER_SEARCH_CUSTOM_ATTRIBUTES or ",".join(settings.user_search_attrs)
 MAX_ACCESS_REQUEST_AGE_SECONDS = settings.MAX_ACCESS_REQUEST_AGE_SECONDS
-MAX_GROUP_REQUEST_AGE_SECONDS = settings.max_group_request_age_seconds
 CLOUDFLARE_APPLICATION_AUDIENCE = settings.CLOUDFLARE_APPLICATION_AUDIENCE
 CLOUDFLARE_TEAM_DOMAIN = settings.CLOUDFLARE_TEAM_DOMAIN
 SECRET_KEY = settings.SECRET_KEY

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -651,8 +651,9 @@ async def expire_group_requests() -> None:
     What that leaves to the approve path: ApproveGroupRequest falls back to
     requested_ownership_ending_at when the approver supplies no resolved value,
     so approving a long-stale request could write an already-expired ownership
-    row and leave the new group unowned. That is repaired there rather than here
-    (it refuses the approval outright); this sweep deliberately stays out of it.
+    row and leave the new group unowned. PR #599 proposes refusing such an
+    approval outright; until it lands the gap is open. Either way, repairing it
+    belongs in the approve path and not in this sweep.
     See test_no_expire_group_request_with_lapsed_ownership_window.
 
     Uses its own cutoff because a group request's approver may need to negotiate

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -27,6 +27,7 @@ from api.models import (
     OktaUserGroupMember,
     RoleGroup,
     RoleGroupMap,
+    RoleRequest,
 )
 from api.models.app_group import get_access_owners, get_app_managers
 from api.models.okta_group import get_group_managers
@@ -35,6 +36,7 @@ from api.operations import (
     DeleteUser,
     ModifyGroupUsers,
     RejectAccessRequest,
+    RejectRoleRequest,
     UnmanageGroup,
 )
 from api.plugins import NotificationHook, send_notification
@@ -585,6 +587,49 @@ async def expire_access_requests() -> None:
     await _expire_each(older_than_request, reject, "access request")
 
     logger.info("Access request expiration finished.")
+
+
+async def expire_role_requests() -> None:
+    """Close pending role requests that aged out or whose window has lapsed.
+
+    Shares MAX_ACCESS_REQUEST_AGE_SECONDS with access requests; both are a
+    yes/no on granting access, so they get the same fuse. The lapsed-window
+    path matters here for the same reason it does for access requests:
+    approving a role request past its request_ending_at would create an
+    already-expired RoleGroupMap.
+    """
+    logger.info("Role request expiration started.")
+    MAX_ACCESS_REQUEST_AGE_SECONDS = settings.MAX_ACCESS_REQUEST_AGE_SECONDS
+
+    def reject(request_id: str) -> Awaitable[RoleRequest]:
+        return RejectRoleRequest(
+            role_request=request_id,
+            rejection_reason=EXPIRED_REQUEST_REASON,
+        ).execute()
+
+    older_than_max = (
+        await db.session.scalars(
+            select(RoleRequest)
+            .where(RoleRequest.status == AccessRequestStatus.PENDING)
+            .where(RoleRequest.resolved_at.is_(None))
+            .where(
+                RoleRequest.created_at < datetime.now(timezone.utc) - timedelta(seconds=MAX_ACCESS_REQUEST_AGE_SECONDS)
+            )
+        )
+    ).all()
+    await _expire_each(older_than_max, reject, "role request")
+
+    older_than_request = (
+        await db.session.scalars(
+            select(RoleRequest)
+            .where(RoleRequest.status == AccessRequestStatus.PENDING)
+            .where(RoleRequest.resolved_at.is_(None))
+            .where(RoleRequest.request_ending_at < func.now())
+        )
+    ).all()
+    await _expire_each(older_than_request, reject, "role request")
+
+    logger.info("Role request expiration finished.")
 
 
 async def expiring_access_notifications_user() -> None:

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -1,8 +1,9 @@
 import asyncio
 import logging
 from collections import defaultdict
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from datetime import date, datetime, timedelta, timezone
+from typing import Any
 
 from sqlalchemy import and_, func, or_, select
 from api.config import settings
@@ -514,9 +515,51 @@ async def sync_group_ownerships(
     logger.info("Ownership sync finished.")
 
 
+# The resolution_reason written when a request is closed for age or for a lapsed
+# window, shared by all three sweeps. Worth knowing when reading the audit
+# trail: a null resolver alone does not identify an expiry, since requester
+# deletion, group deletion, group unmanaging, and a conditional-access denial
+# all close requests with no actor too. This wording is what tells them apart.
+EXPIRED_REQUEST_REASON = "Closed because the request expired"
+
+
+async def _expire_each(
+    requests: Sequence[Any],
+    reject: Callable[[Any], Awaitable[Any]],
+    label: str,
+) -> None:
+    """Reject each request, isolating failures so one bad row can't abort the sweep.
+
+    The reject operations commit per request, so a failure only needs its own
+    transaction rolled back. Without this, a single request that raises (e.g.
+    ConflictError, when a reviewer resolves it mid-sync) aborts expiration for
+    every remaining request and will do so again on the next run.
+
+    IDs are read up front, before any rollback: `db.session.rollback()` expires
+    every instance in the identity map (not just the failed one), so touching an
+    attribute on one of the *other*, not-yet-processed `requests` afterward would
+    force a lazy reload with no async context to run it in (`MissingGreenlet`).
+    `reject` is therefore called with the id, matching the `Model | str`
+    constructor every reject operation already supports.
+    """
+    request_ids = [request.id for request in requests]
+    for request_id in request_ids:
+        try:
+            await reject(request_id)
+        except Exception:
+            logger.exception(f"Failed to expire {label} {request_id}, skipping.")
+            await db.session.rollback()
+
+
 async def expire_access_requests() -> None:
     logger.info("Access request expiration started.")
     MAX_ACCESS_REQUEST_AGE_SECONDS = settings.MAX_ACCESS_REQUEST_AGE_SECONDS
+
+    def reject(request_id: str) -> Awaitable[AccessRequest]:
+        return RejectAccessRequest(
+            access_request=request_id,
+            rejection_reason=EXPIRED_REQUEST_REASON,
+        ).execute()
 
     older_than_max = (
         await db.session.scalars(
@@ -529,11 +572,7 @@ async def expire_access_requests() -> None:
             )
         )
     ).all()
-    for access_request in older_than_max:
-        await RejectAccessRequest(
-            access_request=access_request,
-            rejection_reason="Closed because the request expired",
-        ).execute()
+    await _expire_each(older_than_max, reject, "access request")
 
     older_than_request = (
         await db.session.scalars(
@@ -543,11 +582,7 @@ async def expire_access_requests() -> None:
             .where(AccessRequest.request_ending_at < func.now())
         )
     ).all()
-    for access_request in older_than_request:
-        await RejectAccessRequest(
-            access_request=access_request,
-            rejection_reason="Closed because the request expired",
-        ).execute()
+    await _expire_each(older_than_request, reject, "access request")
 
     logger.info("Access request expiration finished.")
 

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -557,7 +557,7 @@ async def _expire_each(
 
 async def expire_access_requests() -> None:
     logger.info("Access request expiration started.")
-    MAX_ACCESS_REQUEST_AGE_SECONDS = settings.MAX_ACCESS_REQUEST_AGE_SECONDS
+    max_age_seconds = settings.max_access_request_age_seconds
 
     def reject(request_id: str) -> Awaitable[AccessRequest]:
         return RejectAccessRequest(
@@ -565,18 +565,21 @@ async def expire_access_requests() -> None:
             rejection_reason=EXPIRED_REQUEST_REASON,
         ).execute()
 
-    older_than_max = (
-        await db.session.scalars(
-            select(AccessRequest)
-            .where(AccessRequest.status == AccessRequestStatus.PENDING)
-            .where(AccessRequest.resolved_at.is_(None))
-            .where(
-                AccessRequest.created_at
-                < datetime.now(timezone.utc) - timedelta(seconds=MAX_ACCESS_REQUEST_AGE_SECONDS)
+    # Skipped, not short-circuited: the requested-window pass below still runs,
+    # so a request whose own window has passed is closed either way. Logged so
+    # sync output distinguishes "disabled" from "nothing to expire".
+    if max_age_seconds is None:
+        logger.info("Age-based access request expiration is disabled.")
+    else:
+        older_than_max = (
+            await db.session.scalars(
+                select(AccessRequest)
+                .where(AccessRequest.status == AccessRequestStatus.PENDING)
+                .where(AccessRequest.resolved_at.is_(None))
+                .where(AccessRequest.created_at < datetime.now(timezone.utc) - timedelta(seconds=max_age_seconds))
             )
-        )
-    ).all()
-    await _expire_each(older_than_max, reject, "access request")
+        ).all()
+        await _expire_each(older_than_max, reject, "access request")
 
     older_than_request = (
         await db.session.scalars(
@@ -594,14 +597,14 @@ async def expire_access_requests() -> None:
 async def expire_role_requests() -> None:
     """Close pending role requests that aged out or whose window has lapsed.
 
-    Shares MAX_ACCESS_REQUEST_AGE_SECONDS with access requests; both are a
-    yes/no on granting access, so they get the same fuse. The lapsed-window
-    path matters here for the same reason it does for access requests:
+    Shares MAX_ACCESS_REQUEST_AGE_SECONDS with access requests, including its "never"
+    disabled state; both are a yes/no on granting access, so they get the same fuse.
+    The lapsed-window path matters here for the same reason it does for access requests:
     approving a role request past its request_ending_at would create an
     already-expired RoleGroupMap.
     """
     logger.info("Role request expiration started.")
-    MAX_ACCESS_REQUEST_AGE_SECONDS = settings.MAX_ACCESS_REQUEST_AGE_SECONDS
+    max_age_seconds = settings.max_access_request_age_seconds
 
     def reject(request_id: str) -> Awaitable[RoleRequest]:
         return RejectRoleRequest(
@@ -609,17 +612,19 @@ async def expire_role_requests() -> None:
             rejection_reason=EXPIRED_REQUEST_REASON,
         ).execute()
 
-    older_than_max = (
-        await db.session.scalars(
-            select(RoleRequest)
-            .where(RoleRequest.status == AccessRequestStatus.PENDING)
-            .where(RoleRequest.resolved_at.is_(None))
-            .where(
-                RoleRequest.created_at < datetime.now(timezone.utc) - timedelta(seconds=MAX_ACCESS_REQUEST_AGE_SECONDS)
+    # Same shape as the access sweep; the requested-window pass below still runs.
+    if max_age_seconds is None:
+        logger.info("Age-based role request expiration is disabled.")
+    else:
+        older_than_max = (
+            await db.session.scalars(
+                select(RoleRequest)
+                .where(RoleRequest.status == AccessRequestStatus.PENDING)
+                .where(RoleRequest.resolved_at.is_(None))
+                .where(RoleRequest.created_at < datetime.now(timezone.utc) - timedelta(seconds=max_age_seconds))
             )
-        )
-    ).all()
-    await _expire_each(older_than_max, reject, "role request")
+        ).all()
+        await _expire_each(older_than_max, reject, "role request")
 
     older_than_request = (
         await db.session.scalars(
@@ -662,15 +667,20 @@ async def expire_group_requests() -> None:
             rejection_reason=EXPIRED_REQUEST_REASON,
         ).execute()
 
-    older_than_max = (
-        await db.session.scalars(
-            select(GroupRequest)
-            .where(GroupRequest.status == AccessRequestStatus.PENDING)
-            .where(GroupRequest.resolved_at.is_(None))
-            .where(GroupRequest.created_at < datetime.now(timezone.utc) - timedelta(seconds=max_age_seconds))
-        )
-    ).all()
-    await _expire_each(older_than_max, reject, "group request")
+    # Group requests have no second pass, so a disabled cutoff means this sweep
+    # does nothing at all. Logged so that is visible in sync output.
+    if max_age_seconds is None:
+        logger.info("Age-based group request expiration is disabled.")
+    else:
+        older_than_max = (
+            await db.session.scalars(
+                select(GroupRequest)
+                .where(GroupRequest.status == AccessRequestStatus.PENDING)
+                .where(GroupRequest.resolved_at.is_(None))
+                .where(GroupRequest.created_at < datetime.now(timezone.utc) - timedelta(seconds=max_age_seconds))
+            )
+        ).all()
+        await _expire_each(older_than_max, reject, "group request")
 
     logger.info("Group request expiration finished.")
 

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -529,7 +529,7 @@ EXPIRED_REQUEST_REASON = "Closed because the request expired"
 
 async def _expire_each(
     requests: Sequence[Any],
-    reject: Callable[[Any], Awaitable[Any]],
+    reject: Callable[[str], Awaitable[Any]],
     label: str,
 ) -> None:
     """Reject each request, isolating failures so one bad row can't abort the sweep.
@@ -546,7 +546,7 @@ async def _expire_each(
     `reject` is therefore called with the id, matching the `Model | str`
     constructor every reject operation already supports.
     """
-    request_ids = [request.id for request in requests]
+    request_ids: list[str] = [request.id for request in requests]
     for request_id in request_ids:
         try:
             await reject(request_id)
@@ -637,17 +637,30 @@ async def expire_role_requests() -> None:
 async def expire_group_requests() -> None:
     """Close pending group requests that aged out.
 
-    Age cutoff only, deliberately. Unlike an access or role request, a group
-    request past its requested_ownership_ending_at is not moot: its primary
-    payload is "create this group", and the resolver can edit
-    resolved_ownership_ending_at before approving, so no dead-on-arrival grant
-    can result. See test_no_expire_group_request_with_lapsed_ownership_window.
+    Age cutoff only, deliberately, and this is a policy call rather than a
+    claim that nothing can go wrong: a group request's payload is the group
+    itself, and destroying that ask over a stale secondary field (the requested
+    ownership window) loses more than it protects. Access and role requests get
+    a second, lapsed-window sweep because for them the window IS the ask.
+
+    Be aware of what that leaves open: ApproveGroupRequest falls back to
+    requested_ownership_ending_at when the approver supplies no resolved value,
+    and coalesce_ended_at passes a past timestamp straight through, so
+    approving a long-stale request can still write an already-expired ownership
+    row and leave the new group unowned. Repairing that belongs in the approve
+    path, not here. See test_no_expire_group_request_with_lapsed_ownership_window.
 
     Uses its own cutoff because a group request's approver may need to negotiate
     a name and pick tags rather than just answer yes/no.
     """
     logger.info("Group request expiration started.")
     max_age_seconds = settings.max_group_request_age_seconds
+
+    def reject(request_id: str) -> Awaitable[GroupRequest]:
+        return RejectGroupRequest(
+            group_request=request_id,
+            rejection_reason=EXPIRED_REQUEST_REASON,
+        ).execute()
 
     older_than_max = (
         await db.session.scalars(
@@ -657,14 +670,7 @@ async def expire_group_requests() -> None:
             .where(GroupRequest.created_at < datetime.now(timezone.utc) - timedelta(seconds=max_age_seconds))
         )
     ).all()
-    await _expire_each(
-        older_than_max,
-        lambda request_id: RejectGroupRequest(
-            group_request=request_id,
-            rejection_reason=EXPIRED_REQUEST_REASON,
-        ).execute(),
-        "group request",
-    )
+    await _expire_each(older_than_max, reject, "group request")
 
     logger.info("Group request expiration finished.")
 

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -22,6 +22,7 @@ from api.models import (
     AccessRequestStatus,
     App,
     AppGroup,
+    GroupRequest,
     OktaGroup,
     OktaUser,
     OktaUserGroupMember,
@@ -36,6 +37,7 @@ from api.operations import (
     DeleteUser,
     ModifyGroupUsers,
     RejectAccessRequest,
+    RejectGroupRequest,
     RejectRoleRequest,
     UnmanageGroup,
 )
@@ -630,6 +632,41 @@ async def expire_role_requests() -> None:
     await _expire_each(older_than_request, reject, "role request")
 
     logger.info("Role request expiration finished.")
+
+
+async def expire_group_requests() -> None:
+    """Close pending group requests that aged out.
+
+    Age cutoff only, deliberately. Unlike an access or role request, a group
+    request past its requested_ownership_ending_at is not moot: its primary
+    payload is "create this group", and the resolver can edit
+    resolved_ownership_ending_at before approving, so no dead-on-arrival grant
+    can result. See test_no_expire_group_request_with_lapsed_ownership_window.
+
+    Uses its own cutoff because a group request's approver may need to negotiate
+    a name and pick tags rather than just answer yes/no.
+    """
+    logger.info("Group request expiration started.")
+    max_age_seconds = settings.max_group_request_age_seconds
+
+    older_than_max = (
+        await db.session.scalars(
+            select(GroupRequest)
+            .where(GroupRequest.status == AccessRequestStatus.PENDING)
+            .where(GroupRequest.resolved_at.is_(None))
+            .where(GroupRequest.created_at < datetime.now(timezone.utc) - timedelta(seconds=max_age_seconds))
+        )
+    ).all()
+    await _expire_each(
+        older_than_max,
+        lambda request_id: RejectGroupRequest(
+            group_request=request_id,
+            rejection_reason=EXPIRED_REQUEST_REASON,
+        ).execute(),
+        "group request",
+    )
+
+    logger.info("Group request expiration finished.")
 
 
 async def expiring_access_notifications_user() -> None:

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -651,9 +651,8 @@ async def expire_group_requests() -> None:
     What that leaves to the approve path: ApproveGroupRequest falls back to
     requested_ownership_ending_at when the approver supplies no resolved value,
     so approving a long-stale request could write an already-expired ownership
-    row and leave the new group unowned. PR #599 proposes refusing such an
-    approval outright; until it lands the gap is open. Either way, repairing it
-    belongs in the approve path and not in this sweep.
+    row and leave the new group unowned. Repairing that belongs in the approve
+    path and not in this sweep.
     See test_no_expire_group_request_with_lapsed_ownership_window.
 
     Uses its own cutoff because a group request's approver may need to negotiate

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -643,12 +643,12 @@ async def expire_group_requests() -> None:
     ownership window) loses more than it protects. Access and role requests get
     a second, lapsed-window sweep because for them the window IS the ask.
 
-    Be aware of what that leaves open: ApproveGroupRequest falls back to
+    What that leaves to the approve path: ApproveGroupRequest falls back to
     requested_ownership_ending_at when the approver supplies no resolved value,
-    and coalesce_ended_at passes a past timestamp straight through, so
-    approving a long-stale request can still write an already-expired ownership
-    row and leave the new group unowned. Repairing that belongs in the approve
-    path, not here. See test_no_expire_group_request_with_lapsed_ownership_window.
+    so approving a long-stale request could write an already-expired ownership
+    row and leave the new group unowned. That is repaired there rather than here
+    (it refuses the approval outright); this sweep deliberately stays out of it.
+    See test_no_expire_group_request_with_lapsed_ownership_window.
 
     Uses its own cutoff because a group request's approver may need to negotiate
     a name and pick tags rather than just answer yes/no.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,3 +32,19 @@ def test_trusted_hosts() -> None:
         "a.example.com",
         "*.example.com",
     ]
+
+
+def test_max_group_request_age_seconds() -> None:
+    # Unset falls back to the access-request cutoff, so operators who never set
+    # it get the behavior they already had.
+    assert Settings(MAX_ACCESS_REQUEST_AGE_SECONDS=1234).max_group_request_age_seconds == 1234
+    # An explicit value wins.
+    assert (
+        Settings(MAX_ACCESS_REQUEST_AGE_SECONDS=1234, MAX_GROUP_REQUEST_AGE_SECONDS=9999).max_group_request_age_seconds
+        == 9999
+    )
+    # 0 means "expire immediately" and must not be swallowed into the fallback.
+    assert (
+        Settings(MAX_ACCESS_REQUEST_AGE_SECONDS=1234, MAX_GROUP_REQUEST_AGE_SECONDS=0).max_group_request_age_seconds
+        == 0
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,6 @@
+import pytest
+from pydantic import ValidationError
+
 from api.config import Settings
 
 
@@ -34,17 +37,48 @@ def test_trusted_hosts() -> None:
     ]
 
 
-def test_max_group_request_age_seconds() -> None:
-    # Unset falls back to the access-request cutoff, so operators who never set
-    # it get the behavior they already had.
-    assert Settings(MAX_ACCESS_REQUEST_AGE_SECONDS=1234).max_group_request_age_seconds == 1234
-    # An explicit value wins.
-    assert (
-        Settings(MAX_ACCESS_REQUEST_AGE_SECONDS=1234, MAX_GROUP_REQUEST_AGE_SECONDS=9999).max_group_request_age_seconds
-        == 9999
-    )
-    # 0 means "expire immediately" and must not be swallowed into the fallback.
-    assert (
-        Settings(MAX_ACCESS_REQUEST_AGE_SECONDS=1234, MAX_GROUP_REQUEST_AGE_SECONDS=0).max_group_request_age_seconds
-        == 0
-    )
+def test_request_age_defaults_are_one_week_and_independent() -> None:
+    one_week = 7 * 24 * 60 * 60
+    assert Settings().max_access_request_age_seconds == one_week
+    assert Settings().max_group_request_age_seconds == one_week
+    # Independent: setting one does not move the other.
+    s = Settings(MAX_ACCESS_REQUEST_AGE_SECONDS=1234)
+    assert s.max_access_request_age_seconds == 1234
+    assert s.max_group_request_age_seconds == one_week
+    s = Settings(MAX_GROUP_REQUEST_AGE_SECONDS=9999)
+    assert s.max_access_request_age_seconds == one_week
+    assert s.max_group_request_age_seconds == 9999
+
+
+def test_never_disables_each_age_cutoff_independently() -> None:
+    one_week = 7 * 24 * 60 * 60
+    s = Settings(MAX_ACCESS_REQUEST_AGE_SECONDS="never")
+    assert s.max_access_request_age_seconds is None
+    assert s.max_group_request_age_seconds == one_week
+
+    s = Settings(MAX_GROUP_REQUEST_AGE_SECONDS="never")
+    assert s.max_access_request_age_seconds == one_week
+    assert s.max_group_request_age_seconds is None
+
+    s = Settings(MAX_ACCESS_REQUEST_AGE_SECONDS="never", MAX_GROUP_REQUEST_AGE_SECONDS="never")
+    assert s.max_access_request_age_seconds is None
+    assert s.max_group_request_age_seconds is None
+
+
+@pytest.mark.parametrize("bad", ["NEVER", "Never", "nope", "", "none", "null"])
+def test_non_numeric_values_other_than_never_are_rejected(bad: str) -> None:
+    """A typo must fail at startup rather than silently disabling or defaulting."""
+    with pytest.raises(ValidationError):
+        Settings(MAX_ACCESS_REQUEST_AGE_SECONDS=bad)
+    with pytest.raises(ValidationError):
+        Settings(MAX_GROUP_REQUEST_AGE_SECONDS=bad)
+
+
+@pytest.mark.parametrize("bad", [0, -1, -604800])
+def test_ints_below_one_are_rejected_and_the_error_names_never(bad: int) -> None:
+    """`-1` is the likely Unix-habit guess for "disable"; expiring everything
+    because of it would be a bad silent failure."""
+    for field in ("MAX_ACCESS_REQUEST_AGE_SECONDS", "MAX_GROUP_REQUEST_AGE_SECONDS"):
+        with pytest.raises(ValidationError) as exc:
+            Settings(**{field: bad})
+        assert "never" in str(exc.value)

--- a/tests/test_expire_access_request.py
+++ b/tests/test_expire_access_request.py
@@ -4,7 +4,6 @@ from pytest_mock import MockerFixture
 
 from api.models import AccessRequest, AccessRequestStatus, OktaGroup, OktaUser
 from api.extensions import Db
-from api.operations import RejectAccessRequest
 from api.syncer import expire_access_requests
 from tests.factories import AccessRequestFactory
 
@@ -61,10 +60,16 @@ async def test_expire_access_requests_isolates_failures(
     user: OktaUser,
     mocker: MockerFixture,
 ) -> None:
-    """One request that fails to reject must not abort the rest of the sweep.
+    """One request that fails mid-write must not abort or corrupt the rest of the sweep.
 
-    Without per-request isolation a single poisoned row aborts expiration for
-    every other row, and does so again on every subsequent sync run.
+    The failure is injected at the operation's own `commit`, i.e. *after* it has
+    assigned status/resolved_at/resolver_user_id/resolution_reason to the
+    session. That is the state the rollback in `_expire_each` exists for, and
+    the only state that distinguishes it from a no-op: without the rollback the
+    dirty REJECTED row stays pending in the session and the next iteration's
+    `SELECT ... FOR UPDATE` autoflushes it, silently rejecting the very request
+    the sweep logged as skipped. Injecting before any SQL is emitted would leave
+    the session clean and pass with or without the rollback.
     """
     db.session.add(user)
     db.session.add(okta_group)
@@ -81,26 +86,29 @@ async def test_expire_access_requests_isolates_failures(
         ids.append(req.id)
     await db.session.commit()
 
-    # Fail the first reject only; the other two must still be expired.
-    real_execute = RejectAccessRequest.execute
+    # Fail the first commit the sweep attempts; let every later one through.
+    real_commit = db.session.commit
     calls = {"n": 0}
 
-    async def flaky(self: RejectAccessRequest) -> AccessRequest:
+    async def flaky_commit() -> None:
         calls["n"] += 1
         if calls["n"] == 1:
-            raise RuntimeError("boom")
-        return await real_execute(self)
+            raise RuntimeError("commit blew up mid-write")
+        await real_commit()
 
-    mocker.patch.object(RejectAccessRequest, "execute", flaky)
+    mocker.patch.object(db.session, "commit", flaky_commit)
 
     await expire_access_requests()
 
+    mocker.stopall()
     db.session.expire_all()
     statuses = []
     for request_id in ids:
         row = await db.session.get(AccessRequest, request_id)
         statuses.append(row.status)
 
+    # Two expired; the one whose commit failed is still PENDING rather than
+    # having been written by a later iteration's autoflush.
     assert statuses.count(AccessRequestStatus.REJECTED) == 2
     assert statuses.count(AccessRequestStatus.PENDING) == 1
 

--- a/tests/test_expire_access_request.py
+++ b/tests/test_expire_access_request.py
@@ -1,7 +1,9 @@
 from datetime import datetime, timedelta, timezone
 
+import pytest
 from pytest_mock import MockerFixture
 
+from api.config import settings
 from api.models import AccessRequest, AccessRequestStatus, OktaGroup, OktaUser
 from api.extensions import Db
 from api.syncer import expire_access_requests
@@ -137,3 +139,45 @@ async def test_expire_old_temporary_access_request(
     access_request = await db.session.get(AccessRequest, access_request_id)
     assert access_request.status == AccessRequestStatus.REJECTED
     assert access_request.resolved_at is not None
+
+
+async def test_never_disables_the_age_cutoff_but_not_the_requested_window(
+    db: Db,
+    okta_group: OktaGroup,
+    user: OktaUser,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`never` switches off the age sweep only.
+
+    A request that merely sat too long survives; a request whose own
+    `request_ending_at` has passed is still closed, because that sweep is a
+    separate pass and is deliberately not disableable.
+    """
+    monkeypatch.setattr(settings, "MAX_ACCESS_REQUEST_AGE_SECONDS", "never")
+    db.session.add(user)
+    db.session.add(okta_group)
+    await db.session.commit()
+
+    stale = datetime.now(timezone.utc) - timedelta(days=30)
+
+    old_only = AccessRequestFactory.build()
+    old_only.created_at = stale
+    old_only.requested_group_id = okta_group.id
+    old_only.requester_user_id = user.id
+
+    lapsed_window = AccessRequestFactory.build()
+    lapsed_window.created_at = stale
+    lapsed_window.request_ending_at = datetime.now(timezone.utc) - timedelta(hours=12)
+    lapsed_window.requested_group_id = okta_group.id
+    lapsed_window.requester_user_id = user.id
+
+    db.session.add(old_only)
+    db.session.add(lapsed_window)
+    await db.session.commit()
+    old_only_id, lapsed_id = old_only.id, lapsed_window.id
+
+    await expire_access_requests()
+
+    db.session.expire_all()
+    assert (await db.session.get(AccessRequest, old_only_id)).status == AccessRequestStatus.PENDING
+    assert (await db.session.get(AccessRequest, lapsed_id)).status == AccessRequestStatus.REJECTED

--- a/tests/test_expire_access_request.py
+++ b/tests/test_expire_access_request.py
@@ -1,9 +1,12 @@
 from datetime import datetime, timedelta, timezone
 
+from pytest_mock import MockerFixture
 
 from api.models import AccessRequest, AccessRequestStatus, OktaGroup, OktaUser
 from api.extensions import Db
+from api.operations import RejectAccessRequest
 from api.syncer import expire_access_requests
+from tests.factories import AccessRequestFactory
 
 
 async def test_no_expire_new_access_request(
@@ -49,6 +52,57 @@ async def test_expire_old_access_request(
     access_request = await db.session.get(AccessRequest, access_request_id)
     assert access_request.status == AccessRequestStatus.REJECTED
     assert access_request.resolved_at is not None
+
+
+async def test_expire_access_requests_isolates_failures(
+    db: Db,
+    access_request: AccessRequest,
+    okta_group: OktaGroup,
+    user: OktaUser,
+    mocker: MockerFixture,
+) -> None:
+    """One request that fails to reject must not abort the rest of the sweep.
+
+    Without per-request isolation a single poisoned row aborts expiration for
+    every other row, and does so again on every subsequent sync run.
+    """
+    db.session.add(user)
+    db.session.add(okta_group)
+    await db.session.commit()
+
+    stale = datetime.now(timezone.utc) - timedelta(days=30)
+    ids = []
+    for _ in range(3):
+        req = AccessRequestFactory.build()
+        req.created_at = stale
+        req.requested_group_id = okta_group.id
+        req.requester_user_id = user.id
+        db.session.add(req)
+        ids.append(req.id)
+    await db.session.commit()
+
+    # Fail the first reject only; the other two must still be expired.
+    real_execute = RejectAccessRequest.execute
+    calls = {"n": 0}
+
+    async def flaky(self: RejectAccessRequest) -> AccessRequest:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("boom")
+        return await real_execute(self)
+
+    mocker.patch.object(RejectAccessRequest, "execute", flaky)
+
+    await expire_access_requests()
+
+    db.session.expire_all()
+    statuses = []
+    for request_id in ids:
+        row = await db.session.get(AccessRequest, request_id)
+        statuses.append(row.status)
+
+    assert statuses.count(AccessRequestStatus.REJECTED) == 2
+    assert statuses.count(AccessRequestStatus.PENDING) == 1
 
 
 async def test_expire_old_temporary_access_request(

--- a/tests/test_expire_group_request.py
+++ b/tests/test_expire_group_request.py
@@ -56,10 +56,8 @@ async def test_no_expire_group_request_with_lapsed_ownership_window(
     What this leaves to the approve path: ApproveGroupRequest falls back to
     requested_ownership_ending_at when the approver supplies no resolved value,
     so approving a long-stale request could write an already-expired ownership
-    row and leave the new group unowned. PR #599 proposes refusing such an
-    approval outright; until it lands the gap is open. Either way, repairing it
-    belongs in the approve path and not in this sweep; it was never a reason to
-    expire the request here.
+    row and leave the new group unowned. Repairing that belongs in the approve
+    path and not in this sweep; it is not a reason to expire the request here.
     """
     group_request.created_at = datetime.now(timezone.utc) - timedelta(days=1)
     group_request.requested_ownership_ending_at = datetime.now(timezone.utc) - timedelta(hours=12)

--- a/tests/test_expire_group_request.py
+++ b/tests/test_expire_group_request.py
@@ -1,0 +1,81 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from api.config import settings
+from api.extensions import Db
+from api.models import AccessRequestStatus, GroupRequest, OktaUser
+from api.syncer import expire_group_requests
+
+
+async def _persist(db: Db, group_request: GroupRequest, user: OktaUser) -> str:
+    db.session.add(user)
+    await db.session.commit()
+    group_request.requester_user_id = user.id
+    db.session.add(group_request)
+    await db.session.commit()
+    return group_request.id
+
+
+async def test_no_expire_new_group_request(db: Db, group_request: GroupRequest, user: OktaUser) -> None:
+    group_request_id = await _persist(db, group_request, user)
+
+    await expire_group_requests()
+
+    row = await db.session.get(GroupRequest, group_request_id)
+    assert row.status == AccessRequestStatus.PENDING
+    assert row.resolved_at is None
+
+
+async def test_expire_old_group_request(db: Db, group_request: GroupRequest, user: OktaUser) -> None:
+    group_request.created_at = datetime.now(timezone.utc) - timedelta(days=30)
+    group_request_id = await _persist(db, group_request, user)
+
+    await expire_group_requests()
+
+    # The reject operation expired this row's attributes; expire_all so the
+    # awaited get() refreshes it instead of lazy-loading on attribute access.
+    db.session.expire_all()
+    row = await db.session.get(GroupRequest, group_request_id)
+    assert row.status == AccessRequestStatus.REJECTED
+    assert row.resolved_at is not None
+    assert row.resolver_user_id is None
+
+
+async def test_no_expire_group_request_with_lapsed_ownership_window(
+    db: Db, group_request: GroupRequest, user: OktaUser
+) -> None:
+    """A lapsed requested_ownership_ending_at must NOT expire the request.
+
+    Deliberate asymmetry with access and role requests. A group request's
+    primary payload is "create this group"; the ownership window is secondary
+    and the resolver can edit resolved_ownership_ending_at before approving, so
+    a human fix exists and there is no dead-on-arrival grant to prevent. Do not
+    "fix" this by adding a second sweep path.
+    """
+    group_request.created_at = datetime.now(timezone.utc) - timedelta(days=1)
+    group_request.requested_ownership_ending_at = datetime.now(timezone.utc) - timedelta(hours=12)
+    group_request_id = await _persist(db, group_request, user)
+
+    await expire_group_requests()
+
+    row = await db.session.get(GroupRequest, group_request_id)
+    assert row.status == AccessRequestStatus.PENDING
+    assert row.resolved_at is None
+
+
+async def test_group_request_uses_its_own_cutoff(
+    db: Db, group_request: GroupRequest, user: OktaUser, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """MAX_GROUP_REQUEST_AGE_SECONDS governs group requests independently."""
+    monkeypatch.setattr(settings, "MAX_ACCESS_REQUEST_AGE_SECONDS", 7 * 24 * 60 * 60)
+    monkeypatch.setattr(settings, "MAX_GROUP_REQUEST_AGE_SECONDS", 30 * 24 * 60 * 60)
+
+    # 10 days old: past the access cutoff, inside the longer group cutoff.
+    group_request.created_at = datetime.now(timezone.utc) - timedelta(days=10)
+    group_request_id = await _persist(db, group_request, user)
+
+    await expire_group_requests()
+
+    row = await db.session.get(GroupRequest, group_request_id)
+    assert row.status == AccessRequestStatus.PENDING

--- a/tests/test_expire_group_request.py
+++ b/tests/test_expire_group_request.py
@@ -85,3 +85,32 @@ async def test_group_request_uses_its_own_cutoff(
 
     row = await db.session.get(GroupRequest, group_request_id)
     assert row.status == AccessRequestStatus.PENDING
+
+
+async def test_never_disables_group_age_expiry(
+    db: Db, group_request: GroupRequest, user: OktaUser, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "MAX_GROUP_REQUEST_AGE_SECONDS", "never")
+    group_request.created_at = datetime.now(timezone.utc) - timedelta(days=30)
+    group_request_id = await _persist(db, group_request, user)
+
+    await expire_group_requests()
+
+    row = await db.session.get(GroupRequest, group_request_id)
+    assert row.status == AccessRequestStatus.PENDING
+    assert row.resolved_at is None
+
+
+async def test_group_expiry_is_independent_of_the_access_cutoff(
+    db: Db, group_request: GroupRequest, user: OktaUser, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Disabling the access cutoff must not disable the group one."""
+    monkeypatch.setattr(settings, "MAX_ACCESS_REQUEST_AGE_SECONDS", "never")
+    group_request.created_at = datetime.now(timezone.utc) - timedelta(days=30)
+    group_request_id = await _persist(db, group_request, user)
+
+    await expire_group_requests()
+
+    db.session.expire_all()
+    row = await db.session.get(GroupRequest, group_request_id)
+    assert row.status == AccessRequestStatus.REJECTED

--- a/tests/test_expire_group_request.py
+++ b/tests/test_expire_group_request.py
@@ -47,11 +47,18 @@ async def test_no_expire_group_request_with_lapsed_ownership_window(
 ) -> None:
     """A lapsed requested_ownership_ending_at must NOT expire the request.
 
-    Deliberate asymmetry with access and role requests. A group request's
-    primary payload is "create this group"; the ownership window is secondary
-    and the resolver can edit resolved_ownership_ending_at before approving, so
-    a human fix exists and there is no dead-on-arrival grant to prevent. Do not
-    "fix" this by adding a second sweep path.
+    Deliberate asymmetry with access and role requests, and a policy call
+    rather than a claim that nothing can go wrong. A group request's payload is
+    the group itself; throwing the whole ask away over a stale secondary field
+    loses more than it protects. For an access or role request the window IS
+    the ask, which is why those get a second sweep.
+
+    What this leaves open, so nobody mistakes it for safe: ApproveGroupRequest
+    falls back to requested_ownership_ending_at when the approver supplies no
+    resolved value, and coalesce_ended_at passes a past timestamp through
+    unchanged, so approving a long-stale request can still write an
+    already-expired ownership row and leave the new group unowned. That is worth
+    fixing in the approve path; it is not a reason to expire the request here.
     """
     group_request.created_at = datetime.now(timezone.utc) - timedelta(days=1)
     group_request.requested_ownership_ending_at = datetime.now(timezone.utc) - timedelta(hours=12)

--- a/tests/test_expire_group_request.py
+++ b/tests/test_expire_group_request.py
@@ -56,8 +56,10 @@ async def test_no_expire_group_request_with_lapsed_ownership_window(
     What this leaves to the approve path: ApproveGroupRequest falls back to
     requested_ownership_ending_at when the approver supplies no resolved value,
     so approving a long-stale request could write an already-expired ownership
-    row and leave the new group unowned. That is handled there (the approval is
-    refused outright); it was never a reason to expire the request here.
+    row and leave the new group unowned. PR #599 proposes refusing such an
+    approval outright; until it lands the gap is open. Either way, repairing it
+    belongs in the approve path and not in this sweep; it was never a reason to
+    expire the request here.
     """
     group_request.created_at = datetime.now(timezone.utc) - timedelta(days=1)
     group_request.requested_ownership_ending_at = datetime.now(timezone.utc) - timedelta(hours=12)

--- a/tests/test_expire_group_request.py
+++ b/tests/test_expire_group_request.py
@@ -53,12 +53,11 @@ async def test_no_expire_group_request_with_lapsed_ownership_window(
     loses more than it protects. For an access or role request the window IS
     the ask, which is why those get a second sweep.
 
-    What this leaves open, so nobody mistakes it for safe: ApproveGroupRequest
-    falls back to requested_ownership_ending_at when the approver supplies no
-    resolved value, and coalesce_ended_at passes a past timestamp through
-    unchanged, so approving a long-stale request can still write an
-    already-expired ownership row and leave the new group unowned. That is worth
-    fixing in the approve path; it is not a reason to expire the request here.
+    What this leaves to the approve path: ApproveGroupRequest falls back to
+    requested_ownership_ending_at when the approver supplies no resolved value,
+    so approving a long-stale request could write an already-expired ownership
+    row and leave the new group unowned. That is handled there (the approval is
+    refused outright); it was never a reason to expire the request here.
     """
     group_request.created_at = datetime.now(timezone.utc) - timedelta(days=1)
     group_request.requested_ownership_ending_at = datetime.now(timezone.utc) - timedelta(hours=12)

--- a/tests/test_expire_role_request.py
+++ b/tests/test_expire_role_request.py
@@ -1,0 +1,67 @@
+from datetime import datetime, timedelta, timezone
+
+from api.extensions import Db
+from api.models import AccessRequestStatus, OktaGroup, OktaUser, RoleGroup, RoleRequest
+from api.syncer import expire_role_requests
+
+
+async def _persist(
+    db: Db, role_request: RoleRequest, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser
+) -> str:
+    """Persist a role request wired to a role, a target group, and a requester."""
+    db.session.add(user)
+    db.session.add(role_group)
+    db.session.add(okta_group)
+    await db.session.commit()
+    role_request.requester_user_id = user.id
+    role_request.requester_role_id = role_group.id
+    role_request.requested_group_id = okta_group.id
+    db.session.add(role_request)
+    await db.session.commit()
+    return role_request.id
+
+
+async def test_no_expire_new_role_request(
+    db: Db, role_request: RoleRequest, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser
+) -> None:
+    role_request_id = await _persist(db, role_request, role_group, okta_group, user)
+
+    await expire_role_requests()
+
+    row = await db.session.get(RoleRequest, role_request_id)
+    assert row.status == AccessRequestStatus.PENDING
+    assert row.resolved_at is None
+
+
+async def test_expire_old_role_request(
+    db: Db, role_request: RoleRequest, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser
+) -> None:
+    role_request.created_at = datetime.now(timezone.utc) - timedelta(days=30)
+    role_request_id = await _persist(db, role_request, role_group, okta_group, user)
+
+    await expire_role_requests()
+
+    # The reject operation expired this row's attributes; expire_all so the
+    # awaited get() refreshes it instead of lazy-loading on attribute access.
+    db.session.expire_all()
+    row = await db.session.get(RoleRequest, role_request_id)
+    assert row.status == AccessRequestStatus.REJECTED
+    assert row.resolved_at is not None
+    assert row.resolver_user_id is None
+
+
+async def test_expire_role_request_with_lapsed_window(
+    db: Db, role_request: RoleRequest, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser
+) -> None:
+    """A role request past its request_ending_at is moot: approving it would
+    mint an already-expired RoleGroupMap."""
+    role_request.created_at = datetime.now(timezone.utc) - timedelta(days=1)
+    role_request.request_ending_at = datetime.now(timezone.utc) - timedelta(hours=12)
+    role_request_id = await _persist(db, role_request, role_group, okta_group, user)
+
+    await expire_role_requests()
+
+    db.session.expire_all()
+    row = await db.session.get(RoleRequest, role_request_id)
+    assert row.status == AccessRequestStatus.REJECTED
+    assert row.resolved_at is not None

--- a/tests/test_expire_role_request.py
+++ b/tests/test_expire_role_request.py
@@ -1,5 +1,8 @@
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
+from api.config import settings
 from api.extensions import Db
 from api.models import AccessRequestStatus, OktaGroup, OktaUser, RoleGroup, RoleRequest
 from api.syncer import expire_role_requests
@@ -65,3 +68,24 @@ async def test_expire_role_request_with_lapsed_window(
     row = await db.session.get(RoleRequest, role_request_id)
     assert row.status == AccessRequestStatus.REJECTED
     assert row.resolved_at is not None
+
+
+async def test_never_on_the_access_cutoff_also_disables_role_age_expiry(
+    db: Db,
+    role_request: RoleRequest,
+    role_group: RoleGroup,
+    okta_group: OktaGroup,
+    user: OktaUser,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Role requests share MAX_ACCESS_REQUEST_AGE_SECONDS, so disabling it
+    disables theirs too. Pins the shared-fuse decision."""
+    monkeypatch.setattr(settings, "MAX_ACCESS_REQUEST_AGE_SECONDS", "never")
+    role_request.created_at = datetime.now(timezone.utc) - timedelta(days=30)
+    role_request_id = await _persist(db, role_request, role_group, okta_group, user)
+
+    await expire_role_requests()
+
+    row = await db.session.get(RoleRequest, role_request_id)
+    assert row.status == AccessRequestStatus.PENDING
+    assert row.resolved_at is None

--- a/tests/test_expire_role_request.py
+++ b/tests/test_expire_role_request.py
@@ -6,6 +6,7 @@ from api.config import settings
 from api.extensions import Db
 from api.models import AccessRequestStatus, OktaGroup, OktaUser, RoleGroup, RoleRequest
 from api.syncer import expire_role_requests
+from tests.factories import RoleRequestFactory
 
 
 async def _persist(
@@ -79,13 +80,36 @@ async def test_never_on_the_access_cutoff_also_disables_role_age_expiry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Role requests share MAX_ACCESS_REQUEST_AGE_SECONDS, so disabling it
-    disables theirs too. Pins the shared-fuse decision."""
+    disables theirs too. Pins the shared-fuse decision.
+
+    Mirrors test_never_disables_the_age_cutoff_but_not_the_requested_window in
+    tests/test_expire_access_request.py: `never` disables only the age-based
+    half. A role request whose own request_ending_at has lapsed is still
+    closed by the separate, non-disableable requested-window pass.
+    """
     monkeypatch.setattr(settings, "MAX_ACCESS_REQUEST_AGE_SECONDS", "never")
-    role_request.created_at = datetime.now(timezone.utc) - timedelta(days=30)
+    stale = datetime.now(timezone.utc) - timedelta(days=30)
+
+    role_request.created_at = stale
     role_request_id = await _persist(db, role_request, role_group, okta_group, user)
+
+    lapsed_window = RoleRequestFactory.build()
+    lapsed_window.created_at = stale
+    lapsed_window.request_ending_at = datetime.now(timezone.utc) - timedelta(hours=12)
+    lapsed_window.requester_user_id = user.id
+    lapsed_window.requester_role_id = role_group.id
+    lapsed_window.requested_group_id = okta_group.id
+    db.session.add(lapsed_window)
+    await db.session.commit()
+    lapsed_id = lapsed_window.id
 
     await expire_role_requests()
 
-    row = await db.session.get(RoleRequest, role_request_id)
-    assert row.status == AccessRequestStatus.PENDING
-    assert row.resolved_at is None
+    db.session.expire_all()
+    old_only_row = await db.session.get(RoleRequest, role_request_id)
+    assert old_only_row.status == AccessRequestStatus.PENDING
+    assert old_only_row.resolved_at is None
+
+    lapsed_row = await db.session.get(RoleRequest, lapsed_id)
+    assert lapsed_row.status == AccessRequestStatus.REJECTED
+    assert lapsed_row.resolved_at is not None


### PR DESCRIPTION
# Summary

Role requests and group requests never expired; only access requests did. This adds sweeps for both to the `access sync` cronjob, fixes a latent bug where one failing request aborted the whole pass, and lets an operator switch age-based expiration off by setting a cutoff to `never`.

**Urgency**: 5 days
**Expected review effort**: MEDIUM

# Motivation

`expire_access_requests()` has closed stale `AccessRequest` rows at the tail of the sync cronjob for a while. `RoleRequest` and `GroupRequest` had no equivalent, so a pending one stayed pending forever: it accumulated in reviewers' queues, and a role request past its `request_ending_at` remained approvable into a `RoleGroupMap` that was already expired on arrival.

Separately, the existing sweep had no error isolation. One request that failed to reject aborted expiration for every remaining request, and would fail the same way on every subsequent run, so a single poisoned row could stop expiration indefinitely.

Review feedback then asked for a way to disable expiration, which the last two commits add.

<details>
<summary><h1>Description of Changes</h1></summary>

**Three focused sweeps rather than one grown function.** `expire_access_requests` keeps its name and behavior (`api/cli.py` and the existing test import it); `expire_role_requests` and `expire_group_requests` join it in the `sync` command.

| Sweep | Age cutoff | Requested-window pass |
|---|---|---|
| `expire_access_requests` | `MAX_ACCESS_REQUEST_AGE_SECONDS` | `request_ending_at < now()` |
| `expire_role_requests` | `MAX_ACCESS_REQUEST_AGE_SECONDS` | `request_ending_at < now()` |
| `expire_group_requests` | `MAX_GROUP_REQUEST_AGE_SECONDS` | none, deliberately |

**Group requests expire on the age cutoff only.** Every requested-window pass exists to stop an approval producing a dead-on-arrival grant. A role request past `request_ending_at` has that failure mode; a group request's payload is the group itself, and throwing that ask away over a stale secondary field loses more than it protects. A negative test pins this so the apparent omission does not get "fixed" later. Note that this leaves a real gap on the approve path, which #599 addresses separately; the comments here say so rather than claiming it is handled.

**Configuration.** Both `MAX_ACCESS_REQUEST_AGE_SECONDS` and the new `MAX_GROUP_REQUEST_AGE_SECONDS` are `Union[int, Literal["never"]]` with an explicit one-week default. They are **independent**; neither inherits the other, so changing one never silently moves the other. Setting either to `never` switches off its age-based sweep.

`never` rather than `None` because `Settings` reads only env vars and `.env`, where every value is a string: an omitted variable is indistinguishable from one set to nothing, and `""`, `"None"`, and `"null"` all fail int validation, so `None` is unreachable for a setting that must keep a default. A string sentinel also explains itself in a config file, where `0` would need a lookup and the natural wrong guess ("expire immediately") is the opposite of the truth.

A `field_validator` rejects ints below 1 and names `never` in the message, because `-1` is the likely Unix-habit guess for disabling and would otherwise close every pending request on the next sync. `Field(ge=...)` cannot do this: on a `Union[int, Literal["never"]]` the bound applies to the union and rejects the sentinel itself.

**Error isolation.** A shared `_expire_each` helper rejects each request in its own `try`/`except`, logging with `logger.exception` and rolling back before continuing. `RejectRoleRequest` raises `ConflictError` when a reviewer resolves a request mid-sync, which is a live race this now survives. One subtlety worth your attention: `_expire_each` reads every request id **up front**, before any rollback, and calls the reject operation with the id rather than the ORM instance, because `db.session.rollback()` expires the entire identity map and touching an attribute on a not-yet-processed instance afterward raises `MissingGreenlet`.

**No new `EventType`.** The existing `role_request_reject` / `group_request_reject` events are reused with a null actor, so operators' downstream SIEM schemas need no change.

**One intentional break:** the module-level `MAX_ACCESS_REQUEST_AGE_SECONDS` re-export in `api/config.py` is removed. Nothing in-repo read it, and the raw field is now `int | "never"` rather than a duration, so a snapshot of it would be actively misleading. An operator whose private tooling imported that name should read `settings.max_access_request_age_seconds` instead, which resolves the sentinel and returns `Optional[int]`.
</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

- `make test` green: ruff, ty, 892 backend pytest, 37 frontend vitest.
- `tests/test_expire_role_request.py`: fresh request is a no-op; aged past the cutoff expires; past `request_ending_at` expires; `never` disables the age half while the window half still closes a lapsed request.
- `tests/test_expire_group_request.py`: fresh no-op; aged expires; **lapsed `requested_ownership_ending_at` stays PENDING** (pins the asymmetry); the group cutoff is consulted rather than the access one; `never` disables it; and disabling the *access* cutoff does not disable the group one.
- `tests/test_expire_access_request.py` gains an isolation test that injects a failure at the reject operation's own `commit`, after it has dirtied the session, and asserts the failed request is still `PENDING` — verified to fail with the rollback removed.
- `tests/test_config.py`: both defaults; independence in both directions; `never` on each; mis-cased and non-numeric values rejected; ints below 1 rejected with `never` named.
- Every claim added to the README was fact-checked against `api/config.py` and `api/syncer.py`.
- No migration, no Pydantic request/response schema change, no generated-client edit.
</details>

# Guidance for Reviewers

**Read file-by-file rather than commit-by-commit.** The branch changed its own mind partway: the config semantics introduced early (an inheriting `Optional[int]`, with `0` meaning expire-immediately) were replaced later by the independent defaults and the `never` sentinel described above. The commit messages of `d620adb` and `da4fc2a` therefore assert rationale that later commits retract, and reading them in order is misleading.

Three things most merit your eye:

1. **The first sync after deploy closes the whole existing backlog at once**, and each closure notifies the requester and every eligible approver — for a role request, that includes all Access admins. The requested-window pass for role requests is new here and is deliberately **not** covered by the disable setting, so `never` cannot make that first run quiet. Documented in the README; flagging in case you want to time the deploy.
2. **`_expire_each`'s ids-up-front contract.** The comment explains why, but a future sweep that passes it a list built somewhere other than a local query in the same function weakens the `MissingGreenlet` guarantee.
3. **`never` deliberately does not stop everything.** Access and role requests are still closed when the requester's own end date has passed. That asymmetry is intentional — the setting is named for a maximum age — and is pinned by tests on both types, but it is the thing an operator is most likely to be surprised by.

Known and accepted, not fixed here: the three sweeps are near-identical and could collapse into one parameterised helper, and none of them batch or limit. Both are worth doing; neither is new to this branch, and both would enlarge a change that is already at the edge of reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
