### PR TITLE
Pin the searched columns in the role+owner audit search test

### DIFF
--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -713,8 +713,13 @@ async def test_groups_audit_q_with_role_and_owner_pin(client: AsyncClient, db: D
     associated-group `q` filter AND-applies on top of the broad either-side
     filter. A `q` that matches role columns but no group columns must
     return zero rows."""
-    role = await RoleGroupFactory.create_async(name="ZqxRole", description="zqx-only-role")
-    associated = await OktaGroupFactory.create_async(name="GroupGamma", description="gamma")
+    # Pin every column the associated-group `q` filter searches: it matches
+    # `id` as well as `name` and `description`. Factory-generated ids are 20
+    # random alphanumerics, so an associated group whose id happened to contain
+    # "zqx" (about 1 run in 1600) satisfied the filter and returned the very
+    # row this test asserts is filtered out.
+    role = await RoleGroupFactory.create_async(id="ZqxRoleAuditPin00000", name="ZqxRole", description="zqx-only-role")
+    associated = await OktaGroupFactory.create_async(id="GroupGammaAuditPin00", name="GroupGamma", description="gamma")
     owner = await OktaUserFactory.create_async(email="role-pin-owner@example.com", first_name="Pin", last_name="Owner")
     await ModifyRoleGroups(role_group=role, groups_to_add=[associated.id], sync_to_okta=False).execute()
     await ModifyGroupUsers(group=associated, owners_to_add=[owner.id], sync_to_okta=False).execute()


### PR DESCRIPTION
`tests/test_audit.py::test_groups_audit_q_with_role_and_owner_pin` was intermittently flaky, at roughly 1 run in 1600. It reproduced only in long runs, which made it look like cross-test state leakage or unseeded Faker data. It is neither.

With `role_id` pinned, the `q` filter on `/api/audit/groups` narrows to the associated group's columns, and [`id` is one of them](https://github.com/discord/access/blob/9feab29/api/routers/audit.py#L705-L709). The test controls that group's `name` ("GroupGamma") and `description` ("gamma") but not its `id`, which [`_okta_id()`](https://github.com/discord/access/blob/9feab29/tests/factories.py#L68-L71) generates as 20 random alphanumerics. The search term `q="Zqx"` is only three characters, so an id that happened to contain `zqx` in any case satisfied the filter and returned the very row the test asserts is filtered out. Expected rate: 18 windows x (2/62)^3, about 1 in 1580.

Measured over 20,000 iterations of the unmodified test body: 8 failures, and the 8 failing iterations were exactly the 8 whose generated id contained `zqx` (`UWSZQXgkaPI43FrqCXvW`, `UWxElcwK6rsuOOHzQXgL`, `zqXskQZ4FKHuh7cOGy2g`, ...). A 1:1 correspondence with no other failure mode, so nothing else in the test is nondeterministic.

The fix pins the ids, leaving every column the filter searches a literal. The outcome no longer depends on a generated value, so this is determinism rather than a lowered collision probability. No retry, and no global Faker or `random` seed: a fixed seed would make the run reproducible but arbitrary, and any future change to the number of draws would reshuffle every downstream value, turning this rare flake into a rare and far more confusing "adding a test broke an unrelated test".

Notes for a reviewer:

- The audit endpoints are the only ones whose `q` matches `id` columns. Every other `?q=` filter (groups, apps, users, tags, requests) searches names, emails, and descriptions, all of which those tests set explicitly, so the same hazard does not exist there.
- The remaining audit search tests use 5 to 7 character terms, putting their exposure at ~1e-7 or lower. I left them alone rather than churn them, and the new comment names the hazard for the next author who reaches for a short search term.

Verified: 2,000 runs of the fixed test with a fresh database each, plus a full `pytest tests/ examples/plugins` run (881 passed), `ruff`, and `ty`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)