### PR TITLE
Replace react-hook-form-mui with local form field wrappers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-hook-form": "^7.51.2",
-        "react-hook-form-mui": "^6.7.3",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.18.2",
         "styled-components": "^5.3.11"
@@ -7342,29 +7341,6 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18"
-      }
-    },
-    "node_modules/react-hook-form-mui": {
-      "version": "6.7.3",
-      "resolved": "https://registry.npmjs.org/react-hook-form-mui/-/react-hook-form-mui-6.7.3.tgz",
-      "integrity": "sha512-QmqfbeeCL4ms2N8Hj9An/02EyEp4LOW5DRPf4QbMj8lIouRRN7o/jQ0Ltq1CzCIlmagkD+rhfr6ILoXce75Q8g==",
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@mui/icons-material": ">= 5.x <6",
-        "@mui/material": ">= 5.x <6",
-        "@mui/x-date-pickers": ">=6.1.0 <7",
-        "react": ">=17 <19",
-        "react-hook-form": ">=7.33.1"
-      },
-      "peerDependenciesMeta": {
-        "@mui/icons-material": {
-          "optional": true
-        },
-        "@mui/x-date-pickers": {
-          "optional": true
-        }
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-hook-form": "^7.51.2",
-    "react-hook-form-mui": "^6.7.3",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.18.2",
     "styled-components": "^5.3.11"

--- a/src/components/forms/AutocompleteElement.tsx
+++ b/src/components/forms/AutocompleteElement.tsx
@@ -1,0 +1,73 @@
+import Autocomplete, {AutocompleteProps} from '@mui/material/Autocomplete';
+import TextField, {TextFieldProps} from '@mui/material/TextField';
+import {Controller, FieldError, FieldPath, FieldValues, RegisterOptions, useFormContext} from 'react-hook-form';
+
+/**
+ * TypeScript does not infer through a conditional type, so routing `TOption` through
+ * `Deferred` keeps `autocompleteProps` from participating in inference. `TOption` is then
+ * fixed by `options` alone, which is what lets the callbacks inside `autocompleteProps`
+ * (getOptionLabel, isOptionEqualToValue, ...) type correctly with no call-site annotation.
+ * On TypeScript >= 5.4 this can be replaced with the built-in `NoInfer<TOption>`.
+ */
+type Deferred<T> = T extends unknown ? T : never;
+export interface AutocompleteElementProps<TOption, TFieldValues extends FieldValues = FieldValues> {
+  name: FieldPath<TFieldValues>;
+  label?: string;
+  options: readonly TOption[];
+  required?: boolean;
+  loading?: boolean;
+  validation?: RegisterOptions<TFieldValues>;
+  parseError?: (error: FieldError) => string;
+  autocompleteProps?: Partial<
+    Omit<AutocompleteProps<Deferred<TOption>, false, false, false>, 'options' | 'renderInput' | 'value'>
+  >;
+  textFieldProps?: Partial<TextFieldProps>;
+}
+
+export default function AutocompleteElement<TOption, TFieldValues extends FieldValues = FieldValues>({
+  name,
+  label,
+  options,
+  required,
+  loading,
+  validation,
+  parseError,
+  autocompleteProps,
+  textFieldProps,
+}: AutocompleteElementProps<TOption, TFieldValues>) {
+  const {control} = useFormContext<TFieldValues>();
+  const rules: RegisterOptions<TFieldValues> = {
+    ...(required ? {required: 'This field is required'} : {}),
+    ...validation,
+  };
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={rules}
+      render={({field, fieldState: {error}}) => (
+        <Autocomplete
+          {...(autocompleteProps as object)}
+          options={options}
+          loading={loading}
+          value={(field.value ?? null) as TOption | null}
+          onChange={(event, value, reason, details) => {
+            field.onChange(value);
+            autocompleteProps?.onChange?.(event, value as Deferred<TOption>, reason, details);
+          }}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              {...textFieldProps}
+              label={label}
+              required={required}
+              error={!!error}
+              helperText={error ? (parseError ? parseError(error) : error.message ?? '') : textFieldProps?.helperText}
+            />
+          )}
+        />
+      )}
+    />
+  );
+}

