### PR TITLE
Add a Reopen button for expired requests

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -16,3 +16,13 @@ OIDC_CLIENT_SECRETS=<YOUR_CLIENT_SECRETS>
 OIDC_OVERWRITE_REDIRECT_URI=https://<YOUR_ACCESS_DEPLOYMENT_DOMAIN_NAME>/oidc/authorize
 ALLOWED_HOSTS=<YOUR_ACCESS_DEPLOYMENT_DOMAIN_NAME>
 ACCESS_CONFIG_FILE=<NAME_OF_FILE_IN_CONFIG_DIR>
+
+# How long a pending request may sit before the sync cronjob closes it, in
+# seconds. Both default to one week (604800) and are independent of each other.
+# Set either to "never" to switch off its age-based expiration.
+#
+# "never" does not stop everything: an access or role request whose own
+# requested end date has already passed is still closed, because that is a
+# separate check from the maximum age.
+#MAX_ACCESS_REQUEST_AGE_SECONDS=604800
+#MAX_GROUP_REQUEST_AGE_SECONDS=604800

--- a/.env.production.example
+++ b/.env.production.example
@@ -19,10 +19,15 @@ ACCESS_CONFIG_FILE=<NAME_OF_FILE_IN_CONFIG_DIR>
 
 # How long a pending request may sit before the sync cronjob closes it, in
 # seconds. Both default to one week (604800) and are independent of each other.
-# Set either to "never" to switch off its age-based expiration.
+# MAX_ACCESS_REQUEST_AGE_SECONDS governs access and role requests; the group
+# variable governs group requests only. Set either to "never" to switch off
+# its age-based expiration.
 #
 # "never" does not stop everything: an access or role request whose own
 # requested end date has already passed is still closed, because that is a
 # separate check from the maximum age.
+#
+# A value of 0 or less is rejected at startup rather than silently closing
+# every pending request on the next sync; use "never" to disable expiration.
 #MAX_ACCESS_REQUEST_AGE_SECONDS=604800
 #MAX_GROUP_REQUEST_AGE_SECONDS=604800

--- a/README.md
+++ b/README.md
@@ -288,6 +288,38 @@ the values in the default config.
 To use your custom config file, set the `ACCESS_CONFIG_FILE` environment variable to the name of your config
 override file in the project-level `config` directory.
 
