### PR TITLE
Drop the SQLAlchemy dependency from the app-group-lifecycle example plugins

### DIFF
--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -73,8 +73,16 @@ A plugin is an ordinary Python distribution with three parts:
    `requirements.txt` first when one is present, so your own plugin may use one if
    you prefer.
 
+   Declare what the plugin *imports*, not what it runs alongside. The two
+   app-group-lifecycle examples declare neither `pluggy` nor `SQLAlchemy`: they
+   take `hookimpl` from `api.plugins.app_group_lifecycle` and the ORM classes
+   they annotate hook arguments with from `api.models`, so both arrive with the
+   app and neither is imported here. A dep declared without a matching import
+   goes stale silently and, per the pinning rule below, can re-resolve a package
+   the app is using.
+
    Pin deps the app does not itself ship (`slack-sdk`, `datadog`), but keep deps
-   the app supplies (`pluggy`, `SQLAlchemy`) on a compatible range. Plugins are
+   the app supplies (`click`, `SQLAlchemy`) on a compatible range. Plugins are
    installed *into* the app's venv, so an exact pin that disagrees with
    [`pyproject.toml`](../../pyproject.toml) silently re-resolves that package for
    the running app.

--- a/examples/plugins/app_group_lifecycle_audit_logger/pyproject.toml
+++ b/examples/plugins/app_group_lifecycle_audit_logger/pyproject.toml
@@ -17,9 +17,13 @@ name = "app_group_lifecycle_audit_logger"
 version = "0.1.0"
 description = "Example app group lifecycle plugin that logs all group events"
 authors = [{ name = "Discord" }]
-dependencies = [
-    "SQLAlchemy",
-]
+# No runtime dependencies. The plugin reaches Access only through the plugin
+# interface, and everything it needs comes with the app it installs into:
+# `hookimpl` and the context/metadata types from
+# `api.plugins.app_group_lifecycle`, and the ORM classes it annotates hook
+# arguments with from `api.models`. Nothing here imports SQLAlchemy (or pluggy)
+# directly, so nothing here declares them.
+dependencies = []
 
 # Register the plugin with the app group lifecycle plugin system
 [project.entry-points."access_app_group_lifecycle"]

--- a/examples/plugins/app_group_lifecycle_google/pyproject.toml
+++ b/examples/plugins/app_group_lifecycle_google/pyproject.toml
@@ -14,7 +14,6 @@ version = "0.1.0"
 description = "Plugin for managing Google groups linked to Access groups"
 authors = [{ name = "Discord" }]
 dependencies = [
-    "SQLAlchemy",
     "google-api-python-client>=2.0.0",
     "google-auth>=2.0.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -288,12 +288,6 @@ wheels = [
 name = "app-group-lifecycle-audit-logger"
 version = "0.1.0"
 source = { editable = "examples/plugins/app_group_lifecycle_audit_logger" }
-dependencies = [
-    { name = "sqlalchemy" },
-]
-
-[package.metadata]
-requires-dist = [{ name = "sqlalchemy" }]
 
 [[package]]
 name = "asyncpg"


### PR DESCRIPTION
Follow-up on [this review comment](https://github.com/discord/access/pull/604#discussion_r3875311981) from @barborico on [#604](https://github.com/discord/access/pull/604):

> Out of scope for this PR, but I expect that we can remove this here and for the audit logger, given the app group lifecycle plugin interface refactor; the plugin implementations should no longer directly interact with SQL.

That's right for both, and the repo already asserts it for one of them.

## What changed

`SQLAlchemy` comes out of [`app_group_lifecycle_google`](https://github.com/discord/access/blob/pcollins/remove-sqlalchemy-dependency-af429e/examples/plugins/app_group_lifecycle_google/pyproject.toml) and [`app_group_lifecycle_audit_logger`](https://github.com/discord/access/blob/pcollins/remove-sqlalchemy-dependency-af429e/examples/plugins/app_group_lifecycle_audit_logger/pyproject.toml), leaving the latter with no runtime dependencies at all. Neither imports `sqlalchemy`: after the context refactor they take `hookimpl` from `api.plugins.app_group_lifecycle` and use `api.models` classes only as hook-argument annotations plus attribute reads (`group.app`, `group.name`), all of which arrive with the host app. [`test_plugin_only_imports_the_access_plugin_interface`](https://github.com/discord/access/blob/cc44f34/examples/plugins/app_group_lifecycle_google/test_plugin.py#L1370-L1392) already pins that boundary for the Google plugin with `sqlalchemy` explicitly excluded, so the declaration was contradicted by a green test.

Two reasons this is worth more than tidiness. A dependency with no matching import goes stale with nothing to notice, and because plugins install *into* the app's venv, every extra declaration is one more chance to re-resolve a package the running app is using.

## Not all of them: `health_check_plugin` keeps it

[`cli.py`](https://github.com/discord/access/blob/cc44f34/examples/plugins/health_check_plugin/cli.py#L7) does `from sqlalchemy import text` and runs raw `SELECT 1` and `information_schema` queries against the session, so the dependency is real. That plugin extends `access.commands` rather than one of the hook surfaces the refactor cleaned up, and reaching the database is the entire point of a DB health check. Whether that surface should be held to the same self-contained bar as the hook surfaces is a genuine question, but a separate one from this change.

## README

The dependency guidance gains the principle behind the removal (declare what you import, not what you run alongside), since copying the nearest example is how the stale declaration spread. `pluggy` is no longer a useful illustration of an app-supplied dep, because the lifecycle examples deliberately don't declare it either, so `click` takes its place.

## Notes for review

`uv.lock` moves because the audit logger is an editable [`[tool.uv.sources]`](https://github.com/discord/access/blob/cc44f34/pyproject.toml#L91-L92) path dependency, so its `requires-dist` is recorded there; `uv lock --check` is clean. Both plugins were installed into a fresh venv to confirm they build with the declaration gone and that SQLAlchemy is no longer pulled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)