--- a/src/components/forms/DatePickerElement.tsx
+++ b/src/components/forms/DatePickerElement.tsx
@@ -1,0 +1,63 @@
+import {DatePicker, DatePickerProps} from '@mui/x-date-pickers/DatePicker';
+import {Dayjs} from 'dayjs';
+import {Controller, FieldError, FieldPath, FieldValues, RegisterOptions, useFormContext} from 'react-hook-form';
+
+export type DatePickerElementProps<TFieldValues extends FieldValues = FieldValues> = Omit<
+  DatePickerProps<Dayjs>,
+  'name' | 'value' | 'onChange' | 'minDate' | 'maxDate'
+> & {
+  minDate?: Dayjs | null;
+  maxDate?: Dayjs | null;
+  name: FieldPath<TFieldValues>;
+  required?: boolean;
+  validation?: RegisterOptions<TFieldValues>;
+  parseError?: (error: FieldError) => string;
+};
+
+/**
+ * Stores the picker's Dayjs value directly in form state, matching the behavior the
+ * call sites already rely on (they cast the field and call `.toISOString()` on submit).
+ */
+export default function DatePickerElement<TFieldValues extends FieldValues = FieldValues>({
+  name,
+  required,
+  validation,
+  parseError,
+  slotProps,
+  minDate,
+  maxDate,
+  ...datePickerProps
+}: DatePickerElementProps<TFieldValues>) {
+  const {control} = useFormContext<TFieldValues>();
+  const rules: RegisterOptions<TFieldValues> = {
+    ...(required ? {required: 'This field is required'} : {}),
+    ...validation,
+  };
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={rules}
+      render={({field, fieldState: {error}}) => (
+        <DatePicker
+          {...datePickerProps}
+          minDate={minDate ?? undefined}
+          maxDate={maxDate ?? undefined}
+          value={(field.value ?? null) as Dayjs | null}
+          onChange={(value, context) => field.onChange(value)}
+          inputRef={field.ref}
+          slotProps={{
+            ...slotProps,
+            textField: {
+              required,
+              error: !!error,
+              helperText: error ? (parseError ? parseError(error) : error.message ?? '') : undefined,
+              ...(slotProps?.textField as object),
+            },
+          }}
+        />
+      )}
+    />
+  );
+}

--- a/src/components/forms/FormContainer.tsx
+++ b/src/components/forms/FormContainer.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {FieldValues, FormProvider, SubmitHandler, useForm, UseFormProps} from 'react-hook-form';
+
+export interface FormContainerProps<TFieldValues extends FieldValues = FieldValues> extends UseFormProps<TFieldValues> {
+  onSuccess?: SubmitHandler<TFieldValues>;
+  children?: React.ReactNode;
+}
+
+/**
+ * Owns a react-hook-form instance and publishes it via FormProvider, so the field
+ * wrappers in this directory (and any bare `Controller`) can reach it with `useFormContext`.
+ */
+export default function FormContainer<TFieldValues extends FieldValues = FieldValues>({
+  onSuccess,
+  children,
+  ...useFormProps
+}: FormContainerProps<TFieldValues>) {
+  const methods = useForm<TFieldValues>(useFormProps);
+  return (
+    <FormProvider {...methods}>
+      <form noValidate onSubmit={onSuccess ? methods.handleSubmit(onSuccess) : undefined}>
+        {children}
+      </form>
+    </FormProvider>
+  );
+}

