### PR TITLE
Show propagated roles on the tag page with a Tag Source column

### DIFF
--- a/api/routers/tags.py
+++ b/api/routers/tags.py
@@ -8,14 +8,14 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from sqlalchemy import func, nullsfirst, or_, select
-from sqlalchemy.orm import joinedload, selectinload
+from sqlalchemy.orm import aliased, joinedload, selectinload
 from starlette.requests import Request
 
 from api.auth.dependencies import CurrentUserId
 from api.auth.permissions import require_access_admin
 from api.context import get_request_context
 from api.database import DbSession
-from api.models import AppTagMap, OktaUser, Tag
+from api.models import AppTagMap, OktaGroup, OktaGroupTagMap, OktaUser, RoleGroup, RoleGroupMap, Tag
 from api.operations import CreateTag, DeleteTag
 from fastapi_pagination.ext.sqlalchemy import apaginate
 
@@ -29,6 +29,7 @@ from api.schemas import (
     EventType,
     SearchTagQuery,
     TagDetail,
+    TagPropagationTargetDetail,
     UpdateTagBody,
 )
 
@@ -73,7 +74,58 @@ async def get_tag(tag_id: str, db: DbSession, current_user_id: CurrentUserId) ->
     ).first()
     if tag is None:
         raise HTTPException(404, "Not Found")
-    return TagDetail.model_validate(tag, from_attributes=True)
+
+    propagated: list[TagPropagationTargetDetail] = []
+    if tag.propagate_to_roles:
+        # `RoleGroup` is joined-table inheritance on `okta_group`, so selecting
+        # both it and the plain source `OktaGroup` in one query makes the two
+        # entities overlap on the same physical table. Left unaliased,
+        # SQLAlchemy silently auto-aliases RoleGroup's implicit parent join and
+        # later join/where clauses written against the bare `OktaGroup` class
+        # bind to that alias instead of the intended source-group row --
+        # `OktaGroupTagMap.group_id == OktaGroup.id` ends up matching the
+        # role's own row, not the tagged source group, and the query returns
+        # zero rows. Alias the source side explicitly to keep the two apart.
+        SourceGroup = aliased(OktaGroup, name="source_group")
+        rows = (
+            await db.execute(
+                select(RoleGroupMap.is_owner, RoleGroup, SourceGroup)
+                .join(SourceGroup, SourceGroup.id == RoleGroupMap.group_id)
+                .join(RoleGroup, RoleGroup.id == RoleGroupMap.role_group_id)
+                .join(OktaGroupTagMap, OktaGroupTagMap.group_id == SourceGroup.id)
+                .where(OktaGroupTagMap.tag_id == tag.id)
+                .where(
+                    or_(
+                        OktaGroupTagMap.ended_at.is_(None),
+                        OktaGroupTagMap.ended_at > func.now(),
+                    )
+                )
+                .where(
+                    or_(
+                        RoleGroupMap.ended_at.is_(None),
+                        RoleGroupMap.ended_at > func.now(),
+                    )
+                )
+                .where(SourceGroup.deleted_at.is_(None))
+                .where(SourceGroup.is_managed.is_(True))
+                .where(RoleGroup.deleted_at.is_(None))
+            )
+        ).all()
+        propagated = [
+            TagPropagationTargetDetail(
+                group_id=role.id,
+                group_name=role.name,
+                group_type="role_group",
+                source_group_id=source.id,
+                source_group_name=source.name,
+                origin="owner_association" if is_owner else "member_association",
+            )
+            for is_owner, role, source in rows
+        ]
+
+    detail = TagDetail.model_validate(tag, from_attributes=True)
+    detail.propagated_to_groups = propagated
+    return detail
 
 
 @router.post("", name="tags_create", status_code=201)

--- a/api/routers/tags.py
+++ b/api/routers/tags.py
@@ -76,7 +76,10 @@ async def get_tag(tag_id: str, db: DbSession, current_user_id: CurrentUserId) ->
         raise HTTPException(404, "Not Found")
 
     propagated: list[TagPropagationTargetDetail] = []
-    if tag.propagate_to_roles:
+    # `enabled` matters as much as `propagate_to_roles`: `_propagated_sources`
+    # short-circuits on a disabled tag, so listing roles here for one would
+    # claim reach the enforcement path does not have.
+    if tag.propagate_to_roles and tag.enabled:
         # `RoleGroup` is joined-table inheritance on `okta_group`, so selecting
         # both it and the plain source `OktaGroup` in one query makes the two
         # entities overlap on the same physical table. Left unaliased,
