### PR TITLE
Extract the time-limit updates into composable helpers

### DIFF
--- a/api/operations/_time_limits.py
+++ b/api/operations/_time_limits.py
@@ -1,0 +1,151 @@
+"""Applying a time limit to access that groups and roles confer.
+
+Every function here narrows `ended_at` and never extends it: each update is
+guarded on the existing end date being absent or later than the limit. That
+makes them idempotent and safe to compose in any order, which is what lets a
+caller express a policy as a few calls instead of a wall of near-identical
+bulk updates.
+
+None of them commit. The caller owns the transaction.
+
+Constraints apply only to managed, non-deleted entities, and the callers here
+are handed ids they have already filtered; it is the caller that decides an
+entity is subject to a constraint. Re-deriving that would add a join to every
+bulk update and would quietly absorb a caller's mistake instead of letting it
+show. **Callers must pass only managed, non-deleted ids.**
+
+The invariant these maintain: a membership materialized from a role -- one
+carrying a `role_group_map_id` -- must never outlive either of the two records
+it derives from, the user's membership in the role and the role's association
+with the group. `ModifyRoleGroups` and `ModifyGroupUsers` establish that when
+they create such a row, by taking the minimum of the two. Anything that later
+shortens one of those inputs has to re-establish it.
+"""
+
+from datetime import datetime
+from typing import Collection
+
+from sqlalchemy import func, or_, select, update
+
+from api.extensions import db
+from api.models import OktaUserGroupMember, RoleGroupMap
+
+
+async def limit_memberships_to_groups(group_ids: Collection[str], *, is_owner: bool, end_at: datetime) -> None:
+    """Cap the access granted *to* `group_ids` on the `is_owner` side.
+
+    Covers both ways access into a group is held: directly by a user, and by a
+    role whose members inherit it. Passing role ids is meaningful and does the
+    right thing -- a role is a group, and capping its inbound access caps
+    membership of the role. The `RoleGroupMap` half of that is simply empty,
+    since a role can never be another role's target.
+
+    Args:
+        group_ids: The groups whose inbound access is being capped. Must be
+            managed and not deleted; see the module docstring.
+        is_owner: Whether to cap ownership (True) or membership (False).
+        end_at: The end date to cap at.
+    """
+    if len(group_ids) == 0:
+        return
+
+    await db.session.execute(
+        update(OktaUserGroupMember)
+        .where(OktaUserGroupMember.group_id.in_(group_ids))
+        .where(OktaUserGroupMember.is_owner.is_(is_owner))
+        .where(
+            or_(
+                OktaUserGroupMember.ended_at.is_(None),
+                OktaUserGroupMember.ended_at > end_at,
+            )
+        )
+        .values({OktaUserGroupMember.ended_at: end_at})
+        .execution_options(synchronize_session="fetch")
+    )
+
+    await db.session.execute(
+        update(RoleGroupMap)
+        .where(RoleGroupMap.group_id.in_(group_ids))
+        .where(RoleGroupMap.is_owner.is_(is_owner))
+        .where(
+            or_(
+                RoleGroupMap.ended_at.is_(None),
+                RoleGroupMap.ended_at > end_at,
+            )
+        )
+        .values({RoleGroupMap.ended_at: end_at})
+        .execution_options(synchronize_session="fetch")
+    )
+
+
+async def limit_memberships_by_roles(role_ids: Collection[str], *, is_owner: bool, end_at: datetime) -> None:
+    """Cap the access granted *by* `role_ids` through their `is_owner`-side associations.
+
+    These are the materialized rows in the groups each role is associated with.
+    A role's member-side association produces member-side rows and its
+    owner-side association owner-side rows, so `is_owner` selects both together.
+
+    Args:
+        role_ids: The roles whose conferred access is being capped. Must be
+            managed and not deleted; see the module docstring.
+        is_owner: Which association side to follow, and therefore which side of
+            materialized row to cap.
+        end_at: The end date to cap at.
+    """
+    if len(role_ids) == 0:
+        return
+
+    association_ids = (
+        await db.session.scalars(
+            select(RoleGroupMap.id)
+            .where(RoleGroupMap.role_group_id.in_(role_ids))
+            .where(RoleGroupMap.is_owner.is_(is_owner))
+            .where(
+                or_(
+                    RoleGroupMap.ended_at.is_(None),
+                    RoleGroupMap.ended_at > func.now(),
+                )
+            )
+        )
+    ).all()
+    if len(association_ids) == 0:
+        return
+
+    await db.session.execute(
+        update(OktaUserGroupMember)
+        .where(OktaUserGroupMember.role_group_map_id.in_(association_ids))
+        .where(OktaUserGroupMember.is_owner.is_(is_owner))
+        .where(
+            or_(
+                OktaUserGroupMember.ended_at.is_(None),
+                OktaUserGroupMember.ended_at > end_at,
+            )
+        )
+        .values({OktaUserGroupMember.ended_at: end_at})
+        .execution_options(synchronize_session="fetch")
+    )
+
+
+async def limit_access_conferred_by_roles(role_ids: Collection[str], *, end_at: datetime) -> None:
+    """Cap membership of `role_ids` and everything that membership grants.
+
+    A limit reaching a role always lands on its member side -- being a member
+    of a role is what confers the role's access, so that is the only side there
+    is anything to limit. Capping the memberships alone would leave the rows
+    they produced in the associated groups on their old end dates, outliving
+    the membership they exist because of, so both association sides are
+    followed: a role's members hold membership through its member-side
+    associations and ownership through its owner-side ones, and both derive
+    from the same membership.
+
+    Args:
+        role_ids: The roles whose members are being capped. Must be managed and
+            not deleted; see the module docstring.
+        end_at: The end date to cap at.
+    """
+    if len(role_ids) == 0:
+        return
+
+    await limit_memberships_to_groups(role_ids, is_owner=False, end_at=end_at)
+    await limit_memberships_by_roles(role_ids, is_owner=False, end_at=end_at)
+    await limit_memberships_by_roles(role_ids, is_owner=True, end_at=end_at)