--- a/src/components/forms/SelectElement.tsx
+++ b/src/components/forms/SelectElement.tsx
@@ -1,0 +1,83 @@
+import FormControl from '@mui/material/FormControl';
+import FormHelperText from '@mui/material/FormHelperText';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import Select, {SelectProps} from '@mui/material/Select';
+import React, {useId} from 'react';
+import {Controller, FieldError, FieldPath, FieldValues, RegisterOptions, useFormContext} from 'react-hook-form';
+
+/**
+ * Deliberately loose: some call sites pass `Record<string, string>` maps built from
+ * `Object.entries`, which react-hook-form-mui also accepted.
+ */
+export type SelectOption = Record<string, unknown>;
+
+export type SelectElementProps<TFieldValues extends FieldValues = FieldValues> = Omit<
+  SelectProps,
+  'name' | 'error' | 'onChange' | 'value'
+> & {
+  name: FieldPath<TFieldValues>;
+  options: readonly SelectOption[];
+  validation?: RegisterOptions<TFieldValues>;
+  parseError?: (error: FieldError) => string;
+  /**
+   * Receives the selected option id. Typed `any` to match the previous
+   * react-hook-form-mui signature, whose call sites feed it into narrower setters.
+   */
+  onChange?: (value: any) => void;
+  helperText?: string;
+};
+
+export default function SelectElement<TFieldValues extends FieldValues = FieldValues>({
+  name,
+  options,
+  validation,
+  parseError,
+  onChange,
+  required,
+  label,
+  fullWidth,
+  helperText,
+  ...selectProps
+}: SelectElementProps<TFieldValues>) {
+  const {control} = useFormContext<TFieldValues>();
+  const labelId = useId();
+  const rules: RegisterOptions<TFieldValues> = {
+    ...(required ? {required: 'This field is required'} : {}),
+    ...validation,
+  };
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={rules}
+      render={({field, fieldState: {error}}) => (
+        <FormControl fullWidth={fullWidth} required={required} error={!!error}>
+          {label ? <InputLabel id={labelId}>{label}</InputLabel> : null}
+          <Select
+            {...selectProps}
+            {...field}
+            labelId={labelId}
+            label={label}
+            value={field.value ?? ''}
+            onChange={(event) => {
+              field.onChange(event);
+              onChange?.(event.target.value);
+            }}>
+            {options.map((option) => (
+              <MenuItem key={String(option.id)} value={option.id as string | number}>
+                {option.label as React.ReactNode}
+              </MenuItem>
+            ))}
+          </Select>
+          {error || helperText ? (
+            <FormHelperText>
+              {error ? (parseError ? parseError(error) : error.message ?? '') : helperText}
+            </FormHelperText>
+          ) : null}
+        </FormControl>
+      )}
+    />
+  );
+}

--- a/src/components/forms/TextFieldElement.tsx
+++ b/src/components/forms/TextFieldElement.tsx
@@ -1,0 +1,45 @@
+import TextField, {TextFieldProps} from '@mui/material/TextField';
+import {Controller, FieldError, FieldPath, FieldValues, RegisterOptions, useFormContext} from 'react-hook-form';
+
+export type TextFieldElementProps<TFieldValues extends FieldValues = FieldValues> = Omit<
+  TextFieldProps,
+  'name' | 'error' | 'helperText'
+> & {
+  name: FieldPath<TFieldValues>;
+  validation?: RegisterOptions<TFieldValues>;
+  parseError?: (error: FieldError) => string;
+  helperText?: TextFieldProps['helperText'];
+};
+
+export default function TextFieldElement<TFieldValues extends FieldValues = FieldValues>({
+  name,
+  validation,
+  parseError,
+  required,
+  helperText,
+  ...textFieldProps
+}: TextFieldElementProps<TFieldValues>) {
+  const {control} = useFormContext<TFieldValues>();
+  const rules: RegisterOptions<TFieldValues> = {
+    ...(required ? {required: 'This field is required'} : {}),
+    ...validation,
+  };
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={rules}
+      render={({field, fieldState: {error}}) => (
+        <TextField
+          {...textFieldProps}
+          {...field}
+          value={field.value ?? ''}
+          required={required}
+          error={!!error}
+          helperText={error ? (parseError ? parseError(error) : error.message ?? '') : helperText}
+        />
+      )}
+    />
+  );
+}