@@ -109,6 +112,9 @@ async def get_tag(tag_id: str, db: DbSession, current_user_id: CurrentUserId) ->
                 .where(SourceGroup.deleted_at.is_(None))
                 .where(SourceGroup.is_managed.is_(True))
                 .where(RoleGroup.deleted_at.is_(None))
+                # An unmanaged role is exempt from constraint enforcement, so
+                # it receives nothing and must not be listed as a target.
+                .where(RoleGroup.is_managed.is_(True))
             )
         ).all()
         propagated = [

--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -43,6 +43,7 @@ from api.schemas.core_schemas import (  # noqa: F401
     RoleMembersSummary,
     TagDetail,
     TagListItem,
+    TagPropagationTargetDetail,
     TagSummary,
 )
 from api.schemas.delete_message import DeleteMessage  # noqa: F401

--- a/api/schemas/core_schemas.py
+++ b/api/schemas/core_schemas.py
@@ -77,7 +77,8 @@ class TagSummary(BaseModel):
 class TagListItem(BaseModel):
     """Tag list-endpoint item. Slim field set (id, name, description,
     enabled, propagate_to_roles, constraints, created_at, updated_at) — does
-    not hydrate `active_group_tags`, which would be an N+1 across the page."""
+    not hydrate `active_group_tags`, which would be an N+1 across the page,
+    nor `propagated_to_groups`, which needs a per-tag join."""
 
     model_config = ConfigDict(from_attributes=True)
     id: str

--- a/api/schemas/core_schemas.py
+++ b/api/schemas/core_schemas.py
@@ -30,6 +30,17 @@ from api.schemas.datetimes import FlexibleDatetime
 # --- Tags -------------------------------------------------------------------
 
 
+class TagPropagationTargetDetail(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    group_id: str
+    group_name: str
+    group_type: str
+    source_group_id: str
+    source_group_name: str
+    # "member_association" | "owner_association"
+    origin: str
+
+
 class TagDetail(BaseModel):
     model_config = ConfigDict(from_attributes=True)
     id: str
@@ -48,6 +59,10 @@ class TagDetail(BaseModel):
     # `TagResource.get()` `exclude=("all_group_tags", "all_app_tags")`
     # retains the `active_app_tags` projection.
     active_app_tags: list["AppTagMapDetail"] = Field(default_factory=list)
+    # Populated by a query in `get_tag`, not an ORM attribute -- see
+    # `api/routers/tags.py`. Roles reached by tag propagation through an
+    # associated group, gated on `propagate_to_roles`.
+    propagated_to_groups: list["TagPropagationTargetDetail"] = Field(default_factory=list)
 
 
 class TagSummary(BaseModel):

--- a/src/api/apiSchemas.ts
+++ b/src/api/apiSchemas.ts
@@ -1473,6 +1473,7 @@ export type TagDetail = {
   deleted_at?: string | null;
   active_group_tags?: OktaGroupTagMapDetail[];
   active_app_tags?: AppTagMapDetail[];
+  propagated_to_groups?: TagPropagationTargetDetail[];
 };
 
 /**
@@ -1497,6 +1498,15 @@ export type TagListItem = {
   propagate_to_roles?: boolean;
   created_at: string | null;
   updated_at: string | null;
+};
+
+export type TagPropagationTargetDetail = {
+  group_id: string;
+  group_name: string;
+  group_type: string;
+  source_group_id: string;
+  source_group_name: string;
+  origin: string;
 };
 
 export type TagSummary = {

--- a/src/pages/tags/Read.tsx
+++ b/src/pages/tags/Read.tsx
@@ -26,15 +26,7 @@ import Disabled from '@mui/icons-material/PauseCircle';
 import Enabled from '@mui/icons-material/TaskAlt';
 
 import {useTagById, useGroupByIdPut, useAppByIdPut, GroupByIdPutRequestBody} from '../../api/apiComponents';
-import {
-  AppDetail,
-  AppGroupDetail,
-  AppTagMapDetail,
-  GroupDetail,
-  OktaGroupTagMapDetail,
-  TagDetail,
-  UpdateAppBody,
-} from '../../api/apiSchemas';
+import {AppDetail, AppGroupDetail, AppTagMapDetail, GroupDetail, TagDetail, UpdateAppBody} from '../../api/apiSchemas';
 
 import {useCurrentUser} from '../../authentication';
 import {isAccessAdmin} from '../../authorization';
@@ -48,6 +40,7 @@ import DeleteTag from './Delete';
 import {EmptyListEntry} from '../../components/EmptyListEntry';
 import MarkdownDescription from '../../components/MarkdownDescription';
 import PropagationNoteView from './PropagationNoteView';
+import {buildGroupsWithTagRows, chipLabel, hasDirectChip} from './groupsWithTagRows';
 
 export default function ReadTag() {
   const currentUser = useCurrentUser();
@@ -76,6 +69,12 @@ export default function ReadTag() {
   }
 
   const tag = data ?? ({} as TagDetail);
+
+  // Row-per-entity: a group tagged both directly and via its app, or a role
+  // reached by propagation through more than one tagged group, is one row
+  // with one chip per source rather than one row per source. See
+  // groupsWithTagRows.ts.
+  const groupsWithTagRows = buildGroupsWithTagRows(tag.active_group_tags, tag.propagated_to_groups);
 
   const removeTagFromApp = (appToRemove: AppDetail, tagId: string) => {
     let app: UpdateAppBody = {
@@ -336,7 +335,7 @@ export default function ReadTag() {
                     <TableCell colSpan={2}>
                       <Grid container>
                         <Grid item xs={3}>
-                          Direct or via App
+                          Tag Source
                         </Grid>
                         <Grid item xs={9}>
                           <Box
@@ -346,7 +345,7 @@ export default function ReadTag() {
                               alignItems: 'right',
                             }}>
                             <Divider sx={{mx: 2}} orientation="vertical" flexItem />
-                            Total: {tag.active_group_tags ? tag.active_group_tags.length : 0}
+                            Total: {groupsWithTagRows.length}
                           </Box>
                         </Grid>
                       </Grid>
@@ -354,49 +353,44 @@ export default function ReadTag() {
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {tag.active_group_tags && tag.active_group_tags.length > 0 ? (
-                    tag.active_group_tags.map((tagMap: OktaGroupTagMapDetail) => (
-                      <TableRow
-                        key={
-                          'taggedgroups' + tagMap.active_group?.id + (tagMap.active_app_tag_mapping ? 'app' : 'direct')
-                        }>
+                  {groupsWithTagRows.length > 0 ? (
+                    groupsWithTagRows.map((row) => (
+                      <TableRow key={'taggedgroups' + row.groupId}>
                         <TableCell>
                           <Link
-                            to={`/groups/${tagMap.active_group?.name}`}
+                            to={`/groups/${row.groupName}`}
                             sx={{
                               textDecoration: 'none',
                               color: 'inherit',
                             }}
                             component={RouterLink}>
-                            {tagMap.active_group?.name}
+                            {row.groupName}
                           </Link>
                         </TableCell>
                         <TableCell>
-                          {tagMap.active_group?.type == 'role_group'
+                          {row.groupType == 'role_group'
                             ? 'Role Group'
-                            : tagMap.active_group?.type == 'app_group'
+                            : row.groupType == 'app_group'
                               ? 'App Group'
                               : 'Group'}
                         </TableCell>
                         <TableCell>
-                          {tagMap.active_app_tag_mapping ? (
-                            <Chip
-                              key={'group' + tagMap.active_group?.id}
-                              label={(tagMap.active_group as AppGroupDetail).app?.name}
-                              color="primary"
-                              variant="outlined"
-                            />
-                          ) : (
-                            <Chip key={'group' + tagMap.active_group?.id} label="Direct" color="primary" />
-                          )}
+                          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+                            {row.chips.map((chip, index) => (
+                              <Chip
+                                key={'group' + row.groupId + chip.kind + index}
+                                label={chipLabel(chip)}
+                                color="primary"
+                                variant={chip.kind === 'direct' ? 'filled' : 'outlined'}
+                              />
+                            ))}
+                          </Stack>
                         </TableCell>
                         <TableCell align="right">
-                          {isAccessAdmin(currentUser) && !tagMap.active_app_tag_mapping ? (
+                          {isAccessAdmin(currentUser) && hasDirectChip(row) ? (
                             <IconButton
                               size="small"
-                              onClick={() =>
-                                removeTagFromGroup(tagMap.active_group! as unknown as GroupDetail, tag.id)
-                              }>
+                              onClick={() => removeTagFromGroup(row.directGroup! as unknown as GroupDetail, tag.id)}>
                               <DeleteIcon />
                             </IconButton>
                           ) : null}

--- a/src/pages/tags/groupsWithTagRows.test.ts
+++ b/src/pages/tags/groupsWithTagRows.test.ts
@@ -1,0 +1,134 @@
+import {describe, expect, it} from 'vitest';
+
+import {GroupRefForMembership, OktaGroupTagMapDetail, TagPropagationTargetDetail} from '../../api/apiSchemas';
+import {buildGroupsWithTagRows, chipLabel, hasDirectChip} from './groupsWithTagRows';
+
+const group = (overrides: Partial<GroupRefForMembership> = {}): GroupRefForMembership => ({
+  id: 'g1',
+  type: 'okta_group',
+  name: 'group-one',
+  ...overrides,
+});
+
+const directTagMap = (overrides: Partial<OktaGroupTagMapDetail> = {}): OktaGroupTagMapDetail => ({
+  created_at: null,
+  active_group: group(),
+  ...overrides,
+});
+
+const propagationEntry = (overrides: Partial<TagPropagationTargetDetail> = {}): TagPropagationTargetDetail => ({
+  group_id: 'r1',
+  group_name: 'Role-Foo',
+  group_type: 'role_group',
+  source_group_id: 'g1',
+  source_group_name: 'group-one',
+  origin: 'member_association',
+  ...overrides,
+});
+
+describe('buildGroupsWithTagRows', () => {
+  it('returns one row per direct group tag with a direct chip and the group ref', () => {
+    const rows = buildGroupsWithTagRows([directTagMap()], []);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].groupId).toBe('g1');
+    expect(rows[0].chips).toEqual([{kind: 'direct'}]);
+    expect(rows[0].directGroup?.id).toBe('g1');
+  });
+
+  it('renders an app-inherited tag map as an app chip, not direct', () => {
+    const appGroup = group({id: 'ag1', type: 'app_group', app: {id: 'app1', name: 'Foo'}});
+    const rows = buildGroupsWithTagRows(
+      [directTagMap({active_group: appGroup, active_app_tag_mapping: {id: 1} as any})],
+      [],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].chips).toEqual([{kind: 'app', appName: 'Foo'}]);
+    expect(rows[0].directGroup).toBeUndefined();
+  });
+
+  it('lists a role reached only by propagation with a group chip and no direct group ref', () => {
+    const rows = buildGroupsWithTagRows([], [propagationEntry()]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].groupId).toBe('r1');
+    expect(rows[0].groupName).toBe('Role-Foo');
+    expect(rows[0].groupType).toBe('role_group');
+    expect(rows[0].chips).toEqual([{kind: 'group', sourceGroupName: 'group-one'}]);
+    expect(rows[0].directGroup).toBeUndefined();
+  });
+
+  it('merges a group appearing in both a direct tag map and propagation into one row with two chips', () => {
+    // A role can be directly tagged AND reached by propagation through a
+    // different tagged group it belongs to -- both sources should surface
+    // on the same row, not two separate rows for the same entity.
+    const roleGroup = group({id: 'r1', type: 'role_group', name: 'Role-Foo'});
+    const rows = buildGroupsWithTagRows(
+      [directTagMap({active_group: roleGroup})],
+      [propagationEntry({group_id: 'r1', group_name: 'Role-Foo'})],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].chips).toEqual([{kind: 'direct'}, {kind: 'group', sourceGroupName: 'group-one'}]);
+    expect(rows[0].directGroup?.id).toBe('r1');
+  });
+
+  it('produces one row per distinct source group when a role is reached via two groups', () => {
+    const rows = buildGroupsWithTagRows(
+      [],
+      [
+        propagationEntry({source_group_id: 'g1', source_group_name: 'group-one'}),
+        propagationEntry({source_group_id: 'g2', source_group_name: 'group-two'}),
+      ],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].chips).toEqual([
+      {kind: 'group', sourceGroupName: 'group-one'},
+      {kind: 'group', sourceGroupName: 'group-two'},
+    ]);
+  });
+
+  it('returns an empty list when both inputs are empty or missing', () => {
+    expect(buildGroupsWithTagRows([], [])).toEqual([]);
+    expect(buildGroupsWithTagRows(undefined, undefined)).toEqual([]);
+    expect(buildGroupsWithTagRows(null, null)).toEqual([]);
+  });
+
+  it('skips a tag map whose active_group is missing', () => {
+    const rows = buildGroupsWithTagRows([directTagMap({active_group: undefined})], []);
+    expect(rows).toEqual([]);
+  });
+});
+
+describe('chipLabel', () => {
+  it('labels a direct chip', () => {
+    expect(chipLabel({kind: 'direct'})).toBe('Direct');
+  });
+
+  it('labels an app chip with the app name', () => {
+    expect(chipLabel({kind: 'app', appName: 'Foo'})).toBe('App: Foo');
+  });
+
+  it('labels a group chip with the source group name', () => {
+    expect(chipLabel({kind: 'group', sourceGroupName: 'group-one'})).toBe('Group: group-one');
+  });
+});
+
+describe('hasDirectChip', () => {
+  it('is true when a row has a direct chip among others', () => {
+    const row = {
+      groupId: 'g1',
+      groupName: 'g',
+      groupType: 'okta_group',
+      chips: [{kind: 'group' as const, sourceGroupName: 's'}, {kind: 'direct' as const}],
+    };
+    expect(hasDirectChip(row)).toBe(true);
+  });
+
+  it('is false when a row has no direct chip', () => {
+    const row = {
+      groupId: 'g1',
+      groupName: 'g',
+      groupType: 'okta_group',
+      chips: [{kind: 'app' as const, appName: 'Foo'}],
+    };
+    expect(hasDirectChip(row)).toBe(false);
+  });
+});

--- a/src/pages/tags/groupsWithTagRows.test.ts
+++ b/src/pages/tags/groupsWithTagRows.test.ts
@@ -70,7 +70,7 @@ describe('buildGroupsWithTagRows', () => {
     expect(rows[0].directGroup?.id).toBe('r1');
   });
 
-  it('produces one row per distinct source group when a role is reached via two groups', () => {
+  it('keeps a role reached via two groups on one row, with a chip per source group', () => {
     const rows = buildGroupsWithTagRows(
       [],
       [

--- a/src/pages/tags/groupsWithTagRows.ts
+++ b/src/pages/tags/groupsWithTagRows.ts
@@ -1,12 +1,11 @@
 import {GroupRefForMembership, OktaGroupTagMapDetail, TagPropagationTargetDetail} from '../../api/apiSchemas';
 
-// The "Groups with Tag" table used to be row-per-tag-map: a group tagged both
-// directly and via its app produced two rows for the same group, and a role
-// reached only by propagation through an associated group never appeared at
-// all (propagation isn't stored as an `OktaGroupTagMap` row). This module
-// merges `active_group_tags` (direct + app-inherited) and `propagated_to_groups`
-// (role reached via an associated group) into one row per entity, each
-// carrying every source that applies -- see groupsWithTagRows.test.ts.
+// Builds the "Groups with Tag" table as one row per entity, each carrying
+// every source that applies. Merges two inputs: `active_group_tags`, which
+// covers tags applied directly and inherited from an app, and
+// `propagated_to_groups`, which covers roles reached through an associated
+// group -- propagation is computed, not stored as an `OktaGroupTagMap` row, so
+// those roles have no tag-map entry of their own.
 
 export type TagSourceChip =
   | {kind: 'direct'}

--- a/src/pages/tags/groupsWithTagRows.ts
+++ b/src/pages/tags/groupsWithTagRows.ts
@@ -1,0 +1,79 @@
+import {GroupRefForMembership, OktaGroupTagMapDetail, TagPropagationTargetDetail} from '../../api/apiSchemas';
+
+// The "Groups with Tag" table used to be row-per-tag-map: a group tagged both
+// directly and via its app produced two rows for the same group, and a role
+// reached only by propagation through an associated group never appeared at
+// all (propagation isn't stored as an `OktaGroupTagMap` row). This module
+// merges `active_group_tags` (direct + app-inherited) and `propagated_to_groups`
+// (role reached via an associated group) into one row per entity, each
+// carrying every source that applies -- see groupsWithTagRows.test.ts.
+
+export type TagSourceChip =
+  | {kind: 'direct'}
+  | {kind: 'app'; appName: string}
+  | {kind: 'group'; sourceGroupName: string};
+
+export interface GroupWithTagRow {
+  groupId: string;
+  groupName: string;
+  groupType: string;
+  chips: TagSourceChip[];
+  // Only set when `chips` contains a 'direct' entry -- the group ref needed
+  // to end that direct assignment. App-inherited and propagated sources are
+  // removed elsewhere (removing the app tag, or ending the association), not
+  // from this table, so they carry no group ref here.
+  directGroup?: GroupRefForMembership;
+}
+
+export function buildGroupsWithTagRows(
+  activeGroupTags: OktaGroupTagMapDetail[] | undefined | null,
+  propagatedToGroups: TagPropagationTargetDetail[] | undefined | null,
+): GroupWithTagRow[] {
+  const rowsById = new Map<string, GroupWithTagRow>();
+
+  const rowFor = (groupId: string, groupName: string, groupType: string): GroupWithTagRow => {
+    const existing = rowsById.get(groupId);
+    if (existing) {
+      return existing;
+    }
+    const created: GroupWithTagRow = {groupId, groupName, groupType, chips: []};
+    rowsById.set(groupId, created);
+    return created;
+  };
+
+  (activeGroupTags ?? []).forEach((tagMap) => {
+    const group = tagMap.active_group;
+    if (!group?.id) {
+      return;
+    }
+    const row = rowFor(group.id, group.name, group.type);
+    if (tagMap.active_app_tag_mapping) {
+      row.chips.push({kind: 'app', appName: group.app?.name ?? ''});
+    } else {
+      row.chips.push({kind: 'direct'});
+      row.directGroup = group;
+    }
+  });
+
+  (propagatedToGroups ?? []).forEach((entry) => {
+    const row = rowFor(entry.group_id, entry.group_name, entry.group_type);
+    row.chips.push({kind: 'group', sourceGroupName: entry.source_group_name});
+  });
+
+  return Array.from(rowsById.values());
+}
+
+export function chipLabel(chip: TagSourceChip): string {
+  switch (chip.kind) {
+    case 'direct':
+      return 'Direct';
+    case 'app':
+      return `App: ${chip.appName}`;
+    case 'group':
+      return `Group: ${chip.sourceGroupName}`;
+  }
+}
+
+export function hasDirectChip(row: GroupWithTagRow): boolean {
+  return row.chips.some((chip) => chip.kind === 'direct');
+}

--- a/tests/test_effective_constraints_api.py
+++ b/tests/test_effective_constraints_api.py
@@ -105,3 +105,40 @@ async def test_group_detail_app_tag_has_app_origin(app: FastAPI, client: AsyncCl
     constraints = response.json()["effective_constraints"]
     assert len(constraints) == 1
     assert constraints[0]["sources"][0]["origin"] == "app"
+
+
+async def test_tag_detail_lists_roles_reached_by_propagation(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any
+) -> None:
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(name="SOX", constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400})
+    db.session.add_all([group, role, tag])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False))
+    await db.session.commit()
+
+    response = await client.get(url_for("tag_by_id", tag_id=tag.id))
+    assert response.status_code == 200
+    propagated = response.json()["propagated_to_groups"]
+    assert len(propagated) == 1
+    assert propagated[0]["group_id"] == role.id
+    assert propagated[0]["source_group_id"] == group.id
+    assert propagated[0]["origin"] == "member_association"
+
+
+async def test_tag_detail_omits_propagation_when_gated_off(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any
+) -> None:
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(name="SOX", propagate_to_roles=False)
+    db.session.add_all([group, role, tag])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False))
+    await db.session.commit()
+
+    response = await client.get(url_for("tag_by_id", tag_id=tag.id))
+    assert response.json()["propagated_to_groups"] == []

--- a/tests/test_effective_constraints_api.py
+++ b/tests/test_effective_constraints_api.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from httpx import AsyncClient
@@ -5,7 +6,7 @@ from httpx import AsyncClient
 from fastapi import FastAPI
 
 from api.extensions import Db
-from api.models import RoleGroupMap, Tag
+from api.models import OktaGroup, RoleGroup, RoleGroupMap, Tag
 from tests.factories import (
     AppFactory,
     AppGroupFactory,
@@ -15,6 +16,33 @@ from tests.factories import (
     RoleGroupFactory,
     TagFactory,
 )
+
+_PAST = datetime.now(UTC) - timedelta(days=1)
+
+
+async def _build_propagation_scenario(
+    db: Db,
+    *,
+    group_deleted_at: datetime | None = None,
+    group_is_managed: bool = True,
+    role_deleted_at: datetime | None = None,
+    tag_map_ended_at: datetime | None = None,
+    role_map_ended_at: datetime | None = None,
+) -> tuple[OktaGroup, RoleGroup, Tag]:
+    """Builds the shared happy-path propagation scenario -- a managed,
+    non-deleted source group tagged via an active `OktaGroupTagMap`, mapped
+    to a non-deleted role via an active `RoleGroupMap` -- with knobs to break
+    exactly one of the five active-record conditions `get_tag` filters on.
+    With all defaults, the role WOULD appear in `propagated_to_groups`."""
+    group = OktaGroupFactory.build(deleted_at=group_deleted_at, is_managed=group_is_managed)
+    role = RoleGroupFactory.build(deleted_at=role_deleted_at)
+    tag = TagFactory.build(name="SOX", constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400})
+    db.session.add_all([group, role, tag])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id, ended_at=tag_map_ended_at))
+    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False, ended_at=role_map_ended_at))
+    await db.session.commit()
+    return group, role, tag
 
 
 async def test_group_detail_exposes_effective_constraints(
@@ -141,4 +169,65 @@ async def test_tag_detail_omits_propagation_when_gated_off(
     await db.session.commit()
 
     response = await client.get(url_for("tag_by_id", tag_id=tag.id))
+    assert response.json()["propagated_to_groups"] == []
+
+
+async def test_tag_detail_excludes_ended_group_tag_map(app: FastAPI, client: AsyncClient, db: Db, url_for: Any) -> None:
+    """The tag was on the source group but was removed -- the `OktaGroupTagMap`
+    row has an `ended_at` in the past. The role must not be reported as
+    reached by propagation."""
+    _group, _role, tag = await _build_propagation_scenario(db, tag_map_ended_at=_PAST)
+
+    response = await client.get(url_for("tag_by_id", tag_id=tag.id))
+    assert response.status_code == 200
+    assert response.json()["propagated_to_groups"] == []
+
+
+async def test_tag_detail_excludes_ended_role_group_map(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any
+) -> None:
+    """The role was once a member of the source group but that membership has
+    ended -- the `RoleGroupMap` row has an `ended_at` in the past. The role
+    must not be reported as reached by propagation."""
+    _group, _role, tag = await _build_propagation_scenario(db, role_map_ended_at=_PAST)
+
+    response = await client.get(url_for("tag_by_id", tag_id=tag.id))
+    assert response.status_code == 200
+    assert response.json()["propagated_to_groups"] == []
+
+
+async def test_tag_detail_excludes_soft_deleted_source_group(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any
+) -> None:
+    """The source group carrying the tag has been soft-deleted. Even though
+    its `OktaGroupTagMap` and `RoleGroupMap` rows are still active, a deleted
+    source group must not surface a propagated role."""
+    _group, _role, tag = await _build_propagation_scenario(db, group_deleted_at=_PAST)
+
+    response = await client.get(url_for("tag_by_id", tag_id=tag.id))
+    assert response.status_code == 200
+    assert response.json()["propagated_to_groups"] == []
+
+
+async def test_tag_detail_excludes_unmanaged_source_group(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any
+) -> None:
+    """Tags cannot apply to externally managed (`is_managed=False`) groups, so
+    a role reached only through an unmanaged source group must not be
+    reported as propagated to."""
+    _group, _role, tag = await _build_propagation_scenario(db, group_is_managed=False)
+
+    response = await client.get(url_for("tag_by_id", tag_id=tag.id))
+    assert response.status_code == 200
+    assert response.json()["propagated_to_groups"] == []
+
+
+async def test_tag_detail_excludes_soft_deleted_role(app: FastAPI, client: AsyncClient, db: Db, url_for: Any) -> None:
+    """The role itself has been soft-deleted. Even though the source group is
+    still tagged and the `RoleGroupMap` is still active, a deleted role must
+    not be reported as reached by propagation."""
+    _group, _role, tag = await _build_propagation_scenario(db, role_deleted_at=_PAST)
+
+    response = await client.get(url_for("tag_by_id", tag_id=tag.id))
+    assert response.status_code == 200
     assert response.json()["propagated_to_groups"] == []

--- a/tests/test_effective_constraints_api.py
+++ b/tests/test_effective_constraints_api.py
@@ -26,17 +26,19 @@ async def _build_propagation_scenario(
     group_deleted_at: datetime | None = None,
     group_is_managed: bool = True,
     role_deleted_at: datetime | None = None,
+    role_is_managed: bool = True,
+    tag_enabled: bool = True,
     tag_map_ended_at: datetime | None = None,
     role_map_ended_at: datetime | None = None,
 ) -> tuple[OktaGroup, RoleGroup, Tag]:
-    """Builds the shared happy-path propagation scenario -- a managed,
-    non-deleted source group tagged via an active `OktaGroupTagMap`, mapped
-    to a non-deleted role via an active `RoleGroupMap` -- with knobs to break
-    exactly one of the five active-record conditions `get_tag` filters on.
-    With all defaults, the role WOULD appear in `propagated_to_groups`."""
+    """Builds the shared happy-path propagation scenario -- an enabled tag on a
+    managed, non-deleted source group via an active `OktaGroupTagMap`, mapped
+    to a managed, non-deleted role via an active `RoleGroupMap` -- with knobs
+    to break exactly one of the conditions `get_tag` filters on. With all
+    defaults, the role WOULD appear in `propagated_to_groups`."""
     group = OktaGroupFactory.build(deleted_at=group_deleted_at, is_managed=group_is_managed)
-    role = RoleGroupFactory.build(deleted_at=role_deleted_at)
-    tag = TagFactory.build(name="SOX", constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400})
+    role = RoleGroupFactory.build(deleted_at=role_deleted_at, is_managed=role_is_managed)
+    tag = TagFactory.build(name="SOX", enabled=tag_enabled, constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400})
     db.session.add_all([group, role, tag])
     await db.session.commit()
     db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id, ended_at=tag_map_ended_at))
@@ -227,6 +229,32 @@ async def test_tag_detail_excludes_soft_deleted_role(app: FastAPI, client: Async
     still tagged and the `RoleGroupMap` is still active, a deleted role must
     not be reported as reached by propagation."""
     _group, _role, tag = await _build_propagation_scenario(db, role_deleted_at=_PAST)
+
+    response = await client.get(url_for("tag_by_id", tag_id=tag.id))
+    assert response.status_code == 200
+    assert response.json()["propagated_to_groups"] == []
+
+
+async def test_tag_detail_omits_propagation_for_disabled_tag(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any
+) -> None:
+    """A disabled tag enforces nothing -- `_propagated_sources` short-circuits
+    on `tag.enabled` -- so listing the roles it would otherwise reach is
+    display without enforcement, and the tag page's "these constraints do
+    apply to roles" note would be a lie."""
+    _group, _role, tag = await _build_propagation_scenario(db, tag_enabled=False)
+
+    response = await client.get(url_for("tag_by_id", tag_id=tag.id))
+    assert response.status_code == 200
+    assert response.json()["propagated_to_groups"] == []
+
+
+async def test_tag_detail_excludes_unmanaged_role(app: FastAPI, client: AsyncClient, db: Db, url_for: Any) -> None:
+    """An externally managed role is exempt from constraint enforcement
+    (`effective_ended_at` returns early, and the `cap-role-memberships` sweep
+    filters it out), so it receives nothing and must not be listed as a
+    propagation target."""
+    _group, _role, tag = await _build_propagation_scenario(db, role_is_managed=False)
 
     response = await client.get(url_for("tag_by_id", tag_id=tag.id))
     assert response.status_code == 200


### PR DESCRIPTION
# Summary

Shows roles that a tag reaches by propagation on the tag page, and reworks the "Groups with Tag" table from row-per-tag-map to row-per-entity with a **Tag Source** column.

**Stacked on [#601](https://github.com/discord/access/pull/601)** — review and merge that one first. This PR's diff against `main` will look larger than it is until #601 lands; read it against `brynna/tag_constraint_propagation`.

**Urgency**: TODO — set desired turnaround
**Expected review effort**: MEDIUM — 3 commits, one non-obvious SQL detail

# Motivation

#601 makes a tag's constraints reach roles associated with a tagged group. But the tag page still lists only groups the tag is *stored* on, so an operator opening the SOX tag cannot see which roles it actually governs — the propagated ones are invisible.

The table also had a pre-existing shortcoming this fixes: a group tagged both directly and via its app produced two rows for the same group.

<details>
<summary><h1>Description & Screenshots of Changes</h1></summary>

**Backend.** `TagDetail` gains `propagated_to_groups`, populated by a query in `get_tag` that finds roles associated with any group carrying the tag. Each entry names the role, the source group, and whether the association was membership or ownership.

The query is gated on `propagate_to_roles` **and** `enabled`, and filters five active-record conditions: both the `OktaGroupTagMap` and the `RoleGroupMap` must be active, the source group must be non-deleted and managed, and the role must be non-deleted and managed. A disabled tag propagates nothing and an unmanaged role enforces nothing, so listing either would claim reach the enforcement path does not have.

**Frontend.** `groupsWithTagRows.ts` merges `active_group_tags` (direct and app-inherited) with `propagated_to_groups` into one row per entity, each carrying every source that applies. The column becomes **Tag Source** with one chip per source — `Direct`, `App: {name}`, `Group: {name}`. The remove button shows only on a row with a `Direct` chip and removes only the direct assignment; app-inherited and propagated rows are removed by removing the app tag or ending the association.

<img width="1280" height="1060" alt="image" src="https://github.com/user-attachments/assets/01906a6e-471c-418c-81bc-07d88f4f13cc" />
</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

- `make test` green: 924 backend / 63 frontend at head.
- Each of the five active-record filters has a negative regression test, and each was proven load-bearing by removing its `.where(...)` clause and confirming only that test fails.
- The `enabled` gate and the role `is_managed` filter were verified the same way.
- Row-merge logic is extracted as pure functions and unit-tested directly, rather than mounting the table behind mocked MUI.

</details>

# Guidance for Reviewers

Read commit-by-commit; three commits, each green.

One thing worth a careful look: **the `aliased()` in `get_tag`'s query.** `RoleGroup` is joined-table inheritance on `okta_group`, so selecting both it and the plain source `OktaGroup` makes the two overlap on one physical table. Left unaliased, SQLAlchemy silently auto-aliases `RoleGroup`'s implicit parent join, the later `where` clauses bind to that alias instead of the source-group row, and **the query returns zero rows with no error**. That bug was live during development and is exactly the kind a passing test suite would not have caught without the negative filters.

The `Tag Source` column also changes the table's "Total" from a tag-map count to a row count — correct for a row-per-entity table, but operators eyeball that number, so it belongs in release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
