### PR TITLE
Refuse to approve a group request into a lapsed ownership window

### DIFF
--- a/api/operations/approve_group_request.py
+++ b/api/operations/approve_group_request.py
@@ -1,12 +1,13 @@
 import copy
 import logging
+from datetime import UTC, datetime
 from typing import Any, Optional
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload, with_polymorphic
 
 from api.context import get_request_context
-from api.exceptions import ConflictError
+from api.exceptions import ConflictError, InvalidRequestError
 from api.extensions import db
 from api.models import (
     AccessRequestStatus,
@@ -126,6 +127,41 @@ class ApproveGroupRequest:
             if group_request.resolved_plugin_data
             else group_request.requested_plugin_data
         )
+
+        # Same resolved-or-requested fallback as the fields above, hoisted here so
+        # it can be validated before anything is created.
+        resolved_ownership_ending_at = (
+            group_request.resolved_ownership_ending_at
+            if group_request.resolved_ownership_ending_at
+            else group_request.requested_ownership_ending_at
+        )
+        # Refuse to approve into an ownership window that has already closed.
+        # Nothing downstream clamps it: coalesce_ended_at only ever moves the date
+        # earlier, so a past value reaches ModifyGroupUsers and writes an ownership
+        # row that is expired on arrival. get_group_managers filters on ended_at, so
+        # the new group would have no owners at all, and its future approvals would
+        # silently route to the app owner or an Access admin instead of the person
+        # who asked for it.
+        #
+        # This is reachable three ways, which is why the guard lives here rather
+        # than in the router: any client that omits resolved_ownership_ending_at
+        # (the field is optional and only assigned when present), an approver
+        # selecting "Indefinite" in the UI (which sends nothing, so the stale
+        # requested value survives), or an approver leaving the custom date
+        # prefilled with the original — already past — date. Failing loudly makes
+        # the approver name a window they mean, which is the only safe default: the
+        # alternatives silently grant either nothing or more than was asked.
+        if resolved_ownership_ending_at is not None:
+            ending_at = (
+                resolved_ownership_ending_at.replace(tzinfo=UTC)
+                if resolved_ownership_ending_at.tzinfo is None
+                else resolved_ownership_ending_at
+            )
+            if ending_at <= datetime.now(UTC):
+                raise InvalidRequestError(
+                    "The ownership window for this request has already passed. "
+                    "Set an ownership end date when approving it."
+                )
 
         # authorization
         access_owner_ids = {u.id for u in await get_access_owners()}
@@ -280,16 +316,10 @@ class ApproveGroupRequest:
         tags = [tag_map.active_tag for tag_map in created_group_with_tags.active_group_tags]
 
         # Determine the initial ending time: prefer resolved, fall back to requested
-        initial_ending_at = (
-            group_request.resolved_ownership_ending_at
-            if group_request.resolved_ownership_ending_at
-            else group_request.requested_ownership_ending_at
-        )
-
         coalesced_ownership_ending_at = coalesce_ended_at(
             constraint_key=Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY,
             tags=tags,
-            initial_ended_at=initial_ending_at,
+            initial_ended_at=resolved_ownership_ending_at,
             group_is_managed=True,
         )
 

--- a/tests/test_lapsed_ownership_on_approval.py
+++ b/tests/test_lapsed_ownership_on_approval.py
@@ -28,9 +28,7 @@ from api.services import okta
 def _mock_okta(mocker: MockerFixture) -> None:
     mocker.patch.object(okta, "add_user_to_group")
     mocker.patch.object(okta, "add_owner_to_group")
-    mocker.patch.object(
-        okta, "create_group", side_effect=lambda name, desc: Group.from_dict({"id": uuid.uuid4().hex})
-    )
+    mocker.patch.object(okta, "create_group", side_effect=lambda name, desc: Group.from_dict({"id": uuid.uuid4().hex}))
 
 
 async def _access_owner(db: Db) -> OktaUser:
@@ -65,9 +63,7 @@ async def test_approval_rejected_when_requested_ownership_window_has_passed(db: 
     request_id = request.id
 
     with pytest.raises(InvalidRequestError) as exc:
-        await ApproveGroupRequest(
-            group_request=request_id, approver_user=approver, approval_reason="ok"
-        ).execute()
+        await ApproveGroupRequest(group_request=request_id, approver_user=approver, approval_reason="ok").execute()
     assert "already passed" in str(exc.value)
 
     # The guard raises mid-transaction, so unwind it the way the request teardown
@@ -93,9 +89,7 @@ async def test_approval_rejected_when_resolved_ownership_window_has_passed(db: D
     await db.session.commit()
 
     with pytest.raises(InvalidRequestError):
-        await ApproveGroupRequest(
-            group_request=request.id, approver_user=approver, approval_reason="ok"
-        ).execute()
+        await ApproveGroupRequest(group_request=request.id, approver_user=approver, approval_reason="ok").execute()
 
 
 async def test_approval_succeeds_with_a_future_ownership_window(db: Db, user: OktaUser) -> None:
@@ -106,9 +100,7 @@ async def test_approval_succeeds_with_a_future_ownership_window(db: Db, user: Ok
     request.requested_ownership_ending_at = datetime.now(timezone.utc) + timedelta(days=30)
     await db.session.commit()
 
-    await ApproveGroupRequest(
-        group_request=request.id, approver_user=approver, approval_reason="ok"
-    ).execute()
+    await ApproveGroupRequest(group_request=request.id, approver_user=approver, approval_reason="ok").execute()
 
     db.session.expire_all()
     group = (await db.session.scalars(select(OktaGroup).where(OktaGroup.name == "Future"))).first()
@@ -125,9 +117,7 @@ async def test_approval_succeeds_with_an_indefinite_ownership_window(db: Db, use
     request = await _group_request(db, user, "Indefinite")
     assert request.requested_ownership_ending_at is None
 
-    await ApproveGroupRequest(
-        group_request=request.id, approver_user=approver, approval_reason="ok"
-    ).execute()
+    await ApproveGroupRequest(group_request=request.id, approver_user=approver, approval_reason="ok").execute()
 
     db.session.expire_all()
     group = (await db.session.scalars(select(OktaGroup).where(OktaGroup.name == "Indefinite"))).first()

--- a/tests/test_lapsed_ownership_on_approval.py
+++ b/tests/test_lapsed_ownership_on_approval.py
@@ -1,0 +1,136 @@
+"""Approving a group request must not mint an already-expired ownership row.
+
+ApproveGroupRequest falls back to `requested_ownership_ending_at` when the
+approver supplies no resolved value, and `coalesce_ended_at` only ever moves a
+date earlier, so a stale request would otherwise create a group whose sole
+ownership row is expired on arrival -- i.e. a group with no owners, whose future
+approvals route to the app owner or an Access admin rather than the requester.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from okta.models import Group
+from pytest_mock import MockerFixture
+from sqlalchemy import select
+
+from api.config import settings
+from api.exceptions import InvalidRequestError
+from api.extensions import Db
+from api.models import AccessRequestStatus, GroupRequest, OktaGroup, OktaUser
+from api.models.okta_group import get_group_managers
+from api.operations import ApproveGroupRequest, CreateGroupRequest
+from api.services import okta
+
+
+@pytest.fixture(autouse=True)
+def _mock_okta(mocker: MockerFixture) -> None:
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
+    mocker.patch.object(
+        okta, "create_group", side_effect=lambda name, desc: Group.from_dict({"id": uuid.uuid4().hex})
+    )
+
+
+async def _access_owner(db: Db) -> OktaUser:
+    owner = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
+    assert owner is not None
+    return owner
+
+
+async def _group_request(db: Db, user: OktaUser, name: str) -> GroupRequest:
+    request = await CreateGroupRequest(
+        requester_user=user,
+        requested_group_name=name,
+        requested_group_description="test",
+        requested_group_type="okta_group",
+        request_reason="need a group",
+    ).execute()
+    assert request is not None
+    return request
+
+
+async def test_approval_rejected_when_requested_ownership_window_has_passed(db: Db, user: OktaUser) -> None:
+    db.session.add(user)
+    await db.session.commit()
+    approver = await _access_owner(db)
+    request = await _group_request(db, user, "Lapsed")
+    request.requested_ownership_ending_at = datetime.now(timezone.utc) - timedelta(days=1)
+    await db.session.commit()
+    # Captured before expire_all() below: reading request.id afterwards would
+    # refresh an expired instance outside a greenlet (MissingGreenlet).
+    request_id = request.id
+
+    with pytest.raises(InvalidRequestError) as exc:
+        await ApproveGroupRequest(
+            group_request=request_id, approver_user=approver, approval_reason="ok"
+        ).execute()
+    assert "already passed" in str(exc.value)
+
+    # The guard raises mid-transaction, so unwind it the way the request teardown
+    # would before inspecting committed state.
+    await db.session.rollback()
+
+    # Nothing was created, and the request is still actionable.
+    db.session.expire_all()
+    assert (await db.session.scalars(select(OktaGroup).where(OktaGroup.name == "Lapsed"))).first() is None
+    row = await db.session.get(GroupRequest, request_id)
+    assert row.status == AccessRequestStatus.PENDING
+    assert row.resolved_at is None
+
+
+async def test_approval_rejected_when_resolved_ownership_window_has_passed(db: Db, user: OktaUser) -> None:
+    """An explicitly supplied past date is refused too, not just an inherited one."""
+    db.session.add(user)
+    await db.session.commit()
+    approver = await _access_owner(db)
+    request = await _group_request(db, user, "LapsedResolved")
+    request.requested_ownership_ending_at = datetime.now(timezone.utc) + timedelta(days=30)
+    request.resolved_ownership_ending_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    await db.session.commit()
+
+    with pytest.raises(InvalidRequestError):
+        await ApproveGroupRequest(
+            group_request=request.id, approver_user=approver, approval_reason="ok"
+        ).execute()
+
+
+async def test_approval_succeeds_with_a_future_ownership_window(db: Db, user: OktaUser) -> None:
+    db.session.add(user)
+    await db.session.commit()
+    approver = await _access_owner(db)
+    request = await _group_request(db, user, "Future")
+    request.requested_ownership_ending_at = datetime.now(timezone.utc) + timedelta(days=30)
+    await db.session.commit()
+
+    await ApproveGroupRequest(
+        group_request=request.id, approver_user=approver, approval_reason="ok"
+    ).execute()
+
+    db.session.expire_all()
+    group = (await db.session.scalars(select(OktaGroup).where(OktaGroup.name == "Future"))).first()
+    assert group is not None
+    managers = await get_group_managers(group.id)
+    assert [m.id for m in managers] == [user.id]
+
+
+async def test_approval_succeeds_with_an_indefinite_ownership_window(db: Db, user: OktaUser) -> None:
+    """No window at all is untouched by the guard; it means indefinite ownership."""
+    db.session.add(user)
+    await db.session.commit()
+    approver = await _access_owner(db)
+    request = await _group_request(db, user, "Indefinite")
+    assert request.requested_ownership_ending_at is None
+
+    await ApproveGroupRequest(
+        group_request=request.id, approver_user=approver, approval_reason="ok"
+    ).execute()
+
+    db.session.expire_all()
+    group = (await db.session.scalars(select(OktaGroup).where(OktaGroup.name == "Indefinite"))).first()
+    assert group is not None
+    managers = await get_group_managers(group.id)
+    assert [m.id for m in managers] == [user.id]


### PR DESCRIPTION
# Summary

Approving a group request whose requested ownership window has already closed created a group with **no owners at all**. `ApproveGroupRequest` now refuses with a 400 instead.

**Urgency**: 5 days
**Expected review effort**: LOW

Independent of #597 and #598 — this targets `main` and can land in any order relative to them.

# Motivation

Failing to grant ownership of the new group can happen if the request is approved after the requested ownership was set to expire. This isn't ideal because the requestor doesn't get the control they wanted, and Access admins end up as a confused deputy owner.

<details>
<summary><h1>Description of Changes</h1></summary>

Three paths reach it, which is why the guard lives in the operation rather than the router:

- **Any client omitting `resolved_ownership_ending_at`.** The field is `Optional` and the router only assigns it `if body.resolved_ownership_ending_at is not None`, so MCP, `curl`, or a script that leaves it out inherits the stale value.
- **An approver selecting "Indefinite" in the UI.** The frontend's `switch` has `case 'indefinite': break;` — it sends *nothing*, so the stale requested value survives and their intent inverts from "owns forever" to "expired yesterday". `"indefinite"` is in the default `ACCESS_TIME_LABELS` and is offered whenever the group carries no owner time-limit tag. The API cannot express "clear this field": `None` means *don't change*, not *set to null*.
- **An approver leaving the custom date prefilled**, since it defaults to the original — now past — absolute date.

The check is hoisted alongside the other resolved-or-requested fallbacks, **before** the group is created, so a refusal leaves nothing behind and the request stays `PENDING` and actionable. It also removes a duplicate copy of that same fallback expression further down.

**Why refuse rather than repair.** Both repair options pick a policy silently: treating a lapsed window as indefinite grants *more* than was asked, and re-basing the original duration grants a window nobody re-confirmed. Failing makes the approver name a window they mean. An explicitly supplied past date is refused on the same path; no window at all still means indefinite and is untouched.

Worth noting for reviewers: access and role requests do **not** have this bug, because their resolve endpoints pass `ending_at=body.ending_at` with no fallback to the stored request value — omitting the field there means indefinite. The three request types disagreeing about what an omitted ending date means is the actual root cause; this PR fixes the one that fails unsafely rather than unifying all three.
</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

- `make test` green: ruff, ty, 873 backend pytest.
- New `tests/test_lapsed_ownership_on_approval.py`, four cases: a lapsed *requested* window is refused and leaves no group behind with the request still `PENDING`; an explicitly supplied past *resolved* date is refused too; a future window still approves and `get_group_managers` returns the requester; and no window at all still approves as indefinite.
- **Mutation-checked**: both rejection tests fail with the guard removed and pass with it, so they are testing the guard rather than passing incidentally.
- No migration, no schema change, no frontend change.
</details>

# Guidance for Reviewers

Single commit, one operation plus its tests.

The judgement call worth your attention is **refuse vs. repair** — the "Why refuse rather than repair" note above. If you would rather approvers not be interrupted on stale requests, re-basing the original duration is the alternative, and it reuses reconstruction logic #598 already adds.

Second, smaller call: this fixes the group path only. Unifying omitted-`ending_at` semantics across all three request types would be a larger, more invasive change; I did not attempt it here.

Once this and #597 both land, #597's `expire_group_requests` docstring and its `test_no_expire_group_request_with_lapsed_ownership_window` docstring describe this gap as open and should be trimmed to point here instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
