### PR TITLE
Normalize inbound justification text at the boundary

### DIFF
--- a/api/schemas/requests_schemas.py
+++ b/api/schemas/requests_schemas.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import Annotated, Any, Literal, Optional, Self, Union
 
-from pydantic import BaseModel, ConfigDict, Field, StrictBool, field_validator, model_validator
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, StrictBool, field_validator, model_validator
 
 from api.access_config import get_access_config
 from api.config import settings
@@ -47,6 +47,29 @@ _TAG_DESC_MAX_LENGTH = 1024
 
 
 # --- Access requests --------------------------------------------------------
+
+
+def _strip_reason(value: Any) -> Any:
+    """Normalize inbound justification text.
+
+    Whether a reason was given is decided by `CheckForReason` on the stripped
+    value, so stripping on the way in is what makes the gate and the store
+    agree by construction: a reason that reads as blank is treated as absent
+    everywhere, rather than as absent by a tagged group and present by an
+    untagged one. It also reaches the `request_reason` fields, which no
+    constraint consults.
+
+    Non-string input passes through for pydantic to reject or coerce, so this
+    adds no type handling of its own.
+    """
+    return value.strip() if isinstance(value, str) else value
+
+
+#: An inbound justification field. Whitespace-only collapses to `""`, which the
+#: reason constraints already treat as not provided. Response models keep plain
+#: `Optional[str]`: they report what is stored, and normalizing on the way out
+#: would hide stored values that were never normalized.
+ReasonStr = Annotated[Optional[str], BeforeValidator(_strip_reason)]
 
 
 # Discriminated-union refs for the *detail* `requested_group`. Each variant
@@ -157,7 +180,7 @@ class CreateAccessRequestBody(BaseModel):
     model_config = ConfigDict(extra="ignore")
     group_id: str
     group_owner: bool = False
-    reason: Optional[str] = ""
+    reason: ReasonStr = ""
     ending_at: Optional[FlexibleDatetime] = None
 
 
@@ -169,7 +192,7 @@ class ResolveAccessRequestBody(BaseModel):
     # briefly used) interprets every non-empty string as True and silently
     # turns "false" into an APPROVED outcome.
     approved: StrictBool
-    reason: Optional[str] = ""
+    reason: ReasonStr = ""
     ending_at: Optional[FlexibleDatetime] = None
 
 
@@ -251,7 +274,7 @@ class CreateRoleRequestBody(BaseModel):
     role_id: str
     group_id: str
     group_owner: bool = False
-    reason: Optional[str] = ""
+    reason: ReasonStr = ""
     ending_at: Optional[FlexibleDatetime] = None
 
 
@@ -313,7 +336,7 @@ class _GroupRequestBodyBase(BaseModel):
     requested_group_description: Optional[str] = Field(default="", max_length=_GROUP_DESC_MAX_LENGTH)
     requested_group_tags: list[str] = Field(default_factory=list)
     requested_ownership_ending_at: Optional[FlexibleDatetime] = None
-    request_reason: Optional[str] = ""
+    request_reason: ReasonStr = ""
 
     @model_validator(mode="after")
     def _check_description_required(self) -> Self:
@@ -347,7 +370,7 @@ CreateGroupRequestBody = Annotated[
 class ResolveGroupRequestBody(BaseModel):
     model_config = ConfigDict(extra="ignore")
     approved: StrictBool
-    reason: Optional[str] = ""
+    reason: ReasonStr = ""
     resolved_group_name: Optional[str] = None
     resolved_group_description: Optional[str] = None
     resolved_group_type: Optional[str] = None
@@ -606,7 +629,7 @@ class GroupMember(BaseModel):
     members_should_expire: list[int] = Field(default_factory=list)
     owners_should_expire: list[int] = Field(default_factory=list)
     users_added_ending_at: Optional[FlexibleDatetime] = None
-    created_reason: Optional[str] = ""
+    created_reason: ReasonStr = ""
 
 
 class RoleMember(BaseModel):
@@ -626,4 +649,4 @@ class RoleMember(BaseModel):
     groups_should_expire: list[int] = Field(default_factory=list)
     owner_groups_should_expire: list[int] = Field(default_factory=list)
     groups_added_ending_at: Optional[FlexibleDatetime] = None
-    created_reason: Optional[str] = ""
+    created_reason: ReasonStr = ""

--- a/tests/test_request_models.py
+++ b/tests/test_request_models.py
@@ -7,15 +7,25 @@ constraints validated against `Tag.CONSTRAINTS`.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from pydantic import ValidationError
 
 from api.config import settings
 from api.schemas.requests_schemas import (
+    CreateAccessRequestBody,
     CreateAppBody,
+    CreateRoleRequestBody,
     CreateTagBody,
+    GroupMember,
+    ResolveAccessRequestBody,
+    ResolveGroupRequestBody,
+    ResolveRoleRequestBody,
+    RoleMember,
     UpdateAppBody,
     UpdateTagBody,
+    _OktaGroupRequestBody,
 )
 
 
@@ -123,3 +133,87 @@ def test_update_tag_body_partial_skips_description_check(monkeypatch: pytest.Mon
 def test_update_tag_body_unknown_constraint_rejected() -> None:
     with pytest.raises(ValidationError):
         UpdateTagBody.model_validate({"constraints": {"bogus": 1}})
+
+
+# --- Reason normalization ---------------------------------------------------
+#
+# `CheckForReason.invalid_reason` strips before deciding whether a reason was
+# given. Normalizing at the boundary is what makes that gate and the stored
+# value agree: without it, "provided" means one thing on a group whose tag
+# requires a reason and another on a group that does not, and blank-looking
+# text reaches the audit trail either way. It also covers the `request_reason`
+# fields, which no constraint consults.
+
+
+@pytest.mark.parametrize(
+    ("model", "field", "extra"),
+    [
+        (CreateAccessRequestBody, "reason", {"group_id": "a" * 20, "group_owner": False}),
+        (ResolveAccessRequestBody, "reason", {"approved": True}),
+        (ResolveRoleRequestBody, "reason", {"approved": True}),
+        (ResolveGroupRequestBody, "reason", {"approved": True}),
+        (
+            CreateRoleRequestBody,
+            "reason",
+            {"group_id": "a" * 20, "role_id": "b" * 20, "group_owner": False},
+        ),
+        (
+            GroupMember,
+            "created_reason",
+            {
+                "members_to_add": [],
+                "members_to_remove": [],
+                "owners_to_add": [],
+                "owners_to_remove": [],
+            },
+        ),
+        (
+            RoleMember,
+            "created_reason",
+            {
+                "groups_to_add": [],
+                "groups_to_remove": [],
+                "owner_groups_to_add": [],
+                "owner_groups_to_remove": [],
+            },
+        ),
+    ],
+)
+def test_whitespace_only_reason_normalizes_to_empty(model: Any, field: str, extra: dict[str, Any]) -> None:
+    body = model.model_validate({**extra, field: "   \t\n "})
+    assert getattr(body, field) == ""
+
+
+@pytest.mark.parametrize(
+    ("model", "field", "extra"),
+    [
+        (ResolveAccessRequestBody, "reason", {"approved": True}),
+        (
+            GroupMember,
+            "created_reason",
+            {
+                "members_to_add": [],
+                "members_to_remove": [],
+                "owners_to_add": [],
+                "owners_to_remove": [],
+            },
+        ),
+    ],
+)
+def test_surrounding_whitespace_is_trimmed_from_a_real_reason(model: Any, field: str, extra: dict[str, Any]) -> None:
+    body = model.model_validate({**extra, field: "  needs ledger export  "})
+    assert getattr(body, field) == "needs ledger export"
+
+
+def test_group_request_body_normalizes_its_request_reason() -> None:
+    """`request_reason` never reaches `CheckForReason`, so the boundary is the
+    only thing standing between whitespace and the stored record."""
+    body = _OktaGroupRequestBody.model_validate(
+        {
+            "requested_group_name": "Some-Group",
+            "requested_group_description": "d",
+            "requested_group_type": "okta_group",
+            "request_reason": "   ",
+        }
+    )
+    assert body.request_reason == ""

--- a/tests/test_require_reason_constraint.py
+++ b/tests/test_require_reason_constraint.py
@@ -1831,3 +1831,43 @@ async def test_require_reason_approve_access_request(
         )
         == 1
     )
+
+
+async def test_whitespace_only_reason_is_not_stored_on_an_untagged_group(
+    client: AsyncClient,
+    db: Db,
+    okta_group: OktaGroup,
+    user: OktaUser,
+    url_for: Any,
+    mocker: MockerFixture,
+) -> None:
+    """`CheckForReason` treats a whitespace-only reason as absent, and a group
+    with no reason constraint never consults it. Normalizing inbound reasons is
+    what makes both paths agree that this is no reason at all, rather than
+    "provided" meaning one thing on a tagged group and another here."""
+    mocker.patch.object(okta, "add_user_to_group")
+    db.session.add_all([okta_group, user])
+    await db.session.commit()
+    group_id, user_id = okta_group.id, user.id
+
+    response = await client.put(
+        url_for("group_members_by_id_put", group_id=group_id),
+        json={
+            "members_to_add": [user_id],
+            "members_to_remove": [],
+            "owners_to_add": [],
+            "owners_to_remove": [],
+            "created_reason": "   \t ",
+        },
+    )
+    assert response.status_code == 200
+
+    db.session.expire_all()
+    membership = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == group_id)
+            .where(OktaUserGroupMember.user_id == user_id)
+        )
+    ).one()
+    assert membership.created_reason == ""


