### PR TITLE
Reject an explicit null on a partial tag update

### DIFF
--- a/api/schemas/requests_schemas.py
+++ b/api/schemas/requests_schemas.py
@@ -400,6 +400,13 @@ class CreateTagBody(BaseModel):
         return _validate_tag_constraints(v)
 
 
+#: Fields on a tag update whose column forbids null and for which no empty
+#: value is meaningful. `description` and `constraints` are absent because they
+#: have one -- the handler coerces a null there to `""` / `{}`. Omitting a
+#: field remains the way to leave it unchanged.
+_TAG_FIELDS_REJECTING_NULL = ("name", "enabled")
+
+
 class UpdateTagBody(BaseModel):
     """Body for PUT /api/tags/{id}. All fields optional (partial update)."""
 
@@ -416,6 +423,25 @@ class UpdateTagBody(BaseModel):
             return self
         if settings.REQUIRE_DESCRIPTIONS and (self.description is None or self.description == ""):
             raise ValueError("Description is required.")
+        return self
+
+    @model_validator(mode="after")
+    def _reject_explicit_nulls(self) -> Self:
+        """Reject a null sent for a field that cannot hold one.
+
+        Every field is `Optional` so that a partial update may omit it, which
+        makes an explicit `null` indistinguishable from omission by type --
+        only by presence in `model_fields_set`. Left alone it reaches a
+        `NOT NULL` column and fails the flush, turning a client mistake into a
+        500.
+        """
+        nulled = [
+            field
+            for field in _TAG_FIELDS_REJECTING_NULL
+            if field in self.model_fields_set and getattr(self, field) is None
+        ]
+        if nulled:
+            raise ValueError(f"May not be null: {', '.join(nulled)}. Omit a field to leave it unchanged.")
         return self
 
     @field_validator("constraints")

--- a/api/schemas/requests_schemas.py
+++ b/api/schemas/requests_schemas.py
@@ -400,21 +400,32 @@ class CreateTagBody(BaseModel):
         return _validate_tag_constraints(v)
 
 
-#: Fields on a tag update whose column forbids null and for which no empty
-#: value is meaningful. `description` and `constraints` are absent because they
-#: have one -- the handler coerces a null there to `""` / `{}`. Omitting a
-#: field remains the way to leave it unchanged.
-_TAG_FIELDS_REJECTING_NULL = ("name", "enabled")
+def _hide_default(schema: dict[str, Any]) -> None:
+    """Drop `default` from a field's published schema.
+
+    A partial-update field needs *a* default so it may be omitted, but the
+    value is never used: the handler dumps with `exclude_unset=True`, so an
+    omitted field is absent from the payload rather than set to its default.
+    Publishing one would tell a client that omitting the field writes that
+    value, which is the opposite of what happens.
+    """
+    schema.pop("default", None)
 
 
 class UpdateTagBody(BaseModel):
     """Body for PUT /api/tags/{id}. All fields optional (partial update)."""
 
     model_config = ConfigDict(extra="ignore")
-    name: Optional[str] = Field(default=None, min_length=1, max_length=_TAG_NAME_MAX_LENGTH)
+    # `name` and `enabled` are deliberately not `Optional`: their columns
+    # forbid null and neither has a meaningful empty value, so the annotation
+    # rejects an explicit `null` on its own. The defaults exist only to keep
+    # the fields omittable for a partial update and are never applied, hence
+    # `_hide_default`. `description` and `constraints` stay nullable because a
+    # null there *is* meaningful -- the handler coerces it to `""` / `{}`.
+    name: str = Field(default="", min_length=1, max_length=_TAG_NAME_MAX_LENGTH, json_schema_extra=_hide_default)
     description: Optional[str] = Field(default=None, max_length=_TAG_DESC_MAX_LENGTH)
     constraints: Optional[dict[str, Any]] = None
-    enabled: Optional[bool] = None
+    enabled: bool = Field(default=True, json_schema_extra=_hide_default)
 
     @model_validator(mode="after")
     def _check_description_required(self) -> Self:
@@ -423,25 +434,6 @@ class UpdateTagBody(BaseModel):
             return self
         if settings.REQUIRE_DESCRIPTIONS and (self.description is None or self.description == ""):
             raise ValueError("Description is required.")