--- a/api/operations/modify_groups_time_limit.py
+++ b/api/operations/modify_groups_time_limit.py
@@ -1,18 +1,35 @@
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy import func, or_, select, update
+from sqlalchemy import select
+
 from api.extensions import db
-from api.models import OktaGroup, OktaUserGroupMember, RoleGroup, RoleGroupMap, Tag
+from api.models import OktaGroup, RoleGroup, Tag
 from api.models.tag import coalesce_constraints
+from api.operations._time_limits import limit_access_conferred_by_roles, limit_memberships_to_groups
 
 
 class ModifyGroupsTimeLimit:
+    """Apply the time limits a set of tags imposes on a set of groups.
+
+    Runs when a tag's constraints start applying to groups that already have
+    access granted on them -- the tag being attached, edited, or inherited from
+    an app. Existing grants are shortened to fit; nothing is ever extended.
+
+    A tag reaches access on two sides:
+
+    - Its **member** limit caps membership of the tagged groups, and where a
+      tagged group is a role, everything that membership confers in the groups
+      the role is associated with.
+    - Its **owner** limit caps ownership of the tagged groups. Owning a role
+      confers none of the role's access, so nothing follows from it.
+    """
+
     def __init__(self, groups: list[str] | set[str], tags: list[str] | set[str]):
         self.group_ids = groups
         self.tag_ids = tags
 
     async def execute(self) -> None:
-        # Only include groups that are managed
+        # Only managed groups are subject to constraints.
         groups = (
             await db.session.scalars(
                 select(OktaGroup)
@@ -21,6 +38,9 @@ class ModifyGroupsTimeLimit:
                 .where(OktaGroup.is_managed.is_(True))
             )
         ).all()
+        if len(groups) == 0:
+            return
+
         role_groups = (
             await db.session.scalars(
                 select(RoleGroup)
@@ -29,139 +49,30 @@ class ModifyGroupsTimeLimit:
                 .where(RoleGroup.is_managed.is_(True))
             )
         ).all()
-
         tags = list(
             (
                 await db.session.scalars(select(Tag).where(Tag.id.in_(self.tag_ids)).where(Tag.deleted_at.is_(None)))
             ).all()
         )
 
-        if len(groups) == 0:
-            return
+        group_ids = [g.id for g in groups]
+        role_group_ids = [g.id for g in role_groups]
 
-        # Determine the minimum time allowed for group membership and ownership by current group tags
+        # Each side carries its own limit. A tag may set either without the
+        # other, so neither pass can borrow the other's value or depend on the
+        # other having run.
         membership_seconds_limit = coalesce_constraints(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, tags)
