### PR TITLE
Scope Vitest test discovery to src/

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -100,6 +100,13 @@ export default defineConfig(({mode}) => {
       globals: true,
       environment: 'jsdom',
       setupFiles: './src/setupTests.ts',
+      // Scope discovery to src/ instead of Vitest's default project-wide glob.
+      // The default walks every directory under the repo root, and its exclude
+      // list covers only node_modules and .git -- so a nested checkout (a git
+      // worktree, a vendored copy) has its test files collected and run against
+      // *this* checkout's node_modules, reporting failures that belong to some
+      // other branch. Every frontend test lives under src/.
+      include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     },
   };
 });


### PR DESCRIPTION
# Summary

Scopes Vitest test discovery to `src/`, so a checkout with a nested checkout under it (e.g. a worktree) stops collecting and running another branch's test files.

**Urgency**: 5 days — dev tooling only, no runtime or API surface
**Expected review effort**: LOW — one config key plus a comment

# Motivation

Vitest's default `include` globs the entire project root, including test files in nested checkouts under the repo root: the parent checkout collects those test files and runs them against the **parent's** `node_modules`. That produces failures belonging to a different branch, against dependency versions that branch was never resolved with. Concretely, `make test` from a checkout with sibling worktrees reported:

```
Test Files  4 failed | 26 passed (30)
Tests      28 failed | 205 passed (233)
```

with every failure inside a nested checkout and 195 of the 233 tests not from the checkout under test. The same tree scoped to its own tests is `6 passed (6) / 38 passed (38)`.

This is not specific to any one worktree tool. Any nested checkout does it, which is also why the fix is not an `exclude` entry.

<details>
<summary><h1>Description of Changes</h1></summary>

Adds one key to the `test` block in `vite.config.ts`:

```ts
include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
```

The extension set is Vitest's default, unchanged; only the directory scope narrows.

**Why a positive `include` rather than adding the directory to `exclude`.** An `exclude` entry has to name a specific layout, and only helps operators who share it — a different worktree tool, a vendored copy, or a nested clone all slip past it. Stating where the frontend tests actually live holds regardless of what the nested directory is called or where it sits. Given this config ships to every operator, the layout-independent form is the one that generalizes.

All six frontend test files are under `src/` today, and `src/` is already the Vite source root, so this narrows nothing that currently exists. The trade-off is that a future test placed outside `src/` would need the glob widened; the comment in the file records why the scope is there so that is a deliberate edit rather than a puzzling one.

</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

Verified by planting a deliberately failing test inside a nested `src/` directory and running discovery on the same on-disk state before and after:

| Case | Result |
|---|---|
| Nested checkout at `.claude/worktrees/…/src/`, before | collected and run — 7 files / 39 tests, 1 failed |
| Same, after | not collected — 6 files / 38 tests, all pass |
| Nested checkout at `vendor/…/src/`, after | not collected — confirms this is not tied to one directory name |
| New test added under the real `src/`, after | collected — 39 tests, so the scope is not too tight |

The third row is the one that distinguishes this from an `exclude` entry naming a specific directory, which would not have caught it.

`make test` on this branch: ruff and ty clean, 909 backend tests pass, 6 frontend files / 38 tests pass. Probe files removed; the diff is the single config change.

</details>