+#### Request expiration
+
+The `access sync` cronjob closes pending requests that have sat too long. Two
+environment variables control it, both in seconds, both defaulting to one week:
+
+| Variable | Governs | Default |
+| --- | --- | --- |
+| `MAX_ACCESS_REQUEST_AGE_SECONDS` | access requests **and** role requests | `604800` |
+| `MAX_GROUP_REQUEST_AGE_SECONDS` | group requests | `604800` |
+
+Set either to `never` to switch off age-based expiration for the request types
+it governs:
+
+```
+MAX_ACCESS_REQUEST_AGE_SECONDS=never
+```
+
+Three things worth knowing:
+
+- **The two are independent.** Raising `MAX_ACCESS_REQUEST_AGE_SECONDS` does not
+  raise the group cutoff; set both if you want both changed.
+- **Access and role requests share one cutoff.** Disabling
+  `MAX_ACCESS_REQUEST_AGE_SECONDS` stops role requests aging out too.
+- **`never` does not mean nothing is ever closed.** Access and role requests are
+  also closed when the end date the requester asked for has already passed,
+  which is a separate check that `never` does not affect. Group requests have no
+  such check, so `never` stops their expiration entirely.
+
+A value of `0` or less is rejected at startup: it would close every pending
+request on the next sync, and is almost always a mistaken attempt to disable
+expiration. Use `never` for that.
+
 ### Sample Usage
 
 To override environment variables, create an override config file in the `config` directory. (You can name

--- a/README.md
+++ b/README.md
@@ -272,23 +272,7 @@ If you are using Cloudflare Access, ensure that you configure `CLOUDFLARE_TEAM_D
 
 Else, if you are using a generic OIDC identity provider (such as Okta), then you should configure `SECRET_KEY` and `OIDC_CLIENT_SECRETS`. `CLOUDFLARE_TEAM_DOMAIN` and `CLOUDFLARE_APPLICATION_AUDIENCE` do not need to be set and can be removed from your env file. Make sure to also mount your `client-secrets.json` file to the container if you don't have it inline.
 
-### Access application configuration
-
-_All front-end and back-end configuration overrides are **optional**._
-
-The default config for the application is at [`config/config.default.json`](config/config.default.json).
-
-The file is structured with two keys, `FRONTEND` and `BACKEND`, which contain the configuration overrides for the
-front-end and back-end respectively.
-
-If you want to override either front-end or back-end values, create your own config file based on 
-[`config/config.default.json`](config/config.default.json). Any values that you don't override will fall back to 
-the values in the default config.
-
-To use your custom config file, set the `ACCESS_CONFIG_FILE` environment variable to the name of your config
-override file in the project-level `config` directory.
-
-#### Request expiration
+##### Request expiration
 
 The `access sync` cronjob closes pending requests that have sat too long. Two
 environment variables control it, both in seconds, both defaulting to one week:
@@ -297,6 +281,9 @@ environment variables control it, both in seconds, both defaulting to one week:
 | --- | --- | --- |
 | `MAX_ACCESS_REQUEST_AGE_SECONDS` | access requests **and** role requests | `604800` |
 | `MAX_GROUP_REQUEST_AGE_SECONDS` | group requests | `604800` |
+
+These are environment variables; setting them in an `ACCESS_CONFIG_FILE` JSON
+config has no effect.
 
 Set either to `never` to switch off age-based expiration for the request types
 it governs:
@@ -319,6 +306,33 @@ Three things worth knowing:
 A value of `0` or less is rejected at startup: it would close every pending
 request on the next sync, and is almost always a mistaken attempt to disable
 expiration. Use `never` for that.
+
+**The requested-window check for role requests is new and is not covered by
+either cutoff.** The first `access sync` run after upgrading to a version with
+this check will, in a single run, close every existing pending role request
+whose requested end date has already passed; each closure notifies the
+requester and every eligible approver, which for a role request includes
+Access admins. Setting `MAX_ACCESS_REQUEST_AGE_SECONDS=never` before that first
+run only suppresses the age-based half of expiration, not this window check.
+Operators with a large backlog of old role requests may want to plan for this
+rather than be surprised by a burst of notifications on the first sync after
+upgrading.
+
+### Access application configuration
+
+_All front-end and back-end configuration overrides are **optional**._
+
+The default config for the application is at [`config/config.default.json`](config/config.default.json).
+
+The file is structured with two keys, `FRONTEND` and `BACKEND`, which contain the configuration overrides for the
+front-end and back-end respectively.
+
+If you want to override either front-end or back-end values, create your own config file based on 
+[`config/config.default.json`](config/config.default.json). Any values that you don't override will fall back to 
+the values in the default config.
+
+To use your custom config file, set the `ACCESS_CONFIG_FILE` environment variable to the name of your config
+override file in the project-level `config` directory.
 
 ### Sample Usage
 

--- a/README.md
+++ b/README.md
@@ -307,16 +307,11 @@ A value of `0` or less is rejected at startup: it would close every pending
 request on the next sync, and is almost always a mistaken attempt to disable
 expiration. Use `never` for that.
 
-**The requested-window check for role requests is new and is not covered by
-either cutoff.** The first `access sync` run after upgrading to a version with
-this check will, in a single run, close every existing pending role request
-whose requested end date has already passed; each closure notifies the
-requester and every eligible approver, which for a role request includes
-Access admins. Setting `MAX_ACCESS_REQUEST_AGE_SECONDS=never` before that first
-run only suppresses the age-based half of expiration, not this window check.
-Operators with a large backlog of old role requests may want to plan for this
-rather than be surprised by a burst of notifications on the first sync after
-upgrading.
+Closing a request notifies its requester and every approver eligible to review
+it; for a role request that includes Access admins. A sync run that closes many
+requests at once sends a correspondingly large number of notifications, so on a
+busy instance it is worth knowing how many requests are pending past a cutoff or
+past their requested end date.
 
 ### Access application configuration
 

--- a/api/cli.py
+++ b/api/cli.py
@@ -267,6 +267,7 @@ async def sync(
     from api.services import okta
     from api.syncer import (
         expire_access_requests,
+        expire_group_requests,
         expire_role_requests,
         sync_group_memberships,
         sync_group_ownerships,
@@ -311,6 +312,7 @@ async def sync(
                 )
             await expire_access_requests()
             await expire_role_requests()
+            await expire_group_requests()
     finally:
         await okta.stop_pooled_client()
 

--- a/api/cli.py
+++ b/api/cli.py
@@ -267,6 +267,7 @@ async def sync(
     from api.services import okta
     from api.syncer import (
         expire_access_requests,
+        expire_role_requests,
         sync_group_memberships,
         sync_group_ownerships,
         sync_groups,
@@ -309,6 +310,7 @@ async def sync(
                     concurrency=group_fetch_concurrency,
                 )
             await expire_access_requests()
+            await expire_role_requests()
     finally:
         await okta.stop_pooled_client()
 

--- a/api/config.py
+++ b/api/config.py
@@ -10,10 +10,18 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Any, Literal, Optional, Union, cast
+from typing import Any, Final, Literal, Optional, Union, cast
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Sentinel for "no maximum age": disables the age-based expiration sweep for a
+# request type. A string rather than None because Settings comes only from env
+# vars and .env, so every value arrives as a string: an omitted variable is
+# indistinguishable from one set to nothing, and "", "None", and "null" all fail
+# int validation. (config.default.json's BACKEND key feeds AccessConfig, a
+# separate object, not this class.)
+NEVER_EXPIRE: Final = "never"
 
 
 def _read_secret_key() -> Optional[str]:
@@ -116,17 +124,32 @@ class Settings(BaseSettings):
     # User attributes
     USER_DISPLAY_CUSTOM_ATTRIBUTES: str = "Title,Manager"
     USER_SEARCH_CUSTOM_ATTRIBUTES: Optional[str] = None
-    MAX_ACCESS_REQUEST_AGE_SECONDS: int = 7 * 24 * 60 * 60
-    # Group requests get their own cutoff: their approver may need to negotiate a
-    # name and pick tags rather than just answer yes/no, which plausibly wants a
-    # longer fuse than a membership request. Unset falls back to
-    # MAX_ACCESS_REQUEST_AGE_SECONDS via `max_group_request_age_seconds`, so
-    # operators who never set it keep the behavior they already had.
-    # Unset falls back to MAX_ACCESS_REQUEST_AGE_SECONDS. An explicit 0 is
-    # honored and means "close every pending group request on each sync run";
-    # ge=0 rejects a negative value, which would otherwise expire future-dated
-    # rows.
-    MAX_GROUP_REQUEST_AGE_SECONDS: Optional[int] = Field(default=None, ge=0)
+    # How long a pending request may sit before the sync cronjob closes it.
+    # Access and role requests share one cutoff: both are a yes/no on granting
+    # access, so they get the same fuse. Group requests get their own because
+    # their approver may need to negotiate a name and pick tags rather than just
+    # answer yes/no. The two are independent; neither inherits the other.
+    #
+    # Set either to NEVER_EXPIRE ("never") to switch its age-based sweep off.
+    # That does NOT stop the separate requested-window sweep: an access or role
+    # request whose own `request_ending_at` has passed is still closed.
+    MAX_ACCESS_REQUEST_AGE_SECONDS: Union[int, Literal["never"]] = 7 * 24 * 60 * 60
+    MAX_GROUP_REQUEST_AGE_SECONDS: Union[int, Literal["never"]] = 7 * 24 * 60 * 60
+
+    @field_validator("MAX_ACCESS_REQUEST_AGE_SECONDS", "MAX_GROUP_REQUEST_AGE_SECONDS")
+    @classmethod
+    def _reject_non_positive_age(cls, v: Union[int, str]) -> Union[int, str]:
+        # Short-circuit on the sentinel: a Field(ge=...) bound cannot be used
+        # here because it is applied to the union rather than to its int branch
+        # and rejects "never" itself.
+        if v == NEVER_EXPIRE:
+            return v
+        if isinstance(v, int) and v < 1:
+            raise ValueError(
+                f"must be a positive number of seconds, or {NEVER_EXPIRE!r} to disable expiration; "
+                "a value of 0 or less would close every pending request on the next sync"
+            )
+        return v
 
     # Cloudflare Access
     CLOUDFLARE_APPLICATION_AUDIENCE: Optional[str] = None
@@ -249,11 +272,25 @@ class Settings(BaseSettings):
         return [s.strip() for s in self.APP_GROUP_DELETER_ID.split(",") if s.strip()]
 
     @property
-    def max_group_request_age_seconds(self) -> int:
-        # Explicit `is None` rather than `or`: an operator setting 0 means "expire
-        # immediately", which `or` would silently replace with the access default.
-        if self.MAX_GROUP_REQUEST_AGE_SECONDS is None:
-            return self.MAX_ACCESS_REQUEST_AGE_SECONDS
+    def max_access_request_age_seconds(self) -> Optional[int]:
+        """Seconds after which a pending access or role request is closed for age.
+
+        None when the operator disabled the age-based sweep. This does not affect
+        the separate requested-window sweep, which always runs.
+        """
+        if self.MAX_ACCESS_REQUEST_AGE_SECONDS == NEVER_EXPIRE:
+            return None
+        return self.MAX_ACCESS_REQUEST_AGE_SECONDS
+
+    @property
+    def max_group_request_age_seconds(self) -> Optional[int]:
+        """Seconds after which a pending group request is closed for age.
+
+        None when the operator disabled the age-based sweep. Independent of
+        MAX_ACCESS_REQUEST_AGE_SECONDS; group requests have no second sweep.
+        """
+        if self.MAX_GROUP_REQUEST_AGE_SECONDS == NEVER_EXPIRE:
+            return None
         return self.MAX_GROUP_REQUEST_AGE_SECONDS
 
 
@@ -359,7 +396,6 @@ DATABASE_NAME = settings.DATABASE_NAME
 DATABASE_USES_PUBLIC_IP = settings.DATABASE_USES_PUBLIC_IP
 USER_DISPLAY_CUSTOM_ATTRIBUTES = settings.USER_DISPLAY_CUSTOM_ATTRIBUTES
 USER_SEARCH_CUSTOM_ATTRIBUTES = settings.USER_SEARCH_CUSTOM_ATTRIBUTES or ",".join(settings.user_search_attrs)
-MAX_ACCESS_REQUEST_AGE_SECONDS = settings.MAX_ACCESS_REQUEST_AGE_SECONDS
 CLOUDFLARE_APPLICATION_AUDIENCE = settings.CLOUDFLARE_APPLICATION_AUDIENCE
 CLOUDFLARE_TEAM_DOMAIN = settings.CLOUDFLARE_TEAM_DOMAIN
 SECRET_KEY = settings.SECRET_KEY

--- a/api/config.py
+++ b/api/config.py
@@ -117,6 +117,12 @@ class Settings(BaseSettings):
     USER_DISPLAY_CUSTOM_ATTRIBUTES: str = "Title,Manager"
     USER_SEARCH_CUSTOM_ATTRIBUTES: Optional[str] = None
     MAX_ACCESS_REQUEST_AGE_SECONDS: int = 7 * 24 * 60 * 60
+    # Group requests get their own cutoff: their approver may need to negotiate a
+    # name and pick tags rather than just answer yes/no, which plausibly wants a
+    # longer fuse than a membership request. Unset falls back to
+    # MAX_ACCESS_REQUEST_AGE_SECONDS via `max_group_request_age_seconds`, so
+    # operators who never set it keep the behavior they already had.
+    MAX_GROUP_REQUEST_AGE_SECONDS: Optional[int] = None
 
     # Cloudflare Access
     CLOUDFLARE_APPLICATION_AUDIENCE: Optional[str] = None
@@ -238,6 +244,14 @@ class Settings(BaseSettings):
             return []
         return [s.strip() for s in self.APP_GROUP_DELETER_ID.split(",") if s.strip()]
 
+    @property
+    def max_group_request_age_seconds(self) -> int:
+        # Explicit `is None` rather than `or`: an operator setting 0 means "expire
+        # immediately", which `or` would silently replace with the access default.
+        if self.MAX_GROUP_REQUEST_AGE_SECONDS is None:
+            return self.MAX_ACCESS_REQUEST_AGE_SECONDS
+        return self.MAX_GROUP_REQUEST_AGE_SECONDS
+
 
 def _build_settings() -> Settings:
     s = Settings()
@@ -342,6 +356,7 @@ DATABASE_USES_PUBLIC_IP = settings.DATABASE_USES_PUBLIC_IP
 USER_DISPLAY_CUSTOM_ATTRIBUTES = settings.USER_DISPLAY_CUSTOM_ATTRIBUTES
 USER_SEARCH_CUSTOM_ATTRIBUTES = settings.USER_SEARCH_CUSTOM_ATTRIBUTES or ",".join(settings.user_search_attrs)
 MAX_ACCESS_REQUEST_AGE_SECONDS = settings.MAX_ACCESS_REQUEST_AGE_SECONDS
+MAX_GROUP_REQUEST_AGE_SECONDS = settings.max_group_request_age_seconds
 CLOUDFLARE_APPLICATION_AUDIENCE = settings.CLOUDFLARE_APPLICATION_AUDIENCE
 CLOUDFLARE_TEAM_DOMAIN = settings.CLOUDFLARE_TEAM_DOMAIN
 SECRET_KEY = settings.SECRET_KEY

--- a/api/config.py
+++ b/api/config.py
@@ -122,7 +122,11 @@ class Settings(BaseSettings):
     # longer fuse than a membership request. Unset falls back to
     # MAX_ACCESS_REQUEST_AGE_SECONDS via `max_group_request_age_seconds`, so
     # operators who never set it keep the behavior they already had.
-    MAX_GROUP_REQUEST_AGE_SECONDS: Optional[int] = None
+    # Unset falls back to MAX_ACCESS_REQUEST_AGE_SECONDS. An explicit 0 is
+    # honored and means "close every pending group request on each sync run";
+    # ge=0 rejects a negative value, which would otherwise expire future-dated
+    # rows.
+    MAX_GROUP_REQUEST_AGE_SECONDS: Optional[int] = Field(default=None, ge=0)
 
     # Cloudflare Access
     CLOUDFLARE_APPLICATION_AUDIENCE: Optional[str] = None
@@ -356,7 +360,6 @@ DATABASE_USES_PUBLIC_IP = settings.DATABASE_USES_PUBLIC_IP
 USER_DISPLAY_CUSTOM_ATTRIBUTES = settings.USER_DISPLAY_CUSTOM_ATTRIBUTES
 USER_SEARCH_CUSTOM_ATTRIBUTES = settings.USER_SEARCH_CUSTOM_ATTRIBUTES or ",".join(settings.user_search_attrs)
 MAX_ACCESS_REQUEST_AGE_SECONDS = settings.MAX_ACCESS_REQUEST_AGE_SECONDS
-MAX_GROUP_REQUEST_AGE_SECONDS = settings.max_group_request_age_seconds
 CLOUDFLARE_APPLICATION_AUDIENCE = settings.CLOUDFLARE_APPLICATION_AUDIENCE
 CLOUDFLARE_TEAM_DOMAIN = settings.CLOUDFLARE_TEAM_DOMAIN
 SECRET_KEY = settings.SECRET_KEY

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -651,8 +651,9 @@ async def expire_group_requests() -> None:
     What that leaves to the approve path: ApproveGroupRequest falls back to
     requested_ownership_ending_at when the approver supplies no resolved value,
     so approving a long-stale request could write an already-expired ownership
-    row and leave the new group unowned. That is repaired there rather than here
-    (it refuses the approval outright); this sweep deliberately stays out of it.
+    row and leave the new group unowned. PR #599 proposes refusing such an
+    approval outright; until it lands the gap is open. Either way, repairing it
+    belongs in the approve path and not in this sweep.
     See test_no_expire_group_request_with_lapsed_ownership_window.
 
     Uses its own cutoff because a group request's approver may need to negotiate

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -27,6 +27,7 @@ from api.models import (
     OktaUserGroupMember,
     RoleGroup,
     RoleGroupMap,
+    RoleRequest,
 )
 from api.models.app_group import get_access_owners, get_app_managers
 from api.models.okta_group import get_group_managers
@@ -35,6 +36,7 @@ from api.operations import (
     DeleteUser,
     ModifyGroupUsers,
     RejectAccessRequest,
+    RejectRoleRequest,
     UnmanageGroup,
 )
 from api.plugins import NotificationHook, send_notification
@@ -585,6 +587,49 @@ async def expire_access_requests() -> None:
     await _expire_each(older_than_request, reject, "access request")
 
     logger.info("Access request expiration finished.")
+
+
+async def expire_role_requests() -> None:
+    """Close pending role requests that aged out or whose window has lapsed.
+
+    Shares MAX_ACCESS_REQUEST_AGE_SECONDS with access requests; both are a
+    yes/no on granting access, so they get the same fuse. The lapsed-window
+    path matters here for the same reason it does for access requests:
+    approving a role request past its request_ending_at would create an
+    already-expired RoleGroupMap.
+    """
+    logger.info("Role request expiration started.")
+    MAX_ACCESS_REQUEST_AGE_SECONDS = settings.MAX_ACCESS_REQUEST_AGE_SECONDS
+
+    def reject(request_id: str) -> Awaitable[RoleRequest]:
+        return RejectRoleRequest(
+            role_request=request_id,
+            rejection_reason=EXPIRED_REQUEST_REASON,
+        ).execute()
+
+    older_than_max = (
+        await db.session.scalars(
+            select(RoleRequest)
+            .where(RoleRequest.status == AccessRequestStatus.PENDING)
+            .where(RoleRequest.resolved_at.is_(None))
+            .where(
+                RoleRequest.created_at < datetime.now(timezone.utc) - timedelta(seconds=MAX_ACCESS_REQUEST_AGE_SECONDS)
+            )
+        )
+    ).all()
+    await _expire_each(older_than_max, reject, "role request")
+
+    older_than_request = (
+        await db.session.scalars(
+            select(RoleRequest)
+            .where(RoleRequest.status == AccessRequestStatus.PENDING)
+            .where(RoleRequest.resolved_at.is_(None))
+            .where(RoleRequest.request_ending_at < func.now())
+        )
+    ).all()
+    await _expire_each(older_than_request, reject, "role request")
+
+    logger.info("Role request expiration finished.")
 
 
 async def expiring_access_notifications_user() -> None:

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -1,8 +1,9 @@
 import asyncio
 import logging
 from collections import defaultdict
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from datetime import date, datetime, timedelta, timezone
+from typing import Any
 
 from sqlalchemy import and_, func, or_, select
 from api.config import settings
@@ -514,9 +515,51 @@ async def sync_group_ownerships(
     logger.info("Ownership sync finished.")
 
 
+# The resolution_reason written when a request is closed for age or for a lapsed
+# window, shared by all three sweeps. Worth knowing when reading the audit
+# trail: a null resolver alone does not identify an expiry, since requester
+# deletion, group deletion, group unmanaging, and a conditional-access denial
+# all close requests with no actor too. This wording is what tells them apart.
+EXPIRED_REQUEST_REASON = "Closed because the request expired"
+
+
+async def _expire_each(
+    requests: Sequence[Any],
+    reject: Callable[[Any], Awaitable[Any]],
+    label: str,
+) -> None:
+    """Reject each request, isolating failures so one bad row can't abort the sweep.
+
+    The reject operations commit per request, so a failure only needs its own
+    transaction rolled back. Without this, a single request that raises (e.g.
+    ConflictError, when a reviewer resolves it mid-sync) aborts expiration for
+    every remaining request and will do so again on the next run.
+
+    IDs are read up front, before any rollback: `db.session.rollback()` expires
+    every instance in the identity map (not just the failed one), so touching an
+    attribute on one of the *other*, not-yet-processed `requests` afterward would
+    force a lazy reload with no async context to run it in (`MissingGreenlet`).
+    `reject` is therefore called with the id, matching the `Model | str`
+    constructor every reject operation already supports.
+    """
+    request_ids = [request.id for request in requests]
+    for request_id in request_ids:
+        try:
+            await reject(request_id)
+        except Exception:
+            logger.exception(f"Failed to expire {label} {request_id}, skipping.")
+            await db.session.rollback()
+
+
 async def expire_access_requests() -> None:
     logger.info("Access request expiration started.")
     MAX_ACCESS_REQUEST_AGE_SECONDS = settings.MAX_ACCESS_REQUEST_AGE_SECONDS
+
+    def reject(request_id: str) -> Awaitable[AccessRequest]:
+        return RejectAccessRequest(
+            access_request=request_id,
+            rejection_reason=EXPIRED_REQUEST_REASON,
+        ).execute()
 
     older_than_max = (
         await db.session.scalars(
@@ -529,11 +572,7 @@ async def expire_access_requests() -> None:
             )
         )
     ).all()
-    for access_request in older_than_max:
-        await RejectAccessRequest(
-            access_request=access_request,
-            rejection_reason="Closed because the request expired",
-        ).execute()
+    await _expire_each(older_than_max, reject, "access request")
 
     older_than_request = (
         await db.session.scalars(
@@ -543,11 +582,7 @@ async def expire_access_requests() -> None:
             .where(AccessRequest.request_ending_at < func.now())
         )
     ).all()
-    for access_request in older_than_request:
-        await RejectAccessRequest(
-            access_request=access_request,
-            rejection_reason="Closed because the request expired",
-        ).execute()
+    await _expire_each(older_than_request, reject, "access request")
 
     logger.info("Access request expiration finished.")
 

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -557,7 +557,7 @@ async def _expire_each(
 
 async def expire_access_requests() -> None:
     logger.info("Access request expiration started.")
-    MAX_ACCESS_REQUEST_AGE_SECONDS = settings.MAX_ACCESS_REQUEST_AGE_SECONDS
+    max_age_seconds = settings.max_access_request_age_seconds
 
     def reject(request_id: str) -> Awaitable[AccessRequest]:
         return RejectAccessRequest(
@@ -565,18 +565,21 @@ async def expire_access_requests() -> None:
             rejection_reason=EXPIRED_REQUEST_REASON,
         ).execute()
 
-    older_than_max = (
-        await db.session.scalars(
-            select(AccessRequest)
-            .where(AccessRequest.status == AccessRequestStatus.PENDING)
-            .where(AccessRequest.resolved_at.is_(None))
-            .where(
-                AccessRequest.created_at
-                < datetime.now(timezone.utc) - timedelta(seconds=MAX_ACCESS_REQUEST_AGE_SECONDS)
+    # Skipped, not short-circuited: the requested-window pass below still runs,
+    # so a request whose own window has passed is closed either way. Logged so
+    # sync output distinguishes "disabled" from "nothing to expire".
+    if max_age_seconds is None:
+        logger.info("Age-based access request expiration is disabled.")
+    else:
+        older_than_max = (
+            await db.session.scalars(
+                select(AccessRequest)
+                .where(AccessRequest.status == AccessRequestStatus.PENDING)
+                .where(AccessRequest.resolved_at.is_(None))
+                .where(AccessRequest.created_at < datetime.now(timezone.utc) - timedelta(seconds=max_age_seconds))
             )
-        )
-    ).all()
-    await _expire_each(older_than_max, reject, "access request")
+        ).all()
+        await _expire_each(older_than_max, reject, "access request")
 
     older_than_request = (
         await db.session.scalars(
@@ -594,14 +597,14 @@ async def expire_access_requests() -> None:
 async def expire_role_requests() -> None:
     """Close pending role requests that aged out or whose window has lapsed.
 
-    Shares MAX_ACCESS_REQUEST_AGE_SECONDS with access requests; both are a
-    yes/no on granting access, so they get the same fuse. The lapsed-window
-    path matters here for the same reason it does for access requests:
+    Shares MAX_ACCESS_REQUEST_AGE_SECONDS with access requests, including its "never"
+    disabled state; both are a yes/no on granting access, so they get the same fuse.
+    The lapsed-window path matters here for the same reason it does for access requests:
     approving a role request past its request_ending_at would create an
     already-expired RoleGroupMap.
     """
     logger.info("Role request expiration started.")
-    MAX_ACCESS_REQUEST_AGE_SECONDS = settings.MAX_ACCESS_REQUEST_AGE_SECONDS
+    max_age_seconds = settings.max_access_request_age_seconds
 
     def reject(request_id: str) -> Awaitable[RoleRequest]:
         return RejectRoleRequest(
@@ -609,17 +612,19 @@ async def expire_role_requests() -> None:
             rejection_reason=EXPIRED_REQUEST_REASON,
         ).execute()
 
-    older_than_max = (
-        await db.session.scalars(
-            select(RoleRequest)
-            .where(RoleRequest.status == AccessRequestStatus.PENDING)
-            .where(RoleRequest.resolved_at.is_(None))
-            .where(
-                RoleRequest.created_at < datetime.now(timezone.utc) - timedelta(seconds=MAX_ACCESS_REQUEST_AGE_SECONDS)
+    # Same shape as the access sweep; the requested-window pass below still runs.
+    if max_age_seconds is None:
+        logger.info("Age-based role request expiration is disabled.")
+    else:
+        older_than_max = (
+            await db.session.scalars(
+                select(RoleRequest)
+                .where(RoleRequest.status == AccessRequestStatus.PENDING)
+                .where(RoleRequest.resolved_at.is_(None))
+                .where(RoleRequest.created_at < datetime.now(timezone.utc) - timedelta(seconds=max_age_seconds))
             )
-        )
-    ).all()
-    await _expire_each(older_than_max, reject, "role request")
+        ).all()
+        await _expire_each(older_than_max, reject, "role request")
 
     older_than_request = (
         await db.session.scalars(
@@ -662,15 +667,20 @@ async def expire_group_requests() -> None:
             rejection_reason=EXPIRED_REQUEST_REASON,
         ).execute()
 
-    older_than_max = (
-        await db.session.scalars(
-            select(GroupRequest)
-            .where(GroupRequest.status == AccessRequestStatus.PENDING)
-            .where(GroupRequest.resolved_at.is_(None))
-            .where(GroupRequest.created_at < datetime.now(timezone.utc) - timedelta(seconds=max_age_seconds))
-        )
-    ).all()
-    await _expire_each(older_than_max, reject, "group request")
+    # Group requests have no second pass, so a disabled cutoff means this sweep
+    # does nothing at all. Logged so that is visible in sync output.
+    if max_age_seconds is None:
+        logger.info("Age-based group request expiration is disabled.")
+    else:
+        older_than_max = (
+            await db.session.scalars(
+                select(GroupRequest)
+                .where(GroupRequest.status == AccessRequestStatus.PENDING)
+                .where(GroupRequest.resolved_at.is_(None))
+                .where(GroupRequest.created_at < datetime.now(timezone.utc) - timedelta(seconds=max_age_seconds))
+            )
+        ).all()
+        await _expire_each(older_than_max, reject, "group request")
 
     logger.info("Group request expiration finished.")
 

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -529,7 +529,7 @@ EXPIRED_REQUEST_REASON = "Closed because the request expired"
 
 async def _expire_each(
     requests: Sequence[Any],
-    reject: Callable[[Any], Awaitable[Any]],
+    reject: Callable[[str], Awaitable[Any]],
     label: str,
 ) -> None:
     """Reject each request, isolating failures so one bad row can't abort the sweep.
@@ -546,7 +546,7 @@ async def _expire_each(
     `reject` is therefore called with the id, matching the `Model | str`
     constructor every reject operation already supports.
     """
-    request_ids = [request.id for request in requests]
+    request_ids: list[str] = [request.id for request in requests]
     for request_id in request_ids:
         try:
             await reject(request_id)
@@ -637,17 +637,30 @@ async def expire_role_requests() -> None:
 async def expire_group_requests() -> None:
     """Close pending group requests that aged out.
 
-    Age cutoff only, deliberately. Unlike an access or role request, a group
-    request past its requested_ownership_ending_at is not moot: its primary
-    payload is "create this group", and the resolver can edit
-    resolved_ownership_ending_at before approving, so no dead-on-arrival grant
-    can result. See test_no_expire_group_request_with_lapsed_ownership_window.
+    Age cutoff only, deliberately, and this is a policy call rather than a
+    claim that nothing can go wrong: a group request's payload is the group
+    itself, and destroying that ask over a stale secondary field (the requested
+    ownership window) loses more than it protects. Access and role requests get
+    a second, lapsed-window sweep because for them the window IS the ask.
+
+    Be aware of what that leaves open: ApproveGroupRequest falls back to
+    requested_ownership_ending_at when the approver supplies no resolved value,
+    and coalesce_ended_at passes a past timestamp straight through, so
+    approving a long-stale request can still write an already-expired ownership
+    row and leave the new group unowned. Repairing that belongs in the approve
+    path, not here. See test_no_expire_group_request_with_lapsed_ownership_window.
 
     Uses its own cutoff because a group request's approver may need to negotiate
     a name and pick tags rather than just answer yes/no.
     """
     logger.info("Group request expiration started.")
     max_age_seconds = settings.max_group_request_age_seconds
+
+    def reject(request_id: str) -> Awaitable[GroupRequest]:
+        return RejectGroupRequest(
+            group_request=request_id,
+            rejection_reason=EXPIRED_REQUEST_REASON,
+        ).execute()
 
     older_than_max = (
         await db.session.scalars(
@@ -657,14 +670,7 @@ async def expire_group_requests() -> None:
             .where(GroupRequest.created_at < datetime.now(timezone.utc) - timedelta(seconds=max_age_seconds))
         )
     ).all()
-    await _expire_each(
-        older_than_max,
-        lambda request_id: RejectGroupRequest(
-            group_request=request_id,
-            rejection_reason=EXPIRED_REQUEST_REASON,
-        ).execute(),
-        "group request",
-    )
+    await _expire_each(older_than_max, reject, "group request")
 
     logger.info("Group request expiration finished.")
 

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -22,6 +22,7 @@ from api.models import (
     AccessRequestStatus,
     App,
     AppGroup,
+    GroupRequest,
     OktaGroup,
     OktaUser,
     OktaUserGroupMember,
@@ -36,6 +37,7 @@ from api.operations import (
     DeleteUser,
     ModifyGroupUsers,
     RejectAccessRequest,
+    RejectGroupRequest,
     RejectRoleRequest,
     UnmanageGroup,
 )
@@ -630,6 +632,41 @@ async def expire_role_requests() -> None:
     await _expire_each(older_than_request, reject, "role request")
 
     logger.info("Role request expiration finished.")
+
+
+async def expire_group_requests() -> None:
+    """Close pending group requests that aged out.
+
+    Age cutoff only, deliberately. Unlike an access or role request, a group
+    request past its requested_ownership_ending_at is not moot: its primary
+    payload is "create this group", and the resolver can edit
+    resolved_ownership_ending_at before approving, so no dead-on-arrival grant
+    can result. See test_no_expire_group_request_with_lapsed_ownership_window.
+
+    Uses its own cutoff because a group request's approver may need to negotiate
+    a name and pick tags rather than just answer yes/no.
+    """
+    logger.info("Group request expiration started.")
+    max_age_seconds = settings.max_group_request_age_seconds
+
+    older_than_max = (
+        await db.session.scalars(
+            select(GroupRequest)
+            .where(GroupRequest.status == AccessRequestStatus.PENDING)
+            .where(GroupRequest.resolved_at.is_(None))
+            .where(GroupRequest.created_at < datetime.now(timezone.utc) - timedelta(seconds=max_age_seconds))
+        )
+    ).all()
+    await _expire_each(
+        older_than_max,
+        lambda request_id: RejectGroupRequest(
+            group_request=request_id,
+            rejection_reason=EXPIRED_REQUEST_REASON,
+        ).execute(),
+        "group request",
+    )
+
+    logger.info("Group request expiration finished.")
 
 
 async def expiring_access_notifications_user() -> None:

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -651,9 +651,8 @@ async def expire_group_requests() -> None:
     What that leaves to the approve path: ApproveGroupRequest falls back to
     requested_ownership_ending_at when the approver supplies no resolved value,
     so approving a long-stale request could write an already-expired ownership
-    row and leave the new group unowned. PR #599 proposes refusing such an
-    approval outright; until it lands the gap is open. Either way, repairing it
-    belongs in the approve path and not in this sweep.
+    row and leave the new group unowned. Repairing that belongs in the approve
+    path and not in this sweep.
     See test_no_expire_group_request_with_lapsed_ownership_window.
 
     Uses its own cutoff because a group request's approver may need to negotiate

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -643,12 +643,12 @@ async def expire_group_requests() -> None:
     ownership window) loses more than it protects. Access and role requests get
     a second, lapsed-window sweep because for them the window IS the ask.
 
-    Be aware of what that leaves open: ApproveGroupRequest falls back to
+    What that leaves to the approve path: ApproveGroupRequest falls back to
     requested_ownership_ending_at when the approver supplies no resolved value,
-    and coalesce_ended_at passes a past timestamp straight through, so
-    approving a long-stale request can still write an already-expired ownership
-    row and leave the new group unowned. Repairing that belongs in the approve
-    path, not here. See test_no_expire_group_request_with_lapsed_ownership_window.
+    so approving a long-stale request could write an already-expired ownership
+    row and leave the new group unowned. That is repaired there rather than here
+    (it refuses the approval outright); this sweep deliberately stays out of it.
+    See test_no_expire_group_request_with_lapsed_ownership_window.
 
     Uses its own cutoff because a group request's approver may need to negotiate
     a name and pick tags rather than just answer yes/no.

--- a/api/syncer.py
+++ b/api/syncer.py
@@ -524,6 +524,12 @@ async def sync_group_ownerships(
 # trail: a null resolver alone does not identify an expiry, since requester
 # deletion, group deletion, group unmanaging, and a conditional-access denial
 # all close requests with no actor too. This wording is what tells them apart.
+#
+# That makes it a contract with the frontend, not just display text:
+# `isExpiredRequest` in `src/helpers.tsx` matches it verbatim to decide whether
+# to offer a "reopen" button, because expiration is not modelled distinctly in
+# the data model. Rewording here without rewording there silently removes that
+# button; `tests/test_expired_reason_constant.py` pins the pairing.
 EXPIRED_REQUEST_REASON = "Closed because the request expired"
 
 

--- a/src/helpers.test.tsx
+++ b/src/helpers.test.tsx
@@ -1,0 +1,40 @@
+import {describe, expect, it} from 'vitest';
+
+import {EXPIRED_REQUEST_REASON, isExpiredRequest} from './helpers';
+
+describe('isExpiredRequest', () => {
+  it('matches a request closed by the expiration sweep', () => {
+    expect(isExpiredRequest({status: 'REJECTED', resolver: null, resolution_reason: EXPIRED_REQUEST_REASON})).toBe(
+      true,
+    );
+  });
+
+  it('does not match a human rejection, even with no reason given', () => {
+    expect(isExpiredRequest({status: 'REJECTED', resolver: {id: 'u1'}, resolution_reason: 'no thanks'})).toBe(false);
+    expect(isExpiredRequest({status: 'REJECTED', resolver: {id: 'u1'}, resolution_reason: ''})).toBe(false);
+  });
+
+  it('does not match the other system closures, which also have a null resolver', () => {
+    for (const reason of [
+      'Closed because the requestor was deleted',
+      'Closed because the requested group was deleted',
+      'Closed because the requested group is no longer managed by Access',
+      'Denied by conditional access policy',
+    ]) {
+      expect(isExpiredRequest({status: 'REJECTED', resolver: null, resolution_reason: reason})).toBe(false);
+    }
+  });
+
+  it('does not match a pending or approved request', () => {
+    expect(isExpiredRequest({status: 'PENDING', resolver: null, resolution_reason: EXPIRED_REQUEST_REASON})).toBe(
+      false,
+    );
+    expect(isExpiredRequest({status: 'APPROVED', resolver: null, resolution_reason: EXPIRED_REQUEST_REASON})).toBe(
+      false,
+    );
+  });
+
+  it('tolerates missing fields rather than throwing', () => {
+    expect(isExpiredRequest({})).toBe(false);
+  });
+});

--- a/src/helpers.test.tsx
+++ b/src/helpers.test.tsx
@@ -1,6 +1,7 @@
+import dayjs from 'dayjs';
 import {describe, expect, it} from 'vitest';
 
-import {EXPIRED_REQUEST_REASON, isExpiredRequest} from './helpers';
+import {EXPIRED_REQUEST_REASON, isExpiredRequest, reconstructRequestedUntil} from './helpers';
 
 describe('isExpiredRequest', () => {
   it('matches a request closed by the expiration sweep', () => {
@@ -36,5 +37,88 @@ describe('isExpiredRequest', () => {
 
   it('tolerates missing fields rather than throwing', () => {
     expect(isExpiredRequest({})).toBe(false);
+  });
+});
+
+const LABELS: Record<string, string> = {
+  '43200': '12 Hours',
+  '432000': '5 Days',
+  '1209600': 'Two Weeks',
+  '2592000': '30 Days',
+  '7776000': '90 Days',
+  indefinite: 'Indefinite',
+  custom: 'Custom',
+};
+
+describe('reconstructRequestedUntil', () => {
+  it('reports indefinite when there was no end date', () => {
+    expect(reconstructRequestedUntil({createdAt: '2026-01-01T00:00:00', endingAt: null, untilLabels: LABELS})).toEqual({
+      until: 'indefinite',
+      deltaSeconds: null,
+    });
+  });
+
+  it('round-trips a duration that matches an option exactly', () => {
+    // 90 days == 7776000 seconds.
+    const createdAt = '2026-01-01T00:00:00';
+    const endingAt = dayjs(createdAt).add(7776000, 'second').toISOString();
+    expect(reconstructRequestedUntil({createdAt, endingAt, untilLabels: LABELS})).toEqual({
+      until: '7776000',
+      deltaSeconds: 7776000,
+    });
+  });
+
+  it('absorbs sub-second drift via the 100s rounding', () => {
+    const createdAt = '2026-01-01T00:00:00';
+    const endingAt = dayjs(createdAt).add(7776043, 'second').toISOString();
+    expect(reconstructRequestedUntil({createdAt, endingAt, untilLabels: LABELS})).toEqual({
+      until: '7776000',
+      deltaSeconds: 7776000,
+    });
+  });
+
+  it('re-offers a non-matching duration as a custom date based from today', () => {
+    const createdAt = '2026-01-01T00:00:00';
+    const fiftyDays = 50 * 24 * 60 * 60;
+    const endingAt = dayjs(createdAt).add(fiftyDays, 'second').toISOString();
+
+    const result = reconstructRequestedUntil({createdAt, endingAt, untilLabels: LABELS});
+
+    expect(result.until).toBe('custom');
+    expect(result.deltaSeconds).toBe(fiftyDays);
+    // Re-based from now, not the original absolute date, which is in the past.
+    expect(result.customUntil!.diff(dayjs(), 'day')).toBe(50);
+  });
+
+  it('clamps to the largest allowed option when a time limit is now tighter', () => {
+    const createdAt = '2026-01-01T00:00:00';
+    const endingAt = dayjs(createdAt).add(7776000, 'second').toISOString();
+
+    // Tag limit is now 30 days; the original 90-day ask is no longer offerable.
+    // deltaSeconds stays the raw unclamped ask.
+    expect(reconstructRequestedUntil({createdAt, endingAt, untilLabels: LABELS, timeLimit: 2592000})).toEqual({
+      until: '2592000',
+      deltaSeconds: 7776000,
+    });
+  });
+
+  it('clamps indefinite to the largest allowed option under a time limit', () => {
+    expect(
+      reconstructRequestedUntil({
+        createdAt: '2026-01-01T00:00:00',
+        endingAt: null,
+        untilLabels: LABELS,
+        timeLimit: 1209600,
+      }),
+    ).toEqual({until: '1209600', deltaSeconds: null});
+  });
+
+  it('does not clamp when no time limit is given', () => {
+    const createdAt = '2026-01-01T00:00:00';
+    const endingAt = dayjs(createdAt).add(7776000, 'second').toISOString();
+    expect(reconstructRequestedUntil({createdAt, endingAt, untilLabels: LABELS})).toEqual({
+      until: '7776000',
+      deltaSeconds: 7776000,
+    });
   });
 });

--- a/src/helpers.test.tsx
+++ b/src/helpers.test.tsx
@@ -87,7 +87,10 @@ describe('reconstructRequestedUntil', () => {
     expect(result.until).toBe('custom');
     expect(result.deltaSeconds).toBe(fiftyDays);
     // Re-based from now, not the original absolute date, which is in the past.
-    expect(result.customUntil!.diff(dayjs(), 'day')).toBe(50);
+    // Tolerance in seconds: the helper's dayjs() and this assertion's dayjs()
+    // are different instants, and diff() floors, so an exact day comparison
+    // flakes whenever the two land in different milliseconds.
+    expect(Math.abs(result.customUntil!.diff(dayjs(), 'second') - fiftyDays)).toBeLessThanOrEqual(2);
   });
 
   it('clamps to the largest allowed option when a time limit is now tighter', () => {
@@ -120,5 +123,31 @@ describe('reconstructRequestedUntil', () => {
       until: '7776000',
       deltaSeconds: 7776000,
     });
+  });
+
+  it('is unaffected by a time limit looser than the delta, returning the exact option unclamped', () => {
+    const createdAt = '2026-01-01T00:00:00';
+    const endingAt = dayjs(createdAt).add(432000, 'second').toISOString();
+
+    // Tag limit (90 days) is far looser than the 5-day ask, so the exact
+    // option match wins, same as if no timeLimit had been passed at all.
+    expect(reconstructRequestedUntil({createdAt, endingAt, untilLabels: LABELS, timeLimit: 7776000})).toEqual({
+      until: '432000',
+      deltaSeconds: 432000,
+    });
+  });
+
+  it('offers a custom date at exactly the limit when no option is small enough', () => {
+    const createdAt = '2026-01-01T00:00:00';
+    const endingAt = dayjs(createdAt).add(7776000, 'second').toISOString();
+    const oneHour = 60 * 60;
+
+    // Tightest tag limit (1 hour) is below even the smallest option (12
+    // hours), so there is nothing in untilLabels to clamp to.
+    const result = reconstructRequestedUntil({createdAt, endingAt, untilLabels: LABELS, timeLimit: oneHour});
+
+    expect(result.until).toBe('custom');
+    expect(result.deltaSeconds).toBe(7776000);
+    expect(Math.abs(result.customUntil!.diff(dayjs(), 'second') - oneHour)).toBeLessThanOrEqual(2);
   });
 });

--- a/src/helpers.tsx
+++ b/src/helpers.tsx
@@ -1,3 +1,5 @@
+import dayjs, {Dayjs} from 'dayjs';
+
 import {
   OktaUserDetail,
   OktaUserSummary,
@@ -203,4 +205,73 @@ export function isExpiredRequest(request: ExpirableRequest): boolean {
     (request.resolver ?? null) === null &&
     request.resolution_reason === EXPIRED_REQUEST_REASON
   );
+}
+
+export interface ReconstructedUntil {
+  /** An option id from `untilLabels`, or 'indefinite', or 'custom'. */
+  until: string;
+  /** Only set when `until` is 'custom'. A Dayjs, because that is what DatePickerElement consumes. */
+  customUntil?: Dayjs;
+  /**
+   * The raw rounded duration in seconds, or null when there was no end date.
+   * Always unclamped, even when `until` was clamped by `timeLimit`. Exposed so
+   * callers that need the delta for their own logic (the read views' separate
+   * tag-limit clamp) do not recompute it.
+   */
+  deltaSeconds: number | null;
+}
+
+/** The largest numeric option in `untilLabels` that fits within `timeLimit` seconds. */
+function largestAllowedUntil(untilLabels: Record<string, string>, timeLimit: number): string {
+  const allowed = Object.keys(untilLabels)
+    .filter((key) => !isNaN(Number(key)) && Number(key) <= timeLimit)
+    .sort((a, b) => Number(a) - Number(b));
+  return allowed.at(-1) ?? 'custom';
+}
+
+/**
+ * Recover the duration a request originally asked for, re-based from today.
+ *
+ * Requests store an absolute `request_ending_at`, so a request that expired
+ * because its window lapsed has a stored date in the past that cannot be
+ * re-submitted as-is. Diffing against `created_at` recovers the *duration* the
+ * requester picked: an exact match in `untilLabels` round-trips to that option,
+ * and anything else was a custom date, so it is re-offered as one based from
+ * now.
+ *
+ * `timeLimit` (seconds, from a tag constraint) is OPTIONAL and defaults to no
+ * clamping. Pass it only where you want the result restricted to what the tag
+ * currently allows. The two Read.tsx call sites deliberately pass nothing,
+ * because they apply their own clamp separately when building form
+ * defaultValues; passing it there would double-clamp.
+ */
+export function reconstructRequestedUntil(args: {
+  createdAt?: string | null;
+  endingAt?: string | null;
+  untilLabels: Record<string, string>;
+  timeLimit?: number | null;
+}): ReconstructedUntil {
+  const {createdAt, endingAt, untilLabels, timeLimit} = args;
+
+  if (endingAt == null) {
+    // A tag time limit forbids indefinite access, so clamp rather than offer it.
+    if (timeLimit != null) {
+      return {until: largestAllowedUntil(untilLabels, timeLimit), deltaSeconds: null};
+    }
+    return {until: 'indefinite', deltaSeconds: null};
+  }
+
+  // Round to the nearest 100s to absorb the sub-second drift between the form
+  // computing the date and the row being written.
+  const deltaSeconds = Math.round(dayjs(endingAt).diff(dayjs(createdAt), 'second') / 100) * 100;
+
+  if (timeLimit != null && deltaSeconds > timeLimit) {
+    return {until: largestAllowedUntil(untilLabels, timeLimit), deltaSeconds};
+  }
+
+  if (deltaSeconds.toString() in untilLabels) {
+    return {until: deltaSeconds.toString(), deltaSeconds};
+  }
+
+  return {until: 'custom', customUntil: dayjs().add(deltaSeconds, 'second'), deltaSeconds};
 }

--- a/src/helpers.tsx
+++ b/src/helpers.tsx
@@ -259,9 +259,20 @@ function clampedToTimeLimit(
  *
  * `timeLimit` (seconds, from a tag constraint) is OPTIONAL and defaults to no
  * clamping. Pass it only where you want the result restricted to what the tag
- * currently allows. The two Read.tsx call sites deliberately pass nothing,
- * because they apply their own clamp separately when building form
- * defaultValues; passing it there would double-clamp.
+ * currently allows. There are five call sites, for three different reasons:
+ * - `requests/Read.tsx` and `role_requests/Read.tsx` each call this once with
+ *   no `timeLimit`, for the approve form's `requestedUntil`; both apply their
+ *   own clamp separately (via `autofill_until` / `requestedUntilAdjusted`)
+ *   when building form defaultValues, so passing it here too would
+ *   double-clamp.
+ * - Those same two files each call this a second time, for the reopen
+ *   prefill, passing the current `timeLimit` so the prefill respects a tag
+ *   limit that may have tightened since the original request.
+ * - `group_requests/Read.tsx` calls this once, also for a reopen prefill, but
+ *   passes `timeLimit: null` explicitly rather than omitting it: the group
+ *   create form that reopen hands the prefill to applies no tag clamp at all
+ *   (it doesn't import `minTagTime`), so there is nothing to clamp against
+ *   there, ever.
  */
 export function reconstructRequestedUntil(args: {
   createdAt?: string | null;

--- a/src/helpers.tsx
+++ b/src/helpers.tsx
@@ -165,3 +165,42 @@ export function groupMemberships(
 ): Record<string, Array<OktaUserGroupMemberDetail>> {
   return groupBy(memberships ?? [], (membership) => membership.active_user?.id ?? '');
 }
+
+/**
+ * The resolution_reason the backend writes when the sync cronjob closes a
+ * request for age or for a lapsed window. Mirrors `EXPIRED_REQUEST_REASON` in
+ * `api/syncer.py`, which is the producer.
+ *
+ * Expiration is deliberately not modelled as its own status or column, so this
+ * string plus a null resolver is how the UI recognizes it. Keep the two in
+ * sync; `tests/test_expired_reason_constant.py` fails if they drift.
+ */
+export const EXPIRED_REQUEST_REASON = 'Closed because the request expired';
+
+export interface ExpirableRequest {
+  status?: string | null;
+  resolver?: {id?: string} | null;
+  resolution_reason?: string | null;
+}
+
+/**
+ * True when a request was closed by the expiration sweep rather than by a
+ * person or by another system path.
+ *
+ * A null resolver alone is not enough: user deletion, group deletion, group
+ * unmanaging, and a conditional-access plugin denial all close requests with no
+ * resolver too. The reason string is what separates expiration from those, and
+ * in particular from a policy denial, which must never be offered a one-click
+ * reopen.
+ *
+ * Checks `resolver`, NOT `resolver_user_id`: AccessRequestDetail and
+ * RoleRequestDetail expose both, but GroupRequestDetail exposes only `resolver`,
+ * so keying off the id would silently never match on group requests.
+ */
+export function isExpiredRequest(request: ExpirableRequest): boolean {
+  return (
+    request.status === 'REJECTED' &&
+    (request.resolver ?? null) === null &&
+    request.resolution_reason === EXPIRED_REQUEST_REASON
+  );
+}

--- a/src/helpers.tsx
+++ b/src/helpers.tsx
@@ -210,7 +210,12 @@ export function isExpiredRequest(request: ExpirableRequest): boolean {
 export interface ReconstructedUntil {
   /** An option id from `untilLabels`, or 'indefinite', or 'custom'. */
   until: string;
-  /** Only set when `until` is 'custom'. A Dayjs, because that is what DatePickerElement consumes. */
+  /**
+   * Set whenever `until` is 'custom' — including the clamped case, where it
+   * is a valid date set to exactly the tag's `timeLimit` from now, so a form
+   * fed this result always has something to show in the date picker. A
+   * Dayjs, because that is what DatePickerElement consumes.
+   */
   customUntil?: Dayjs;
   /**
    * The raw rounded duration in seconds, or null when there was no end date.
@@ -221,12 +226,25 @@ export interface ReconstructedUntil {
   deltaSeconds: number | null;
 }
 
-/** The largest numeric option in `untilLabels` that fits within `timeLimit` seconds. */
-function largestAllowedUntil(untilLabels: Record<string, string>, timeLimit: number): string {
+/**
+ * The clamped result for a tag `timeLimit`: the largest numeric option that
+ * fits, or a custom date at exactly the limit when no option is small enough.
+ */
+function clampedToTimeLimit(
+  untilLabels: Record<string, string>,
+  timeLimit: number,
+  deltaSeconds: number | null,
+): ReconstructedUntil {
   const allowed = Object.keys(untilLabels)
     .filter((key) => !isNaN(Number(key)) && Number(key) <= timeLimit)
     .sort((a, b) => Number(a) - Number(b));
-  return allowed.at(-1) ?? 'custom';
+  const largest = allowed.at(-1);
+  if (largest != null) {
+    return {until: largest, deltaSeconds};
+  }
+  // No option fits the limit; offer a custom date at exactly the limit rather
+  // than a 'custom' selection with nothing in the picker.
+  return {until: 'custom', customUntil: dayjs().add(timeLimit, 'second'), deltaSeconds};
 }
 
 /**
@@ -256,7 +274,7 @@ export function reconstructRequestedUntil(args: {
   if (endingAt == null) {
     // A tag time limit forbids indefinite access, so clamp rather than offer it.
     if (timeLimit != null) {
-      return {until: largestAllowedUntil(untilLabels, timeLimit), deltaSeconds: null};
+      return clampedToTimeLimit(untilLabels, timeLimit, null);
     }
     return {until: 'indefinite', deltaSeconds: null};
   }
@@ -266,7 +284,7 @@ export function reconstructRequestedUntil(args: {
   const deltaSeconds = Math.round(dayjs(endingAt).diff(dayjs(createdAt), 'second') / 100) * 100;
 
   if (timeLimit != null && deltaSeconds > timeLimit) {
-    return {until: largestAllowedUntil(untilLabels, timeLimit), deltaSeconds};
+    return clampedToTimeLimit(untilLabels, timeLimit, deltaSeconds);
   }
 
   if (deltaSeconds.toString() in untilLabels) {

--- a/src/pages/group_requests/Create.tsx
+++ b/src/pages/group_requests/Create.tsx
@@ -63,7 +63,12 @@ const APP_GROUP_PREFIX = 'App-';
 const APP_NAME_APP_GROUP_SEPARATOR = '-';
 const ROLE_GROUP_PREFIX = 'Role-';
 
-const UNTIL_ID_TO_LABELS: Record<string, string> = {
+// Exported so the reopen prefill computed in Read.tsx can be built against
+// exactly what this form offers, rather than against
+// accessConfig.ACCESS_TIME_LABELS (used elsewhere in Read.tsx for the
+// resolve/approve form), which an operator may configure differently; doing
+// so would risk prefilling a value this form's own select doesn't list.
+export const UNTIL_ID_TO_LABELS: Record<string, string> = {
   '43200': '12 Hours',
   '432000': '5 Days',
   '1209600': 'Two Weeks',
@@ -88,7 +93,13 @@ interface CreateGroupRequestForm {
   plugin_data?: Record<string, any>;
 }
 
-/** Prefill payload used when reopening an expired group request. */
+/**
+ * Prefill payload used when reopening an expired group request.
+ *
+ * A single object here, unlike the loose per-field props the access-request
+ * and role-request reopen views take: nine fields makes loose props unwieldy
+ * for this view specifically, not a pattern change for the other two.
+ */
 export interface GroupRequestPrefill {
   type: 'okta_group' | 'app_group' | 'role_group';
   app?: AppDetail;
@@ -109,7 +120,12 @@ interface CreateRequestButtonProps {
 
 function CreateRequestButton(props: CreateRequestButtonProps) {
   return (
-    <Tooltip title="Request that a new group or role be created.">
+    <Tooltip
+      title={
+        props.reopen
+          ? 'Resubmit this expired group request with the same details.'
+          : 'Request that a new group or role be created.'
+      }>
       <span>
         <Button variant="contained" onClick={() => props.setOpen(true)} endIcon={<GroupRequestIcon />}>
           {props.reopen ? 'Reopen Request' : 'Create Request'}
@@ -136,7 +152,13 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
     props.prefill?.type ?? 'okta_group',
   );
   const [selectedApp, setSelectedApp] = React.useState<AppDetail | null>(props.prefill?.app ?? null);
-  const [appSearchInput, setAppSearchInput] = React.useState('');
+  // Also seeded from the prefill: the app Autocomplete's options come from a
+  // 10-item search seeded with an empty string, so a prefilled `selectedApp`
+  // may not be among them, which MUI logs as an invalid Autocomplete value.
+  // Seeding the search input with the prefilled app's name makes the search
+  // return it. (The multi-tag Autocomplete below has the same issue with no
+  // equally clean fix, and is intentionally left as-is.)
+  const [appSearchInput, setAppSearchInput] = React.useState(props.prefill?.app?.name ?? '');
   const [tagSearchInput, setTagSearchInput] = React.useState('');
   const [nameInput, setNameInput] = React.useState(props.prefill?.name ?? '');
   const [selectedTags, setSelectedTags] = React.useState<Array<TagDetail>>(props.prefill?.tags ?? []);
@@ -271,6 +293,11 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
   return (
     <FormContainer<CreateGroupRequestForm>
       defaultValues={{
+        // Mirrors the state seeded from props.prefill above (see the comment
+        // on the `groupType` state); react-hook-form's defaultValues and the
+        // plain useState above it both need the same prefill, one for
+        // controlled-field defaults and one for the plain logic that gates
+        // rendering and detection.
         type: props.prefill?.type ?? 'okta_group',
         app: props.prefill?.app,
         name: props.prefill?.name,

--- a/src/pages/group_requests/Create.tsx
+++ b/src/pages/group_requests/Create.tsx
@@ -83,10 +83,28 @@ interface CreateGroupRequestForm {
   ownershipUntil?: string;
   customOwnershipUntil?: string;
   reason?: string;
+  // Registered dynamically by AppGroupLifecyclePluginConfigurationForm as
+  // `plugin_data.<pluginId>.configuration.<prop>`; declared so it can be seeded.
+  plugin_data?: Record<string, any>;
+}
+
+/** Prefill payload used when reopening an expired group request. */
+export interface GroupRequestPrefill {
+  type: 'okta_group' | 'app_group' | 'role_group';
+  app?: AppDetail;
+  name: string;
+  description?: string;
+  ownershipUntil?: string;
+  customOwnershipUntil?: Dayjs;
+  reason?: string;
+  /** Full tag objects, not ids: the form's selectedTags state holds objects. */
+  tags: TagDetail[];
+  pluginData?: Record<string, any>;
 }
 
 interface CreateRequestButtonProps {
   setOpen(open: boolean): void;
+  reopen?: boolean;
 }
 
 function CreateRequestButton(props: CreateRequestButtonProps) {
@@ -94,7 +112,7 @@ function CreateRequestButton(props: CreateRequestButtonProps) {
     <Tooltip title="Request that a new group or role be created.">
       <span>
         <Button variant="contained" onClick={() => props.setOpen(true)} endIcon={<GroupRequestIcon />}>
-          Create Request
+          {props.reopen ? 'Reopen Request' : 'Create Request'}
         </Button>
       </span>
     </Tooltip>
@@ -104,18 +122,27 @@ function CreateRequestButton(props: CreateRequestButtonProps) {
 interface CreateRequestContainerProps {
   currentUser: OktaUserDetail;
   setOpen(open: boolean): void;
+  // Prefill, used when reopening an expired request.
+  prefill?: GroupRequestPrefill;
 }
 
 function CreateRequestContainer(props: CreateRequestContainerProps) {
   const navigate = useNavigate();
 
-  const [groupType, setGroupType] = React.useState<'okta_group' | 'app_group' | 'role_group'>('okta_group');
-  const [selectedApp, setSelectedApp] = React.useState<AppDetail | null>(null);
+  // Seeded from the prefill when reopening an expired request. `groupType` in
+  // particular gates whether the app selector renders, and `nameInput` feeds the
+  // "App-…-" prefix detection, so neither can be left at its empty default.
+  const [groupType, setGroupType] = React.useState<'okta_group' | 'app_group' | 'role_group'>(
+    props.prefill?.type ?? 'okta_group',
+  );
+  const [selectedApp, setSelectedApp] = React.useState<AppDetail | null>(props.prefill?.app ?? null);
   const [appSearchInput, setAppSearchInput] = React.useState('');
   const [tagSearchInput, setTagSearchInput] = React.useState('');
-  const [nameInput, setNameInput] = React.useState('');
-  const [selectedTags, setSelectedTags] = React.useState<Array<TagDetail>>([]);
-  const [ownershipUntil, setOwnershipUntil] = React.useState(accessConfig.DEFAULT_ACCESS_TIME);
+  const [nameInput, setNameInput] = React.useState(props.prefill?.name ?? '');
+  const [selectedTags, setSelectedTags] = React.useState<Array<TagDetail>>(props.prefill?.tags ?? []);
+  const [ownershipUntil, setOwnershipUntil] = React.useState(
+    props.prefill?.ownershipUntil ?? accessConfig.DEFAULT_ACCESS_TIME,
+  );
   const [requestError, setRequestError] = React.useState('');
   const [submitting, setSubmitting] = React.useState(false);
 
@@ -243,7 +270,17 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
 
   return (
     <FormContainer<CreateGroupRequestForm>
-      defaultValues={{type: 'okta_group', ownershipUntil: '1209600'}}
+      defaultValues={{
+        type: props.prefill?.type ?? 'okta_group',
+        app: props.prefill?.app,
+        name: props.prefill?.name,
+        description: props.prefill?.description,
+        ownershipUntil: props.prefill?.ownershipUntil ?? '1209600',
+        // Typed string, holds a Dayjs at runtime; same convention as the other forms.
+        customOwnershipUntil: props.prefill?.customOwnershipUntil as unknown as string,
+        reason: props.prefill?.reason,
+        plugin_data: props.prefill?.pluginData ?? {},
+      }}
       onSuccess={(formData) => submit(formData)}>
       <DialogTitle> Create Group Request</DialogTitle>
       <DialogContent>
@@ -407,6 +444,8 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
 interface CreateRequestDialogProps {
   currentUser: OktaUserDetail;
   setOpen(open: boolean): void;
+  // Prefill, used when reopening an expired request.
+  prefill?: GroupRequestPrefill;
 }
 
 function CreateRequestDialog(props: CreateRequestDialogProps) {
@@ -419,8 +458,11 @@ function CreateRequestDialog(props: CreateRequestDialogProps) {
 
 interface CreateRequestProps {
   currentUser: OktaUserDetail;
+  reopen?: boolean;
   open?: boolean;
   setOpen?: (open: boolean) => void;
+  // Prefill, used when reopening an expired request.
+  prefill?: GroupRequestPrefill;
 }
 
 export default function CreateRequest(props: CreateRequestProps) {
@@ -430,8 +472,8 @@ export default function CreateRequest(props: CreateRequestProps) {
 
   return (
     <>
-      {props.setOpen == null && <CreateRequestButton setOpen={setOpen} />}
-      {open && <CreateRequestDialog currentUser={props.currentUser} setOpen={setOpen} />}
+      {props.setOpen == null && <CreateRequestButton setOpen={setOpen} reopen={props.reopen} />}
+      {open && <CreateRequestDialog currentUser={props.currentUser} setOpen={setOpen} prefill={props.prefill} />}
     </>
   );
 }

--- a/src/pages/group_requests/Read.tsx
+++ b/src/pages/group_requests/Read.tsx
@@ -209,9 +209,6 @@ export default function ReadGroupRequest() {
   const requestedAppId = groupRequest.requested_app_id ?? null;
   const requestedTagNames: string[] = groupRequest.requested_group_tags ?? [];
 
-  // Anyone may request a group, so reopen is offered to any authenticated
-  // viewer; it is a shortcut for the create form they could already open.
-  const canReopen = isExpiredRequest(groupRequest);
   // Compute against the create form's own option map (CREATE_FORM_UNTIL_ID_TO_LABELS,
   // imported from Create.tsx), not the UNTIL_ID_TO_LABELS above (which is this
   // file's resolve/approve-form map, sourced from accessConfig.ACCESS_TIME_LABELS
@@ -242,6 +239,18 @@ export default function ReadGroupRequest() {
     {pathParams: {appId: requestedAppId ?? ''}},
     {enabled: requestedAppId != null && requestedGroupType === 'app_group'},
   );
+
+  // Anyone may request a group, so reopen is offered to any authenticated
+  // viewer; it is a shortcut for the create form they could already open.
+  //
+  // The one exception is an app_group request whose app no longer resolves:
+  // strippedRequestedName then falls back to the full stored name, and the
+  // create form re-prepends the prefix of whichever app the user picks, yielding
+  // `App-Bar-App-Foo-Reporting`. That submits a valid-looking but wrong name, so
+  // suppress the affordance rather than prefill it; a fresh request by hand
+  // still works.
+  const reopenNameIsSafe = requestedGroupType !== 'app_group' || (requestedAppData?.name ?? null) !== null;
+  const canReopen = isExpiredRequest(groupRequest) && reopenNameIsSafe;
   // The lifecycle plugin configured on the target app (null if none).
   const requestPluginId = pluginIdForApp(requestedAppData);
 

--- a/src/pages/group_requests/Read.tsx
+++ b/src/pages/group_requests/Read.tsx
@@ -71,7 +71,7 @@ import Loading from '../../components/Loading';
 import accessConfig from '../../config/accessConfig';
 import {pluginIdForApp, extractRequestedPluginData, prefillablePluginData} from './pluginConfig';
 import PluginConfigDisplay from './PluginConfigDisplay';
-import CreateRequest from './Create';
+import CreateRequest, {UNTIL_ID_TO_LABELS as CREATE_FORM_UNTIL_ID_TO_LABELS} from './Create';
 import ChangeTitle from '../../tab-title';
 import NotFound from '../NotFound';
 
@@ -212,10 +212,16 @@ export default function ReadGroupRequest() {
   // Anyone may request a group, so reopen is offered to any authenticated
   // viewer; it is a shortcut for the create form they could already open.
   const canReopen = isExpiredRequest(groupRequest);
+  // Compute against the create form's own option map (CREATE_FORM_UNTIL_ID_TO_LABELS,
+  // imported from Create.tsx), not the UNTIL_ID_TO_LABELS above (which is this
+  // file's resolve/approve-form map, sourced from accessConfig.ACCESS_TIME_LABELS
+  // and operator-configurable). Reopen hands its prefill to that create form, so
+  // the prefilled value must only ever be one that form's select actually lists;
+  // timeLimit is always null here because the create form applies no tag clamp.
   const reopenOwnershipUntil = reconstructRequestedUntil({
     createdAt: groupRequest.created_at,
     endingAt: groupRequest.requested_ownership_ending_at,
-    untilLabels: UNTIL_ID_TO_LABELS,
+    untilLabels: CREATE_FORM_UNTIL_ID_TO_LABELS,
     timeLimit: null,
   });
 
@@ -1055,7 +1061,12 @@ export default function ReadGroupRequest() {
                             prefill={{
                               type: requestedGroupType as 'okta_group' | 'app_group' | 'role_group',
                               app: requestedAppData,
-                              name: groupRequest.requested_group_name ?? '',
+                              // The un-prefixed suffix, not the full stored name: the
+                              // create form's Name field holds only the suffix (it
+                              // renders "App-<app>-"/"Role-" as static Typography
+                              // beside it) and re-prepends the prefix on submit, so
+                              // passing the full name here would double it up.
+                              name: strippedRequestedName,
                               description: groupRequest.requested_group_description ?? '',
                               ownershipUntil: reopenOwnershipUntil.until,
                               customOwnershipUntil: reopenOwnershipUntil.customUntil,

--- a/src/pages/group_requests/Read.tsx
+++ b/src/pages/group_requests/Read.tsx
@@ -64,13 +64,14 @@ import {
 } from '../../api/apiSchemas';
 import {useCurrentUser} from '../../authentication';
 import {isAccessAdmin, isAppOwnerGroupOwner} from '../../authorization';
-import {displayUserName, minTagTime} from '../../helpers';
+import {displayUserName, minTagTime, isExpiredRequest, reconstructRequestedUntil} from '../../helpers';
 
 import AppGroupLifecyclePluginConfigurationForm from '../../components/AppGroupLifecyclePluginConfigurationForm';
 import Loading from '../../components/Loading';
 import accessConfig from '../../config/accessConfig';
-import {pluginIdForApp, extractRequestedPluginData} from './pluginConfig';
+import {pluginIdForApp, extractRequestedPluginData, prefillablePluginData} from './pluginConfig';
 import PluginConfigDisplay from './PluginConfigDisplay';
+import CreateRequest from './Create';
 import ChangeTitle from '../../tab-title';
 import NotFound from '../NotFound';
 
@@ -207,6 +208,16 @@ export default function ReadGroupRequest() {
   const requestedGroupType = groupRequest.requested_group_type ?? 'okta_group';
   const requestedAppId = groupRequest.requested_app_id ?? null;
   const requestedTagNames: string[] = groupRequest.requested_group_tags ?? [];
+
+  // Anyone may request a group, so reopen is offered to any authenticated
+  // viewer; it is a shortcut for the create form they could already open.
+  const canReopen = isExpiredRequest(groupRequest);
+  const reopenOwnershipUntil = reconstructRequestedUntil({
+    createdAt: groupRequest.created_at,
+    endingAt: groupRequest.requested_ownership_ending_at,
+    untilLabels: UNTIL_ID_TO_LABELS,
+    timeLimit: null,
+  });
 
   const [typesSeeded, setTypesSeeded] = React.useState(false);
   React.useEffect(() => {
@@ -1036,6 +1047,25 @@ export default function ReadGroupRequest() {
                         <b>Reason:</b>{' '}
                         {groupRequest.resolution_reason ? groupRequest.resolution_reason : 'No reason given'}
                       </Typography>
+                      {canReopen ? (
+                        <Box sx={{mt: 2}}>
+                          <CreateRequest
+                            currentUser={currentUser}
+                            reopen
+                            prefill={{
+                              type: requestedGroupType as 'okta_group' | 'app_group' | 'role_group',
+                              app: requestedAppData,
+                              name: groupRequest.requested_group_name ?? '',
+                              description: groupRequest.requested_group_description ?? '',
+                              ownershipUntil: reopenOwnershipUntil.until,
+                              customOwnershipUntil: reopenOwnershipUntil.customUntil,
+                              reason: groupRequest.request_reason ?? '',
+                              tags: requestedTags,
+                              pluginData: prefillablePluginData(requestedAppData, groupRequest.requested_plugin_data),
+                            }}
+                          />
+                        </Box>
+                      ) : null}
                       {groupRequest.status === 'APPROVED' && approvedDetails.length > 0 && (
                         <Box sx={{mt: 1}}>
                           <Typography variant="body1" sx={{mb: 0.5}}>

--- a/src/pages/group_requests/pluginConfig.test.ts
+++ b/src/pages/group_requests/pluginConfig.test.ts
@@ -1,5 +1,11 @@
 import {describe, it, expect} from 'vitest';
-import {pluginIdForApp, extractRequestedPluginData, visiblePluginConfigEntries, pluginConfigRows} from './pluginConfig';
+import {
+  pluginIdForApp,
+  extractRequestedPluginData,
+  visiblePluginConfigEntries,
+  pluginConfigRows,
+  prefillablePluginData,
+} from './pluginConfig';
 
 describe('pluginIdForApp', () => {
   it('returns the plugin id when the app has one', () => {
@@ -63,5 +69,30 @@ describe('pluginConfigRows', () => {
   it('treats a newly-added key (absent in previous) as changed with an undefined from', () => {
     const rows = pluginConfigRows({region: 'us'}, {});
     expect(rows).toEqual([{key: 'region', value: 'us', changed: true, from: undefined}]);
+  });
+});
+
+describe('prefillablePluginData', () => {
+  const stored = {'plugin-a': {configuration: {channel: '#eng'}}};
+
+  it('keeps the stored config when the app still uses that plugin', () => {
+    expect(prefillablePluginData({id: 'app1', app_group_lifecycle_plugin: 'plugin-a'}, stored)).toEqual(stored);
+  });
+
+  it('drops the config when the app switched plugins', () => {
+    expect(prefillablePluginData({id: 'app1', app_group_lifecycle_plugin: 'plugin-b'}, stored)).toEqual({});
+  });
+
+  it('drops the config when the app has no lifecycle plugin', () => {
+    expect(prefillablePluginData({id: 'app1', app_group_lifecycle_plugin: null}, stored)).toEqual({});
+  });
+
+  it('drops the config when there is no app at all', () => {
+    expect(prefillablePluginData(null, stored)).toEqual({});
+  });
+
+  it('returns an empty object for empty or missing stored data', () => {
+    expect(prefillablePluginData({id: 'app1', app_group_lifecycle_plugin: 'plugin-a'}, {})).toEqual({});
+    expect(prefillablePluginData({id: 'app1', app_group_lifecycle_plugin: 'plugin-a'}, undefined)).toEqual({});
   });
 });

--- a/src/pages/group_requests/pluginConfig.test.ts
+++ b/src/pages/group_requests/pluginConfig.test.ts
@@ -95,4 +95,18 @@ describe('prefillablePluginData', () => {
     expect(prefillablePluginData({id: 'app1', app_group_lifecycle_plugin: 'plugin-a'}, {})).toEqual({});
     expect(prefillablePluginData({id: 'app1', app_group_lifecycle_plugin: 'plugin-a'}, undefined)).toEqual({});
   });
+
+  it('narrows to only the matching plugin key when multiple are stored', () => {
+    // Guards against an implementation that returns the whole storedPluginData
+    // object whenever storedPluginData[pluginId] != null; the single-key fixture
+    // above cannot distinguish that from the correct {[pluginId]: configuration}
+    // narrowing.
+    const multiStored = {
+      'plugin-a': {configuration: {channel: '#eng'}},
+      'plugin-b': {configuration: {region: 'us'}},
+    };
+    expect(prefillablePluginData({id: 'app1', app_group_lifecycle_plugin: 'plugin-a'}, multiStored)).toEqual({
+      'plugin-a': {configuration: {channel: '#eng'}},
+    });
+  });
 });

--- a/src/pages/group_requests/pluginConfig.ts
+++ b/src/pages/group_requests/pluginConfig.ts
@@ -54,3 +54,24 @@ export function pluginConfigRows(
     return {key, value, changed: hasPrevious && from !== value, from};
   });
 }
+
+/**
+ * The subset of a stored `requested_plugin_data` that is still safe to prefill.
+ *
+ * An app's lifecycle plugin can change after a group request is written. The
+ * stored config is keyed by the plugin id that was configured then, so seeding
+ * it blindly would populate a form section for a plugin the app no longer uses.
+ * Keep the config only when the app's current plugin id still matches; drop it
+ * otherwise and let the rest of the prefill proceed.
+ */
+export function prefillablePluginData(
+  app: AppLike,
+  storedPluginData: Record<string, any> | null | undefined,
+): Record<string, any> {
+  const pluginId = pluginIdForApp(app);
+  if (pluginId == null || storedPluginData == null) {
+    return {};
+  }
+  const configuration = storedPluginData[pluginId];
+  return configuration == null ? {} : {[pluginId]: configuration};
+}

--- a/src/pages/requests/Create.tsx
+++ b/src/pages/requests/Create.tsx
@@ -242,7 +242,11 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
   const untilLabels: [string, Array<Record<string, string>>] = timeLimit
     ? filterUntilLabels(timeLimit)
     : [accessConfig.DEFAULT_ACCESS_TIME, UNTIL_OPTIONS];
-  const [until, setUntil] = React.useState(untilLabels[0]);
+  // Seeded from the prefill, not just from `defaultValues`: the custom-date
+  // picker below is gated on this state, so a 'custom' prefill would otherwise
+  // show a Custom selection with no date field -- and submit the hidden seeded
+  // date without the picker's `required` validation ever running.
+  const [until, setUntil] = React.useState(props.until ?? untilLabels[0]);
   const [labels, setLabels] = React.useState<Array<Record<string, string>>>(untilLabels[1]);
 
   const complete = (

--- a/src/pages/requests/Create.tsx
+++ b/src/pages/requests/Create.tsx
@@ -57,6 +57,7 @@ interface CreateRequestButtonProps {
   group?: GroupDetail;
   owner?: boolean;
   renew?: boolean;
+  reopen?: boolean;
   expired?: boolean;
 }
 
@@ -67,11 +68,13 @@ function CreateRequestButton(props: CreateRequestButtonProps) {
         <Button variant="contained" onClick={() => props.setOpen(true)} endIcon={<AccessRequestIcon />}>
           {props.group == null
             ? 'Create Request'
-            : props.renew
-              ? 'Renew'
-              : props.owner
-                ? 'Request Ownership'
-                : 'Request Membership'}
+            : props.reopen
+              ? 'Reopen Request'
+              : props.renew
+                ? 'Renew'
+                : props.owner
+                  ? 'Request Ownership'
+                  : 'Request Membership'}
         </Button>
       </span>
     </Tooltip>
@@ -169,6 +172,10 @@ interface CreateRequestContainerProps {
   group?: GroupDetail;
   owner?: boolean;
   renew?: boolean;
+  // Prefill, used when reopening an expired request.
+  until?: string;
+  customUntil?: Dayjs;
+  reason?: string;
 }
 interface CreateRequestForm {
   group: GroupDetail;
@@ -322,7 +329,12 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
     <FormContainer<CreateRequestForm>
       defaultValues={{
         group: props.group,
-        until: accessConfig.DEFAULT_ACCESS_TIME,
+        until: props.until ?? accessConfig.DEFAULT_ACCESS_TIME,
+        // `customUntil` is typed string on CreateRequestForm but holds a Dayjs at
+        // runtime: DatePickerElement produces one and the submit handler casts it
+        // back (`as unknown as Dayjs`, above). Match that existing convention.
+        customUntil: props.customUntil as unknown as string,
+        reason: props.reason,
         ownerOrMember: props.owner != null ? (props.owner ? 'owner' : 'member') : undefined,
       }}
       onSuccess={(formData) => submit(formData)}>
@@ -478,6 +490,9 @@ interface CreateRequestDialogProps {
   group?: GroupDetail;
   owner?: boolean;
   renew?: boolean;
+  until?: string;
+  customUntil?: Dayjs;
+  reason?: string;
 }
 
 function CreateRequestDialog(props: CreateRequestDialogProps) {
@@ -515,9 +530,14 @@ interface CreateRequestProps {
   group?: GroupDetail;
   owner?: boolean;
   renew?: boolean;
+  reopen?: boolean;
   expired?: boolean;
   open?: boolean;
   setOpen?: (open: boolean) => void;
+  // Prefill, used when reopening an expired request.
+  until?: string;
+  customUntil?: Dayjs;
+  reason?: string;
 }
 
 export default function CreateRequest(props: CreateRequestProps) {
@@ -552,6 +572,7 @@ export default function CreateRequest(props: CreateRequestProps) {
           group={props.group}
           owner={props.owner}
           renew={props.renew}
+          reopen={props.reopen}
           expired={props.expired}
         />
       )}

--- a/src/pages/requests/Read.tsx
+++ b/src/pages/requests/Read.tsx
@@ -45,6 +45,7 @@ import IsSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 import {
   groupBy,
   displayUserName,
+  isExpiredRequest,
   minTagTime,
   minTagTimeGroups,
   reconstructRequestedUntil,
@@ -53,6 +54,7 @@ import {
 } from '../../helpers';
 import {useCurrentUser} from '../../authentication';
 import {canManageGroup, ACCESS_APP_RESERVED_NAME} from '../../authorization';
+import CreateRequest from './Create';
 import {
   useAccessRequestById,
   useGroupById,
@@ -222,6 +224,19 @@ export default function ReadRequest() {
 
   const timeLimit: number | null = constraints[0] as number | null;
   const reason: boolean = constraints[1] as boolean;
+
+  // Reopen is offered only on a request the sweep closed, and only to the
+  // original requester: an access request targets its own requester, so nobody
+  // else can recreate *this* request. `ownRequest` is already computed above.
+  const canReopen = isExpiredRequest(accessRequest) && ownRequest;
+  // Unlike `requestedUntil` above, this passes `timeLimit` so the prefill
+  // respects a tag limit that may have tightened since the original request.
+  const reopenPrefill = reconstructRequestedUntil({
+    createdAt: accessRequest.created_at,
+    endingAt: accessRequest.request_ending_at,
+    untilLabels: UNTIL_ID_TO_LABELS,
+    timeLimit: timeLimit,
+  });
 
   let autofill_until = false;
   if (requestedUntilDelta && timeLimit && requestedUntilDelta <= timeLimit) {
@@ -1000,6 +1015,19 @@ export default function ReadRequest() {
                         <b>Reason:</b>{' '}
                         {accessRequest.resolution_reason ? accessRequest.resolution_reason : 'No reason given'}
                       </Typography>
+                      {canReopen ? (
+                        <Box sx={{mt: 2}}>
+                          <CreateRequest
+                            currentUser={currentUser}
+                            group={group}
+                            owner={accessRequest.request_ownership ?? false}
+                            reopen
+                            until={reopenPrefill.until}
+                            customUntil={reopenPrefill.customUntil}
+                            reason={accessRequest.request_reason ?? ''}
+                          />
+                        </Box>
+                      ) : null}
                     </Paper>
                   )}
                 </TimelineContent>

--- a/src/pages/requests/Read.tsx
+++ b/src/pages/requests/Read.tsx
@@ -47,6 +47,7 @@ import {
   displayUserName,
   minTagTime,
   minTagTimeGroups,
+  reconstructRequestedUntil,
   requiredReason,
   requiredReasonGroups,
 } from '../../helpers';
@@ -178,17 +179,13 @@ export default function ReadRequest() {
   const ownRequest = accessRequest.requester?.id == currentUser.id;
 
   const requestEndingAt = dayjs(accessRequest.request_ending_at);
-  // round the delta to adjust based on partial seconds
-  const requestedUntilDelta =
-    accessRequest.request_ending_at == null
-      ? null
-      : Math.round(requestEndingAt.diff(dayjs(accessRequest.created_at), 'second') / 100) * 100;
-  const requestedUntil =
-    requestedUntilDelta == null
-      ? 'indefinite'
-      : requestedUntilDelta in UNTIL_ID_TO_LABELS
-        ? requestedUntilDelta.toString()
-        : 'custom';
+  // No timeLimit: the clamp for a tag limit that dropped below the original ask
+  // is applied separately below, via autofill_until / requestedUntilAdjusted.
+  const {until: requestedUntil, deltaSeconds: requestedUntilDelta} = reconstructRequestedUntil({
+    createdAt: accessRequest.created_at,
+    endingAt: accessRequest.request_ending_at,
+    untilLabels: UNTIL_ID_TO_LABELS,
+  });
 
   const requestedGroupManager = canManageGroup(currentUser, accessRequest.requested_group);
 

--- a/src/pages/role_requests/Create.tsx
+++ b/src/pages/role_requests/Create.tsx
@@ -203,7 +203,11 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
   const untilLabels: [string, Array<Record<string, string>>] = timeLimit
     ? filterUntilLabels(timeLimit)
     : ['1209600', UNTIL_OPTIONS];
-  const [until, setUntil] = React.useState(untilLabels[0]);
+  // Seeded from the prefill, not just from `defaultValues`: the custom-date
+  // picker below is gated on this state, so a 'custom' prefill would otherwise
+  // show a Custom selection with no date field -- and submit the hidden seeded
+  // date without the picker's `required` validation ever running.
+  const [until, setUntil] = React.useState(props.until ?? untilLabels[0]);
   const [labels, setLabels] = React.useState<Array<Record<string, string>>>(untilLabels[1]);
 
   const complete = (

--- a/src/pages/role_requests/Create.tsx
+++ b/src/pages/role_requests/Create.tsx
@@ -62,6 +62,7 @@ interface CreateRequestButtonProps {
   group?: GroupDetail;
   owner?: boolean;
   renew?: boolean;
+  reopen?: boolean;
 }
 
 function CreateRequestButton(props: CreateRequestButtonProps) {
@@ -80,11 +81,13 @@ function CreateRequestButton(props: CreateRequestButtonProps) {
           disabled={!props.enabled}>
           {props.group == null
             ? 'Create Request'
-            : props.renew
-              ? 'Renew'
-              : props.owner
-                ? 'Request Ownership'
-                : 'Request Membership'}
+            : props.reopen
+              ? 'Reopen Request'
+              : props.renew
+                ? 'Renew'
+                : props.owner
+                  ? 'Request Ownership'
+                  : 'Request Membership'}
         </Button>
       </span>
     </Tooltip>
@@ -102,6 +105,10 @@ interface CreateRequestContainerProps {
   group?: GroupDetail;
   owner?: boolean;
   renew?: boolean;
+  // Prefill, used when reopening an expired request.
+  until?: string;
+  customUntil?: Dayjs;
+  reason?: string;
 }
 interface CreateRequestForm {
   role: RoleGroupDetail;
@@ -295,7 +302,10 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
       defaultValues={{
         role: props.role,
         group: props.group,
-        until: '1209600',
+        until: props.until ?? '1209600',
+        // Typed string, holds a Dayjs at runtime; same convention as the access form.
+        customUntil: props.customUntil as unknown as string,
+        reason: props.reason,
         ownerOrMember: props.owner != null ? (props.owner ? 'owner' : 'member') : undefined,
       }}
       onSuccess={(formData) => submit(formData)}>
@@ -490,6 +500,9 @@ interface CreateRequestDialogProps {
   group?: GroupDetail;
   owner?: boolean;
   renew?: boolean;
+  until?: string;
+  customUntil?: Dayjs;
+  reason?: string;
 }
 
 function CreateRequestDialog(props: CreateRequestDialogProps) {
@@ -510,8 +523,13 @@ interface CreateRequestProps {
   group?: OktaGroupDetail | AppGroupDetail;
   owner?: boolean;
   renew?: boolean;
+  reopen?: boolean;
   open?: boolean;
   setOpen?: (open: boolean) => void;
+  // Prefill, used when reopening an expired request.
+  until?: string;
+  customUntil?: Dayjs;
+  reason?: string;
 }
 
 export default function CreateRequest(props: CreateRequestProps) {
@@ -538,6 +556,7 @@ export default function CreateRequest(props: CreateRequestProps) {
           group={props.group as GroupDetail | undefined}
           owner={props.owner}
           renew={props.renew}
+          reopen={props.reopen}
         />
       )}
       {open ? (

--- a/src/pages/role_requests/Read.tsx
+++ b/src/pages/role_requests/Read.tsx
@@ -269,6 +269,8 @@ export default function ReadRoleRequest() {
   // Role requests must be submitted by an owner of the role, so reopen is
   // offered to current role owners rather than only the original requester.
   const canReopen = isExpiredRequest(roleRequest) && canManageGroup(currentUser, roleRequest.requester_role);
+  // Unlike `requestedUntil` above, this passes `timeLimit` so the prefill
+  // respects a tag limit that may have tightened since the original request.
   const reopenPrefill = reconstructRequestedUntil({
     createdAt: roleRequest.created_at,
     endingAt: roleRequest.request_ending_at,

--- a/src/pages/role_requests/Read.tsx
+++ b/src/pages/role_requests/Read.tsx
@@ -48,6 +48,7 @@ import RoleMembers from './RoleMembers';
 import {
   groupBy,
   displayUserName,
+  isExpiredRequest,
   minTagTime,
   minTagTimeGroups,
   ownerCantAddSelf,
@@ -73,6 +74,7 @@ import {
   AppGroupDetail,
   AppGroupForAppDetail,
   GroupRefForMembership,
+  OktaGroupDetail,
   OktaUserGroupMemberDetail,
   OktaUserSummary,
   GroupDetail,
@@ -88,6 +90,7 @@ import NotFound from '../NotFound';
 import Loading from '../../components/Loading';
 import ChangeTitle from '../../tab-title';
 import AccessHistory from '../../components/AccessHistory';
+import CreateRequest from './Create';
 
 dayjs.extend(RelativeTime);
 dayjs.extend(IsSameOrBefore);
@@ -262,6 +265,16 @@ export default function ReadRoleRequest() {
 
   const timeLimit: number | null = constraints[0] as number | null;
   const reason: boolean = constraints[1] as boolean;
+
+  // Role requests must be submitted by an owner of the role, so reopen is
+  // offered to current role owners rather than only the original requester.
+  const canReopen = isExpiredRequest(roleRequest) && canManageGroup(currentUser, roleRequest.requester_role);
+  const reopenPrefill = reconstructRequestedUntil({
+    createdAt: roleRequest.created_at,
+    endingAt: roleRequest.request_ending_at,
+    untilLabels: UNTIL_ID_TO_LABELS,
+    timeLimit: timeLimit,
+  });
 
   let autofill_until = false;
   if (requestedUntilDelta && timeLimit && requestedUntilDelta <= timeLimit) {
@@ -1108,6 +1121,21 @@ export default function ReadRoleRequest() {
                         <b>Reason:</b>{' '}
                         {roleRequest.resolution_reason ? roleRequest.resolution_reason : 'No reason given'}
                       </Typography>
+                      {canReopen ? (
+                        <Box sx={{mt: 2}}>
+                          <CreateRequest
+                            enabled
+                            currentUser={currentUser}
+                            role={roleRequest.requester_role as RoleGroupDetail}
+                            group={roleRequest.requested_group as OktaGroupDetail | AppGroupDetail}
+                            owner={roleRequest.request_ownership ?? false}
+                            reopen
+                            until={reopenPrefill.until}
+                            customUntil={reopenPrefill.customUntil}
+                            reason={roleRequest.request_reason ?? ''}
+                          />
+                        </Box>
+                      ) : null}
                     </Paper>
                   )}
                 </TimelineContent>

--- a/src/pages/role_requests/Read.tsx
+++ b/src/pages/role_requests/Read.tsx
@@ -51,6 +51,7 @@ import {
   minTagTime,
   minTagTimeGroups,
   ownerCantAddSelf,
+  reconstructRequestedUntil,
   requiredReason,
   requiredReasonGroups,
 } from '../../helpers';
@@ -195,17 +196,12 @@ export default function ReadRoleRequest() {
   const ownRequest = roleRequest.requester?.id == currentUser.id;
 
   const requestEndingAt = dayjs(roleRequest.request_ending_at);
-  // round the delta to adjust based on partial seconds
-  const requestedUntilDelta =
-    roleRequest.request_ending_at == null
-      ? null
-      : Math.round(requestEndingAt.diff(dayjs(roleRequest.created_at), 'second') / 100) * 100;
-  const requestedUntil =
-    requestedUntilDelta == null
-      ? 'indefinite'
-      : requestedUntilDelta in UNTIL_ID_TO_LABELS
-        ? requestedUntilDelta.toString()
-        : 'custom';
+  // No timeLimit here either; see the comment in requests/Read.tsx.
+  const {until: requestedUntil, deltaSeconds: requestedUntilDelta} = reconstructRequestedUntil({
+    createdAt: roleRequest.created_at,
+    endingAt: roleRequest.request_ending_at,
+    untilLabels: UNTIL_ID_TO_LABELS,
+  });
 
   // Check to see if current user is a blocked group owner
   const ownedGroup = currentUser.active_group_ownerships

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,3 +32,19 @@ def test_trusted_hosts() -> None:
         "a.example.com",
         "*.example.com",
     ]
+
+
+def test_max_group_request_age_seconds() -> None:
+    # Unset falls back to the access-request cutoff, so operators who never set
+    # it get the behavior they already had.
+    assert Settings(MAX_ACCESS_REQUEST_AGE_SECONDS=1234).max_group_request_age_seconds == 1234
+    # An explicit value wins.
+    assert (
+        Settings(MAX_ACCESS_REQUEST_AGE_SECONDS=1234, MAX_GROUP_REQUEST_AGE_SECONDS=9999).max_group_request_age_seconds
+        == 9999
+    )
+    # 0 means "expire immediately" and must not be swallowed into the fallback.
+    assert (
+        Settings(MAX_ACCESS_REQUEST_AGE_SECONDS=1234, MAX_GROUP_REQUEST_AGE_SECONDS=0).max_group_request_age_seconds
+        == 0
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,6 @@
+import pytest
+from pydantic import ValidationError
+
 from api.config import Settings
 
 
@@ -34,17 +37,48 @@ def test_trusted_hosts() -> None:
     ]
 
 
-def test_max_group_request_age_seconds() -> None:
-    # Unset falls back to the access-request cutoff, so operators who never set
-    # it get the behavior they already had.
-    assert Settings(MAX_ACCESS_REQUEST_AGE_SECONDS=1234).max_group_request_age_seconds == 1234
-    # An explicit value wins.
-    assert (
-        Settings(MAX_ACCESS_REQUEST_AGE_SECONDS=1234, MAX_GROUP_REQUEST_AGE_SECONDS=9999).max_group_request_age_seconds
-        == 9999
-    )
-    # 0 means "expire immediately" and must not be swallowed into the fallback.
-    assert (
-        Settings(MAX_ACCESS_REQUEST_AGE_SECONDS=1234, MAX_GROUP_REQUEST_AGE_SECONDS=0).max_group_request_age_seconds
-        == 0
-    )
+def test_request_age_defaults_are_one_week_and_independent() -> None:
+    one_week = 7 * 24 * 60 * 60
+    assert Settings().max_access_request_age_seconds == one_week
+    assert Settings().max_group_request_age_seconds == one_week
+    # Independent: setting one does not move the other.
+    s = Settings(MAX_ACCESS_REQUEST_AGE_SECONDS=1234)
+    assert s.max_access_request_age_seconds == 1234
+    assert s.max_group_request_age_seconds == one_week
+    s = Settings(MAX_GROUP_REQUEST_AGE_SECONDS=9999)
+    assert s.max_access_request_age_seconds == one_week
+    assert s.max_group_request_age_seconds == 9999
+
+
+def test_never_disables_each_age_cutoff_independently() -> None:
+    one_week = 7 * 24 * 60 * 60
+    s = Settings(MAX_ACCESS_REQUEST_AGE_SECONDS="never")
+    assert s.max_access_request_age_seconds is None
+    assert s.max_group_request_age_seconds == one_week
+
+    s = Settings(MAX_GROUP_REQUEST_AGE_SECONDS="never")
+    assert s.max_access_request_age_seconds == one_week
+    assert s.max_group_request_age_seconds is None
+
+    s = Settings(MAX_ACCESS_REQUEST_AGE_SECONDS="never", MAX_GROUP_REQUEST_AGE_SECONDS="never")
+    assert s.max_access_request_age_seconds is None
+    assert s.max_group_request_age_seconds is None
+
+
+@pytest.mark.parametrize("bad", ["NEVER", "Never", "nope", "", "none", "null"])
+def test_non_numeric_values_other_than_never_are_rejected(bad: str) -> None:
+    """A typo must fail at startup rather than silently disabling or defaulting."""
+    with pytest.raises(ValidationError):
+        Settings(MAX_ACCESS_REQUEST_AGE_SECONDS=bad)
+    with pytest.raises(ValidationError):
+        Settings(MAX_GROUP_REQUEST_AGE_SECONDS=bad)
+
+
+@pytest.mark.parametrize("bad", [0, -1, -604800])
+def test_ints_below_one_are_rejected_and_the_error_names_never(bad: int) -> None:
+    """`-1` is the likely Unix-habit guess for "disable"; expiring everything
+    because of it would be a bad silent failure."""
+    for field in ("MAX_ACCESS_REQUEST_AGE_SECONDS", "MAX_GROUP_REQUEST_AGE_SECONDS"):
+        with pytest.raises(ValidationError) as exc:
+            Settings(**{field: bad})
+        assert "never" in str(exc.value)

--- a/tests/test_expire_access_request.py
+++ b/tests/test_expire_access_request.py
@@ -4,7 +4,6 @@ from pytest_mock import MockerFixture
 
 from api.models import AccessRequest, AccessRequestStatus, OktaGroup, OktaUser
 from api.extensions import Db
-from api.operations import RejectAccessRequest
 from api.syncer import expire_access_requests
 from tests.factories import AccessRequestFactory
 
@@ -61,10 +60,16 @@ async def test_expire_access_requests_isolates_failures(
     user: OktaUser,
     mocker: MockerFixture,
 ) -> None:
-    """One request that fails to reject must not abort the rest of the sweep.
+    """One request that fails mid-write must not abort or corrupt the rest of the sweep.
 
-    Without per-request isolation a single poisoned row aborts expiration for
-    every other row, and does so again on every subsequent sync run.
+    The failure is injected at the operation's own `commit`, i.e. *after* it has
+    assigned status/resolved_at/resolver_user_id/resolution_reason to the
+    session. That is the state the rollback in `_expire_each` exists for, and
+    the only state that distinguishes it from a no-op: without the rollback the
+    dirty REJECTED row stays pending in the session and the next iteration's
+    `SELECT ... FOR UPDATE` autoflushes it, silently rejecting the very request
+    the sweep logged as skipped. Injecting before any SQL is emitted would leave
+    the session clean and pass with or without the rollback.
     """
     db.session.add(user)
     db.session.add(okta_group)
@@ -81,26 +86,29 @@ async def test_expire_access_requests_isolates_failures(
         ids.append(req.id)
     await db.session.commit()
 
-    # Fail the first reject only; the other two must still be expired.
-    real_execute = RejectAccessRequest.execute
+    # Fail the first commit the sweep attempts; let every later one through.
+    real_commit = db.session.commit
     calls = {"n": 0}
 
-    async def flaky(self: RejectAccessRequest) -> AccessRequest:
+    async def flaky_commit() -> None:
         calls["n"] += 1
         if calls["n"] == 1:
-            raise RuntimeError("boom")
-        return await real_execute(self)
+            raise RuntimeError("commit blew up mid-write")
+        await real_commit()
 
-    mocker.patch.object(RejectAccessRequest, "execute", flaky)
+    mocker.patch.object(db.session, "commit", flaky_commit)
 
     await expire_access_requests()
 
+    mocker.stopall()
     db.session.expire_all()
     statuses = []
     for request_id in ids:
         row = await db.session.get(AccessRequest, request_id)
         statuses.append(row.status)
 
+    # Two expired; the one whose commit failed is still PENDING rather than
+    # having been written by a later iteration's autoflush.
     assert statuses.count(AccessRequestStatus.REJECTED) == 2
     assert statuses.count(AccessRequestStatus.PENDING) == 1
 

--- a/tests/test_expire_access_request.py
+++ b/tests/test_expire_access_request.py
@@ -1,7 +1,9 @@
 from datetime import datetime, timedelta, timezone
 
+import pytest
 from pytest_mock import MockerFixture
 
+from api.config import settings
 from api.models import AccessRequest, AccessRequestStatus, OktaGroup, OktaUser
 from api.extensions import Db
 from api.syncer import expire_access_requests
@@ -137,3 +139,45 @@ async def test_expire_old_temporary_access_request(
     access_request = await db.session.get(AccessRequest, access_request_id)
     assert access_request.status == AccessRequestStatus.REJECTED
     assert access_request.resolved_at is not None
+
+
+async def test_never_disables_the_age_cutoff_but_not_the_requested_window(
+    db: Db,
+    okta_group: OktaGroup,
+    user: OktaUser,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`never` switches off the age sweep only.
+
+    A request that merely sat too long survives; a request whose own
+    `request_ending_at` has passed is still closed, because that sweep is a
+    separate pass and is deliberately not disableable.
+    """
+    monkeypatch.setattr(settings, "MAX_ACCESS_REQUEST_AGE_SECONDS", "never")
+    db.session.add(user)
+    db.session.add(okta_group)
+    await db.session.commit()
+
+    stale = datetime.now(timezone.utc) - timedelta(days=30)
+
+    old_only = AccessRequestFactory.build()
+    old_only.created_at = stale
+    old_only.requested_group_id = okta_group.id
+    old_only.requester_user_id = user.id
+
+    lapsed_window = AccessRequestFactory.build()
+    lapsed_window.created_at = stale
+    lapsed_window.request_ending_at = datetime.now(timezone.utc) - timedelta(hours=12)
+    lapsed_window.requested_group_id = okta_group.id
+    lapsed_window.requester_user_id = user.id
+
+    db.session.add(old_only)
+    db.session.add(lapsed_window)
+    await db.session.commit()
+    old_only_id, lapsed_id = old_only.id, lapsed_window.id
+
+    await expire_access_requests()
+
+    db.session.expire_all()
+    assert (await db.session.get(AccessRequest, old_only_id)).status == AccessRequestStatus.PENDING
+    assert (await db.session.get(AccessRequest, lapsed_id)).status == AccessRequestStatus.REJECTED

--- a/tests/test_expire_access_request.py
+++ b/tests/test_expire_access_request.py
@@ -1,9 +1,12 @@
 from datetime import datetime, timedelta, timezone
 
+from pytest_mock import MockerFixture
 
 from api.models import AccessRequest, AccessRequestStatus, OktaGroup, OktaUser
 from api.extensions import Db
+from api.operations import RejectAccessRequest
 from api.syncer import expire_access_requests
+from tests.factories import AccessRequestFactory
 
 
 async def test_no_expire_new_access_request(
@@ -49,6 +52,57 @@ async def test_expire_old_access_request(
     access_request = await db.session.get(AccessRequest, access_request_id)
     assert access_request.status == AccessRequestStatus.REJECTED
     assert access_request.resolved_at is not None
+
+
+async def test_expire_access_requests_isolates_failures(
+    db: Db,
+    access_request: AccessRequest,
+    okta_group: OktaGroup,
+    user: OktaUser,
+    mocker: MockerFixture,
+) -> None:
+    """One request that fails to reject must not abort the rest of the sweep.
+
+    Without per-request isolation a single poisoned row aborts expiration for
+    every other row, and does so again on every subsequent sync run.
+    """
+    db.session.add(user)
+    db.session.add(okta_group)
+    await db.session.commit()
+
+    stale = datetime.now(timezone.utc) - timedelta(days=30)
+    ids = []
+    for _ in range(3):
+        req = AccessRequestFactory.build()
+        req.created_at = stale
+        req.requested_group_id = okta_group.id
+        req.requester_user_id = user.id
+        db.session.add(req)
+        ids.append(req.id)
+    await db.session.commit()
+
+    # Fail the first reject only; the other two must still be expired.
+    real_execute = RejectAccessRequest.execute
+    calls = {"n": 0}
+
+    async def flaky(self: RejectAccessRequest) -> AccessRequest:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("boom")
+        return await real_execute(self)
+
+    mocker.patch.object(RejectAccessRequest, "execute", flaky)
+
+    await expire_access_requests()
+
+    db.session.expire_all()
+    statuses = []
+    for request_id in ids:
+        row = await db.session.get(AccessRequest, request_id)
+        statuses.append(row.status)
+
+    assert statuses.count(AccessRequestStatus.REJECTED) == 2
+    assert statuses.count(AccessRequestStatus.PENDING) == 1
 
 
 async def test_expire_old_temporary_access_request(

--- a/tests/test_expire_group_request.py
+++ b/tests/test_expire_group_request.py
@@ -56,10 +56,8 @@ async def test_no_expire_group_request_with_lapsed_ownership_window(
     What this leaves to the approve path: ApproveGroupRequest falls back to
     requested_ownership_ending_at when the approver supplies no resolved value,
     so approving a long-stale request could write an already-expired ownership
-    row and leave the new group unowned. PR #599 proposes refusing such an
-    approval outright; until it lands the gap is open. Either way, repairing it
-    belongs in the approve path and not in this sweep; it was never a reason to
-    expire the request here.
+    row and leave the new group unowned. Repairing that belongs in the approve
+    path and not in this sweep; it is not a reason to expire the request here.
     """
     group_request.created_at = datetime.now(timezone.utc) - timedelta(days=1)
     group_request.requested_ownership_ending_at = datetime.now(timezone.utc) - timedelta(hours=12)

--- a/tests/test_expire_group_request.py
+++ b/tests/test_expire_group_request.py
@@ -1,0 +1,81 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from api.config import settings
+from api.extensions import Db
+from api.models import AccessRequestStatus, GroupRequest, OktaUser
+from api.syncer import expire_group_requests
+
+
+async def _persist(db: Db, group_request: GroupRequest, user: OktaUser) -> str:
+    db.session.add(user)
+    await db.session.commit()
+    group_request.requester_user_id = user.id
+    db.session.add(group_request)
+    await db.session.commit()
+    return group_request.id
+
+
+async def test_no_expire_new_group_request(db: Db, group_request: GroupRequest, user: OktaUser) -> None:
+    group_request_id = await _persist(db, group_request, user)
+
+    await expire_group_requests()
+
+    row = await db.session.get(GroupRequest, group_request_id)
+    assert row.status == AccessRequestStatus.PENDING
+    assert row.resolved_at is None
+
+
+async def test_expire_old_group_request(db: Db, group_request: GroupRequest, user: OktaUser) -> None:
+    group_request.created_at = datetime.now(timezone.utc) - timedelta(days=30)
+    group_request_id = await _persist(db, group_request, user)
+
+    await expire_group_requests()
+
+    # The reject operation expired this row's attributes; expire_all so the
+    # awaited get() refreshes it instead of lazy-loading on attribute access.
+    db.session.expire_all()
+    row = await db.session.get(GroupRequest, group_request_id)
+    assert row.status == AccessRequestStatus.REJECTED
+    assert row.resolved_at is not None
+    assert row.resolver_user_id is None
+
+
+async def test_no_expire_group_request_with_lapsed_ownership_window(
+    db: Db, group_request: GroupRequest, user: OktaUser
+) -> None:
+    """A lapsed requested_ownership_ending_at must NOT expire the request.
+
+    Deliberate asymmetry with access and role requests. A group request's
+    primary payload is "create this group"; the ownership window is secondary
+    and the resolver can edit resolved_ownership_ending_at before approving, so
+    a human fix exists and there is no dead-on-arrival grant to prevent. Do not
+    "fix" this by adding a second sweep path.
+    """
+    group_request.created_at = datetime.now(timezone.utc) - timedelta(days=1)
+    group_request.requested_ownership_ending_at = datetime.now(timezone.utc) - timedelta(hours=12)
+    group_request_id = await _persist(db, group_request, user)
+
+    await expire_group_requests()
+
+    row = await db.session.get(GroupRequest, group_request_id)
+    assert row.status == AccessRequestStatus.PENDING
+    assert row.resolved_at is None
+
+
+async def test_group_request_uses_its_own_cutoff(
+    db: Db, group_request: GroupRequest, user: OktaUser, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """MAX_GROUP_REQUEST_AGE_SECONDS governs group requests independently."""
+    monkeypatch.setattr(settings, "MAX_ACCESS_REQUEST_AGE_SECONDS", 7 * 24 * 60 * 60)
+    monkeypatch.setattr(settings, "MAX_GROUP_REQUEST_AGE_SECONDS", 30 * 24 * 60 * 60)
+
+    # 10 days old: past the access cutoff, inside the longer group cutoff.
+    group_request.created_at = datetime.now(timezone.utc) - timedelta(days=10)
+    group_request_id = await _persist(db, group_request, user)
+
+    await expire_group_requests()
+
+    row = await db.session.get(GroupRequest, group_request_id)
+    assert row.status == AccessRequestStatus.PENDING

--- a/tests/test_expire_group_request.py
+++ b/tests/test_expire_group_request.py
@@ -85,3 +85,32 @@ async def test_group_request_uses_its_own_cutoff(
 
     row = await db.session.get(GroupRequest, group_request_id)
     assert row.status == AccessRequestStatus.PENDING
+
+
+async def test_never_disables_group_age_expiry(
+    db: Db, group_request: GroupRequest, user: OktaUser, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "MAX_GROUP_REQUEST_AGE_SECONDS", "never")
+    group_request.created_at = datetime.now(timezone.utc) - timedelta(days=30)
+    group_request_id = await _persist(db, group_request, user)
+
+    await expire_group_requests()
+
+    row = await db.session.get(GroupRequest, group_request_id)
+    assert row.status == AccessRequestStatus.PENDING
+    assert row.resolved_at is None
+
+
+async def test_group_expiry_is_independent_of_the_access_cutoff(
+    db: Db, group_request: GroupRequest, user: OktaUser, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Disabling the access cutoff must not disable the group one."""
+    monkeypatch.setattr(settings, "MAX_ACCESS_REQUEST_AGE_SECONDS", "never")
+    group_request.created_at = datetime.now(timezone.utc) - timedelta(days=30)
+    group_request_id = await _persist(db, group_request, user)
+
+    await expire_group_requests()
+
+    db.session.expire_all()
+    row = await db.session.get(GroupRequest, group_request_id)
+    assert row.status == AccessRequestStatus.REJECTED

--- a/tests/test_expire_group_request.py
+++ b/tests/test_expire_group_request.py
@@ -47,11 +47,18 @@ async def test_no_expire_group_request_with_lapsed_ownership_window(
 ) -> None:
     """A lapsed requested_ownership_ending_at must NOT expire the request.
 
-    Deliberate asymmetry with access and role requests. A group request's
-    primary payload is "create this group"; the ownership window is secondary
-    and the resolver can edit resolved_ownership_ending_at before approving, so
-    a human fix exists and there is no dead-on-arrival grant to prevent. Do not
-    "fix" this by adding a second sweep path.
+    Deliberate asymmetry with access and role requests, and a policy call
+    rather than a claim that nothing can go wrong. A group request's payload is
+    the group itself; throwing the whole ask away over a stale secondary field
+    loses more than it protects. For an access or role request the window IS
+    the ask, which is why those get a second sweep.
+
+    What this leaves open, so nobody mistakes it for safe: ApproveGroupRequest
+    falls back to requested_ownership_ending_at when the approver supplies no
+    resolved value, and coalesce_ended_at passes a past timestamp through
+    unchanged, so approving a long-stale request can still write an
+    already-expired ownership row and leave the new group unowned. That is worth
+    fixing in the approve path; it is not a reason to expire the request here.
     """
     group_request.created_at = datetime.now(timezone.utc) - timedelta(days=1)
     group_request.requested_ownership_ending_at = datetime.now(timezone.utc) - timedelta(hours=12)

--- a/tests/test_expire_group_request.py
+++ b/tests/test_expire_group_request.py
@@ -56,8 +56,10 @@ async def test_no_expire_group_request_with_lapsed_ownership_window(
     What this leaves to the approve path: ApproveGroupRequest falls back to
     requested_ownership_ending_at when the approver supplies no resolved value,
     so approving a long-stale request could write an already-expired ownership
-    row and leave the new group unowned. That is handled there (the approval is
-    refused outright); it was never a reason to expire the request here.
+    row and leave the new group unowned. PR #599 proposes refusing such an
+    approval outright; until it lands the gap is open. Either way, repairing it
+    belongs in the approve path and not in this sweep; it was never a reason to
+    expire the request here.
     """
     group_request.created_at = datetime.now(timezone.utc) - timedelta(days=1)
     group_request.requested_ownership_ending_at = datetime.now(timezone.utc) - timedelta(hours=12)

--- a/tests/test_expire_group_request.py
+++ b/tests/test_expire_group_request.py
@@ -53,12 +53,11 @@ async def test_no_expire_group_request_with_lapsed_ownership_window(
     loses more than it protects. For an access or role request the window IS
     the ask, which is why those get a second sweep.
 
-    What this leaves open, so nobody mistakes it for safe: ApproveGroupRequest
-    falls back to requested_ownership_ending_at when the approver supplies no
-    resolved value, and coalesce_ended_at passes a past timestamp through
-    unchanged, so approving a long-stale request can still write an
-    already-expired ownership row and leave the new group unowned. That is worth
-    fixing in the approve path; it is not a reason to expire the request here.
+    What this leaves to the approve path: ApproveGroupRequest falls back to
+    requested_ownership_ending_at when the approver supplies no resolved value,
+    so approving a long-stale request could write an already-expired ownership
+    row and leave the new group unowned. That is handled there (the approval is
+    refused outright); it was never a reason to expire the request here.
     """
     group_request.created_at = datetime.now(timezone.utc) - timedelta(days=1)
     group_request.requested_ownership_ending_at = datetime.now(timezone.utc) - timedelta(hours=12)

--- a/tests/test_expire_role_request.py
+++ b/tests/test_expire_role_request.py
@@ -1,0 +1,67 @@
+from datetime import datetime, timedelta, timezone
+
+from api.extensions import Db
+from api.models import AccessRequestStatus, OktaGroup, OktaUser, RoleGroup, RoleRequest
+from api.syncer import expire_role_requests
+
+
+async def _persist(
+    db: Db, role_request: RoleRequest, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser
+) -> str:
+    """Persist a role request wired to a role, a target group, and a requester."""
+    db.session.add(user)
+    db.session.add(role_group)
+    db.session.add(okta_group)
+    await db.session.commit()
+    role_request.requester_user_id = user.id
+    role_request.requester_role_id = role_group.id
+    role_request.requested_group_id = okta_group.id
+    db.session.add(role_request)
+    await db.session.commit()
+    return role_request.id
+
+
+async def test_no_expire_new_role_request(
+    db: Db, role_request: RoleRequest, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser
+) -> None:
+    role_request_id = await _persist(db, role_request, role_group, okta_group, user)
+
+    await expire_role_requests()
+
+    row = await db.session.get(RoleRequest, role_request_id)
+    assert row.status == AccessRequestStatus.PENDING
+    assert row.resolved_at is None
+
+
+async def test_expire_old_role_request(
+    db: Db, role_request: RoleRequest, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser
+) -> None:
+    role_request.created_at = datetime.now(timezone.utc) - timedelta(days=30)
+    role_request_id = await _persist(db, role_request, role_group, okta_group, user)
+
+    await expire_role_requests()
+
+    # The reject operation expired this row's attributes; expire_all so the
+    # awaited get() refreshes it instead of lazy-loading on attribute access.
+    db.session.expire_all()
+    row = await db.session.get(RoleRequest, role_request_id)
+    assert row.status == AccessRequestStatus.REJECTED
+    assert row.resolved_at is not None
+    assert row.resolver_user_id is None
+
+
+async def test_expire_role_request_with_lapsed_window(
+    db: Db, role_request: RoleRequest, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser
+) -> None:
+    """A role request past its request_ending_at is moot: approving it would
+    mint an already-expired RoleGroupMap."""
+    role_request.created_at = datetime.now(timezone.utc) - timedelta(days=1)
+    role_request.request_ending_at = datetime.now(timezone.utc) - timedelta(hours=12)
+    role_request_id = await _persist(db, role_request, role_group, okta_group, user)
+
+    await expire_role_requests()
+
+    db.session.expire_all()
+    row = await db.session.get(RoleRequest, role_request_id)
+    assert row.status == AccessRequestStatus.REJECTED
+    assert row.resolved_at is not None

--- a/tests/test_expire_role_request.py
+++ b/tests/test_expire_role_request.py
@@ -1,5 +1,8 @@
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
+from api.config import settings
 from api.extensions import Db
 from api.models import AccessRequestStatus, OktaGroup, OktaUser, RoleGroup, RoleRequest
 from api.syncer import expire_role_requests
@@ -65,3 +68,24 @@ async def test_expire_role_request_with_lapsed_window(
     row = await db.session.get(RoleRequest, role_request_id)
     assert row.status == AccessRequestStatus.REJECTED
     assert row.resolved_at is not None
+
+
+async def test_never_on_the_access_cutoff_also_disables_role_age_expiry(
+    db: Db,
+    role_request: RoleRequest,
+    role_group: RoleGroup,
+    okta_group: OktaGroup,
+    user: OktaUser,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Role requests share MAX_ACCESS_REQUEST_AGE_SECONDS, so disabling it
+    disables theirs too. Pins the shared-fuse decision."""
+    monkeypatch.setattr(settings, "MAX_ACCESS_REQUEST_AGE_SECONDS", "never")
+    role_request.created_at = datetime.now(timezone.utc) - timedelta(days=30)
+    role_request_id = await _persist(db, role_request, role_group, okta_group, user)
+
+    await expire_role_requests()
+
+    row = await db.session.get(RoleRequest, role_request_id)
+    assert row.status == AccessRequestStatus.PENDING
+    assert row.resolved_at is None

--- a/tests/test_expire_role_request.py
+++ b/tests/test_expire_role_request.py
@@ -6,6 +6,7 @@ from api.config import settings
 from api.extensions import Db
 from api.models import AccessRequestStatus, OktaGroup, OktaUser, RoleGroup, RoleRequest
 from api.syncer import expire_role_requests
+from tests.factories import RoleRequestFactory
 
 
 async def _persist(
@@ -79,13 +80,36 @@ async def test_never_on_the_access_cutoff_also_disables_role_age_expiry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Role requests share MAX_ACCESS_REQUEST_AGE_SECONDS, so disabling it
-    disables theirs too. Pins the shared-fuse decision."""
+    disables theirs too. Pins the shared-fuse decision.
+
+    Mirrors test_never_disables_the_age_cutoff_but_not_the_requested_window in
+    tests/test_expire_access_request.py: `never` disables only the age-based
+    half. A role request whose own request_ending_at has lapsed is still
+    closed by the separate, non-disableable requested-window pass.
+    """
     monkeypatch.setattr(settings, "MAX_ACCESS_REQUEST_AGE_SECONDS", "never")
-    role_request.created_at = datetime.now(timezone.utc) - timedelta(days=30)
+    stale = datetime.now(timezone.utc) - timedelta(days=30)
+
+    role_request.created_at = stale
     role_request_id = await _persist(db, role_request, role_group, okta_group, user)
+
+    lapsed_window = RoleRequestFactory.build()
+    lapsed_window.created_at = stale
+    lapsed_window.request_ending_at = datetime.now(timezone.utc) - timedelta(hours=12)
+    lapsed_window.requester_user_id = user.id
+    lapsed_window.requester_role_id = role_group.id
+    lapsed_window.requested_group_id = okta_group.id
+    db.session.add(lapsed_window)
+    await db.session.commit()
+    lapsed_id = lapsed_window.id
 
     await expire_role_requests()
 
-    row = await db.session.get(RoleRequest, role_request_id)
-    assert row.status == AccessRequestStatus.PENDING
-    assert row.resolved_at is None
+    db.session.expire_all()
+    old_only_row = await db.session.get(RoleRequest, role_request_id)
+    assert old_only_row.status == AccessRequestStatus.PENDING
+    assert old_only_row.resolved_at is None
+
+    lapsed_row = await db.session.get(RoleRequest, lapsed_id)
+    assert lapsed_row.status == AccessRequestStatus.REJECTED
+    assert lapsed_row.resolved_at is not None

--- a/tests/test_expired_reason_constant.py
+++ b/tests/test_expired_reason_constant.py
@@ -1,0 +1,22 @@
+"""The expiration reason string is a contract between the syncer and the SPA.
+
+Expiration is not modelled as its own status or column, so `isExpiredRequest`
+in `src/helpers.tsx` matches the backend's reason text verbatim to decide
+whether to offer a "reopen" button. Rewording one side without the other
+silently removes that button, with no other test failing. This pins the pair.
+"""
+
+from pathlib import Path
+
+from api.syncer import EXPIRED_REQUEST_REASON
+
+_HELPERS = Path(__file__).resolve().parent.parent / "src" / "helpers.tsx"
+
+
+def test_frontend_mirrors_the_expired_reason() -> None:
+    source = _HELPERS.read_text(encoding="utf-8")
+    assert f"'{EXPIRED_REQUEST_REASON}'" in source, (
+        f"{_HELPERS} must contain the exact reason string {EXPIRED_REQUEST_REASON!r}. "
+        "If you reworded api.syncer.EXPIRED_REQUEST_REASON, update "
+        "EXPIRED_REQUEST_REASON in src/helpers.tsx to match."
+    )


### PR DESCRIPTION
# Summary

Adds a "Reopen Request" button to the view for expired access, role, and group requests. It opens the normal create dialog prefilled from the lapsed request.

**Urgency**: LOW - 2 weeks?
**Expected review effort**: MEDIUM

**Stacked on #597** — please review that one first; this branch targets `brynna/request_expiration`.

# Motivation

#597 makes role and group requests expire, which means more requests will lapse without anyone having said no. Today a user whose request expired has no path back other than rebuilding it by hand from the read view: retyping the group, the duration, and the justification. This makes the common case one click.

Reopen is deliberately an ergonomic shortcut for "create a fresh one", not a new operation. It adds no endpoint; it drives the existing create endpoints, so tag constraints and conditional-access hooks re-run exactly as they would on a hand-built request.

<details>
<summary><h1>Description & Screenshots of Changes</h1></summary>

**Recognising an expired request.** Expiration is not modelled as its own status or column, so `isExpiredRequest` (`src/helpers.tsx`) infers it from `status === 'REJECTED'` + a null resolver + an exact match on the sweep's reason string. A null resolver alone is not enough: user deletion, group deletion, group unmanaging, and a conditional-access plugin denial all close requests with no resolver, and a **policy denial in particular must never get a one-click reopen**. The check goes through `resolver`, not `resolver_user_id`, because `GroupRequestDetail` exposes only the former — keying off the id would silently never match on group requests.

The reason string is duplicated across the language boundary and pinned by `tests/test_expired_reason_constant.py`, which reads `src/helpers.tsx` and asserts the backend constant appears in it.

**Duration prefill is an extraction, not new logic.** Recovering the duration a request originally asked for already existed, duplicated, in `requests/Read.tsx` and `role_requests/Read.tsx`. It moved to `reconstructRequestedUntil` in `src/helpers.tsx` and both call sites now use it, so this leaves one copy where there were two. The option-label map is a parameter rather than an assumption, because the access and role views source it differently (`accessConfig.ACCESS_TIME_LABELS` vs a hardcoded map) — unifying those is out of scope.

Requests store an absolute `request_ending_at`, so a request that expired because its window lapsed has a stored date in the past. Diffing against `created_at` recovers the *duration*: an exact match round-trips to that option, anything else is re-offered as a custom date based from today, and a tag time limit that has since tightened clamps the result.

**The button lives inside `CreateRequest`.** It is rendered via a new `reopen` prop (mirroring the existing `renew` prop) rather than as a separate button in the read view, so it sits *inside* `CreateRequest`'s own null-return guards. A hand-rolled button plus controlled `open`/`setOpen` would gate the button and the dialog on different conditions and produce a dead button — visible, clicked, opening nothing — for a requester who has since become an owner of the group.

**Visibility mirrors who may create the same request:**

| Type | Who sees reopen | Why |
|---|---|---|
| Access request | the original requester only | an access request targets its own requester, so nobody else can recreate *that* request |
| Role request | current owners of the role | a role request must be submitted by a role owner, so any of them can |
| Group request | any authenticated viewer | anyone may request a group |

**Group requests carry the most prefill** (type, app, name, description, ownership duration, reason, tags, plugin config) and need two client-side resolutions the API returns bare — app id → `AppDetail`, tag ids → `TagDetail[]`. Both reuse locals the read view already computes; no new fetches. Plugin config is dropped when the app's lifecycle plugin changed since the request was written, since the stored config is keyed by the plugin id configured *then*; the rest of the prefill still applies.

**Screenshot** — reopening an expired individual access request:

<img width="800" height="551" alt="image" src="https://github.com/user-attachments/assets/e9fba6fc-2c5a-41d2-873d-a315bb2f9f63" />

**Screenshot** — reopening an expired app-group request. Note the name field holds the un-prefixed suffix (`Reporting`) beside the static `App-Zztestapp-`, matching how the create form works:

<img width="800" height="551" alt="image" src="https://github.com/user-attachments/assets/59716d52-80a6-41f0-8251-82572b5588cf" />
</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

- `make test` green: ruff, ty, 879 backend pytest, 57 frontend vitest. `npm run tsc` clean.
- Unit tests on the pure helpers, which is where the decision logic lives: `isExpiredRequest` (the true case, a human rejection with both a populated and an empty reason, each of the four other null-resolver closure reasons, pending/approved, and missing fields); `reconstructRequestedUntil` (indefinite, exact-option round-trip, the 100-second rounding, the custom re-base, both clamp paths, and the no-clamp default); `prefillablePluginData` (matching plugin, switched plugin, no plugin, no app, and that it narrows to only the matching plugin's entry).
- The cross-language pin was tamper-checked: rewording the frontend constant makes it fail, and it passes again on revert.
- **Browser-verified** against a locally seeded database (`make run-backend` + `make run-frontend`, six seeded requests):
  - [x] Button appears on the expired access, role, and group requests; **absent** on a control access request rejected by a person with reason "Not this quarter." — which is the discrimination the reason-string match buys.
  - [x] Access request: group `App-Access-Default`, `until` reconstructed to `7776000` / "90 Days" from the original 90-day ask, reason verbatim, Member toggle set (Owner false).
  - [x] Role request: role `Role-Zz-Reopen-Demo`, target group, "90 Days", reason verbatim, Member toggle. Dialog opened, so no dead button.
  - [x] `app_group`: name field holds `Reporting` with `App-Zztestapp-` rendered as static text beside it — **not** `App-Zztestapp-Reporting`. This is the case only a browser catches; the pre-fix bug produced a *valid* name, so no test, type check, or lint would flag it. Type correctly seeded to `app_group` so the app selector rendered at all, app `Zztestapp` selected, tag chip `Zz-Quarterly-Renewal` resolved from its stored id, ownership "90 Days", reason verbatim.
  - [x] `role_group`: `Role-Zz-Analytics` → name `Zz-Analytics`.
  - [x] `okta_group`: `Zzwidgets` left intact — no over-stripping of a name that has no prefix.
  - [x] No console warnings, including no MUI Autocomplete "none of the options match". All `/api/` calls 200.
  - [x] **A request whose original duration was a *custom date*** (47 days, not one of the preset options): the "Custom End Date" field renders and is pre-filled with today + 47 days. This case was broken until review caught it — the earlier pass only exercised the exact-option ("90 Days") path, which is the path that worked.
- No page render tests: this repo has essentially no such infrastructure (two files use React Testing Library) and `.claude/access-dev-testing.md` says coverage is concentrated on pure helpers and form logic. That is why the browser checklist above matters rather than being belt-and-braces.
- No migration, no Pydantic schema change, no generated-client edit, no new endpoint.
</details>

# Guidance for Reviewers

Go **file-by-file** rather than commit-by-commit — the last commit is a fix pass that touches several of the earlier files, so the commits do not cleanly reflect final state.

Three callouts:

1. **The inferred-expiry approach** (`isExpiredRequest`). It matches a display string, which is a bit janky. The argument for it: reopen only opens a prefilled form, and submitting re-runs constraints and conditional-access hooks, so a wrongly-shown button self-corrects rather than granting anything. If we would rather pay for robustness, I think the right shape is added nuance in the status enum, but that's a heftier change.
2. **Why the button is a `reopen` prop on `CreateRequest`** rather than a button in the read view. This is load-bearing against the dead-button case described above; a future "simplification" that pulls it back out would reintroduce it.
3. **`reconstructRequestedUntil`'s optional `timeLimit`.** The two pre-existing read-view call sites deliberately pass none, because they apply their own clamp separately when building the approve form's `defaultValues`. The three reopen call sites do pass it. Passing it at the wrong site silently changes what the approve form defaults to; both the helper and each call site carry a comment saying so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