-        return self
-
-    @model_validator(mode="after")
-    def _reject_explicit_nulls(self) -> Self:
-        """Reject a null sent for a field that cannot hold one.
-
-        Every field is `Optional` so that a partial update may omit it, which
-        makes an explicit `null` indistinguishable from omission by type --
-        only by presence in `model_fields_set`. Left alone it reaches a
-        `NOT NULL` column and fails the flush, turning a client mistake into a
-        500.
-        """
-        nulled = [
-            field
-            for field in _TAG_FIELDS_REJECTING_NULL
-            if field in self.model_fields_set and getattr(self, field) is None
-        ]
-        if nulled:
-            raise ValueError(f"May not be null: {', '.join(nulled)}. Omit a field to leave it unchanged.")
         return self
 
     @field_validator("constraints")

--- a/src/api/apiSchemas.ts
+++ b/src/api/apiSchemas.ts
@@ -1492,12 +1492,16 @@ export type UpdateAppBody = {
  * Body for PUT /api/tags/{id}. All fields optional (partial update).
  */
 export type UpdateTagBody = {
-  name?: string | null;
+  /**
+   * @maxLength 255
+   * @minLength 1
+   */
+  name?: string;
   description?: string | null;
   constraints?: {
     [key: string]: any;
   } | null;
-  enabled?: boolean | null;
+  enabled?: boolean;
 };
 
 export type AccessRequestAppGroupRef = {

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -542,3 +542,73 @@ async def test_get_tag_detail_active_group_tags_carries_group_description(
         if entry.get("active_group") is not None
     ]
     assert "tag-detail-description-fixture" in descriptions
+
+
+# --- Explicit nulls on a partial tag update ---------------------------------
+#
+# `UpdateTagBody` types every field `Optional[...]` so a partial PUT can omit
+# it. That makes an explicit JSON `null` indistinguishable from omission by
+# type, but not by presence: `exclude_unset` keeps it, and the handler then
+# writes it to a column that forbids it. `description` and `constraints` have a
+# meaningful empty value and are coerced to it; `name` and `enabled` do not, so
+# a null there is a client error rather than a request to clear.
+
+
+@pytest.mark.parametrize("field", ["name", "enabled"])
+async def test_put_tag_rejects_an_explicit_null(
+    client: AsyncClient, db: Db, tag: Tag, url_for: Any, field: str
+) -> None:
+    db.session.add(tag)
+    await db.session.commit()
+    tag_id, tag_name, tag_enabled = tag.id, tag.name, tag.enabled
+
+    response = await client.put(url_for("api-tags.tag_by_id", tag_id=tag_id), json={field: None})
+    assert response.status_code == 400
+    assert field in response.text
+
+    # The row is untouched, rather than left holding a null the column forbids.
+    db.session.expire_all()
+    reloaded = await db.session.get(Tag, tag_id)
+    assert reloaded is not None
+    assert reloaded.name == tag_name
+    assert reloaded.enabled == tag_enabled
+
+
+async def test_put_tag_still_clears_the_fields_that_have_an_empty_value(
+    client: AsyncClient, db: Db, tag: Tag, url_for: Any
+) -> None:
+    """`description` and `constraints` keep their null-to-empty coercion."""
+    tag.description = "something"
+    tag.constraints = {Tag.REQUIRE_MEMBER_REASON_CONSTRAINT_KEY: True}
+    db.session.add(tag)
+    await db.session.commit()
+    tag_id = tag.id
+
+    response = await client.put(
+        url_for("api-tags.tag_by_id", tag_id=tag_id), json={"description": None, "constraints": None}
+    )
+    assert response.status_code == 200
+
+    db.session.expire_all()
+    reloaded = await db.session.get(Tag, tag_id)
+    assert reloaded is not None
+    assert reloaded.description == ""
+    assert reloaded.constraints == {}
+
+
+async def test_put_tag_leaves_omitted_fields_alone(client: AsyncClient, db: Db, tag: Tag, url_for: Any) -> None:
+    """The point of the rejection is that omission remains the way to say
+    "leave this as it is"."""
+    tag.enabled = False
+    db.session.add(tag)
+    await db.session.commit()
+    tag_id, tag_name = tag.id, tag.name
+
+    response = await client.put(url_for("api-tags.tag_by_id", tag_id=tag_id), json={"description": "updated"})
+    assert response.status_code == 200
+
+    db.session.expire_all()
+    reloaded = await db.session.get(Tag, tag_id)
+    assert reloaded is not None
+    assert reloaded.name == tag_name
+    assert reloaded.enabled is False

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -546,12 +546,12 @@ async def test_get_tag_detail_active_group_tags_carries_group_description(
 
 # --- Explicit nulls on a partial tag update ---------------------------------
 #
-# `UpdateTagBody` types every field `Optional[...]` so a partial PUT can omit
-# it. That makes an explicit JSON `null` indistinguishable from omission by
-# type, but not by presence: `exclude_unset` keeps it, and the handler then
-# writes it to a column that forbids it. `description` and `constraints` have a
-# meaningful empty value and are coerced to it; `name` and `enabled` do not, so
-# a null there is a client error rather than a request to clear.
+# A partial PUT may omit any field, which `UpdateTagBody` allows by giving each
+# one a default. Nullability is a separate question: `name` and `enabled` back
+# columns that forbid null and have no meaningful empty value, so they are not
+# typed `Optional` and an explicit JSON `null` is rejected rather than written.
+# `description` and `constraints` do have one and stay nullable, coerced by the
+# handler to `""` / `{}`.
 
 
 @pytest.mark.parametrize("field", ["name", "enabled"])


### PR DESCRIPTION
# Summary

`PUT /api/tags/{id}` returns a 500 when a client sends an explicit `null` for `name` or `enabled`. Types those two fields so they cannot hold one, giving the caller a 400 naming the field — and a generated client that will not let them send it at all.

**Urgency**: 1 week
**Expected review effort**: LOW — two field declarations, plus tests.

# Motivation

`UpdateTagBody` typed every field `Optional[...]` so a partial `PUT` could omit it. That conflates two separate things: a field is omittable because it has a **default**, and nullable because of its **annotation**. Only the first is needed for a partial update.

The consequence was that an explicit JSON `null` was indistinguishable from omission by type — the two differed only by presence in `model_fields_set`, which `exclude_unset=True` preserves. The handler then wrote the `None` straight through:

```python
for key in ("name", "description", "constraints", "enabled"):
    if key in payload:
        setattr(tag, key, payload[key])
```

`name` and `enabled` back `NOT NULL` columns, so the flush failed and a client mistake surfaced as an unhandled `IntegrityError` → HTTP 500. Verified against a running instance:

| body | before |
|---|---|
| `{"name": null}` | **500** |
| `{"enabled": null}` | **500** |
| `{"description": null}` | 400 / coerced to `""` |
| `{"constraints": null}` | 200, coerced to `{}` |

Nothing invalid was persisted — the transaction fails — so this is a wrong status code and an unhelpful error, not corruption.

<details>
<summary><h1>Description of Changes</h1></summary>

`name` and `enabled` are declared `str` and `bool` rather than `Optional`. Pydantic then rejects an explicit null before any validator runs, and the generated TypeScript types them as non-nullable, so a caller is stopped at compile time rather than by a round trip.

`description` and `constraints` stay nullable. Both have a meaningful empty value and the handler already coerces a null to `""` and `{}`. Treating a null there as "clear this" is reasonable; for a boolean or a name there is no equivalent, so a null is a client error rather than an instruction.

**On the defaults.** A non-`Optional` field still needs one, or it becomes *required* and partial updates break. Those defaults are never applied — the handler dumps with `exclude_unset=True`, so an omitted field is absent from the payload rather than set to its default — but Pydantic publishes them, and `default: ""` beside `minLength: 1` would tell a client that omitting the name writes an empty string. A small `json_schema_extra` hook drops `default` from the published schema for these two fields.

The result is a contract that is accurate in every respect: the field may be omitted, may not be null, and has no default.

```diff
- name?: string | null;
+ /** @maxLength 255 @minLength 1 */
+ name?: string;
- enabled?: boolean | null;
+ enabled?: boolean;
```

</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

- Parametrized test over `name` and `enabled`: explicit null returns 400, names the field, and leaves the row untouched. Both confirmed to fail before the change with `IntegrityError` → 500.
- Two positive controls, to pin what the rejection must *not* break: `description`/`constraints` still coerce a null to their empty value, and omitting a field still leaves it unchanged.
- The published schema checked directly: no `default` on either field, `type: string` rather than `anyOf` with null, and neither field in `required`.
- `make test` green: ruff, ty, 913 backend, 38 frontend.

</details>

# Guidance for Reviewers

The design question is reject-vs-coerce. Coercing a null to the column default would silently flip `enabled` to `True` for a client that sent something meaningless, which seemed worse than an error. Rejecting also keeps omission as the single documented way to say "leave this unchanged".

`UpdateAppBody`, directly below, still has the older `Optional[...] = Field(default=None, ...)` shape for its own partial update. Left alone deliberately to keep this diff to the reported bug; worth deciding separately whether it should follow.