-        ownership_seconds_limit = coalesce_constraints(Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY, tags)
-        # Handle group time limit constraints when adding tags with time limit contraints to a group
         if membership_seconds_limit is not None:
-            membership_time_limit_from_now = datetime.now(UTC) + timedelta(seconds=membership_seconds_limit)
-            # Reduce all user memberships for the given groups to minimum allowed time limit
-            await db.session.execute(
-                update(OktaUserGroupMember)
-                .where(OktaUserGroupMember.group_id.in_([g.id for g in groups]))
-                .where(OktaUserGroupMember.is_owner.is_(False))
-                .where(
-                    or_(
-                        OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > membership_time_limit_from_now,
-                    )
-                )
-                .values({OktaUserGroupMember.ended_at: membership_time_limit_from_now})
-                .execution_options(synchronize_session="fetch")
-            )
-            # Reduce all role memberships for the given groups to the minimum allowed time limit
-            await db.session.execute(
-                update(RoleGroupMap)
-                .where(RoleGroupMap.group_id.in_([g.id for g in groups]))
-                .where(RoleGroupMap.is_owner.is_(False))
-                .where(
-                    or_(
-                        RoleGroupMap.ended_at.is_(None),
-                        RoleGroupMap.ended_at > membership_time_limit_from_now,
-                    )
-                )
-                .values({RoleGroupMap.ended_at: membership_time_limit_from_now})
-                .execution_options(synchronize_session="fetch")
-            )
-            # Reduce all user memberships for groups associated with any given role groups
-            # to the minimum allowed time limit
-            role_group_map_associations = (
-                await db.session.scalars(
-                    select(RoleGroupMap)
-                    .where(RoleGroupMap.role_group_id.in_([g.id for g in role_groups]))
-                    .where(RoleGroupMap.is_owner.is_(False))
-                    .where(
-                        or_(
-                            RoleGroupMap.ended_at.is_(None),
-                            RoleGroupMap.ended_at > func.now(),
-                        )
-                    )
-                )
-            ).all()
-            await db.session.execute(
-                update(OktaUserGroupMember)
-                .where(OktaUserGroupMember.role_group_map_id.in_([m.id for m in role_group_map_associations]))
-                .where(OktaUserGroupMember.is_owner.is_(False))
-                .where(
-                    or_(
-                        OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > membership_time_limit_from_now,
-                    )
-                )
-                .values({OktaUserGroupMember.ended_at: membership_time_limit_from_now})
-                .execution_options(synchronize_session="fetch")
-            )
-            # A role confers its access on its MEMBERS, so the ownerships a
-            # role grants in the groups it owns are held by those members and
-            # are bounded by the same membership limit. They are materialized
-            # as min(role membership, role-group map), so capping the
-            # membership without capping these would leave them outliving the
-            # membership they exist because of.
-            role_owner_map_associations = (
-                await db.session.scalars(
-                    select(RoleGroupMap)
-                    .where(RoleGroupMap.role_group_id.in_([g.id for g in role_groups]))
-                    .where(RoleGroupMap.is_owner.is_(True))
-                    .where(
-                        or_(
-                            RoleGroupMap.ended_at.is_(None),
-                            RoleGroupMap.ended_at > func.now(),
-                        )
-                    )
-                )
-            ).all()
-            await db.session.execute(
-                update(OktaUserGroupMember)
-                .where(OktaUserGroupMember.role_group_map_id.in_([m.id for m in role_owner_map_associations]))
-                .where(OktaUserGroupMember.is_owner.is_(True))
-                .where(
-                    or_(
-                        OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > membership_time_limit_from_now,
-                    )
-                )
-                .values({OktaUserGroupMember.ended_at: membership_time_limit_from_now})
-                .execution_options(synchronize_session="fetch")
-            )
-            await db.session.commit()
+            end_at = datetime.now(UTC) + timedelta(seconds=membership_seconds_limit)
+            await limit_memberships_to_groups(group_ids, is_owner=False, end_at=end_at)
+            # Where a tagged group is a role, the rows its members materialize
+            # in the groups it is associated with derive from the memberships
+            # capped above, and must not outlive them -- on either axis.
+            await limit_access_conferred_by_roles(role_group_ids, end_at=end_at)
+
+        ownership_seconds_limit = coalesce_constraints(Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY, tags)
         if ownership_seconds_limit is not None:
-            ownership_time_limit_from_now = datetime.now(UTC) + timedelta(seconds=ownership_seconds_limit)
-            # Reduce all user ownerships for the given groups to minimum allowed time limit
-            await db.session.execute(
-                update(OktaUserGroupMember)
-                .where(OktaUserGroupMember.group_id.in_([g.id for g in groups]))
-                .where(OktaUserGroupMember.is_owner.is_(True))
-                .where(
-                    or_(
-                        OktaUserGroupMember.ended_at.is_(None),
-                        OktaUserGroupMember.ended_at > ownership_time_limit_from_now,
-                    )
-                )
-                .values({OktaUserGroupMember.ended_at: ownership_time_limit_from_now})
-                .execution_options(synchronize_session="fetch")
-            )
-            # Reduce all role ownerships for the given groups to the minimum allowed time limit
-            await db.session.execute(
-                update(RoleGroupMap)
-                .where(RoleGroupMap.group_id.in_([g.id for g in groups]))
-                .where(RoleGroupMap.is_owner.is_(True))
-                .where(
-                    or_(
-                        RoleGroupMap.ended_at.is_(None),
-                        RoleGroupMap.ended_at > ownership_time_limit_from_now,
-                    )
-                )
-                .values({RoleGroupMap.ended_at: ownership_time_limit_from_now})
-                .execution_options(synchronize_session="fetch")
-            )
-            await db.session.commit()
+            end_at = datetime.now(UTC) + timedelta(seconds=ownership_seconds_limit)
+            await limit_memberships_to_groups(group_ids, is_owner=True, end_at=end_at)
+
+        await db.session.commit()


### PR DESCRIPTION
# Summary

Extracts the bulk `update` statements in `ModifyGroupsTimeLimit` into three named helpers in `api/operations/_time_limits.py`. **No behavior change** — no test changed, and the same 875 pass.

**Urgency**: 3 days
**Expected review effort**: LOW — verify it is a no-op; the tests are unchanged on purpose.

> [!NOTE]
> Stacked on **#594**, which fixes the defect described below. Review that first; this PR's diff is against its branch and GitHub will retarget to `main` when it merges.

# Motivation

`ModifyGroupsTimeLimit.execute()` was three walls of near-identical bulk `update` statements, differing only in which table, which `is_owner` side, and which limit variable. Two problems with that shape:

**It caused a real defect.** The ownership branch reached for the membership branch's local, which is the bug #594 fixes. When four statements differ by one identifier each, picking the wrong identifier is invisible at review.

**It hides the rule.** What the statements collectively express — that a membership materialized from a role must never outlive either record it derives from — lived only in the shape of the SQL. There was nowhere to write it down and nothing to point a future caller at.

<details>
<summary><h1>Description of Changes</h1></summary>

Three helpers, named for the question each answers:

- `limit_memberships_to_groups(group_ids, *, is_owner, end_at)` — cap access granted **to** these groups, covering both the direct user rows and the `RoleGroupMap`s.
- `limit_memberships_by_roles(role_ids, *, is_owner, end_at)` — cap access granted **by** these roles through one association side.
- `limit_access_conferred_by_roles(role_ids, *, end_at)` — the composite: cap membership of the roles and everything that membership confers, following both association sides.

Each narrows `ended_at` and never extends it — every update is guarded on the existing end date being absent or later than the limit — so they are idempotent and compose in any order. None of them commit; the caller owns the transaction.

The module docstring carries two things that previously had nowhere to live: the invariant above, and the precondition that callers pass only managed, non-deleted ids. That filter stays with the caller deliberately — re-deriving it inside every helper would add a join to each bulk update and would quietly absorb a caller's mistake rather than letting it surface.

</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

- **No test file is touched.** That is the claim: `git diff --name-only` lists one file. The suite that covered the old shape covers the new one unchanged.
- `make test` green: ruff, ty, 875 backend, 38 frontend — the same count as the base branch.

</details>

# Guidance for Reviewers

Read this as a no-op and check that it is one. The mapping is one helper call per former statement group, so the useful review is confirming each call reproduces the `WHERE` clause it replaced — same table, same `is_owner` side, same limit.

One intentional difference: the two mid-method commits become a single commit at the end, so a failure in the ownership pass no longer leaves the membership pass durably applied. That is a change in transaction boundary, not in the rows written.