### PR DESCRIPTION
# Summary

Strips whitespace off inbound justification text at the request boundary for consistency.

**Urgency**: 1 week
**Expected review effort**: LOW — one annotated type applied to seven fields, plus tests.

# Motivation

See Elisa's comment: https://github.com/discord/access/pull/601#discussion_r3877303099

Currently, there's some inconsistency in how we process provided reasons: `CheckForReason.invalid_reason` decides whether a reason was given by stripping it. The routes store the value as received. Those two standards disagree on whitespace, and the disagreement is visible to users:

- On a group whose tag requires a reason, `"   "` is rejected.
- On a group with no such tag, the same `"   "` is stored verbatim and shows up in the audit trail as a justification.

So whether a reason counts as provided depends on a tag rather than on the reason, and blank-looking text reaches the record either way.

Additionally, whitespace `request_reason` fields on the access, role and group request bodies goes straight into the record.

<details>
<summary><h1>Description of Changes</h1></summary>

`ReasonStr` is `Optional[str]` with a `BeforeValidator` that strips. Applied to every **inbound** reason field:

- `created_reason` on `GroupMember` and `RoleMember`
- `reason` on `ResolveAccessRequestBody` (inherited by `ResolveRoleRequestBody`), `ResolveGroupRequestBody`, `CreateAccessRequestBody`, `CreateRoleRequestBody`
- `request_reason` on `_GroupRequestBodyBase`, inherited by the three group-request variants

Normalizing at the boundary rather than adding a second `.strip()` at each write site is what makes the gate and the store agree by construction, instead of by two call sites remembering to agree.

Three things deliberately left alone:

- **Response models** keep a plain `Optional[str]`. They report what is stored, and normalizing on the way out would hide values that were never normalized.
- **`invalid_reason` keeps its own `.strip()`.** The operations are reachable from the syncer and the CLI, which construct reasons directly and never pass through a request body.
- **No OpenAPI change.** A `BeforeValidator` does not alter the emitted schema, so the generated client is untouched — confirmed by regenerating and diffing.

</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

- Parametrized model tests over all seven fields: whitespace-only collapses to `""`, and surrounding whitespace is trimmed from a real reason.
- An end-to-end test that a whitespace-only `created_reason` submitted against an **untagged** group — the path that never consults the constraint — is stored as `""` rather than verbatim. Confirmed to fail before the change with `assert '   \t ' == ''`.
- `make test` green: ruff, ty, 920 backend, 38 frontend.

</details>