--- a/src/components/forms/ToggleButtonGroupElement.tsx
+++ b/src/components/forms/ToggleButtonGroupElement.tsx
@@ -1,0 +1,75 @@
+import FormControl from '@mui/material/FormControl';
+import FormHelperText from '@mui/material/FormHelperText';
+import ToggleButton, {ToggleButtonProps} from '@mui/material/ToggleButton';
+import ToggleButtonGroup, {ToggleButtonGroupProps} from '@mui/material/ToggleButtonGroup';
+import React from 'react';
+import {Controller, FieldError, FieldPath, FieldValues, RegisterOptions, useFormContext} from 'react-hook-form';
+
+/** Mirrors react-hook-form-mui: an option may carry any ToggleButton prop (`selected`, `sx`, ...). */
+export type ToggleButtonOption = Omit<ToggleButtonProps, 'value' | 'children'> & {
+  id: string | number;
+  label: React.ReactNode;
+};
+
+export type ToggleButtonGroupElementProps<TFieldValues extends FieldValues = FieldValues> = Omit<
+  ToggleButtonGroupProps,
+  'name' | 'value' | 'onChange' | 'exclusive'
+> & {
+  name: FieldPath<TFieldValues>;
+  options: readonly ToggleButtonOption[];
+  exclusive?: boolean;
+  /** Ignore a deselect that would leave nothing selected. */
+  enforceAtLeastOneSelected?: boolean;
+  required?: boolean;
+  validation?: RegisterOptions<TFieldValues>;
+  parseError?: (error: FieldError) => string;
+  onChange?: (event: React.MouseEvent<HTMLElement>, value: unknown) => void;
+};
+
+export default function ToggleButtonGroupElement<TFieldValues extends FieldValues = FieldValues>({
+  name,
+  options,
+  exclusive,
+  enforceAtLeastOneSelected,
+  required,
+  validation,
+  parseError,
+  onChange,
+  ...toggleButtonGroupProps
+}: ToggleButtonGroupElementProps<TFieldValues>) {
+  const {control} = useFormContext<TFieldValues>();
+  const rules: RegisterOptions<TFieldValues> = {
+    ...(required ? {required: 'This field is required'} : {}),
+    ...validation,
+  };
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={rules}
+      render={({field, fieldState: {error}}) => (
+        <FormControl required={required} error={!!error}>
+          <ToggleButtonGroup
+            {...toggleButtonGroupProps}
+            exclusive={exclusive}
+            value={field.value ?? (exclusive ? null : [])}
+            onChange={(event, value) => {
+              if (enforceAtLeastOneSelected && (value == null || (Array.isArray(value) && value.length === 0))) {
+                return;
+              }
+              field.onChange(value);
+              onChange?.(event, value);
+            }}>
+            {options.map(({id, label, ...buttonProps}) => (
+              <ToggleButton key={id} value={id} {...buttonProps}>
+                {label}
+              </ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+          {error ? <FormHelperText>{parseError ? parseError(error) : error.message ?? ''}</FormHelperText> : null}
+        </FormControl>
+      )}
+    />
+  );
+}

--- a/src/components/forms/index.ts
+++ b/src/components/forms/index.ts
@@ -1,0 +1,12 @@
+export {default as AutocompleteElement} from './AutocompleteElement';
+export type {AutocompleteElementProps} from './AutocompleteElement';
+export {default as DatePickerElement} from './DatePickerElement';
+export type {DatePickerElementProps} from './DatePickerElement';
+export {default as FormContainer} from './FormContainer';
+export type {FormContainerProps} from './FormContainer';
+export {default as SelectElement} from './SelectElement';
+export type {SelectElementProps, SelectOption} from './SelectElement';
+export {default as TextFieldElement} from './TextFieldElement';
+export type {TextFieldElementProps} from './TextFieldElement';
+export {default as ToggleButtonGroupElement} from './ToggleButtonGroupElement';
+export type {ToggleButtonGroupElementProps, ToggleButtonOption} from './ToggleButtonGroupElement';

--- a/src/pages/apps/CreateUpdate.tsx
+++ b/src/pages/apps/CreateUpdate.tsx
@@ -15,7 +15,7 @@ import FormControl from '@mui/material/FormControl';
 import IconButton from '@mui/material/IconButton';
 import TextField from '@mui/material/TextField';
 
-import {FormContainer, TextFieldElement} from 'react-hook-form-mui';
+import {FormContainer, TextFieldElement} from '../../components/forms';
 
 import {
   useAppsCreate,

--- a/src/pages/group_requests/Create.tsx
+++ b/src/pages/group_requests/Create.tsx
@@ -25,7 +25,7 @@ import {
   SelectElement,
   DatePickerElement,
   TextFieldElement,
-} from 'react-hook-form-mui';
+} from '../../components/forms';
 
 import {
   useGroupRequestsCreate,
@@ -264,7 +264,7 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
         </FormControl>
         {groupType === 'app_group' && (
           <FormControl margin="normal" fullWidth required>
-            <AutocompleteElement
+            <AutocompleteElement<(typeof appSearchOptions)[number]>
               label="App"
               name="app"
               options={appSearchOptions}

--- a/src/pages/group_requests/Read.tsx
+++ b/src/pages/group_requests/Read.tsx
@@ -34,12 +34,11 @@ import {
   FormContainer,
   SelectElement,
   TextFieldElement,
-  useFormContext,
-} from 'react-hook-form-mui';
+} from '../../components/forms';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
-import {Controller} from 'react-hook-form';
+import {Controller, useFormContext} from 'react-hook-form';
 
 import dayjs, {Dayjs} from 'dayjs';
 import IsSameOrBefore from 'dayjs/plugin/isSameOrBefore';
@@ -793,7 +792,7 @@ export default function ReadGroupRequest() {
                                   {groupType == 'app_group' ? (
                                     <Grid item xs={6}>
                                       <FormControl margin="normal" fullWidth required>
-                                        <AutocompleteElement
+                                        <AutocompleteElement<(typeof appSearchOptions)[number]>
                                           label="App"
                                           name="resolved_app"
                                           options={appSearchOptions}

--- a/src/pages/groups/AddRoles.tsx
+++ b/src/pages/groups/AddRoles.tsx
@@ -28,7 +28,7 @@ import {
   FormContainer,
   SelectElement,
   TextFieldElement,
-} from 'react-hook-form-mui';
+} from '../../components/forms';
 
 import {
   useRoles,
@@ -315,7 +315,7 @@ function AddRolesDialog(props: AddRolesDialogProps) {
             />
           </FormControl>
           <FormControl margin="normal" fullWidth>
-            <AutocompleteElement
+            <AutocompleteElement<(typeof userSearchOptions)[number]>
               label={'Search for Roles to Add'}
               name="user"
               options={userSearchOptions}

--- a/src/pages/groups/AddUsers.tsx
+++ b/src/pages/groups/AddUsers.tsx
@@ -28,7 +28,7 @@ import {
   AutocompleteElement,
   DatePickerElement,
   TextFieldElement,
-} from 'react-hook-form-mui';
+} from '../../components/forms';
 
 import {
   useUsers,
@@ -303,7 +303,7 @@ function AddUsersDialog(props: AddUsersDialogProps) {
             />
           </FormControl>
           <FormControl fullWidth sx={{margin: '8px 0'}}>
-            <AutocompleteElement
+            <AutocompleteElement<(typeof userSearchOptions)[number]>
               label={'Search for ' + addUsersText + ' to Add'}
               name="user"
               options={userSearchOptions}

--- a/src/pages/groups/BulkRenewal.tsx
+++ b/src/pages/groups/BulkRenewal.tsx
@@ -22,7 +22,7 @@ import Typography from '@mui/material/Typography';
 
 import AccessRequestIcon from '../../components/icons/MoreTime';
 
-import {FormContainer, DatePickerElement, TextFieldElement} from 'react-hook-form-mui';
+import {FormContainer, DatePickerElement, TextFieldElement} from '../../components/forms';
 
 import {GridColDef, GridRenderCellParams} from '@mui/x-data-grid';
 import {useTheme} from '@mui/material';

--- a/src/pages/groups/CreateUpdate.tsx
+++ b/src/pages/groups/CreateUpdate.tsx
@@ -17,7 +17,7 @@ import IconButton from '@mui/material/IconButton';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 
-import {FormContainer, SelectElement, AutocompleteElement, TextFieldElement} from 'react-hook-form-mui';
+import {FormContainer, SelectElement, AutocompleteElement, TextFieldElement} from '../../components/forms';
 
 import {
   useApps,
@@ -241,7 +241,7 @@ function GroupDialog(props: GroupDialogProps) {
           </FormControl>
           {groupType == 'app_group' ? (
             <FormControl margin="normal" fullWidth required>
-              <AutocompleteElement
+              <AutocompleteElement<(typeof appSearchOptions)[number]>
                 label="App"
                 name="app"
                 options={appSearchOptions}

--- a/src/pages/requests/Create.tsx
+++ b/src/pages/requests/Create.tsx
@@ -28,7 +28,7 @@ import {
   DatePickerElement,
   TextFieldElement,
   ToggleButtonGroupElement,
-} from 'react-hook-form-mui';
+} from '../../components/forms';
 
 import {
   useGroups,
@@ -342,7 +342,7 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
         </Typography>
         {requestError != '' ? <Alert severity="error">{requestError}</Alert> : null}
         <FormControl margin="normal" fullWidth>
-          <AutocompleteElement
+          <AutocompleteElement<GroupDetail>
             label={'For which group?'}
             name="group"
             options={groupSearchOptions}

--- a/src/pages/requests/Read.tsx
+++ b/src/pages/requests/Read.tsx
@@ -36,7 +36,7 @@ import {
   DatePickerElement,
   TextFieldElement,
   ToggleButtonGroupElement,
-} from 'react-hook-form-mui';
+} from '../../components/forms';
 
 import dayjs, {Dayjs} from 'dayjs';
 import RelativeTime from 'dayjs/plugin/relativeTime';

--- a/src/pages/role_requests/Create.tsx
+++ b/src/pages/role_requests/Create.tsx
@@ -27,7 +27,7 @@ import {
   DatePickerElement,
   TextFieldElement,
   ToggleButtonGroupElement,
-} from 'react-hook-form-mui';
+} from '../../components/forms';
 
 import {
   useRoleRequestsCreate,
@@ -315,7 +315,7 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
         </Typography>
         {requestError != '' ? <Alert severity="error">{requestError}</Alert> : null}
         <FormControl margin="normal" fullWidth>
-          <AutocompleteElement
+          <AutocompleteElement<(typeof roleSearchOptions)[number]>
             label={'For which role?'}
             name="role"
             options={roleSearchOptions}
@@ -353,7 +353,7 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
           />
         </FormControl>
         <FormControl margin="normal" fullWidth>
-          <AutocompleteElement
+          <AutocompleteElement<(typeof groupSearchOptions)[number]>
             label={'For which group?'}
             name="group"
             options={groupSearchOptions}

--- a/src/pages/role_requests/Read.tsx
+++ b/src/pages/role_requests/Read.tsx
@@ -38,7 +38,7 @@ import {
   DatePickerElement,
   TextFieldElement,
   ToggleButtonGroupElement,
-} from 'react-hook-form-mui';
+} from '../../components/forms';
 
 import dayjs, {Dayjs} from 'dayjs';
 import RelativeTime from 'dayjs/plugin/relativeTime';

--- a/src/pages/roles/AddGroups.tsx
+++ b/src/pages/roles/AddGroups.tsx
@@ -30,7 +30,7 @@ import {
   AutocompleteElement,
   DatePickerElement,
   TextFieldElement,
-} from 'react-hook-form-mui';
+} from '../../components/forms';
 
 import {
   useGroups,
@@ -302,7 +302,7 @@ function AddGroupsDialog(props: AddGroupsDialogProps) {
             />
           </FormControl>
           <FormControl fullWidth sx={{margin: '8px 0'}}>
-            <AutocompleteElement
+            <AutocompleteElement<(typeof autocompleteOptions)[number]>
               label={'Search for ' + addGroupsText + ' to Add'}
               name="group"
               options={autocompleteOptions}

--- a/src/pages/roles/BulkRenewal.tsx
+++ b/src/pages/roles/BulkRenewal.tsx
@@ -22,7 +22,7 @@ import Typography from '@mui/material/Typography';
 
 import AccessRequestIcon from '../../components/icons/MoreTime';
 
-import {FormContainer, DatePickerElement, TextFieldElement} from 'react-hook-form-mui';
+import {FormContainer, DatePickerElement, TextFieldElement} from '../../components/forms';
 
 import {GridColDef, GridRenderCellParams} from '@mui/x-data-grid';
 import {useTheme} from '@mui/material';

--- a/src/pages/tags/AddApps.tsx
+++ b/src/pages/tags/AddApps.tsx
@@ -20,7 +20,7 @@ import InputLabel from '@mui/material/InputLabel';
 import DeleteIcon from '@mui/icons-material/Close';
 import CircularProgress from '@mui/material/CircularProgress';
 
-import {FormContainer, SelectElement, AutocompleteElement} from 'react-hook-form-mui';
+import {FormContainer, SelectElement, AutocompleteElement} from '../../components/forms';
 
 import {useApps, useAppByIdPut, AppByIdPutError, AppByIdPutVariables} from '../../api/apiComponents';
 import {AppDetail, OktaUserDetail, TagDetail, UpdateAppBody} from '../../api/apiSchemas';
@@ -128,7 +128,7 @@ function AddAppsDialog(props: AddAppsDialogProps) {
         <DialogContent>
           {requestError != '' ? <Alert severity="error">{requestError}</Alert> : null}
           <FormControl margin="normal" fullWidth>
-            <AutocompleteElement
+            <AutocompleteElement<(typeof appSearchOptions)[number]>
               label={'Search for Apps to Add'}
               name="app"
               options={appSearchOptions}

--- a/src/pages/tags/AddGroups.tsx
+++ b/src/pages/tags/AddGroups.tsx
@@ -20,7 +20,7 @@ import InputLabel from '@mui/material/InputLabel';
 import DeleteIcon from '@mui/icons-material/Close';
 import CircularProgress from '@mui/material/CircularProgress';
 
-import {FormContainer, AutocompleteElement} from 'react-hook-form-mui';
+import {FormContainer, AutocompleteElement} from '../../components/forms';
 
 import {
   useGroups,
@@ -146,7 +146,7 @@ function AddGroupsDialog(props: AddGroupsDialogProps) {
         <DialogContent>
           {requestError != '' ? <Alert severity="error">{requestError}</Alert> : null}
           <FormControl margin="normal" fullWidth>
-            <AutocompleteElement
+            <AutocompleteElement<(typeof groupSearchOptions)[number]>
               label={'Search for Groups to Add'}
               name="group"
               options={groupSearchOptions}

--- a/src/pages/tags/CreateUpdate.tsx
+++ b/src/pages/tags/CreateUpdate.tsx
@@ -16,7 +16,7 @@ import FormControl from '@mui/material/FormControl';
 import Grid from '@mui/material/Grid';
 import IconButton from '@mui/material/IconButton';
 
-import {ToggleButtonGroupElement, FormContainer, TextFieldElement} from 'react-hook-form-mui';
+import {ToggleButtonGroupElement, FormContainer, TextFieldElement} from '../../components/forms';
 
 import {
   useTagsCreate,


### PR DESCRIPTION
## Why

`react-hook-form-mui` pins the MUI major it supports. v6.7.3 peers `@mui/material ">= 5.x <6"` and `@mui/x-date-pickers ">=6.1.0 <7"`, and those pins make npm refuse a MUI v6 install outright. In practice the dependency gates MUI upgrades instead of helping with them, and it would gate them again at the next major. It is also a thin layer: the six components we use are `Controller` wrappers around MUI inputs we already depend on.

Removing it drops the MUI v6 migration from 69 type errors to 11, and unblocks the `@mui/x-date-pickers` v7 upgrade that MUI v6 requires. It is a prerequisite for #490 (vite 8), which needs MUI v6 to fix a CJS interop regression that breaks every `@mui/icons-material` deep import.

## What

Reimplements the six components in use (`FormContainer`, `TextFieldElement`, `AutocompleteElement`, `SelectElement`, `DatePickerElement`, `ToggleButtonGroupElement`) under `src/components/forms/`, keeping component and prop names identical. Call sites change only their import path.

Behavior is preserved by construction, including the parts that are load-bearing but not obvious:

- `DatePickerElement` stores the raw `Dayjs` in form state, which call sites rely on when they cast the field and call `.toISOString()` on submit.
- `SelectElement`'s `onChange` keeps the library's loose `(value: any)` signature, since call sites feed it into narrower setters. Tightening it would need call-site casts and is left as a follow-up.
- Toggle options keep accepting arbitrary `ToggleButton` props, not just `id` and `label`.

One deliberate improvement: `AutocompleteElement` now carries a real option type. The library's version had no option generic at all, so `option` in `getOptionLabel` and friends was effectively `any`. TypeScript 4.9 cannot infer the type through the `autocompleteProps` position, so each call site passes it explicitly; on TypeScript >= 5.4, `NoInfer` would make that inferred again.

## Note on verification

Beyond typecheck, tests, and build, the access request form was exercised in a browser end to end, since equivalence here is behavioral rather than structural: required-field errors, the API-backed group search with its custom `renderOption`, `shouldDisableDate`, `enforceAtLeastOneSelected`, and a successful submit carrying the expected `request_ending_at`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)