### PR TITLE
Propagate tag constraints from tagged groups to associated roles

### DIFF
--- a/api/cli.py
+++ b/api/cli.py
@@ -353,6 +353,23 @@ async def fix_role_memberships(dry_run: bool) -> None:
     await verify_and_fix_role_memberships(dry_run=dry_run)
 
 
+@cli.command("cap-role-memberships")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="If set will run as dry run and not make any changes",
+)
+@_with_app_context
+async def cap_role_memberships_command(dry_run: bool) -> None:
+    """Cap existing role memberships against time limits propagated from tagged groups."""
+    from api.integrity import cap_role_memberships
+
+    capped = await cap_role_memberships(dry_run=dry_run)
+    click.echo(f"{'Would cap' if dry_run else 'Capped'} {capped} role membership(s)")
+
+
 @cli.command("notify")
 @click.option(
     "--owner",

--- a/api/integrity.py
+++ b/api/integrity.py
@@ -2,13 +2,13 @@ import logging
 from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import func, or_, select, update
-from sqlalchemy.orm import selectinload
 from api.extensions import db
-from api.models import OktaGroup, OktaGroupTagMap, OktaUserGroupMember, RoleGroup, RoleGroupMap, Tag
+from api.models import OktaGroup, OktaUserGroupMember, RoleGroup, RoleGroupMap, Tag
 from api.models.tag import effective_constraint
+from api.operations import UnmanageGroup
 from api.operations._derived_reason import role_derived_reason
 from api.operations._time_limits import limit_access_conferred_by_roles
-from api.operations import UnmanageGroup
+from api.routers._eager import effective_constraint_options
 from api.services import okta
 
 logger = logging.getLogger(__name__)
@@ -190,17 +190,7 @@ async def cap_role_memberships(dry_run: bool = False) -> int:
     roles = (
         await db.session.scalars(
             select(RoleGroup)
-            .options(
-                selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
-                selectinload(RoleGroup.active_role_associated_group_member_mappings)
-                .joinedload(RoleGroupMap.active_group)
-                .selectinload(OktaGroup.active_group_tags)
-                .joinedload(OktaGroupTagMap.active_tag),
-                selectinload(RoleGroup.active_role_associated_group_owner_mappings)
-                .joinedload(RoleGroupMap.active_group)
-                .selectinload(OktaGroup.active_group_tags)
-                .joinedload(OktaGroupTagMap.active_tag),
-            )
+            .options(*effective_constraint_options())
             .where(RoleGroup.deleted_at.is_(None))
             .where(RoleGroup.is_managed.is_(True))
         )
@@ -227,11 +217,6 @@ async def cap_role_memberships(dry_run: bool = False) -> int:
         ).all()
         capped += len(over_long)
         if not dry_run and len(over_long) > 0:
-            # Go through the shared helper rather than assigning `ended_at`
-            # here: capping the membership alone leaves the rows it
-            # materialized in the role's associated groups on their old end
-            # dates, so the sweep would shorten the membership without
-            # shortening the access it actually confers.
             await limit_access_conferred_by_roles([role.id], end_at=limit_from_now)
         if len(over_long) > 0:
             logger.info(

--- a/api/integrity.py
+++ b/api/integrity.py
@@ -1,9 +1,13 @@
 import logging
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import func, or_, select, update
+from sqlalchemy.orm import selectinload
 from api.extensions import db
-from api.models import OktaGroup, OktaUserGroupMember, RoleGroupMap
+from api.models import OktaGroup, OktaGroupTagMap, OktaUserGroupMember, RoleGroup, RoleGroupMap, Tag
+from api.models.tag import effective_constraint
 from api.operations._derived_reason import role_derived_reason
+from api.operations._time_limits import limit_access_conferred_by_roles
 from api.operations import UnmanageGroup
 from api.services import okta
 
@@ -174,3 +178,70 @@ async def verify_and_fix_role_memberships(dry_run: bool = False) -> None:
                         # Remove user from okta group owners
                         # https://help.okta.com/en-us/Content/Topics/identity-governance/group-owner.htm
                         await okta.remove_owner_from_group(active_role_group_map.group_id, user_id)
+
+
+async def cap_role_memberships(dry_run: bool = False) -> int:
+    """Cap existing role memberships against propagated time limits.
+
+    The enforcement path (grant time) is complete on its own; this is the
+    one-off sweep over grants that predate the feature. Delta-based, so it is
+    safe to re-run: a membership already at or under its limit is skipped.
+    """
+    roles = (
+        await db.session.scalars(
+            select(RoleGroup)
+            .options(
+                selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
+                selectinload(RoleGroup.active_role_associated_group_member_mappings)
+                .joinedload(RoleGroupMap.active_group)
+                .selectinload(OktaGroup.active_group_tags)
+                .joinedload(OktaGroupTagMap.active_tag),
+                selectinload(RoleGroup.active_role_associated_group_owner_mappings)
+                .joinedload(RoleGroupMap.active_group)
+                .selectinload(OktaGroup.active_group_tags)
+                .joinedload(OktaGroupTagMap.active_tag),
+            )
+            .where(RoleGroup.deleted_at.is_(None))
+            .where(RoleGroup.is_managed.is_(True))
+        )
+    ).all()
+
+    capped = 0
+    for role in roles:
+        seconds_limit = effective_constraint(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, role)
+        if seconds_limit is None:
+            continue
+        limit_from_now = datetime.now(UTC) + timedelta(seconds=seconds_limit)
+        over_long = (
+            await db.session.scalars(
+                select(OktaUserGroupMember)
+                .where(OktaUserGroupMember.group_id == role.id)
+                .where(OktaUserGroupMember.is_owner.is_(False))
+                .where(
+                    or_(
+                        OktaUserGroupMember.ended_at.is_(None),
+                        OktaUserGroupMember.ended_at > limit_from_now,
+                    )
+                )
+            )
+        ).all()
+        capped += len(over_long)
+        if not dry_run and len(over_long) > 0:
+            # Go through the shared helper rather than assigning `ended_at`
+            # here: capping the membership alone leaves the rows it
+            # materialized in the role's associated groups on their old end
+            # dates, so the sweep would shorten the membership without
+            # shortening the access it actually confers.
+            await limit_access_conferred_by_roles([role.id], end_at=limit_from_now)
+        if len(over_long) > 0:
+            logger.info(
+                "cap_role_memberships: role=%s limit=%ss over_long=%d dry_run=%s",
+                role.name,
+                seconds_limit,
+                len(over_long),
+                dry_run,
+            )
+
+    if not dry_run:
+        await db.session.commit()
+    return capped

--- a/api/integrity.py
+++ b/api/integrity.py
@@ -181,11 +181,17 @@ async def verify_and_fix_role_memberships(dry_run: bool = False) -> None:
 
 
 async def cap_role_memberships(dry_run: bool = False) -> int:
-    """Cap existing role memberships against propagated time limits.
+    """Cap role memberships that outlast the limit their role's associations impose.
 
-    The enforcement path (grant time) is complete on its own; this is the
-    one-off sweep over grants that predate the feature. Delta-based, so it is
-    safe to re-run: a membership already at or under its limit is skipped.
+    A repair sweep. The grant-time path bounds membership as access is granted,
+    so this covers memberships that path never saw. Delta-based and safe to
+    re-run: a membership already at or under its limit is skipped.
+
+    Args:
+        dry_run: Report what would be capped without writing.
+
+    Returns:
+        The number of memberships found at or over their limit.
     """
     roles = (
         await db.session.scalars(

--- a/api/models/core_models.py
+++ b/api/models/core_models.py
@@ -1146,6 +1146,14 @@ class Tag(Base):
 
     enabled: Mapped[bool] = mapped_column(Boolean(), nullable=False, default=True)
 
+    # Whether this tag's constraints reach roles associated with a tagged group.
+    # Distinct from `enabled`: `enabled=False` turns the tag off everywhere,
+    # whereas this only stops propagation. On unless an operator opts out, so a
+    # tag constrains every path to the access it governs by default.
+    propagate_to_roles: Mapped[bool] = mapped_column(
+        Boolean(), nullable=False, default=True, server_default=expression.true()
+    )
+
     # Field containing additional data about externally managed groups
     constraints: Mapped[Dict[str, Any]] = mapped_column(
         mutable_json_type(

--- a/api/models/tag.py
+++ b/api/models/tag.py
@@ -1,7 +1,8 @@
 from datetime import UTC, datetime, timedelta
-from typing import Any, Optional
+from enum import StrEnum
+from typing import Any, NamedTuple, Optional
 
-from api.models.core_models import Tag
+from api.models.core_models import OktaGroup, RoleGroup, RoleGroupMap, Tag, TagConstraint
 
 
 def coalesce_constraints(constraint_key: str, tags: list[Tag]) -> Any:
@@ -35,3 +36,291 @@ def coalesce_ended_at(
             return constraint_ended_at
         else:
             return min(constraint_ended_at, initial_ended_at.replace(tzinfo=UTC))
+
+
+# A role confers access upon its MEMBERS. So propagation always feeds the
+# role's member-side constraints; an association where the role is an OWNER of
+# the group reads that group's owner-side key instead. These three pairs cover
+# all six constraints. Membership of this dict is also what decides whether a
+# key propagates at all: owner-side keys on a role receive nothing, because
+# owning a role does not confer the role's grants.
+OWNER_SIDE_COUNTERPART: dict[str, str] = {
+    Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY,
+    Tag.REQUIRE_MEMBER_REASON_CONSTRAINT_KEY: Tag.REQUIRE_OWNER_REASON_CONSTRAINT_KEY,
+    Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY: Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY,
+}
+
+
+class ConstraintOrigin(StrEnum):
+    """How a tag reaches the group a constraint is being evaluated for.
+
+    A `StrEnum` so it serializes as the bare string it always was: the JSON
+    contract is unchanged, but the OpenAPI schema now carries the value set,
+    and the generated TypeScript client gets a literal union instead of
+    `string`.
+    """
+
+    #: Applied to the group itself.
+    DIRECT = "direct"
+    #: Inherited from the group's app.
+    APP = "app"
+    #: Reaches a role because the role is a member of the tagged group.
+    MEMBER_ASSOCIATION = "member_association"
+    #: Reaches a role because the role owns the tagged group.
+    OWNER_ASSOCIATION = "owner_association"
+
+
+class ConstraintSource(NamedTuple):
+    """One tag contributing a value for a constraint, and where it came from."""
+
+    tag: Tag
+    value: Any
+    origin: ConstraintOrigin
+    #: The App for an `APP` origin, the source group for an association origin,
+    #: and None for a `DIRECT` one. Named without "group" because it is not
+    #: always a group.
+    source_id: Optional[str]
+    source_name: Optional[str]
+
+
+def _own_tag_sources(constraint_key: str, group: OktaGroup, include_provenance: bool) -> list[ConstraintSource]:
+    """Tags carrying `constraint_key` that sit on `group` itself, directly or via its app."""
+    sources: list[ConstraintSource] = []
+    for tag_map in group.active_group_tags:
+        tag = tag_map.active_tag
+        if not tag.enabled or constraint_key not in tag.constraints:
+            continue
+        origin = ConstraintOrigin.DIRECT
+        source_id = None
+        source_name = None
+        if include_provenance and tag_map.active_app_tag_mapping is not None:
+            origin = ConstraintOrigin.APP
+            # `active_app` filters `deleted_at`, so it is None for a
+            # soft-deleted app; fall back to no source rather than raising, as
+            # every other `active_*` read here does.
+            app = tag_map.active_app_tag_mapping.active_app
+            source_id = getattr(app, "id", None)
+            source_name = getattr(app, "name", None)
+        sources.append(
+            ConstraintSource(
+                tag=tag,
+                value=tag.constraints[constraint_key],
+                origin=origin,
+                source_id=source_id,
+                source_name=source_name,
+            )
+        )
+    return sources
+
+
+def _propagated_sources(constraint_key: str, group: OktaGroup) -> list[ConstraintSource]:
+    """Tags reaching `group` because it is a role associated with a tagged group.
+
+    Reads `active_role_associated_group_member_mappings` and
+    `active_role_associated_group_owner_mappings`, each joined through
+    `active_group` to `active_group_tags` -> `active_tag`. All four are
+    `lazy="raise_on_sql"`; callers must eager-load them.
+    """
+    if type(group) is not RoleGroup:
+        return []
+    # An unmanaged role enforces nothing, so nothing should propagate onto it.
+    # Gating here rather than at each caller keeps display and enforcement
+    # agreeing: every enforcement path already checks `is_managed` separately,
+    # and without this the read surface would advertise constraints that
+    # nothing applies.
+    if not group.is_managed:
+        return []
+    # Owner-side keys never propagate onto a role.
+    if constraint_key not in OWNER_SIDE_COUNTERPART:
+        return []
+
+    # One entry per association direction: the key read on the source group
+    # differs, but the handling is otherwise identical.
+    association_axes: tuple[tuple[ConstraintOrigin, str, list[RoleGroupMap]], ...] = (
+        (
+            ConstraintOrigin.MEMBER_ASSOCIATION,
+            constraint_key,
+            group.active_role_associated_group_member_mappings,
+        ),
+        (
+            ConstraintOrigin.OWNER_ASSOCIATION,
+            OWNER_SIDE_COUNTERPART[constraint_key],
+            group.active_role_associated_group_owner_mappings,
+        ),
+    )
+
+    sources: list[ConstraintSource] = []
+    for origin, key, mappings in association_axes:
+        for mapping in mappings:
+            # `active_group` filters `deleted_at`, so it is None when the
+            # source group has been soft-deleted while the mapping is still
+            # active. Skip rather than raise, matching how this module treats
+            # every other `active_*` read.
+            source_group = mapping.active_group
+            if source_group is None or not source_group.is_managed:
+                continue
+            for tag_map in source_group.active_group_tags:
+                tag = tag_map.active_tag
+                if not tag.enabled or not tag.propagate_to_roles:
+                    continue
+                if key not in tag.constraints:
+                    continue
+                sources.append(
+                    ConstraintSource(
+                        tag=tag,
+                        value=tag.constraints[key],
+                        origin=origin,
+                        source_id=source_group.id,
+                        source_name=source_group.name,
+                    )
+                )
+    return sources
+
+
+def _fold(constraint: TagConstraint, sources: list[ConstraintSource]) -> Any:
+    """Coalesce `sources`' values pairwise under `constraint.coalesce`.
+
+    Seeded on `is None`, not on truthiness: a first source contributing a falsy
+    value (`False`, or a `0`-second time limit) is a real contribution and must
+    seed the fold rather than be skipped.
+    """
+    value = None
+    for source in sources:
+        value = source.value if value is None else constraint.coalesce(value, source.value)
+    return value
+
+
+def constraint_sources(
+    constraint_key: str, group: OktaGroup, *, include_provenance: bool = False
+) -> list[ConstraintSource]:
+    """Collect every tag contributing a value for `constraint_key` to `group`.
+
+    Covers tags on the group itself and, when `group` is a role, tags reaching
+    it from the groups it is associated with. Only enabled tags contribute, and
+    a propagated tag contributes only if it has `propagate_to_roles` set, its
+    source group is managed, and the role itself is managed.
+
+    Args:
+        constraint_key: A key from `Tag.CONSTRAINTS`.
+        group: The group to evaluate. Association reads only happen when this
+            is a `RoleGroup`.
+        include_provenance: Whether to distinguish `APP` from `DIRECT` origins.
+            Doing so reads `OktaGroupTagMap.active_app_tag_mapping`, so
+            enforcement paths leave this False and avoid having to eager-load
+            it. Display paths set it True.
+
+    Returns:
+        Every contributing source, unordered and not deduplicated -- one entry
+        per tag per origin. Empty if nothing sets the constraint.
+
+    Raises:
+        InvalidRequestError: If a relationship this reads was not eager-loaded.
+            All of them are `lazy="raise_on_sql"`; see
+            `api/routers/_eager.py`.
+    """
+    return _own_tag_sources(constraint_key, group, include_provenance) + _propagated_sources(constraint_key, group)
+
+
+def effective_constraint(constraint_key: str, group: OktaGroup) -> Any:
+    """Resolve the value of `constraint_key` actually in force on `group`.
+
+    Coalesces every contributing tag under that constraint's own rule -- the
+    minimum for time limits, logical OR for flags -- across the group's own
+    tags and anything reaching it from an associated group.
+
+    Args:
+        constraint_key: A key from `Tag.CONSTRAINTS`.
+        group: The group to evaluate.
+
+    Returns:
+        The coalesced value, or None if no tag sets this constraint.
+
+    Raises:
+        InvalidRequestError: If a relationship this reads was not eager-loaded.
+    """
+    return _fold(Tag.CONSTRAINTS[constraint_key], constraint_sources(constraint_key, group))
+
+
+def effective_ended_at(
+    constraint_key: str, group: OktaGroup, initial_ended_at: Optional[datetime]
+) -> Optional[datetime]:
+    """Apply a time-limit constraint to a proposed access end date.
+
+    Caps `initial_ended_at` at the limit `constraint_key` resolves to for
+    `group`, so a grant can never outlive what the tags in force allow. An
+    indefinite grant becomes bounded; an already-shorter one is left alone.
+
+    Args:
+        constraint_key: `MEMBER_TIME_LIMIT_CONSTRAINT_KEY` or
+            `OWNER_TIME_LIMIT_CONSTRAINT_KEY`.
+        group: The group the access is being granted on.
+        initial_ended_at: The requested end date, or None for indefinite.
+
+    Returns:
+        The capped end date, or `initial_ended_at` unchanged when no limit
+        applies or `group` is unmanaged (unmanaged groups enforce nothing).
+
+    Raises:
+        InvalidRequestError: If a relationship this reads was not eager-loaded.
+    """
+    if not group.is_managed:
+        return initial_ended_at
+
+    seconds_limit = effective_constraint(constraint_key, group)
+    if seconds_limit is None:
+        return initial_ended_at
+    constraint_ended_at = datetime.now(UTC) + timedelta(seconds=seconds_limit)
+    if initial_ended_at is None:
+        return constraint_ended_at
+    return min(constraint_ended_at, initial_ended_at.replace(tzinfo=UTC))
+
+
+def _source_phrase(source: ConstraintSource) -> str:
+    """Name one source the way it should read inside an error message."""
+    if source.origin == ConstraintOrigin.MEMBER_ASSOCIATION:
+        return f"tags on {source.source_name}, which this role is a member of"
+    if source.origin == ConstraintOrigin.OWNER_ASSOCIATION:
+        return f"tags on {source.source_name}, which this role owns"
+    return "tags on this group"
+
+
+def _join_phrases(phrases: list[str]) -> str:
+    """Join phrases as prose: "a", "a and b", "a, b and c"."""
+    if len(phrases) == 1:
+        return phrases[0]
+    return f"{', '.join(phrases[:-1])} and {phrases[-1]}"
+
+
+def constraint_source_clause(constraint_key: str, group: OktaGroup) -> str:
+    """Build a trailing clause naming why `constraint_key` blocks an action.
+
+    Names every source imposing the constraint, not just one. These are the
+    boolean constraints, whose coalesce is logical OR, so each truthy source
+    blocks independently -- resolving one would not unblock the action, and a
+    message naming a single source would send someone to fix the wrong thing.
+
+    Args:
+        constraint_key: A key from `Tag.CONSTRAINTS`.
+        group: The group whose action is being blocked.
+
+    Returns:
+        A clause beginning "due to ...", suitable for appending to an error
+        message. Names the group itself when no source contributes a truthy
+        value -- callers only reach this after the constraint has resolved
+        true, so that fallback means the value came from somewhere this
+        function cannot attribute.
+
+    Raises:
+        InvalidRequestError: If a relationship this reads was not eager-loaded.
+    """
+    phrases: list[str] = []
+    for source in constraint_sources(constraint_key, group):
+        if not source.value:
+            continue
+        phrase = _source_phrase(source)
+        # Two tags on one source group produce the same phrase; say it once.
+        if phrase not in phrases:
+            phrases.append(phrase)
+    if not phrases:
+        return "due to tags on this group"
+    return f"due to {_join_phrases(phrases)}"

--- a/api/operations/_time_limits.py
+++ b/api/operations/_time_limits.py
@@ -23,12 +23,13 @@ shortens one of those inputs has to re-establish it.
 """
 
 from datetime import datetime
-from typing import Collection
+from typing import Collection, Optional
 
 from sqlalchemy import func, or_, select, update
 
 from api.extensions import db
-from api.models import OktaUserGroupMember, RoleGroupMap
+from api.models import OktaGroupTagMap, OktaUserGroupMember, RoleGroup, RoleGroupMap, Tag
+from api.models.tag import coalesce_constraints
 
 
 async def limit_memberships_to_groups(group_ids: Collection[str], *, is_owner: bool, end_at: datetime) -> None:
@@ -149,3 +150,81 @@ async def limit_access_conferred_by_roles(role_ids: Collection[str], *, end_at: 
     await limit_memberships_to_groups(role_ids, is_owner=False, end_at=end_at)
     await limit_memberships_by_roles(role_ids, is_owner=False, end_at=end_at)
     await limit_memberships_by_roles(role_ids, is_owner=True, end_at=end_at)
+
+
+async def limit_roles_associated_with_groups(group_ids: Collection[str], *, is_owner: bool, end_at: datetime) -> None:
+    """Cap the roles reached by a constraint on `group_ids`.
+
+    `is_owner` selects the association axis, not the side the limit lands on:
+    a role that is a member of these groups is reached by their member-side
+    limit and a role that owns them by their owner-side limit, but either way
+    the limit applies to the role's members. Unmanaged and deleted roles are
+    skipped, matching `effective_ended_at` and the `cap-role-memberships`
+    sweep.
+
+    Args:
+        group_ids: The groups the constraint sits on.
+        is_owner: The association axis to follow.
+        end_at: The end date to cap at.
+    """
+    if len(group_ids) == 0:
+        return
+
+    associated_role_ids = (
+        await db.session.scalars(
+            select(RoleGroupMap.role_group_id)
+            .join(RoleGroup, RoleGroup.id == RoleGroupMap.role_group_id)
+            .where(RoleGroupMap.group_id.in_(group_ids))
+            .where(RoleGroupMap.is_owner.is_(is_owner))
+            .where(RoleGroup.deleted_at.is_(None))
+            .where(RoleGroup.is_managed.is_(True))
+            .where(
+                or_(
+                    RoleGroupMap.ended_at.is_(None),
+                    RoleGroupMap.ended_at > func.now(),
+                )
+            )
+        )
+    ).all()
+
+    await limit_access_conferred_by_roles(associated_role_ids, end_at=end_at)
+
+
+async def propagating_seconds_limit(group_ids: Collection[str], constraint_key: str) -> Optional[int]:
+    """The limit `group_ids`' tags impose on a role associated with them.
+
+    Reads the groups' active tags directly rather than through
+    `effective_constraint`, because the caller has ids rather than a loaded
+    object graph. Only enabled tags that propagate contribute.
+
+    Args:
+        group_ids: The groups the role is being associated with.
+        constraint_key: `MEMBER_TIME_LIMIT_CONSTRAINT_KEY` for a member-side
+            association, `OWNER_TIME_LIMIT_CONSTRAINT_KEY` for an owner-side one.
+
+    Returns:
+        The coalesced limit in seconds, or None if no propagating tag sets it.
+    """
+    if len(group_ids) == 0:
+        return None
+
+    tags = (
+        await db.session.scalars(
+            select(Tag)
+            .join(OktaGroupTagMap, OktaGroupTagMap.tag_id == Tag.id)
+            .where(OktaGroupTagMap.group_id.in_(group_ids))
+            .where(
+                or_(
+                    OktaGroupTagMap.ended_at.is_(None),
+                    OktaGroupTagMap.ended_at > func.now(),
+                )
+            )
+            .where(Tag.deleted_at.is_(None))
+            .where(Tag.propagate_to_roles.is_(True))
+        )
+    ).all()
+
+    # `coalesce_constraints` applies the `enabled` filter and the constraint's
+    # own coalesce rule, so the minimum here comes from the same code that
+    # resolves it everywhere else.
+    return coalesce_constraints(constraint_key, list(tags))

--- a/api/operations/_time_limits.py
+++ b/api/operations/_time_limits.py
@@ -198,7 +198,11 @@ async def propagating_seconds_limit(group_ids: Collection[str], constraint_key: 
     object graph. Only enabled tags that propagate contribute.
 
     Args:
-        group_ids: The groups the role is being associated with.
+        group_ids: The groups the role is being associated with. Must be
+            managed and not deleted, as everything else in this module
+            requires; `_propagated_sources` skips an unmanaged source group,
+            so passing one here would report a limit the read side does not
+            show.
         constraint_key: `MEMBER_TIME_LIMIT_CONSTRAINT_KEY` for a member-side
             association, `OWNER_TIME_LIMIT_CONSTRAINT_KEY` for an owner-side one.
 

--- a/api/operations/approve_group_request.py
+++ b/api/operations/approve_group_request.py
@@ -23,7 +23,7 @@ from api.models import (
 )
 from api.models.access_request import get_all_possible_request_approvers
 from api.models.app_group import get_access_owners
-from api.models.tag import coalesce_ended_at
+from api.models.tag import effective_ended_at
 from api.operations._fan_out import defer_notification
 from api.operations.constraints.check_for_self_add import CheckForSelfAdd
 from api.operations.create_group import CreateGroup
@@ -136,7 +136,7 @@ class ApproveGroupRequest:
             else group_request.requested_ownership_ending_at
         )
         # Refuse to approve into an ownership window that has already closed.
-        # Nothing downstream clamps it: coalesce_ended_at only ever moves the date
+        # Nothing downstream clamps it: effective_ended_at only ever moves the date
         # earlier, so a past value reaches ModifyGroupUsers and writes an ownership
         # row that is expired on arrival. get_group_managers filters on ended_at, so
         # the new group would have no owners at all, and its future approvals would
@@ -313,14 +313,8 @@ class ApproveGroupRequest:
         ).first()
         assert created_group_with_tags is not None
 
-        tags = [tag_map.active_tag for tag_map in created_group_with_tags.active_group_tags]
-
-        # Determine the initial ending time: prefer resolved, fall back to requested
-        coalesced_ownership_ending_at = coalesce_ended_at(
-            constraint_key=Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY,
-            tags=tags,
-            initial_ended_at=resolved_ownership_ending_at,
-            group_is_managed=True,
+        coalesced_ownership_ending_at = effective_ended_at(
+            Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY, created_group_with_tags, resolved_ownership_ending_at
         )
 
         # Update the group request with the coalesced value to ensure consistency

--- a/api/operations/constraints/check_for_reason.py
+++ b/api/operations/constraints/check_for_reason.py
@@ -7,8 +7,9 @@ from sqlalchemy.orm import (
 )
 
 from api.extensions import db
-from api.models import AppGroup, OktaGroup, OktaGroupTagMap, RoleGroup, RoleGroupMap, Tag
+from api.models import AppGroup, OktaGroup, OktaGroupTagMap, RoleGroup, Tag
 from api.models.tag import coalesce_constraints, constraint_source_clause, effective_constraint
+from api.routers._eager import effective_constraint_options
 
 
 class CheckForReason:
@@ -38,16 +39,12 @@ class CheckForReason:
             await db.session.scalars(
                 select(OktaGroup)
                 .options(
+                    # The subtype loader stays here rather than in the helper: it is
+                    # what makes the `RoleGroup` paths resolvable on a polymorphic
+                    # `OktaGroup` query, and a query selecting `RoleGroup` directly
+                    # needs no such pairing.
                     selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
-                    selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
-                    selectinload(RoleGroup.active_role_associated_group_member_mappings)
-                    .joinedload(RoleGroupMap.active_group)
-                    .selectinload(OktaGroup.active_group_tags)
-                    .joinedload(OktaGroupTagMap.active_tag),
-                    selectinload(RoleGroup.active_role_associated_group_owner_mappings)
-                    .joinedload(RoleGroupMap.active_group)
-                    .selectinload(OktaGroup.active_group_tags)
-                    .joinedload(OktaGroupTagMap.active_tag),
+                    *effective_constraint_options(),
                 )
                 .where(OktaGroup.deleted_at.is_(None))
                 .where(OktaGroup.id == self.group_id)
@@ -73,16 +70,12 @@ class CheckForReason:
             await db.session.scalars(
                 select(OktaGroup)
                 .options(
+                    # The subtype loader stays here rather than in the helper: it is
+                    # what makes the `RoleGroup` paths resolvable on a polymorphic
+                    # `OktaGroup` query, and a query selecting `RoleGroup` directly
+                    # needs no such pairing.
                     selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
-                    selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
-                    selectinload(RoleGroup.active_role_associated_group_member_mappings)
-                    .joinedload(RoleGroupMap.active_group)
-                    .selectinload(OktaGroup.active_group_tags)
-                    .joinedload(OktaGroupTagMap.active_tag),
-                    selectinload(RoleGroup.active_role_associated_group_owner_mappings)
-                    .joinedload(RoleGroupMap.active_group)
-                    .selectinload(OktaGroup.active_group_tags)
-                    .joinedload(OktaGroupTagMap.active_tag),
+                    *effective_constraint_options(),
                 )
                 .where(OktaGroup.deleted_at.is_(None))
                 .where(OktaGroup.id == self.group_id)

--- a/api/operations/constraints/check_for_reason.py
+++ b/api/operations/constraints/check_for_reason.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import (
 
 from api.extensions import db
 from api.models import AppGroup, OktaGroup, OktaGroupTagMap, RoleGroup, RoleGroupMap, Tag
-from api.models.tag import coalesce_constraints
+from api.models.tag import coalesce_constraints, constraint_source_clause, effective_constraint
 
 
 class CheckForReason:
@@ -56,47 +56,16 @@ class CheckForReason:
         assert group is not None
 
         if self.invalid_reason(self.reason):
-            tags = [tag_map.active_tag for tag_map in group.active_group_tags]
             if len(self.owners_to_add) > 0:
-                require_owner_reason = coalesce_constraints(
-                    constraint_key=Tag.REQUIRE_OWNER_REASON_CONSTRAINT_KEY, tags=tags
-                )
-                if group.is_managed and require_owner_reason is True:
-                    return False, f"Reason for adding owners to {group.name} group is required due to group tags"
+                key = Tag.REQUIRE_OWNER_REASON_CONSTRAINT_KEY
+                if group.is_managed and effective_constraint(key, group) is True:
+                    clause = constraint_source_clause(key, group)
+                    return False, f"Reason for adding owners to {group.name} group is required {clause}"
             if len(self.members_to_add) > 0:
-                require_member_reason = coalesce_constraints(
-                    constraint_key=Tag.REQUIRE_MEMBER_REASON_CONSTRAINT_KEY, tags=tags
-                )
-                if group.is_managed and require_member_reason is True:
-                    return False, f"Reason for adding members to {group.name} group is required due to group tags"
-
-                # If the group is a role group check to see if a reason is required for adding members or owners
-                # to the associated groups
-                if type(group) is RoleGroup and group.is_managed:
-                    member_groups = [rm.active_group for rm in group.active_role_associated_group_member_mappings]
-                    for member_group in member_groups:
-                        require_member_reason = coalesce_constraints(
-                            constraint_key=Tag.REQUIRE_MEMBER_REASON_CONSTRAINT_KEY,
-                            tags=[tag_map.active_tag for tag_map in member_group.active_group_tags],
-                        )
-                        if member_group.is_managed and require_member_reason is True:
-                            return (
-                                False,
-                                f"Reason for adding members to {member_group.name} group associated "
-                                + f"with role {group.name} is required due to group tags",
-                            )
-                    owner_groups = [rm.active_group for rm in group.active_role_associated_group_owner_mappings]
-                    for owner_group in owner_groups:
-                        require_owner_reason = coalesce_constraints(
-                            constraint_key=Tag.REQUIRE_OWNER_REASON_CONSTRAINT_KEY,
-                            tags=[tag_map.active_tag for tag_map in owner_group.active_group_tags],
-                        )
-                        if owner_group.is_managed and require_owner_reason is True:
-                            return (
-                                False,
-                                f"Reason for adding owners to {owner_group.name} group associated "
-                                + f"with role {group.name} is required due to group tags",
-                            )
+                key = Tag.REQUIRE_MEMBER_REASON_CONSTRAINT_KEY
+                if group.is_managed and effective_constraint(key, group) is True:
+                    clause = constraint_source_clause(key, group)
+                    return False, f"Reason for adding members to {group.name} group is required {clause}"
         return True, ""
 
     async def execute_for_role(self) -> Tuple[bool, str]:

--- a/api/operations/constraints/check_for_reason.py
+++ b/api/operations/constraints/check_for_reason.py
@@ -39,10 +39,6 @@ class CheckForReason:
             await db.session.scalars(
                 select(OktaGroup)
                 .options(
-                    # The subtype loader stays here rather than in the helper: it is
-                    # what makes the `RoleGroup` paths resolvable on a polymorphic
-                    # `OktaGroup` query, and a query selecting `RoleGroup` directly
-                    # needs no such pairing.
                     selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
                     *effective_constraint_options(),
                 )
@@ -70,10 +66,6 @@ class CheckForReason:
             await db.session.scalars(
                 select(OktaGroup)
                 .options(
-                    # The subtype loader stays here rather than in the helper: it is
-                    # what makes the `RoleGroup` paths resolvable on a polymorphic
-                    # `OktaGroup` query, and a query selecting `RoleGroup` directly
-                    # needs no such pairing.
                     selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
                     *effective_constraint_options(),
                 )

--- a/api/operations/constraints/check_for_self_add.py
+++ b/api/operations/constraints/check_for_self_add.py
@@ -9,7 +9,7 @@ from sqlalchemy import func, or_, select
 from api.auth.permissions import is_access_admin as _is_access_admin
 from api.extensions import db
 from api.models import AppGroup, OktaGroup, OktaGroupTagMap, OktaUser, OktaUserGroupMember, RoleGroup, RoleGroupMap, Tag
-from api.models.tag import coalesce_constraints
+from api.models.tag import coalesce_constraints, constraint_source_clause, effective_constraint
 
 
 class CheckForSelfAdd:
@@ -66,57 +66,26 @@ class CheckForSelfAdd:
             return True, ""
 
         if len(self.owners_to_add) > 0 and current_user.id in self.owners_to_add:
-            disallow_self_add_ownership = coalesce_constraints(
-                constraint_key=Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY,
-                tags=[tag_map.active_tag for tag_map in group.active_group_tags],
-            )
-            if group.is_managed and disallow_self_add_ownership is True:
+            key = Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY
+            if group.is_managed and effective_constraint(key, group) is True:
+                clause = constraint_source_clause(key, group)
                 return (
                     False,
                     "Current user is a group owner who is restricted "
-                    + f"from re-adding themself as owner to {group.name} due to group tags",
+                    + f"from re-adding themself as owner to {group.name} {clause}",
                 )
         if len(self.members_to_add) > 0 and current_user.id in self.members_to_add:
-            disallow_self_add_membership = coalesce_constraints(
-                constraint_key=Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY,
-                tags=[tag_map.active_tag for tag_map in group.active_group_tags],
-            )
-            if group.is_managed and disallow_self_add_membership is True:
+            # For a role, `effective_constraint` also covers the groups the
+            # role is a member of (same key) and the groups it owns (owner-side
+            # key). The clause names which group imposed the restriction.
+            key = Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY
+            if group.is_managed and effective_constraint(key, group) is True:
+                clause = constraint_source_clause(key, group)
                 return (
                     False,
                     "Current user is a group owner who is restricted "
-                    + f"from adding themself as member to {group.name} due to group tags",
+                    + f"from adding themself as member to {group.name} {clause}",
                 )
-
-            # If the group is a role group check to see if a reason is required for adding members or owners
-            # to the associated groups
-            if type(group) is RoleGroup and group.is_managed:
-                member_groups = [rm.active_group for rm in group.active_role_associated_group_member_mappings]
-                for member_group in member_groups:
-                    disallow_self_add_membership = coalesce_constraints(
-                        constraint_key=Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY,
-                        tags=[tag_map.active_tag for tag_map in member_group.active_group_tags],
-                    )
-                    if member_group.is_managed and disallow_self_add_membership is True:
-                        return (
-                            False,
-                            "Current user is a role owner who is restricted from adding themself as "
-                            + f"member to {group.name} because the associated group {member_group.name} "
-                            + "has group tags which restricts self-adding membership",
-                        )
-                owner_groups = [rm.active_group for rm in group.active_role_associated_group_owner_mappings]
-                for owner_group in owner_groups:
-                    disallow_self_add_ownership = coalesce_constraints(
-                        constraint_key=Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY,
-                        tags=[tag_map.active_tag for tag_map in owner_group.active_group_tags],
-                    )
-                    if owner_group.is_managed and disallow_self_add_ownership is True:
-                        return (
-                            False,
-                            "Current user is a role owner who is restricted from adding themself as "
-                            + f"member to {group.name} because the associated group {owner_group.name} "
-                            + "has group tags which restricts self-adding ownership",
-                        )
         return True, ""
 
     async def execute_for_role(self) -> Tuple[bool, str]:

--- a/api/operations/constraints/check_for_self_add.py
+++ b/api/operations/constraints/check_for_self_add.py
@@ -8,8 +8,9 @@ from sqlalchemy.orm import (
 from sqlalchemy import func, or_, select
 from api.auth.permissions import is_access_admin as _is_access_admin
 from api.extensions import db
-from api.models import AppGroup, OktaGroup, OktaGroupTagMap, OktaUser, OktaUserGroupMember, RoleGroup, RoleGroupMap, Tag
+from api.models import AppGroup, OktaGroup, OktaGroupTagMap, OktaUser, OktaUserGroupMember, RoleGroup, Tag
 from api.models.tag import coalesce_constraints, constraint_source_clause, effective_constraint
+from api.routers._eager import effective_constraint_options
 
 
 class CheckForSelfAdd:
@@ -36,16 +37,12 @@ class CheckForSelfAdd:
             await db.session.scalars(
                 select(OktaGroup)
                 .options(
+                    # The subtype loader stays here rather than in the helper: it is
+                    # what makes the `RoleGroup` paths resolvable on a polymorphic
+                    # `OktaGroup` query, and a query selecting `RoleGroup` directly
+                    # needs no such pairing.
                     selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
-                    selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
-                    selectinload(RoleGroup.active_role_associated_group_member_mappings)
-                    .joinedload(RoleGroupMap.active_group)
-                    .selectinload(OktaGroup.active_group_tags)
-                    .joinedload(OktaGroupTagMap.active_tag),
-                    selectinload(RoleGroup.active_role_associated_group_owner_mappings)
-                    .joinedload(RoleGroupMap.active_group)
-                    .selectinload(OktaGroup.active_group_tags)
-                    .joinedload(OktaGroupTagMap.active_tag),
+                    *effective_constraint_options(),
                 )
                 .where(OktaGroup.deleted_at.is_(None))
                 .where(OktaGroup.id == self.group_id)
@@ -93,16 +90,12 @@ class CheckForSelfAdd:
             await db.session.scalars(
                 select(OktaGroup)
                 .options(
+                    # The subtype loader stays here rather than in the helper: it is
+                    # what makes the `RoleGroup` paths resolvable on a polymorphic
+                    # `OktaGroup` query, and a query selecting `RoleGroup` directly
+                    # needs no such pairing.
                     selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
-                    selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
-                    selectinload(RoleGroup.active_role_associated_group_member_mappings)
-                    .joinedload(RoleGroupMap.active_group)
-                    .selectinload(OktaGroup.active_group_tags)
-                    .joinedload(OktaGroupTagMap.active_tag),
-                    selectinload(RoleGroup.active_role_associated_group_owner_mappings)
-                    .joinedload(RoleGroupMap.active_group)
-                    .selectinload(OktaGroup.active_group_tags)
-                    .joinedload(OktaGroupTagMap.active_tag),
+                    *effective_constraint_options(),
                 )
                 .where(OktaGroup.deleted_at.is_(None))
                 .where(OktaGroup.id == self.group_id)

--- a/api/operations/constraints/check_for_self_add.py
+++ b/api/operations/constraints/check_for_self_add.py
@@ -37,10 +37,6 @@ class CheckForSelfAdd:
             await db.session.scalars(
                 select(OktaGroup)
                 .options(
-                    # The subtype loader stays here rather than in the helper: it is
-                    # what makes the `RoleGroup` paths resolvable on a polymorphic
-                    # `OktaGroup` query, and a query selecting `RoleGroup` directly
-                    # needs no such pairing.
                     selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
                     *effective_constraint_options(),
                 )
@@ -90,10 +86,6 @@ class CheckForSelfAdd:
             await db.session.scalars(
                 select(OktaGroup)
                 .options(
-                    # The subtype loader stays here rather than in the helper: it is
-                    # what makes the `RoleGroup` paths resolvable on a polymorphic
-                    # `OktaGroup` query, and a query selecting `RoleGroup` directly
-                    # needs no such pairing.
                     selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
                     *effective_constraint_options(),
                 )

--- a/api/operations/create_role_request.py
+++ b/api/operations/create_role_request.py
@@ -23,7 +23,7 @@ from api.models import (
 )
 from api.models.app_group import get_access_owners, get_app_managers
 from api.models.okta_group import get_group_managers
-from api.models.tag import coalesce_constraints
+from api.models.tag import effective_constraint
 from api.operations.approve_role_request import ApproveRoleRequest
 from api.operations.reject_role_request import RejectRoleRequest
 from api.operations._fan_out import defer_notification
@@ -102,8 +102,6 @@ class CreateRoleRequest:
         # Fetch the users to notify
         approvers = await get_group_managers(requested_group.id)
 
-        requested_group_tags = [tm.active_tag for tm in requested_group.active_group_tags]
-
         role_memberships = [
             u.user_id
             for u in (
@@ -123,16 +121,14 @@ class CreateRoleRequest:
 
         # If group tagged with disallow self add constraint, filter out approvers who are also members of the role
         if self.request_ownership:
-            disallow_self_add_owner = coalesce_constraints(
-                constraint_key=Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY,
-                tags=requested_group_tags,
+            disallow_self_add_owner = effective_constraint(
+                Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY, requested_group
             )
             if disallow_self_add_owner:
                 approvers = [a for a in approvers if a.id not in role_memberships]
         else:
-            disallow_self_add_member = coalesce_constraints(
-                constraint_key=Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY,
-                tags=requested_group_tags,
+            disallow_self_add_member = effective_constraint(
+                Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY, requested_group
             )
             if disallow_self_add_member:
                 approvers = [a for a in approvers if a.id not in role_memberships]

--- a/api/operations/modify_group_users.py
+++ b/api/operations/modify_group_users.py
@@ -24,7 +24,7 @@ from api.models import (
     Tag,
 )
 from api.models.access_request import get_all_possible_request_approvers
-from api.models.tag import coalesce_ended_at
+from api.models.tag import effective_ended_at
 from api.operations.constraints import CheckForReason, CheckForSelfAdd
 from api.plugins import NotificationHook
 from api.operations._lifecycle_fan_out import defer_or_invoke_lifecycle_hook
@@ -74,6 +74,19 @@ class ModifyGroupUsers:
                     selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
                     joinedload(AppGroup.app),
                     selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
+                    # `effective_ended_at` below reads both association
+                    # directions and each associated group's tags to find the
+                    # time limits reaching a role. They are `raise_on_sql`, so
+                    # they must be loaded here even when this group is not a
+                    # role and the collections come back empty.
+                    selectinload(RoleGroup.active_role_associated_group_member_mappings)
+                    .joinedload(RoleGroupMap.active_group)
+                    .selectinload(OktaGroup.active_group_tags)
+                    .joinedload(OktaGroupTagMap.active_tag),
+                    selectinload(RoleGroup.active_role_associated_group_owner_mappings)
+                    .joinedload(RoleGroupMap.active_group)
+                    .selectinload(OktaGroup.active_group_tags)
+                    .joinedload(OktaGroupTagMap.active_tag),
                 )
                 .where(OktaGroup.deleted_at.is_(None))
                 .where(OktaGroup.id == self.group_id)
@@ -81,19 +94,13 @@ class ModifyGroupUsers:
         ).first()
         assert group is not None
 
-        # Determine the minimum time allowed for group membership and ownership by current group tags
-        tags = [tag_map.active_tag for tag_map in group.active_group_tags]
-        members_added_ended_at = coalesce_ended_at(
-            constraint_key=Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY,
-            tags=tags,
-            initial_ended_at=self.users_added_ended_at,
-            group_is_managed=group.is_managed,
+        # Determine the minimum time allowed for group membership and ownership,
+        # including any constraints propagated from associated groups if this is a role
+        members_added_ended_at = effective_ended_at(
+            Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, group, self.users_added_ended_at
         )
-        owners_added_ended_at = coalesce_ended_at(
-            constraint_key=Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY,
-            tags=tags,
-            initial_ended_at=self.users_added_ended_at,
-            group_is_managed=group.is_managed,
+        owners_added_ended_at = effective_ended_at(
+            Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY, group, self.users_added_ended_at
         )
 
         members_to_add: list[OktaUser] = []

--- a/api/operations/modify_group_users.py
+++ b/api/operations/modify_group_users.py
@@ -16,7 +16,6 @@ from api.models import (
     AccessRequestStatus,
     AppGroup,
     OktaGroup,
-    OktaGroupTagMap,
     OktaUser,
     OktaUserGroupMember,
     RoleGroup,
@@ -25,6 +24,7 @@ from api.models import (
 )
 from api.models.access_request import get_all_possible_request_approvers
 from api.models.tag import effective_ended_at
+from api.routers._eager import effective_constraint_options
 from api.operations.constraints import CheckForReason, CheckForSelfAdd
 from api.plugins import NotificationHook
 from api.operations._lifecycle_fan_out import defer_or_invoke_lifecycle_hook
@@ -71,22 +71,18 @@ class ModifyGroupUsers:
             await db.session.scalars(
                 select(OktaGroup)
                 .options(
+                    # The subtype loader stays here rather than in the helper: it is
+                    # what makes the `RoleGroup` paths resolvable on a polymorphic
+                    # `OktaGroup` query, and a query selecting `RoleGroup` directly
+                    # needs no such pairing.
                     selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
                     joinedload(AppGroup.app),
-                    selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
-                    # `effective_ended_at` below reads both association
-                    # directions and each associated group's tags to find the
-                    # time limits reaching a role. They are `raise_on_sql`, so
-                    # they must be loaded here even when this group is not a
-                    # role and the collections come back empty.
-                    selectinload(RoleGroup.active_role_associated_group_member_mappings)
-                    .joinedload(RoleGroupMap.active_group)
-                    .selectinload(OktaGroup.active_group_tags)
-                    .joinedload(OktaGroupTagMap.active_tag),
-                    selectinload(RoleGroup.active_role_associated_group_owner_mappings)
-                    .joinedload(RoleGroupMap.active_group)
-                    .selectinload(OktaGroup.active_group_tags)
-                    .joinedload(OktaGroupTagMap.active_tag),
+                    # `effective_ended_at` below reads both association directions
+                    # and each associated group's tags to find the time limits
+                    # reaching a role. They are `raise_on_sql`, so they must be
+                    # loaded here even when this group is not a role and the
+                    # collections come back empty.
+                    *effective_constraint_options(),
                 )
                 .where(OktaGroup.deleted_at.is_(None))
                 .where(OktaGroup.id == self.group_id)

--- a/api/operations/modify_groups_time_limit.py
+++ b/api/operations/modify_groups_time_limit.py
@@ -5,7 +5,11 @@ from sqlalchemy import select
 from api.extensions import db
 from api.models import OktaGroup, RoleGroup, Tag
 from api.models.tag import coalesce_constraints
-from api.operations._time_limits import limit_access_conferred_by_roles, limit_memberships_to_groups
+from api.operations._time_limits import (
+    limit_access_conferred_by_roles,
+    limit_memberships_to_groups,
+    limit_roles_associated_with_groups,
+)
 
 
 class ModifyGroupsTimeLimit:
@@ -15,13 +19,16 @@ class ModifyGroupsTimeLimit:
     access granted on them -- the tag being attached, edited, or inherited from
     an app. Existing grants are shortened to fit; nothing is ever extended.
 
-    A tag reaches access on two sides:
+    A tag reaches access three ways:
 
     - Its **member** limit caps membership of the tagged groups, and where a
       tagged group is a role, everything that membership confers in the groups
       the role is associated with.
     - Its **owner** limit caps ownership of the tagged groups. Owning a role
       confers none of the role's access, so nothing follows from it.
+    - By **propagation**, to roles associated with a tagged group: their
+      members are governed by the tagged group's limit, and so is everything
+      those memberships in turn confer.
     """
 
     def __init__(self, groups: list[str] | set[str], tags: list[str] | set[str]):
@@ -74,5 +81,25 @@ class ModifyGroupsTimeLimit:
         if ownership_seconds_limit is not None:
             end_at = datetime.now(UTC) + timedelta(seconds=ownership_seconds_limit)
             await limit_memberships_to_groups(group_ids, is_owner=True, end_at=end_at)
+
+        # Propagation to associated roles. Only tags that propagate contribute,
+        # and the axis decides which key is read: a role that is a MEMBER of
+        # these groups is governed by their member limit, a role that OWNS them
+        # by their owner limit. Either way the limit lands on the role's own
+        # members, so this is independent of whether the group's own limits
+        # above applied.
+        propagating_tags = [t for t in tags if t.propagate_to_roles]
+        for is_owner, constraint_key in (
+            (False, Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY),
+            (True, Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY),
+        ):
+            propagated_seconds_limit = coalesce_constraints(constraint_key, propagating_tags)
+            if propagated_seconds_limit is None:
+                continue
+            await limit_roles_associated_with_groups(
+                group_ids,
+                is_owner=is_owner,
+                end_at=datetime.now(UTC) + timedelta(seconds=propagated_seconds_limit),
+            )
 
         await db.session.commit()

--- a/api/operations/modify_role_groups.py
+++ b/api/operations/modify_role_groups.py
@@ -1,5 +1,5 @@
 import asyncio
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Dict, Optional
 
 import logging
@@ -25,8 +25,9 @@ from api.models import (
     Tag,
 )
 from api.models.access_request import get_all_possible_request_approvers
-from api.models.tag import coalesce_ended_at
+from api.models.tag import effective_ended_at
 from api.operations.constraints import CheckForReason, CheckForSelfAdd
+from api.operations._time_limits import limit_access_conferred_by_roles, propagating_seconds_limit
 from api.plugins import NotificationHook
 from api.operations._lifecycle_fan_out import defer_or_invoke_lifecycle_hook
 from api.plugins.app_group_lifecycle import (
@@ -391,11 +392,8 @@ class ModifyRoleGroups:
             for group in groups_to_add:
                 # Handle group time limit constraints when roles are added to groups
                 # with tagged time limits as members
-                membership_ended_at = coalesce_ended_at(
-                    constraint_key=Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY,
-                    tags=[tag_map.active_tag for tag_map in group.active_group_tags],
-                    initial_ended_at=self.groups_added_ended_at,
-                    group_is_managed=group.is_managed,
+                membership_ended_at = effective_ended_at(
+                    Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, group, self.groups_added_ended_at
                 )
                 membership_to_add = RoleGroupMap(
                     group_id=group.id,
@@ -413,11 +411,8 @@ class ModifyRoleGroups:
             for owner_group in owner_groups_to_add:
                 # Handle group time limit constraints when roles are added to groups
                 # with tagged time limits as owners
-                ownership_ended_at = coalesce_ended_at(
-                    constraint_key=Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY,
-                    tags=[tag_map.active_tag for tag_map in owner_group.active_group_tags],
-                    initial_ended_at=self.groups_added_ended_at,
-                    group_is_managed=owner_group.is_managed,
+                ownership_ended_at = effective_ended_at(
+                    Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY, owner_group, self.groups_added_ended_at
                 )
                 ownership_to_add = RoleGroupMap(
                     group_id=owner_group.id,
@@ -654,6 +649,34 @@ class ModifyRoleGroups:
 
         # Commit all changes
         await db.session.commit()
+
+        # Attaching a role to a group is one of the two moments its members
+        # start being governed by that group's time limits; the other is a
+        # time-limited tag landing on a group the role is already associated
+        # with. Both reach membership of the role and everything that
+        # membership confers.
+        #
+        # The role's own access is bounded either way -- the `RoleGroupMap` is
+        # capped at creation and derived rows take the minimum -- but without
+        # this, membership of the role is never forced through review, so
+        # renewing the role's access rebuilds each derived grant from a
+        # membership nobody re-examined.
+        if self.role.is_managed:
+            # A role that is a MEMBER of a group is governed by that group's
+            # member limit and one that OWNS it by the owner limit, but both
+            # land on the role's own member side, so the tighter governs.
+            propagated_limits = [
+                await propagating_seconds_limit([g.id for g in groups_to_add], Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY),
+                await propagating_seconds_limit(
+                    [g.id for g in owner_groups_to_add], Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY
+                ),
+            ]
+            seconds_limit = min((limit for limit in propagated_limits if limit is not None), default=None)
+            if seconds_limit is not None:
+                await limit_access_conferred_by_roles(
+                    [self.role.id], end_at=datetime.now(UTC) + timedelta(seconds=seconds_limit)
+                )
+                await db.session.commit()
 
         # Resolve everything the notification hooks need on the main coroutine
         # before spawning tasks: spawned tasks must only perform network I/O,

--- a/api/operations/modify_role_groups.py
+++ b/api/operations/modify_role_groups.py
@@ -665,6 +665,10 @@ class ModifyRoleGroups:
             # A role that is a MEMBER of a group is governed by that group's
             # member limit and one that OWNS it by the owner limit, but both
             # land on the role's own member side, so the tighter governs.
+            #
+            # Both lists are filtered to managed, non-deleted groups where they
+            # are loaded at the top of this method, which is the precondition
+            # `propagating_seconds_limit` states -- it does not re-derive it.
             propagated_limits = [
                 await propagating_seconds_limit([g.id for g in groups_to_add], Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY),
                 await propagating_seconds_limit(

--- a/api/operations/modify_role_groups.py
+++ b/api/operations/modify_role_groups.py
@@ -426,8 +426,10 @@ class ModifyRoleGroups:
                 role_ownerships_added[owner_group.id] = ownership_to_add
                 db.session.add(ownership_to_add)
 
-            # Commit changes so far so we can reference the ids of the new role group maps in the OktaUserGroupMembers
-            await db.session.commit()
+            # Flush, not commit: the new role group maps need ids for the
+            # OktaUserGroupMembers below, and staying in this transaction is
+            # what lets the cap at the end of this block be atomic with them.
+            await db.session.flush()
 
             # Group members of a role should be added as members to all newly added groups
             # and owner groups associated with that role
@@ -557,7 +559,35 @@ class ModifyRoleGroups:
                     role_associated_ownership_added[member.user_id] = ownership_to_add
                     db.session.add(ownership_to_add)
 
-            # Commit changes so far, so we can reference OktaUserGroupMember in approved AccessRequests
+            # A group's time limits govern the members of any role associated
+            # with it. Capping the association alone is not enough: membership
+            # of the role would stay unbounded, and renewing the role's access
+            # would rebuild each derived grant from a membership nobody
+            # re-examined.
+            if self.role.is_managed:
+                # A role that is a MEMBER of a group is governed by that
+                # group's member limit and one that OWNS it by the owner
+                # limit, but both land on the role's own member side, so the
+                # tighter governs. Both lists hold managed, non-deleted groups
+                # -- the precondition `propagating_seconds_limit` states.
+                propagated_limits = [
+                    await propagating_seconds_limit(
+                        [g.id for g in groups_to_add], Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY
+                    ),
+                    await propagating_seconds_limit(
+                        [g.id for g in owner_groups_to_add], Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY
+                    ),
+                ]
+                seconds_limit = min((limit for limit in propagated_limits if limit is not None), default=None)
+                if seconds_limit is not None:
+                    await limit_access_conferred_by_roles(
+                        [self.role.id], end_at=datetime.now(UTC) + timedelta(seconds=seconds_limit)
+                    )
+
+            # The associations, the access they confer and the cap on the
+            # role's members commit together: a cap that cannot be applied must
+            # not leave the associations that require it durable. The committed
+            # OktaUserGroupMember ids are referenced below.
             await db.session.commit()
 
             # Now that the additions are durable, tell the lifecycle plugin about them.
@@ -649,38 +679,6 @@ class ModifyRoleGroups:
 
         # Commit all changes
         await db.session.commit()
-
-        # Attaching a role to a group is one of the two moments its members
-        # start being governed by that group's time limits; the other is a
-        # time-limited tag landing on a group the role is already associated
-        # with. Both reach membership of the role and everything that
-        # membership confers.
-        #
-        # The role's own access is bounded either way -- the `RoleGroupMap` is
-        # capped at creation and derived rows take the minimum -- but without
-        # this, membership of the role is never forced through review, so
-        # renewing the role's access rebuilds each derived grant from a
-        # membership nobody re-examined.
-        if self.role.is_managed:
-            # A role that is a MEMBER of a group is governed by that group's
-            # member limit and one that OWNS it by the owner limit, but both
-            # land on the role's own member side, so the tighter governs.
-            #
-            # Both lists are filtered to managed, non-deleted groups where they
-            # are loaded at the top of this method, which is the precondition
-            # `propagating_seconds_limit` states -- it does not re-derive it.
-            propagated_limits = [
-                await propagating_seconds_limit([g.id for g in groups_to_add], Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY),
-                await propagating_seconds_limit(
-                    [g.id for g in owner_groups_to_add], Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY
-                ),
-            ]
-            seconds_limit = min((limit for limit in propagated_limits if limit is not None), default=None)
-            if seconds_limit is not None:
-                await limit_access_conferred_by_roles(
-                    [self.role.id], end_at=datetime.now(UTC) + timedelta(seconds=seconds_limit)
-                )
-                await db.session.commit()
 
         # Resolve everything the notification hooks need on the main coroutine
         # before spawning tasks: spawned tasks must only perform network I/O,

--- a/api/routers/_eager.py
+++ b/api/routers/_eager.py
@@ -121,3 +121,29 @@ def group_tag_map_options() -> tuple:
         joinedload(OktaGroupTagMap.active_tag),
         selectinload(OktaGroupTagMap.active_group).options(*polymorphic_group_options()),
     )
+
+
+def effective_constraint_options() -> tuple:
+    """Eager-load everything `effective_constraints(group)` reads.
+
+    Both association relationships plus each associated group's tags. Omitting
+    these raises `InvalidRequestError` at serialization time, not at query
+    time -- `lazy="raise_on_sql"`.
+
+    Uses `selectinload` (not `joinedload`) for `RoleGroupMap.active_group` to
+    match the strategy `role_group_map_options()` already declares for that
+    path in `groups.py`'s `DEFAULT_LOAD_OPTIONS` -- mixing strategies on the
+    same path raises `InvalidRequestError: Loader strategies ... conflict` at
+    query-compile time. Callers that load `active_role_associated_group_*_mappings`
+    with a different (or no) prior strategy for `.active_group` are unaffected.
+    """
+    return (
+        selectinload(RoleGroup.active_role_associated_group_member_mappings)
+        .selectinload(RoleGroupMap.active_group)
+        .selectinload(OktaGroup.active_group_tags)
+        .joinedload(OktaGroupTagMap.active_tag),
+        selectinload(RoleGroup.active_role_associated_group_owner_mappings)
+        .selectinload(RoleGroupMap.active_group)
+        .selectinload(OktaGroup.active_group_tags)
+        .joinedload(OktaGroupTagMap.active_tag),
+    )

--- a/api/routers/_eager.py
+++ b/api/routers/_eager.py
@@ -124,11 +124,19 @@ def group_tag_map_options() -> tuple:
 
 
 def effective_constraint_options() -> tuple:
-    """Eager-load everything `effective_constraints(group)` reads.
+    """Eager-load everything `effective_constraint(key, group)` reads.
 
-    Both association relationships plus each associated group's tags. Omitting
-    these raises `InvalidRequestError` at serialization time, not at query
-    time -- `lazy="raise_on_sql"`.
+    The group's own tags, plus -- for a `RoleGroup` -- both association
+    relationships and each associated group's tags, since a role's effective
+    constraints include the ones propagated from the groups it belongs to and
+    owns. `active_tag` is nested under every tag map because the constraint
+    lookup reads each tag's `constraints` payload. Omitting any of these raises
+    `InvalidRequestError` at read time, not at query time -- `lazy="raise_on_sql"`.
+
+    Callers loading a polymorphic `OktaGroup` must pair this with
+    `selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup])` (or
+    `polymorphic_group_options()`) so the `RoleGroup` paths resolve; a query
+    selecting `RoleGroup` directly needs no such pairing.
 
     Uses `selectinload` (not `joinedload`) for `RoleGroupMap.active_group` to
     match the strategy `role_group_map_options()` already declares for that
@@ -138,6 +146,7 @@ def effective_constraint_options() -> tuple:
     with a different (or no) prior strategy for `.active_group` are unaffected.
     """
     return (
+        selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
         selectinload(RoleGroup.active_role_associated_group_member_mappings)
         .selectinload(RoleGroupMap.active_group)
         .selectinload(OktaGroup.active_group_tags)

--- a/api/routers/role_requests.py
+++ b/api/routers/role_requests.py
@@ -7,7 +7,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from sqlalchemy import String, and_, cast, false, not_, or_, select
-from sqlalchemy.orm import aliased, joinedload, selectinload
+from sqlalchemy.orm import aliased, joinedload, selectin_polymorphic, selectinload
 from starlette.requests import Request
 
 from api.auth.dependencies import CurrentUserId
@@ -21,10 +21,11 @@ from api.models import (
     OktaUser,
     OktaUserGroupMember,
     RoleGroup,
+    RoleGroupMap,
     RoleRequest,
     Tag,
 )
-from api.models.tag import coalesce_constraints
+from api.models.tag import effective_constraint
 from api.operations import ApproveRoleRequest, CreateRoleRequest, RejectRoleRequest
 from fastapi_pagination.ext.sqlalchemy import apaginate
 
@@ -185,16 +186,30 @@ async def list_role_requests(
                                         joinedload(OktaGroupTagMap.active_tag)
                                     ),
                                     selectinload(OktaGroup.active_user_ownerships),
+                                    # `requested_group` can be a RoleGroup (e.g.
+                                    # `ModifyGroupType` converted a group that already
+                                    # had a pending role request). `effective_constraint`
+                                    # then consults propagation -- unconditionally, tags
+                                    # or not -- and reads these `raise_on_sql`
+                                    # relationships. Loaded for both the owner-side and
+                                    # member-side queries so the eager-load set doesn't
+                                    # depend on which constraint key happens to be passed.
+                                    selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
+                                    selectinload(RoleGroup.active_role_associated_group_member_mappings)
+                                    .joinedload(RoleGroupMap.active_group)
+                                    .selectinload(OktaGroup.active_group_tags)
+                                    .joinedload(OktaGroupTagMap.active_tag),
+                                    selectinload(RoleGroup.active_role_associated_group_owner_mappings)
+                                    .joinedload(RoleGroupMap.active_group)
+                                    .selectinload(OktaGroup.active_group_tags)
+                                    .joinedload(OktaGroupTagMap.active_tag),
                                 ),
                             )
                             .where(RoleRequest.status == AccessRequestStatus.PENDING)
                             .where(RoleRequest.request_ownership.is_(True))
                         )
                     ).all()
-                    if coalesce_constraints(
-                        constraint_key=Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY,
-                        tags=[tm.active_tag for tm in rr.requested_group.active_group_tags],
-                    )
+                    if effective_constraint(Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY, rr.requested_group)
                 ]
                 tagged_member_requests = [
                     rr
@@ -214,16 +229,30 @@ async def list_role_requests(
                                         joinedload(OktaGroupTagMap.active_tag)
                                     ),
                                     selectinload(OktaGroup.active_user_ownerships),
+                                    # `requested_group` can be a RoleGroup (e.g.
+                                    # `ModifyGroupType` converted a group that already
+                                    # had a pending role request). `effective_constraint`
+                                    # then consults propagation -- unconditionally, tags
+                                    # or not -- and reads these `raise_on_sql`
+                                    # relationships. Loaded for both the owner-side and
+                                    # member-side queries so the eager-load set doesn't
+                                    # depend on which constraint key happens to be passed.
+                                    selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
+                                    selectinload(RoleGroup.active_role_associated_group_member_mappings)
+                                    .joinedload(RoleGroupMap.active_group)
+                                    .selectinload(OktaGroup.active_group_tags)
+                                    .joinedload(OktaGroupTagMap.active_tag),
+                                    selectinload(RoleGroup.active_role_associated_group_owner_mappings)
+                                    .joinedload(RoleGroupMap.active_group)
+                                    .selectinload(OktaGroup.active_group_tags)
+                                    .joinedload(OktaGroupTagMap.active_tag),
                                 ),
                             )
                             .where(RoleRequest.status == AccessRequestStatus.PENDING)
                             .where(RoleRequest.request_ownership.is_(False))
                         )
                     ).all()
-                    if coalesce_constraints(
-                        constraint_key=Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY,
-                        tags=[tm.active_tag for tm in rr.requested_group.active_group_tags],
-                    )
+                    if effective_constraint(Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY, rr.requested_group)
                 ]
 
                 blocked_request_ids: list[str] = []
@@ -253,10 +282,26 @@ async def list_role_requests(
                             select(OktaGroup)
                             # `active_tag` is read per tag below; nest its loader so
                             # OktaGroupTagMap.active_tag isn't left on raise_on_sql.
+                            # `owned_groups` has no type filter, so `g` can be a
+                            # RoleGroup here (a role owner's own role); the
+                            # selectin_polymorphic plus the two
+                            # active_role_associated_group_*_mappings loaders below
+                            # let `effective_constraint` read the propagated
+                            # member/owner tags a RoleGroup picks up from the
+                            # groups it belongs to / owns.
                             .options(
+                                selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
                                 selectinload(OktaGroup.active_group_tags).options(
                                     joinedload(OktaGroupTagMap.active_tag)
-                                )
+                                ),
+                                selectinload(RoleGroup.active_role_associated_group_member_mappings)
+                                .joinedload(RoleGroupMap.active_group)
+                                .selectinload(OktaGroup.active_group_tags)
+                                .joinedload(OktaGroupTagMap.active_tag),
+                                selectinload(RoleGroup.active_role_associated_group_owner_mappings)
+                                .joinedload(RoleGroupMap.active_group)
+                                .selectinload(OktaGroup.active_group_tags)
+                                .joinedload(OktaGroupTagMap.active_tag),
                             )
                             .where(
                                 or_(
@@ -272,18 +317,12 @@ async def list_role_requests(
                 owned_groups_no_self_owner = [
                     g.id
                     for g in owned_groups
-                    if coalesce_constraints(
-                        constraint_key=Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY,
-                        tags=[tm.active_tag for tm in g.active_group_tags],
-                    )
+                    if effective_constraint(Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY, g)
                 ]
                 owned_groups_no_self_member = [
                     g.id
                     for g in owned_groups
-                    if coalesce_constraints(
-                        constraint_key=Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY,
-                        tags=[tm.active_tag for tm in g.active_group_tags],
-                    )
+                    if effective_constraint(Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY, g)
                 ]
                 role_membership_ids = [
                     rg.id

--- a/api/routers/role_requests.py
+++ b/api/routers/role_requests.py
@@ -17,11 +17,9 @@ from api.models import (
     App,
     AppGroup,
     OktaGroup,
-    OktaGroupTagMap,
     OktaUser,
     OktaUserGroupMember,
     RoleGroup,
-    RoleGroupMap,
     RoleRequest,
     Tag,
 )
@@ -31,6 +29,7 @@ from fastapi_pagination.ext.sqlalchemy import apaginate
 
 from api.pagination import Page, validated
 from api.routers._eager import (
+    effective_constraint_options,
     group_tag_map_options,
     polymorphic_group_options,
     user_group_member_options,
@@ -178,31 +177,15 @@ async def list_role_requests(
                                     selectinload(OktaGroup.active_user_memberships)
                                 ),
                                 joinedload(RoleRequest.requested_group).options(
-                                    # `active_tag` is read per tag below in the
-                                    # disallow-self-add constraint check, so nest its
-                                    # loader — selectinload of the collection alone
-                                    # leaves OktaGroupTagMap.active_tag on raise_on_sql.
-                                    selectinload(OktaGroup.active_group_tags).options(
-                                        joinedload(OktaGroupTagMap.active_tag)
-                                    ),
                                     selectinload(OktaGroup.active_user_ownerships),
                                     # `requested_group` can be a RoleGroup (e.g.
                                     # `ModifyGroupType` converted a group that already
-                                    # had a pending role request). `effective_constraint`
-                                    # then consults propagation -- unconditionally, tags
-                                    # or not -- and reads these `raise_on_sql`
-                                    # relationships. Loaded for both the owner-side and
-                                    # member-side queries so the eager-load set doesn't
-                                    # depend on which constraint key happens to be passed.
+                                    # had a pending role request), so the constraint
+                                    # lookup below may consult propagation. The
+                                    # polymorphic loader is what lets the RoleGroup
+                                    # paths in `effective_constraint_options` resolve.
                                     selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
-                                    selectinload(RoleGroup.active_role_associated_group_member_mappings)
-                                    .joinedload(RoleGroupMap.active_group)
-                                    .selectinload(OktaGroup.active_group_tags)
-                                    .joinedload(OktaGroupTagMap.active_tag),
-                                    selectinload(RoleGroup.active_role_associated_group_owner_mappings)
-                                    .joinedload(RoleGroupMap.active_group)
-                                    .selectinload(OktaGroup.active_group_tags)
-                                    .joinedload(OktaGroupTagMap.active_tag),
+                                    *effective_constraint_options(),
                                 ),
                             )
                             .where(RoleRequest.status == AccessRequestStatus.PENDING)
@@ -221,31 +204,15 @@ async def list_role_requests(
                                     selectinload(OktaGroup.active_user_memberships)
                                 ),
                                 joinedload(RoleRequest.requested_group).options(
-                                    # `active_tag` is read per tag below in the
-                                    # disallow-self-add constraint check, so nest its
-                                    # loader — selectinload of the collection alone
-                                    # leaves OktaGroupTagMap.active_tag on raise_on_sql.
-                                    selectinload(OktaGroup.active_group_tags).options(
-                                        joinedload(OktaGroupTagMap.active_tag)
-                                    ),
                                     selectinload(OktaGroup.active_user_ownerships),
                                     # `requested_group` can be a RoleGroup (e.g.
                                     # `ModifyGroupType` converted a group that already
-                                    # had a pending role request). `effective_constraint`
-                                    # then consults propagation -- unconditionally, tags
-                                    # or not -- and reads these `raise_on_sql`
-                                    # relationships. Loaded for both the owner-side and
-                                    # member-side queries so the eager-load set doesn't
-                                    # depend on which constraint key happens to be passed.
+                                    # had a pending role request), so the constraint
+                                    # lookup below may consult propagation. The
+                                    # polymorphic loader is what lets the RoleGroup
+                                    # paths in `effective_constraint_options` resolve.
                                     selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
-                                    selectinload(RoleGroup.active_role_associated_group_member_mappings)
-                                    .joinedload(RoleGroupMap.active_group)
-                                    .selectinload(OktaGroup.active_group_tags)
-                                    .joinedload(OktaGroupTagMap.active_tag),
-                                    selectinload(RoleGroup.active_role_associated_group_owner_mappings)
-                                    .joinedload(RoleGroupMap.active_group)
-                                    .selectinload(OktaGroup.active_group_tags)
-                                    .joinedload(OktaGroupTagMap.active_tag),
+                                    *effective_constraint_options(),
                                 ),
                             )
                             .where(RoleRequest.status == AccessRequestStatus.PENDING)
@@ -280,28 +247,13 @@ async def list_role_requests(
                     (
                         await db.scalars(
                             select(OktaGroup)
-                            # `active_tag` is read per tag below; nest its loader so
-                            # OktaGroupTagMap.active_tag isn't left on raise_on_sql.
                             # `owned_groups` has no type filter, so `g` can be a
                             # RoleGroup here (a role owner's own role); the
-                            # selectin_polymorphic plus the two
-                            # active_role_associated_group_*_mappings loaders below
-                            # let `effective_constraint` read the propagated
-                            # member/owner tags a RoleGroup picks up from the
-                            # groups it belongs to / owns.
+                            # polymorphic loader is what lets the RoleGroup paths
+                            # in `effective_constraint_options` resolve.
                             .options(
                                 selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
-                                selectinload(OktaGroup.active_group_tags).options(
-                                    joinedload(OktaGroupTagMap.active_tag)
-                                ),
-                                selectinload(RoleGroup.active_role_associated_group_member_mappings)
-                                .joinedload(RoleGroupMap.active_group)
-                                .selectinload(OktaGroup.active_group_tags)
-                                .joinedload(OktaGroupTagMap.active_tag),
-                                selectinload(RoleGroup.active_role_associated_group_owner_mappings)
-                                .joinedload(RoleGroupMap.active_group)
-                                .selectinload(OktaGroup.active_group_tags)
-                                .joinedload(OktaGroupTagMap.active_tag),
+                                *effective_constraint_options(),
                             )
                             .where(
                                 or_(

--- a/api/routers/role_requests.py
+++ b/api/routers/role_requests.py
@@ -178,12 +178,6 @@ async def list_role_requests(
                                 ),
                                 joinedload(RoleRequest.requested_group).options(
                                     selectinload(OktaGroup.active_user_ownerships),
-                                    # `requested_group` can be a RoleGroup (e.g.
-                                    # `ModifyGroupType` converted a group that already
-                                    # had a pending role request), so the constraint
-                                    # lookup below may consult propagation. The
-                                    # polymorphic loader is what lets the RoleGroup
-                                    # paths in `effective_constraint_options` resolve.
                                     selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
                                     *effective_constraint_options(),
                                 ),
@@ -205,12 +199,6 @@ async def list_role_requests(
                                 ),
                                 joinedload(RoleRequest.requested_group).options(
                                     selectinload(OktaGroup.active_user_ownerships),
-                                    # `requested_group` can be a RoleGroup (e.g.
-                                    # `ModifyGroupType` converted a group that already
-                                    # had a pending role request), so the constraint
-                                    # lookup below may consult propagation. The
-                                    # polymorphic loader is what lets the RoleGroup
-                                    # paths in `effective_constraint_options` resolve.
                                     selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
                                     *effective_constraint_options(),
                                 ),
@@ -247,10 +235,6 @@ async def list_role_requests(
                     (
                         await db.scalars(
                             select(OktaGroup)
-                            # `owned_groups` has no type filter, so `g` can be a
-                            # RoleGroup here (a role owner's own role); the
-                            # polymorphic loader is what lets the RoleGroup paths
-                            # in `effective_constraint_options` resolve.
                             .options(
                                 selectin_polymorphic(OktaGroup, [AppGroup, RoleGroup]),
                                 *effective_constraint_options(),

--- a/api/routers/tags.py
+++ b/api/routers/tags.py
@@ -99,6 +99,7 @@ async def post_tag(
         description=body.description if body.description is not None else "",
         constraints=body.constraints or {},
         enabled=body.enabled,
+        propagate_to_roles=True if body.propagate_to_roles is None else body.propagate_to_roles,
     )
     created = await CreateTag(tag=tag, current_user_id=current_user_id).execute()
     # Drop cached ORM state so the response reflects what the operation
@@ -136,6 +137,7 @@ async def put_tag(
         description=tag.description,
         constraints=tag.constraints,
         enabled=tag.enabled,
+        propagate_to_roles=tag.propagate_to_roles,
     )
 
     # Reject renames that collide with another existing tag (case-insensitive).
@@ -156,7 +158,7 @@ async def put_tag(
         payload["constraints"] = {}
     if "description" in payload and payload["description"] is None:
         payload["description"] = ""
-    for key in ("name", "description", "constraints", "enabled"):
+    for key in ("name", "description", "constraints", "enabled", "propagate_to_roles"):
         if key in payload:
             setattr(tag, key, payload[key])
     await db.commit()

--- a/api/schemas/core_schemas.py
+++ b/api/schemas/core_schemas.py
@@ -36,6 +36,7 @@ class TagDetail(BaseModel):
     description: Optional[str] = None
     constraints: dict[str, Any] = Field(default_factory=dict)
     enabled: bool = True
+    propagate_to_roles: bool = True
     created_at: FlexibleDatetime
     updated_at: FlexibleDatetime
     deleted_at: Optional[FlexibleDatetime] = None
@@ -54,12 +55,13 @@ class TagSummary(BaseModel):
     name: str
     constraints: dict[str, Any] = Field(default_factory=dict)
     enabled: bool = True
+    propagate_to_roles: bool = True
 
 
 class TagListItem(BaseModel):
     """Tag list-endpoint item. Slim field set (id, name, description,
-    enabled, constraints, created_at, updated_at) — does not hydrate
-    `active_group_tags`, which would be an N+1 across the page."""
+    enabled, propagate_to_roles, constraints, created_at, updated_at) — does
+    not hydrate `active_group_tags`, which would be an N+1 across the page."""
 
     model_config = ConfigDict(from_attributes=True)
     id: str
@@ -67,6 +69,7 @@ class TagListItem(BaseModel):
     description: Optional[str] = None
     constraints: dict[str, Any] = Field(default_factory=dict)
     enabled: bool = True
+    propagate_to_roles: bool = True
     created_at: FlexibleDatetime
     updated_at: FlexibleDatetime
 

--- a/api/schemas/requests_schemas.py
+++ b/api/schemas/requests_schemas.py
@@ -410,6 +410,7 @@ class CreateTagBody(BaseModel):
     description: Optional[str] = Field(default=None, max_length=_TAG_DESC_MAX_LENGTH)
     constraints: Optional[dict[str, Any]] = None
     enabled: bool = True
+    propagate_to_roles: Optional[bool] = None
 
     @model_validator(mode="after")
     def _check_description_required(self) -> Self:
@@ -439,16 +440,18 @@ class UpdateTagBody(BaseModel):
     """Body for PUT /api/tags/{id}. All fields optional (partial update)."""
 
     model_config = ConfigDict(extra="ignore")
-    # `name` and `enabled` are deliberately not `Optional`: their columns
-    # forbid null and neither has a meaningful empty value, so the annotation
-    # rejects an explicit `null` on its own. The defaults exist only to keep
-    # the fields omittable for a partial update and are never applied, hence
-    # `_hide_default`. `description` and `constraints` stay nullable because a
-    # null there *is* meaningful -- the handler coerces it to `""` / `{}`.
+    # `name`, `enabled` and `propagate_to_roles` are deliberately not
+    # `Optional`: their columns forbid null and none of them has a meaningful
+    # empty value, so the annotation rejects an explicit `null` on its own. The
+    # defaults exist only to keep the fields omittable for a partial update and
+    # are never applied, hence `_hide_default`. `description` and `constraints`
+    # stay nullable because a null there *is* meaningful -- the handler coerces
+    # it to `""` / `{}`.
     name: str = Field(default="", min_length=1, max_length=_TAG_NAME_MAX_LENGTH, json_schema_extra=_hide_default)
     description: Optional[str] = Field(default=None, max_length=_TAG_DESC_MAX_LENGTH)
     constraints: Optional[dict[str, Any]] = None
     enabled: bool = Field(default=True, json_schema_extra=_hide_default)
+    propagate_to_roles: bool = Field(default=True, json_schema_extra=_hide_default)
 
     @model_validator(mode="after")
     def _check_description_required(self) -> Self:

--- a/migrations/versions/09099786c745_tag_propagate_to_roles.py
+++ b/migrations/versions/09099786c745_tag_propagate_to_roles.py
@@ -1,0 +1,35 @@
+"""tag propagate_to_roles
+
+Revision ID: 09099786c745
+Revises: c8f9ba49f867
+Create Date: 2026-08-23 18:16:19.279682
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import expression
+
+
+# revision identifiers, used by Alembic.
+revision = "09099786c745"
+down_revision = "c8f9ba49f867"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("tag", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "propagate_to_roles",
+                sa.Boolean(),
+                server_default=expression.true(),
+                nullable=False,
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("tag", schema=None) as batch_op:
+        batch_op.drop_column("propagate_to_roles")

--- a/src/api/apiSchemas.ts
+++ b/src/api/apiSchemas.ts
@@ -421,6 +421,7 @@ export type CreateTagBody = {
    * @default true
    */
   enabled?: boolean;
+  propagate_to_roles?: boolean | null;
 };
 
 export type DeleteMessage = {
@@ -1435,6 +1436,10 @@ export type TagDetail = {
    * @default true
    */
   enabled?: boolean;
+  /**
+   * @default true
+   */
+  propagate_to_roles?: boolean;
   created_at: string | null;
   updated_at: string | null;
   deleted_at?: string | null;
@@ -1444,8 +1449,8 @@ export type TagDetail = {
 
 /**
  * Tag list-endpoint item. Slim field set (id, name, description,
- * enabled, constraints, created_at, updated_at) — does not hydrate
- * `active_group_tags`, which would be an N+1 across the page.
+ * enabled, propagate_to_roles, constraints, created_at, updated_at) — does
+ * not hydrate `active_group_tags`, which would be an N+1 across the page.
  */
 export type TagListItem = {
   id: string;
@@ -1458,6 +1463,10 @@ export type TagListItem = {
    * @default true
    */
   enabled?: boolean;
+  /**
+   * @default true
+   */
+  propagate_to_roles?: boolean;
   created_at: string | null;
   updated_at: string | null;
 };
@@ -1472,6 +1481,10 @@ export type TagSummary = {
    * @default true
    */
   enabled?: boolean;
+  /**
+   * @default true
+   */
+  propagate_to_roles?: boolean;
 };
 
 /**
@@ -1502,6 +1515,7 @@ export type UpdateTagBody = {
     [key: string]: any;
   } | null;
   enabled?: boolean;
+  propagate_to_roles?: boolean;
 };
 
 export type AccessRequestAppGroupRef = {

--- a/tests/test_cap_role_memberships_cli.py
+++ b/tests/test_cap_role_memberships_cli.py
@@ -1,0 +1,129 @@
+from pytest_mock import MockerFixture
+from sqlalchemy import select
+
+from api.extensions import Db
+from api.integrity import cap_role_memberships
+from api.models import OktaUser, OktaUserGroupMember, RoleGroupMap, Tag
+from api.services import okta
+from tests.factories import (
+    OktaGroupFactory,
+    OktaGroupTagMapFactory,
+    OktaUserFactory,
+    RoleGroupFactory,
+    TagFactory,
+)
+
+
+async def _uncapped_role_membership(db: Db, *, propagate: bool = True, grant_is_owner: bool = False) -> tuple[str, str]:
+    """A role that is a member of a tagged, member-time-limited group, holding
+    one uncapped user grant. `grant_is_owner` makes that grant an *ownership*
+    of the role rather than a membership."""
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400}, propagate_to_roles=propagate)
+    user = OktaUserFactory.build()
+    db.session.add_all([group, role, tag, user])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False))
+    db.session.add(OktaUserGroupMember(group_id=role.id, user_id=user.id, is_owner=grant_is_owner))
+    await db.session.commit()
+    return role.id, user.id
+
+
+async def _ended_at(db: Db, role_id: str, user_id: str):
+    db.session.expire_all()
+    return (
+        (
+            await db.session.scalars(
+                select(OktaUserGroupMember)
+                .where(OktaUserGroupMember.group_id == role_id)
+                .where(OktaUserGroupMember.user_id == user_id)
+            )
+        )
+        .one()
+        .ended_at
+    )
+
+
+async def test_sweep_caps_preexisting_grants(db: Db) -> None:
+    role_id, user_id = await _uncapped_role_membership(db)
+    capped = await cap_role_memberships(dry_run=False)
+    assert capped == 1
+    assert await _ended_at(db, role_id, user_id) is not None
+
+
+async def test_dry_run_writes_nothing(db: Db) -> None:
+    role_id, user_id = await _uncapped_role_membership(db)
+    capped = await cap_role_memberships(dry_run=True)
+    assert capped == 1
+    assert await _ended_at(db, role_id, user_id) is None
+
+
+async def test_sweep_is_idempotent(db: Db) -> None:
+    await _uncapped_role_membership(db)
+    assert await cap_role_memberships(dry_run=False) == 1
+    assert await cap_role_memberships(dry_run=False) == 0
+
+
+async def test_sweep_respects_the_gate(db: Db) -> None:
+    role_id, user_id = await _uncapped_role_membership(db, propagate=False)
+    assert await cap_role_memberships(dry_run=False) == 0
+    assert await _ended_at(db, role_id, user_id) is None
+
+
+async def test_sweep_leaves_role_owners_alone(db: Db) -> None:
+    """Owning a role confers none of the role's grants, so nothing propagates
+    onto a role's owner side -- `OWNER_SIDE_COUNTERPART` has no entry mapping
+    *to* a role's own owner constraints. The sweep must therefore cap only
+    `is_owner=False` grants; capping role owners would silently expire the
+    very people who administer the role.
+
+    Same fixture as `test_sweep_caps_preexisting_grants` except the grant is
+    an ownership, so the only difference in outcome is the `is_owner` filter."""
+    role_id, user_id = await _uncapped_role_membership(db, grant_is_owner=True)
+    assert await cap_role_memberships(dry_run=False) == 0
+    assert await _ended_at(db, role_id, user_id) is None
+
+
+async def test_sweep_also_caps_the_access_the_membership_confers(db: Db, mocker: MockerFixture, user: OktaUser) -> None:
+    """Capping a role membership without capping what it materialized would
+    shorten the membership while leaving the access it grants indefinite --
+    and that access is the row actually holding the Okta group."""
+    mocker.patch.object(okta, "add_user_to_group")
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400}, propagate_to_roles=True)
+    db.session.add_all([group, role, tag, user])
+    await db.session.commit()
+    mapping = RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False)
+    db.session.add(mapping)
+    await db.session.commit()
+    db.session.add(OktaUserGroupMember(group_id=role.id, user_id=user.id, is_owner=False))
+    db.session.add(
+        OktaUserGroupMember(group_id=group.id, user_id=user.id, is_owner=False, role_group_map_id=mapping.id)
+    )
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    await db.session.commit()
+    role_id, group_id, user_id = role.id, group.id, user.id
+
+    assert await cap_role_memberships(dry_run=False) == 1
+
+    db.session.expire_all()
+    membership = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role_id)
+            .where(OktaUserGroupMember.user_id == user_id)
+        )
+    ).one()
+    conferred = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == group_id)
+            .where(OktaUserGroupMember.user_id == user_id)
+        )
+    ).one()
+    assert membership.ended_at is not None
+    assert conferred.ended_at is not None
+    assert conferred.ended_at <= membership.ended_at

--- a/tests/test_constraint_propagation.py
+++ b/tests/test_constraint_propagation.py
@@ -1,0 +1,661 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pytest_mock import MockerFixture
+from sqlalchemy import select
+
+from api.extensions import Db
+from api.models import OktaGroup, OktaUser, OktaUserGroupMember, RoleGroup, RoleGroupMap, Tag
+from api.operations import ModifyGroupsTimeLimit, ModifyGroupUsers, ModifyRoleGroups
+from api.services import okta
+from tests.factories import (
+    OktaGroupFactory,
+    OktaGroupTagMapFactory,
+    OktaUserFactory,
+    RoleGroupFactory,
+    TagFactory,
+)
+
+
+ONE_DAY = 86400
+
+
+async def _role_associated_with_tagged_group(
+    db: Db, *, constraints: dict, is_owner: bool, propagate: bool = True
+) -> tuple[RoleGroup, OktaGroup]:
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(constraints=constraints, propagate_to_roles=propagate)
+    db.session.add_all([group, role, tag])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=is_owner))
+    await db.session.commit()
+    return role, group
+
+
+async def test_owner_association_blocks_self_add_to_role(db: Db, mocker: MockerFixture, user: OktaUser) -> None:
+    """A role that OWNS a group with disallow_self_add_ownership: the role's
+    owner cannot add themself as a member of the role. The group's owner-side
+    key governs the role's member side, because members of a role that owns a
+    group become owners of it."""
+    mocker.patch.object(okta, "add_user_to_group")
+    role, _ = await _role_associated_with_tagged_group(
+        db, constraints={Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY: True}, is_owner=True
+    )
+    db.session.add(user)
+    await db.session.commit()
+
+    await ModifyGroupUsers(group=role, members_to_add=[user.id], current_user_id=user.id, sync_to_okta=False).execute()
+
+    refreshed = await db.session.get(RoleGroup, role.id)
+    assert refreshed is not None
+    # The self-add was rejected, so no membership was created.
+    memberships = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+        )
+    ).all()
+    assert len(memberships) == 0
+
+
+async def test_owner_association_requires_reason_to_add_role_member(
+    db: Db, mocker: MockerFixture, user: OktaUser
+) -> None:
+    """A role that OWNS a group tagged require_owner_reason: True, with no
+    member association to any tagged group. Adding a member to the role
+    without a reason must be rejected; with a reason it must succeed. This
+    isolates the owner-association branch of CheckForReason.execute_for_group
+    -- the only other test touching this path (test_require_reason_modify_group_users)
+    is confounded because its role is simultaneously a member of a
+    require_member_reason group and an owner of a require_owner_reason group,
+    so either source alone would make it pass even if this branch regressed."""
+    mocker.patch.object(okta, "add_user_to_group")
+    role, _ = await _role_associated_with_tagged_group(
+        db, constraints={Tag.REQUIRE_OWNER_REASON_CONSTRAINT_KEY: True}, is_owner=True
+    )
+    db.session.add(user)
+    await db.session.commit()
+
+    # Without a reason, the add is rejected.
+    await ModifyGroupUsers(group=role, members_to_add=[user.id], current_user_id=user.id, sync_to_okta=False).execute()
+
+    memberships = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+        )
+    ).all()
+    assert len(memberships) == 0
+
+    # With a reason, the same add succeeds -- proving the rejection above came
+    # from the reason constraint, not from some other cause.
+    await ModifyGroupUsers(
+        group=role,
+        members_to_add=[user.id],
+        current_user_id=user.id,
+        sync_to_okta=False,
+        created_reason="need this for on-call rotation",
+    ).execute()
+
+    memberships = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+        )
+    ).all()
+    assert len(memberships) == 1
+
+
+async def test_member_association_blocks_self_add_to_role(db: Db, mocker: MockerFixture, user: OktaUser) -> None:
+    """A role that is a MEMBER of a group with disallow_self_add_membership
+    blocks its owner from self-adding, reading the same key on the group."""
+    mocker.patch.object(okta, "add_user_to_group")
+    role, _ = await _role_associated_with_tagged_group(
+        db, constraints={Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY: True}, is_owner=False
+    )
+    db.session.add(user)
+    await db.session.commit()
+
+    await ModifyGroupUsers(group=role, members_to_add=[user.id], current_user_id=user.id, sync_to_okta=False).execute()
+
+    memberships = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+        )
+    ).all()
+    assert len(memberships) == 0
+
+
+async def test_gate_off_allows_self_add_to_role(db: Db, mocker: MockerFixture, user: OktaUser) -> None:
+    mocker.patch.object(okta, "add_user_to_group")
+    role, _ = await _role_associated_with_tagged_group(
+        db,
+        constraints={Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY: True},
+        is_owner=False,
+        propagate=False,
+    )
+    db.session.add(user)
+    await db.session.commit()
+
+    await ModifyGroupUsers(group=role, members_to_add=[user.id], current_user_id=user.id, sync_to_okta=False).execute()
+
+    memberships = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+        )
+    ).all()
+    assert len(memberships) == 1
+
+
+async def test_member_time_limit_reaches_role_members(db: Db, mocker: MockerFixture, user: OktaUser) -> None:
+    mocker.patch.object(okta, "add_user_to_group")
+    role, _ = await _role_associated_with_tagged_group(
+        db, constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400}, is_owner=False
+    )
+    actor = OktaUserFactory.build()
+    db.session.add_all([user, actor])
+    await db.session.commit()
+
+    await ModifyGroupUsers(group=role, members_to_add=[user.id], current_user_id=actor.id, sync_to_okta=False).execute()
+
+    membership = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+        )
+    ).one()
+    assert membership.ended_at is not None
+    expected = datetime.now(UTC) + timedelta(seconds=86400)
+    assert abs((membership.ended_at.replace(tzinfo=UTC) - expected).total_seconds()) < 60
+
+
+async def test_owner_time_limit_reaches_members_of_an_owning_role(
+    db: Db, mocker: MockerFixture, user: OktaUser
+) -> None:
+    """The new control: a role that OWNS a group is capped by that group's
+    OWNER time limit."""
+    mocker.patch.object(okta, "add_user_to_group")
+    role, _ = await _role_associated_with_tagged_group(
+        db, constraints={Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: 3600}, is_owner=True
+    )
+    actor = OktaUserFactory.build()
+    db.session.add_all([user, actor])
+    await db.session.commit()
+
+    await ModifyGroupUsers(group=role, members_to_add=[user.id], current_user_id=actor.id, sync_to_okta=False).execute()
+
+    membership = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+        )
+    ).one()
+    assert membership.ended_at is not None
+    expected = datetime.now(UTC) + timedelta(seconds=3600)
+    assert abs((membership.ended_at.replace(tzinfo=UTC) - expected).total_seconds()) < 60
+
+
+async def test_retroactive_capping_reaches_existing_role_members(db: Db, mocker: MockerFixture, user: OktaUser) -> None:
+    """A pre-existing, uncapped membership in a role is capped when a
+    time-limited tag lands on a group the role is a member of."""
+    mocker.patch.object(okta, "add_user_to_group")
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400})
+    actor = OktaUserFactory.build()
+    db.session.add_all([group, role, tag, user, actor])
+    await db.session.commit()
+    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False))
+    db.session.add(OktaUserGroupMember(group_id=role.id, user_id=user.id, is_owner=False))
+    await db.session.commit()
+
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    await db.session.commit()
+    await ModifyGroupsTimeLimit(groups=[group.id], tags=[tag.id]).execute()
+
+    membership = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+        )
+    ).one()
+    assert membership.ended_at is not None
+
+
+async def test_retroactive_capping_reaches_existing_members_of_an_owning_role(
+    db: Db, mocker: MockerFixture, user: OktaUser
+) -> None:
+    """The owner-association direction: a role that OWNS a group is capped,
+    on its own pre-existing user memberships, by that group's OWNER time
+    limit when a time-limited tag lands on the group. A member limit is also
+    set on the tag (large enough to be a no-op for this scenario, since the
+    role is never a *member* of the group) purely so the group carries both
+    constraint keys, matching how tags are configured in practice."""
+    mocker.patch.object(okta, "add_user_to_group")
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(
+        constraints={
+            Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 999_999,
+            Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: 3600,
+        }
+    )
+    actor = OktaUserFactory.build()
+    db.session.add_all([group, role, tag, user, actor])
+    await db.session.commit()
+    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=True))
+    db.session.add(OktaUserGroupMember(group_id=role.id, user_id=user.id, is_owner=False))
+    await db.session.commit()
+
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    await db.session.commit()
+    await ModifyGroupsTimeLimit(groups=[group.id], tags=[tag.id]).execute()
+
+    membership = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+        )
+    ).one()
+    assert membership.ended_at is not None
+    expected = datetime.now(UTC) + timedelta(seconds=3600)
+    assert abs((membership.ended_at.replace(tzinfo=UTC) - expected).total_seconds()) < 60
+
+
+async def test_retroactive_capping_respects_the_gate(db: Db, mocker: MockerFixture, user: OktaUser) -> None:
+    mocker.patch.object(okta, "add_user_to_group")
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400}, propagate_to_roles=False)
+    db.session.add_all([group, role, tag, user])
+    await db.session.commit()
+    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False))
+    db.session.add(OktaUserGroupMember(group_id=role.id, user_id=user.id, is_owner=False))
+    await db.session.commit()
+
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    await db.session.commit()
+    await ModifyGroupsTimeLimit(groups=[group.id], tags=[tag.id]).execute()
+
+    membership = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+        )
+    ).one()
+    assert membership.ended_at is None
+
+
+@pytest.mark.parametrize(
+    ("member_limit", "owner_limit"),
+    [(3600, 999_999), (999_999, 3600)],
+    ids=["member_side_shorter", "owner_side_shorter"],
+)
+async def test_member_and_owner_associations_to_one_group_coalesce_to_the_minimum(
+    db: Db, mocker: MockerFixture, user: OktaUser, member_limit: int, owner_limit: int
+) -> None:
+    """A role can be both a MEMBER and an OWNER of the same tagged group. The
+    member association reads the group's member limit; the owner association
+    reads the owner-side counterpart. Both feed the role's member side, so the
+    effective limit is the minimum of the two.
+
+    Parametrized so each direction takes a turn being the shorter one -- if
+    either association were dropped, exactly one case would regress to the
+    other's (deliberately far larger) limit."""
+    mocker.patch.object(okta, "add_user_to_group")
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(
+        constraints={
+            Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: member_limit,
+            Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: owner_limit,
+        }
+    )
+    actor = OktaUserFactory.build()
+    db.session.add_all([group, role, tag, user, actor])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False))
+    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=True))
+    await db.session.commit()
+
+    await ModifyGroupUsers(group=role, members_to_add=[user.id], current_user_id=actor.id, sync_to_okta=False).execute()
+
+    membership = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+        )
+    ).one()
+    assert membership.ended_at is not None
+    expected = datetime.now(UTC) + timedelta(seconds=min(member_limit, owner_limit))
+    assert abs((membership.ended_at.replace(tzinfo=UTC) - expected).total_seconds()) < 60
+
+
+async def test_retroactive_capping_skips_unmanaged_roles(db: Db, mocker: MockerFixture, user: OktaUser) -> None:
+    """An externally managed role is exempt from constraint enforcement: both
+    `effective_ended_at` (grant time) and the `cap-role-memberships` sweep
+    return early for one. The retroactive bulk update must agree, or a tag
+    landing on the group would cap grants the other two paths never touch."""
+    mocker.patch.object(okta, "add_user_to_group")
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build(is_managed=False)
+    tag = TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400})
+    db.session.add_all([group, role, tag, user])
+    await db.session.commit()
+    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False))
+    db.session.add(OktaUserGroupMember(group_id=role.id, user_id=user.id, is_owner=False))
+    await db.session.commit()
+
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    await db.session.commit()
+    role_id, user_id = role.id, user.id
+    await ModifyGroupsTimeLimit(groups=[group.id], tags=[tag.id]).execute()
+
+    db.session.expire_all()
+    membership = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role_id)
+            .where(OktaUserGroupMember.user_id == user_id)
+        )
+    ).one()
+    assert membership.ended_at is None
+
+
+# --- Capping when the association is created -------------------------------
+#
+# The retroactive block above runs when a time-limited *tag* lands on a group.
+# The other way an association starts being governed is the association itself
+# being created, and that path never triggered a cap: a role with existing
+# indefinite members attached to a time-limited group left every one of those
+# memberships uncapped. The role's access to the group is bounded (the
+# `RoleGroupMap` is capped at creation, and derived rows take the minimum), but
+# membership *of the role* is never forced through review -- so renewing the
+# role's access rebuilds every derived grant from memberships nobody
+# re-examined. This recurs on every new association, not just historically.
+
+
+async def test_attaching_a_role_caps_its_existing_members(db: Db, mocker: MockerFixture, user: OktaUser) -> None:
+    mocker.patch.object(okta, "add_user_to_group")
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400})
+    db.session.add_all([group, role, tag, user])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    # Indefinite membership of the role, established before any association
+    # to the tagged group exists.
+    db.session.add(OktaUserGroupMember(group_id=role.id, user_id=user.id, is_owner=False))
+    await db.session.commit()
+    role_id, user_id = role.id, user.id
+
+    await ModifyRoleGroups(role_group=role_id, groups_to_add=[group.id], sync_to_okta=False).execute()
+
+    db.session.expire_all()
+    membership = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role_id)
+            .where(OktaUserGroupMember.user_id == user_id)
+        )
+    ).one()
+    assert membership.ended_at is not None
+    expected = datetime.now(UTC) + timedelta(seconds=86400)
+    assert abs((membership.ended_at.replace(tzinfo=UTC) - expected).total_seconds()) < 60
+
+
+async def test_attaching_a_role_as_owner_caps_its_existing_members(
+    db: Db, mocker: MockerFixture, user: OktaUser
+) -> None:
+    """Members of a role that owns a group become owners of it, so the role's
+    member side is capped by the group's OWNER limit. Covering only the member
+    association would leave this branch of the fix untested."""
+    mocker.patch.object(okta, "add_owner_to_group")
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(
+        constraints={
+            Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 999_999,
+            Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: 3600,
+        }
+    )
+    db.session.add_all([group, role, tag, user])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    db.session.add(OktaUserGroupMember(group_id=role.id, user_id=user.id, is_owner=False))
+    await db.session.commit()
+    role_id, user_id = role.id, user.id
+
+    await ModifyRoleGroups(role_group=role_id, owner_groups_to_add=[group.id], sync_to_okta=False).execute()
+
+    db.session.expire_all()
+    membership = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role_id)
+            .where(OktaUserGroupMember.user_id == user_id)
+        )
+    ).one()
+    assert membership.ended_at is not None
+    expected = datetime.now(UTC) + timedelta(seconds=3600)
+    assert abs((membership.ended_at.replace(tzinfo=UTC) - expected).total_seconds()) < 60
+
+
+async def test_attaching_a_role_respects_the_gate(db: Db, mocker: MockerFixture, user: OktaUser) -> None:
+    """A tag that does not propagate must not cap the role's members when the
+    association is created, exactly as it does not when the tag lands."""
+    mocker.patch.object(okta, "add_user_to_group")
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400}, propagate_to_roles=False)
+    db.session.add_all([group, role, tag, user])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    db.session.add(OktaUserGroupMember(group_id=role.id, user_id=user.id, is_owner=False))
+    await db.session.commit()
+    role_id, user_id = role.id, user.id
+
+    await ModifyRoleGroups(role_group=role_id, groups_to_add=[group.id], sync_to_okta=False).execute()
+
+    db.session.expire_all()
+    membership = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role_id)
+            .where(OktaUserGroupMember.user_id == user_id)
+        )
+    ).one()
+    assert membership.ended_at is None
+
+
+async def test_attaching_a_role_to_an_untagged_group_leaves_members_alone(
+    db: Db, mocker: MockerFixture, user: OktaUser
+) -> None:
+    """The common case must not acquire a cap -- or a wasted query pass -- just
+    because the capping call was added to this operation."""
+    mocker.patch.object(okta, "add_user_to_group")
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    db.session.add_all([group, role, user])
+    await db.session.commit()
+    db.session.add(OktaUserGroupMember(group_id=role.id, user_id=user.id, is_owner=False))
+    await db.session.commit()
+    role_id, user_id = role.id, user.id
+
+    await ModifyRoleGroups(role_group=role_id, groups_to_add=[group.id], sync_to_okta=False).execute()
+
+    db.session.expire_all()
+    membership = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role_id)
+            .where(OktaUserGroupMember.user_id == user_id)
+        )
+    ).one()
+    assert membership.ended_at is None
+
+
+async def test_attaching_a_role_does_not_leak_one_groups_limit_onto_another(
+    db: Db, mocker: MockerFixture, user: OktaUser
+) -> None:
+    """`ModifyGroupsTimeLimit(groups=G, tags=T)` applies T to every group in G,
+    so the groups added by one operation cannot be unioned into a single call.
+    Attaching a role to a tagged group and an untagged group together must
+    leave the untagged group's own direct grants indefinite."""
+    mocker.patch.object(okta, "add_user_to_group")
+    tagged_group = OktaGroupFactory.build()
+    untagged_group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400})
+    db.session.add_all([tagged_group, untagged_group, role, tag, user])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=tagged_group.id, tag_id=tag.id))
+    # A direct, indefinite grant in the untagged group -- nothing about this
+    # operation should touch it.
+    db.session.add(OktaUserGroupMember(group_id=untagged_group.id, user_id=user.id, is_owner=False))
+    await db.session.commit()
+    untagged_group_id, user_id = untagged_group.id, user.id
+
+    await ModifyRoleGroups(
+        role_group=role.id,
+        groups_to_add=[tagged_group.id, untagged_group.id],
+        sync_to_okta=False,
+    ).execute()
+
+    db.session.expire_all()
+    direct = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == untagged_group_id)
+            .where(OktaUserGroupMember.user_id == user_id)
+            .where(OktaUserGroupMember.role_group_map_id.is_(None))
+        )
+    ).one()
+    assert direct.ended_at is None
+
+
+# --- A constraint reaching a role must behave the same however it got there --
+#
+# A time limit on a role caps two things: membership *of* the role, and the
+# access that membership grants *through* the role to every group the role is
+# associated with. Both hold however the limit reaches the role -- a tag on the
+# role itself, or one propagating from a group it is associated with. Capping
+# only the first leaves a user whose role membership has just been shortened
+# still holding derived access to the role's other groups, outliving the
+# membership it exists because of.
+
+
+async def test_propagated_limit_also_caps_access_the_role_grants(db: Db, mocker: MockerFixture, user: OktaUser) -> None:
+    mocker.patch.object(okta, "add_user_to_group")
+    tagged_group = OktaGroupFactory.build()
+    other_group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: ONE_DAY})
+    db.session.add_all([tagged_group, other_group, role, tag, user])
+    await db.session.commit()
+
+    # The role is a member of both groups, and the user is an indefinite
+    # member of the role, so their access to `other_group` is derived.
+    member_map = RoleGroupMap(group_id=tagged_group.id, role_group_id=role.id, is_owner=False)
+    other_map = RoleGroupMap(group_id=other_group.id, role_group_id=role.id, is_owner=False)
+    db.session.add_all([member_map, other_map])
+    await db.session.commit()
+    db.session.add(OktaUserGroupMember(group_id=role.id, user_id=user.id, is_owner=False))
+    await db.session.commit()
+    derived = OktaUserGroupMember(
+        group_id=other_group.id, user_id=user.id, is_owner=False, role_group_map_id=other_map.id
+    )
+    db.session.add(derived)
+    await db.session.commit()
+    role_id, other_group_id, user_id = role.id, other_group.id, user.id
+
+    db.session.add(OktaGroupTagMapFactory.build(group_id=tagged_group.id, tag_id=tag.id))
+    await db.session.commit()
+    await ModifyGroupsTimeLimit(groups=[tagged_group.id], tags=[tag.id]).execute()
+
+    db.session.expire_all()
+    in_role = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role_id)
+            .where(OktaUserGroupMember.user_id == user_id)
+        )
+    ).one()
+    granted_by_role = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == other_group_id)
+            .where(OktaUserGroupMember.user_id == user_id)
+        )
+    ).one()
+
+    assert in_role.ended_at is not None
+    # The access the role grants must not outlive the membership that confers it.
+    assert granted_by_role.ended_at is not None
+    assert granted_by_role.ended_at <= in_role.ended_at
+
+
+async def test_attaching_a_role_also_caps_access_it_already_grants(
+    db: Db, mocker: MockerFixture, user: OktaUser
+) -> None:
+    """The attach path has to reach as far as the tag-landing path. Capping the
+    role's memberships alone would leave the access those memberships already
+    confer elsewhere on its old end date."""
+    mocker.patch.object(okta, "add_user_to_group")
+    tagged_group = OktaGroupFactory.build()
+    other_group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: ONE_DAY})
+    db.session.add_all([tagged_group, other_group, role, tag, user])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=tagged_group.id, tag_id=tag.id))
+    db.session.add(OktaUserGroupMember(group_id=role.id, user_id=user.id, is_owner=False))
+    await db.session.commit()
+
+    # The role already confers access to `other_group`, indefinitely.
+    other_map = RoleGroupMap(group_id=other_group.id, role_group_id=role.id, is_owner=False)
+    db.session.add(other_map)
+    await db.session.commit()
+    db.session.add(
+        OktaUserGroupMember(group_id=other_group.id, user_id=user.id, is_owner=False, role_group_map_id=other_map.id)
+    )
+    await db.session.commit()
+    role_id, other_group_id, user_id = role.id, other_group.id, user.id
+
+    await ModifyRoleGroups(role_group=role_id, groups_to_add=[tagged_group.id], sync_to_okta=False).execute()
+
+    db.session.expire_all()
+    in_role = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role_id)
+            .where(OktaUserGroupMember.user_id == user_id)
+        )
+    ).one()
+    granted_by_role = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == other_group_id)
+            .where(OktaUserGroupMember.user_id == user_id)
+        )
+    ).one()
+
+    assert in_role.ended_at is not None
+    assert granted_by_role.ended_at is not None
+    assert granted_by_role.ended_at <= in_role.ended_at

--- a/tests/test_constraint_propagation.py
+++ b/tests/test_constraint_propagation.py
@@ -380,15 +380,12 @@ async def test_retroactive_capping_skips_unmanaged_roles(db: Db, mocker: MockerF
 
 # --- Capping when the association is created -------------------------------
 #
-# The retroactive block above runs when a time-limited *tag* lands on a group.
+# The retroactive block above covers a time-limited *tag* landing on a group.
 # The other way an association starts being governed is the association itself
-# being created, and that path never triggered a cap: a role with existing
-# indefinite members attached to a time-limited group left every one of those
-# memberships uncapped. The role's access to the group is bounded (the
-# `RoleGroupMap` is capped at creation, and derived rows take the minimum), but
-# membership *of the role* is never forced through review -- so renewing the
-# role's access rebuilds every derived grant from memberships nobody
-# re-examined. This recurs on every new association, not just historically.
+# being created: attaching a role to a time-limited group must cap the role's
+# existing members, not only the `RoleGroupMap`. Bounding the association alone
+# would leave membership *of the role* indefinite, so renewing the role's access
+# would rebuild every derived grant from memberships nobody re-examined.
 
 
 async def test_attaching_a_role_caps_its_existing_members(db: Db, mocker: MockerFixture, user: OktaUser) -> None:

--- a/tests/test_constraint_propagation.py
+++ b/tests/test_constraint_propagation.py
@@ -660,7 +660,7 @@ async def test_attaching_a_role_also_caps_access_it_already_grants(
 ) -> None:
     """The attach path has to reach as far as the tag-landing path. Capping the
     role's memberships alone would leave the access those memberships already
-    confer elsewhere on its old end date."""
+    confer elsewhere on its existing end date."""
     mocker.patch.object(okta, "add_user_to_group")
     tagged_group = OktaGroupFactory.build()
     other_group = OktaGroupFactory.build()

--- a/tests/test_constraint_propagation.py
+++ b/tests/test_constraint_propagation.py
@@ -417,6 +417,53 @@ async def test_attaching_a_role_caps_its_existing_members(db: Db, mocker: Mocker
     assert abs((membership.ended_at.replace(tzinfo=UTC) - expected).total_seconds()) < 60
 
 
+async def test_a_failed_cap_leaves_no_association_behind(db: Db, mocker: MockerFixture, user: OktaUser) -> None:
+    """The association and the cap it makes necessary commit together.
+
+    The cap is only correct alongside the association that imposes it, so if
+    it cannot be applied the association must not survive either -- otherwise
+    the role is attached to a time-limited group while its members keep the
+    indefinite membership the association was supposed to bound.
+    """
+    mocker.patch.object(okta, "add_user_to_group")
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: ONE_DAY})
+    db.session.add_all([group, role, tag, user])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    db.session.add(OktaUserGroupMember(group_id=role.id, user_id=user.id, is_owner=False))
+    await db.session.commit()
+    role_id, group_id, user_id = role.id, group.id, user.id
+
+    mocker.patch(
+        "api.operations.modify_role_groups.limit_access_conferred_by_roles",
+        side_effect=RuntimeError("cap failed"),
+    )
+
+    with pytest.raises(RuntimeError):
+        await ModifyRoleGroups(role_group=role_id, groups_to_add=[group_id], sync_to_okta=False).execute()
+
+    await db.session.rollback()
+    db.session.expire_all()
+
+    association = (
+        await db.session.scalars(
+            select(RoleGroupMap).where(RoleGroupMap.role_group_id == role_id).where(RoleGroupMap.group_id == group_id)
+        )
+    ).all()
+    assert association == []
+
+    membership = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role_id)
+            .where(OktaUserGroupMember.user_id == user_id)
+        )
+    ).one()
+    assert membership.ended_at is None
+
+
 async def test_attaching_a_role_as_owner_caps_its_existing_members(
     db: Db, mocker: MockerFixture, user: OktaUser
 ) -> None:

--- a/tests/test_effective_constraints.py
+++ b/tests/test_effective_constraints.py
@@ -1,8 +1,11 @@
+from datetime import UTC, datetime, timedelta
+
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from api.extensions import Db
 from api.models import AppTagMap, OktaGroup, OktaGroupTagMap, RoleGroup, RoleGroupMap, Tag
+from api.routers._eager import effective_constraint_options
 from api.models.tag import (
     constraint_source_clause,
     constraint_sources,
@@ -18,22 +21,15 @@ from tests.factories import (
 
 
 async def _load_role(db: Db, role_id: str) -> RoleGroup:
-    """Load a role with everything `effective_constraint` reads."""
+    """Load a role with everything `effective_constraint` reads.
+
+    Through the same builder the enforcement paths use, so a change to the
+    loaders cannot pass here while breaking them. `select(RoleGroup)` needs no
+    `selectin_polymorphic` pairing.
+    """
     return (
         await db.session.scalars(
-            select(RoleGroup)
-            .options(
-                selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
-                selectinload(RoleGroup.active_role_associated_group_member_mappings)
-                .joinedload(RoleGroupMap.active_group)
-                .selectinload(OktaGroup.active_group_tags)
-                .joinedload(OktaGroupTagMap.active_tag),
-                selectinload(RoleGroup.active_role_associated_group_owner_mappings)
-                .joinedload(RoleGroupMap.active_group)
-                .selectinload(OktaGroup.active_group_tags)
-                .joinedload(OktaGroupTagMap.active_tag),
-            )
-            .where(RoleGroup.id == role_id)
+            select(RoleGroup).options(*effective_constraint_options()).where(RoleGroup.id == role_id)
         )
     ).one()
 
@@ -225,6 +221,35 @@ async def test_constraint_source_clause_falls_back_to_the_group_itself(db: Db) -
     assert constraint_source_clause(Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY, loaded) == (
         "due to tags on this group"
     )
+
+
+async def test_soft_deleted_source_group_contributes_nothing(db: Db) -> None:
+    """A mapping whose group has been soft-deleted while the mapping is still
+    active reaches `_propagated_sources` with `active_group` as None.
+
+    Reachable only under `selectinload`: `RoleGroupMap.active_group` carries
+    `innerjoin=True`, so a `joinedload` drops the whole mapping instead and the
+    None branch never runs. `effective_constraint_options` declares
+    `selectinload`, so this is the path the enforcement sites take."""
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400})
+    db.session.add_all([group, role, tag])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False))
+    await db.session.commit()
+
+    group.deleted_at = datetime.now(UTC) - timedelta(days=1)
+    db.session.add(group)
+    await db.session.commit()
+    role_id = role.id
+
+    db.session.expire_all()
+    loaded = await _load_role(db, role_id)
+    (mapping,) = loaded.active_role_associated_group_member_mappings
+    assert mapping.active_group is None
+    assert effective_constraint(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, loaded) is None
 
 
 async def test_nothing_propagates_onto_an_unmanaged_role(db: Db) -> None:

--- a/tests/test_effective_constraints.py
+++ b/tests/test_effective_constraints.py
@@ -1,0 +1,255 @@
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from api.extensions import Db
+from api.models import AppTagMap, OktaGroup, OktaGroupTagMap, RoleGroup, RoleGroupMap, Tag
+from api.models.tag import (
+    constraint_source_clause,
+    constraint_sources,
+    effective_constraint,
+    effective_ended_at,
+)
+from tests.factories import (
+    OktaGroupFactory,
+    OktaGroupTagMapFactory,
+    RoleGroupFactory,
+    TagFactory,
+)
+
+
+async def _load_role(db: Db, role_id: str) -> RoleGroup:
+    """Load a role with everything `effective_constraint` reads."""
+    return (
+        await db.session.scalars(
+            select(RoleGroup)
+            .options(
+                selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
+                selectinload(RoleGroup.active_role_associated_group_member_mappings)
+                .joinedload(RoleGroupMap.active_group)
+                .selectinload(OktaGroup.active_group_tags)
+                .joinedload(OktaGroupTagMap.active_tag),
+                selectinload(RoleGroup.active_role_associated_group_owner_mappings)
+                .joinedload(RoleGroupMap.active_group)
+                .selectinload(OktaGroup.active_group_tags)
+                .joinedload(OktaGroupTagMap.active_tag),
+            )
+            .where(RoleGroup.id == role_id)
+        )
+    ).one()
+
+
+async def _load_group_with_provenance(db: Db, group_id: str) -> OktaGroup:
+    """Load a group with everything `effective_constraints` reads, including
+    `active_app_tag_mapping` -- the relationship `_own_tag_sources` uses to
+    distinguish a tag applied directly to the group ("direct") from one
+    inherited via the group's `App` ("app"). `_load_role` above does NOT load
+    this relationship, since `effective_constraint` (no provenance) never
+    reads it; calling `effective_constraints` on a group loaded via
+    `_load_role` would raise on this `lazy="raise_on_sql"` relationship.
+
+    Also loads `AppTagMap.active_app`, matching `group_tag_map_options()` in
+    `api/routers/_eager.py` -- `_own_tag_sources` reads it to populate
+    `source_name` for an "app" origin."""
+    return (
+        await db.session.scalars(
+            select(OktaGroup)
+            .options(
+                selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
+                selectinload(OktaGroup.active_group_tags)
+                .joinedload(OktaGroupTagMap.active_app_tag_mapping)
+                .joinedload(AppTagMap.active_app),
+            )
+            .where(OktaGroup.id == group_id)
+        )
+    ).one()
+
+
+async def _setup(db: Db, *, constraints: dict, is_owner: bool, propagate: bool = True) -> RoleGroup:
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(constraints=constraints, propagate_to_roles=propagate)
+    db.session.add_all([group, role, tag])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=is_owner))
+    await db.session.commit()
+    return await _load_role(db, role.id)
+
+
+async def test_member_association_propagates_same_key(db: Db) -> None:
+    role = await _setup(db, constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400}, is_owner=False)
+    assert effective_constraint(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, role) == 86400
+
+
+async def test_owner_association_propagates_counterpart_key(db: Db) -> None:
+    """A role that OWNS a group reads that group's OWNER-side limit onto its
+    own MEMBER-side constraint. This is the new control."""
+    role = await _setup(db, constraints={Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: 3600}, is_owner=True)
+    assert effective_constraint(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, role) == 3600
+
+
+async def test_owner_association_does_not_propagate_member_key(db: Db) -> None:
+    role = await _setup(db, constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 3600}, is_owner=True)
+    assert effective_constraint(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, role) is None
+
+
+async def test_nothing_reaches_the_roles_owner_side(db: Db) -> None:
+    role = await _setup(db, constraints={Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY: 3600}, is_owner=False)
+    assert effective_constraint(Tag.OWNER_TIME_LIMIT_CONSTRAINT_KEY, role) is None
+
+
+async def test_gate_off_blocks_propagation(db: Db) -> None:
+    role = await _setup(
+        db,
+        constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400},
+        is_owner=False,
+        propagate=False,
+    )
+    assert effective_constraint(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, role) is None
+
+
+async def test_disabled_tag_contributes_nothing(db: Db) -> None:
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400}, enabled=False)
+    db.session.add_all([group, role, tag])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False))
+    await db.session.commit()
+    loaded = await _load_role(db, role.id)
+    assert effective_constraint(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, loaded) is None
+
+
+async def test_unmanaged_source_group_contributes_nothing(db: Db) -> None:
+    group = OktaGroupFactory.build(is_managed=False)
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400})
+    db.session.add_all([group, role, tag])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False))
+    await db.session.commit()
+    loaded = await _load_role(db, role.id)
+    assert effective_constraint(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, loaded) is None
+
+
+async def test_per_tag_not_global(db: Db) -> None:
+    """One propagating and one non-propagating tag on the same group:
+    only the propagating tag's constraints reach the role."""
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    propagating = TagFactory.build(
+        name="propagating",
+        constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400},
+        propagate_to_roles=True,
+    )
+    blocked = TagFactory.build(
+        name="blocked",
+        constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 60},
+        propagate_to_roles=False,
+    )
+    db.session.add_all([group, role, propagating, blocked])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=propagating.id))
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=blocked.id))
+    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False))
+    await db.session.commit()
+    loaded = await _load_role(db, role.id)
+    # 60 would win a `min` coalesce -- it must not be considered at all.
+    assert effective_constraint(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, loaded) == 86400
+
+
+async def test_non_role_group_reads_only_its_own_tags(db: Db) -> None:
+    group = OktaGroupFactory.build()
+    tag = TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400})
+    db.session.add_all([group, tag])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    await db.session.commit()
+    loaded = (
+        await db.session.scalars(
+            select(OktaGroup)
+            .options(selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag))
+            .where(OktaGroup.id == group.id)
+        )
+    ).one()
+    assert effective_constraint(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, loaded) == 86400
+
+
+async def test_constraint_source_clause_names_the_member_association(db: Db) -> None:
+    role = await _setup(db, constraints={Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY: True}, is_owner=False)
+    clause = constraint_source_clause(Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY, role)
+    assert "which this role is a member of" in clause
+    (source,) = constraint_sources(Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY, role)
+    assert source.source_name in clause
+
+
+async def test_constraint_source_clause_names_the_owner_association(db: Db) -> None:
+    role = await _setup(db, constraints={Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY: True}, is_owner=True)
+    clause = constraint_source_clause(Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY, role)
+    assert "which this role owns" in clause
+
+
+async def test_constraint_source_clause_names_every_blocking_source(db: Db) -> None:
+    """Each truthy source blocks independently, so the message names them all."""
+    group_a = OktaGroupFactory.build()
+    group_b = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(constraints={Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY: True})
+    db.session.add_all([group_a, group_b, role, tag])
+    await db.session.commit()
+    db.session.add_all(
+        [
+            OktaGroupTagMapFactory.build(group_id=group_a.id, tag_id=tag.id),
+            OktaGroupTagMapFactory.build(group_id=group_b.id, tag_id=tag.id),
+            RoleGroupMap(group_id=group_a.id, role_group_id=role.id, is_owner=False),
+            RoleGroupMap(group_id=group_b.id, role_group_id=role.id, is_owner=False),
+        ]
+    )
+    await db.session.commit()
+    clause = constraint_source_clause(Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY, await _load_role(db, role.id))
+    assert group_a.name in clause
+    assert group_b.name in clause
+    assert " and " in clause
+
+
+async def test_constraint_source_clause_falls_back_to_the_group_itself(db: Db) -> None:
+    group = OktaGroupFactory.build()
+    tag = TagFactory.build(constraints={Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY: True})
+    db.session.add_all([group, tag])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    await db.session.commit()
+    loaded = await _load_group_with_provenance(db, group.id)
+    assert constraint_source_clause(Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY, loaded) == (
+        "due to tags on this group"
+    )
+
+
+async def test_nothing_propagates_onto_an_unmanaged_role(db: Db) -> None:
+    """An unmanaged role enforces nothing, so nothing may propagate onto it.
+
+    Every enforcement path gates on `is_managed` separately. Without the gate
+    inside `_propagated_sources` the read surface would advertise a limit and a
+    self-add prohibition that nothing applies, and the two would disagree.
+    """
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build(is_managed=False)
+    tag = TagFactory.build(
+        constraints={
+            Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400,
+            Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY: True,
+        },
+    )
+    db.session.add_all([group, role, tag])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False))
+    await db.session.commit()
+
+    loaded = await _load_role(db, role.id)
+    assert effective_constraint(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, loaded) is None
+    assert effective_constraint(Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY, loaded) is None
+    # Enforcement agrees, which is the point -- the two must not diverge.
+    assert effective_ended_at(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, loaded, None) is None

--- a/tests/test_role_request.py
+++ b/tests/test_role_request.py
@@ -1471,6 +1471,71 @@ async def test_role_request_list_filters_via_http(client: AsyncClient, db: Db, u
     assert target_rr.id in found and other_rr.id not in found
 
 
+async def test_role_request_assignee_filter_excludes_propagated_self_add_role_target(
+    client: AsyncClient, db: Db, tag: Tag, url_for: Any
+) -> None:
+    """`owned_groups_no_self_member` in the `assignee_user_id` branch of the
+    role-requests list must key off `effective_constraint`, which also sees
+    `disallow_self_add_membership` propagated onto a *role* the assignee owns
+    (because that role is itself a member of a tagged group), not only tags
+    applied directly to the role. Keying off only directly-applied tags would
+    offer the assignee a request their approval would then be blocked from
+    resolving."""
+    role_owner = await OktaUserFactory.create_async()
+    other_member = await OktaUserFactory.create_async()
+    owned_role = await RoleGroupFactory.create_async()
+    tagged_group = await OktaGroupFactory.create_async()
+    other_role = await RoleGroupFactory.create_async()
+
+    # `role_owner` owns `owned_role`, and is separately a plain member of
+    # `other_role` alongside `other_member` -- `other_member` is who actually
+    # submits the (fixture-inserted) request below, so the unconditional
+    # "never show the assignee their own requests" filter doesn't hide it
+    # for an unrelated reason.
+    await ModifyGroupUsers(group=owned_role, owners_to_add=[role_owner.id], sync_to_okta=False).execute()
+    await ModifyGroupUsers(
+        group=other_role, members_to_add=[role_owner.id, other_member.id], sync_to_okta=False
+    ).execute()
+
+    # `owned_role` becomes a MEMBER of `tagged_group` -- this is what
+    # propagates the constraint onto `owned_role` without tagging it directly.
+    await ModifyRoleGroups(
+        role_group=owned_role, groups_to_add=[tagged_group.id], sync_to_okta=False, created_reason="test"
+    ).execute()
+
+    tag.constraints = {Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY: True}
+    db.session.add(tag)
+    await db.session.commit()
+    await OktaGroupTagMapFactory.create_async(group_id=tagged_group.id, tag_id=tag.id)
+
+    # Inserted directly (bypassing `CreateRoleRequest`, which refuses a role
+    # as `requested_group`) to exercise the router's list-filtering query in
+    # isolation against a role target carrying only a propagated constraint.
+    pending_rr = await RoleRequestFactory.create_async(
+        requester_user_id=other_member.id,
+        requester_role_id=other_role.id,
+        requested_group_id=owned_role.id,
+        request_ownership=False,
+    )
+
+    assignee_user_id = role_owner.id
+    pending_rr_id = pending_rr.id
+
+    # The test session already loaded `owned_role`'s (previously empty)
+    # `active_role_associated_group_member_mappings` collection earlier in
+    # this test (e.g. via factory/operation calls before the mapping row
+    # existed); expire it so the endpoint's own query -- sharing this same
+    # session -- repopulates it instead of reading the stale cached state.
+    # A real request never has this staleness since it starts a fresh session.
+    db.session.expire_all()
+
+    list_url = url_for("api-role-requests.role_requests")
+    rep = await client.get(list_url, params={"assignee_user_id": assignee_user_id, "status": "PENDING"})
+    assert rep.status_code == 200
+    ids = [r["id"] for r in rep.json()["items"]]
+    assert pending_rr_id not in ids
+
+
 async def test_get_role_request_detail_requested_group_for_app_group(
     client: AsyncClient,
     db: Db,
@@ -1615,3 +1680,42 @@ async def test_reject_role_request_notify_false_suppresses_completion(
 
     assert (await db.session.get(RoleRequest, role_request.id)).status == AccessRequestStatus.REJECTED
     assert completed_spy.call_count == 0
+
+
+async def test_role_request_assignee_admin_branch_loads_role_target_propagation(
+    client: AsyncClient, db: Db, url_for: Any
+) -> None:
+    """The Access-admin branch of the `assignee_user_id` role-requests list
+    evaluates `effective_constraint(DISALLOW_SELF_ADD_MEMBERSHIP, ...)` over
+    every pending request's `requested_group`. That key is in
+    `OWNER_SIDE_COUNTERPART`, so for a `RoleGroup` target the helper reads the
+    role's `active_role_associated_group_*_mappings` -- all `raise_on_sql`.
+    Without those loaders the endpoint 500s, and it does so whether or not the
+    role carries any tags, because propagation is consulted unconditionally.
+
+    A `RoleGroup` can become a `RoleRequest.requested_group` in production via
+    `ModifyGroupType` converting a group that already has a pending request."""
+    admin = (
+        await db.session.scalars(select(OktaUser).where(OktaUser.email == settings.CURRENT_OKTA_USER_EMAIL))
+    ).first()
+    assert admin is not None
+    admin_id = admin.id
+
+    requester = await OktaUserFactory.create_async()
+    requester_role = await RoleGroupFactory.create_async()
+    # The request target is itself a role -- the shape `ModifyGroupType`
+    # produces when it converts a group with a pending role request.
+    target_role = await RoleGroupFactory.create_async()
+
+    await RoleRequestFactory.create_async(
+        requester_user_id=requester.id,
+        requester_role_id=requester_role.id,
+        requested_group_id=target_role.id,
+        request_ownership=False,
+    )
+
+    db.session.expire_all()
+
+    list_url = url_for("api-role-requests.role_requests")
+    rep = await client.get(list_url, params={"assignee_user_id": admin_id, "status": "PENDING"})
+    assert rep.status_code == 200

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -455,7 +455,16 @@ async def test_list_tags_response_is_summary_shape(
     item = matched[0]
     assert "active_group_tags" not in item
     assert "deleted_at" not in item
-    expected_keys = {"id", "name", "description", "constraints", "enabled", "created_at", "updated_at"}
+    expected_keys = {
+        "id",
+        "name",
+        "description",
+        "constraints",
+        "enabled",
+        "propagate_to_roles",
+        "created_at",
+        "updated_at",
+    }
     assert set(item.keys()) == expected_keys
 
 

--- a/tests/test_tag_propagate_to_roles.py
+++ b/tests/test_tag_propagate_to_roles.py
@@ -1,0 +1,96 @@
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+
+from fastapi import FastAPI
+
+from sqlalchemy import select
+from api.extensions import Db
+from api.models import Tag
+from tests.factories import TagFactory
+
+
+async def test_tag_defaults_to_propagating(db: Db) -> None:
+    tag = TagFactory.build(name="SOX")
+    db.session.add(tag)
+    await db.session.commit()
+
+    loaded = (await db.session.scalars(select(Tag).where(Tag.id == tag.id))).one()
+    assert loaded.propagate_to_roles is True
+
+
+async def test_put_tag_round_trips_propagate_to_roles(app: FastAPI, client: AsyncClient, db: Db, url_for: Any) -> None:
+    tag = TagFactory.build(name="SOX")
+    db.session.add(tag)
+    await db.session.commit()
+    tag_id = tag.id
+
+    response = await client.put(
+        url_for("tag_by_id_put", tag_id=tag_id),
+        json={"propagate_to_roles": False},
+    )
+    assert response.status_code == 200
+    assert response.json()["propagate_to_roles"] is False
+
+    db.session.expire_all()
+    loaded = (await db.session.scalars(select(Tag).where(Tag.id == tag_id))).one()
+    assert loaded.propagate_to_roles is False
+
+
+async def test_put_tag_leaves_propagate_to_roles_alone_when_absent(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any
+) -> None:
+    """A tag edit that does not mention the field must not reset it."""
+    tag = TagFactory.build(name="SOX", propagate_to_roles=False)
+    db.session.add(tag)
+    await db.session.commit()
+
+    response = await client.put(
+        url_for("tag_by_id_put", tag_id=tag.id),
+        json={"description": "updated"},
+    )
+    assert response.status_code == 200
+    assert response.json()["propagate_to_roles"] is False
+
+
+@pytest.mark.parametrize("propagate", [True, False])
+async def test_post_tag_round_trips_explicit_propagate_to_roles(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any, propagate: bool
+) -> None:
+    """`post_tag` translates the optional body field with a ternary (absent
+    means the `True` default). Covering only the omitted case would leave the
+    gate that decides whether a tag's constraints reach roles at all untested
+    on the create path -- PUT is covered, POST was not."""
+    response = await client.post(
+        url_for("tags_create"),
+        json={
+            "name": f"SOX-{propagate}",
+            "description": "test tag",
+            "propagate_to_roles": propagate,
+        },
+    )
+    assert response.status_code == 201
+    assert response.json()["propagate_to_roles"] is propagate
+    tag_id = response.json()["id"]
+
+    db.session.expire_all()
+    loaded = (await db.session.scalars(select(Tag).where(Tag.id == tag_id))).one()
+    assert loaded.propagate_to_roles is propagate
+
+
+async def test_post_tag_defaults_propagate_to_roles_when_absent(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any
+) -> None:
+    """The other half of the same ternary: an omitted field must land on the
+    documented `True` default, not on `None`/falsy."""
+    response = await client.post(
+        url_for("tags_create"),
+        json={"name": "SOX-absent", "description": "test tag"},
+    )
+    assert response.status_code == 201
+    assert response.json()["propagate_to_roles"] is True
+
+    db.session.expire_all()
+    loaded = (await db.session.scalars(select(Tag).where(Tag.id == response.json()["id"]))).one()
+    assert loaded.propagate_to_roles is True

--- a/tests/test_tag_propagate_to_roles.py
+++ b/tests/test_tag_propagate_to_roles.py
@@ -59,9 +59,9 @@ async def test_post_tag_round_trips_explicit_propagate_to_roles(
     app: FastAPI, client: AsyncClient, db: Db, url_for: Any, propagate: bool
 ) -> None:
     """`post_tag` translates the optional body field with a ternary (absent
-    means the `True` default). Covering only the omitted case would leave the
-    gate that decides whether a tag's constraints reach roles at all untested
-    on the create path -- PUT is covered, POST was not."""
+    means the `True` default), so the create path needs coverage of its own:
+    the gate deciding whether a tag's constraints reach roles is set here as
+    well as on update."""
     response = await client.post(
         url_for("tags_create"),
         json={

--- a/tests/test_time_limit_constraint.py
+++ b/tests/test_time_limit_constraint.py
@@ -923,6 +923,12 @@ async def test_time_limit_add_group_tags(
     user: OktaUser,
     url_for: Any,
 ) -> None:
+    # A time-limited tag landing on a group caps the members of roles
+    # associated with that group, and everything those memberships confer.
+    # So the role's own membership row moves into the capped bucket, and so
+    # does the access the role grants its members in every *other* group it
+    # is associated with -- that access exists only by virtue of a
+    # membership the tag just shortened.
     # Set primary tag constraint time limit to 3 days
     tags = TagFactory.batch(
         3,
@@ -1004,9 +1010,9 @@ async def test_time_limit_add_group_tags(
                 OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
             ),
         )
-        == 4
+        == 7
     )
-    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 5
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 2
     assert (
         await db_count(
             db.session,
@@ -1034,6 +1040,9 @@ async def test_time_limit_add_group_tags(
     assert await db_count(db.session, select(AppTagMap).where(AppTagMap.ended_at.is_(None))) == 0
     assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 4
 
+    # The 3-day tag on `okta_group` already reached everything the role
+    # confers, so the role's own 7-day tag finds only its ownership row
+    # still uncapped -- these updates shorten and never extend.
     assert (
         await db_count(
             db.session,
@@ -1042,7 +1051,7 @@ async def test_time_limit_add_group_tags(
                 OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
             ),
         )
-        == 4
+        == 7
     )
     assert (
         await db_count(
@@ -1052,7 +1061,7 @@ async def test_time_limit_add_group_tags(
                 OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
             ),
         )
-        == 4
+        == 1
     )
     assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 1
     assert (
@@ -1095,6 +1104,8 @@ async def test_time_limit_add_group_tags(
     assert await db_count(db.session, select(AppTagMap).where(AppTagMap.ended_at.is_(None))) == 0
     assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 6
 
+    # Unchanged from the previous step: everything this 7-day tag reaches is
+    # already held to 3 days by the tag on `okta_group`.
     assert (
         await db_count(
             db.session,
@@ -1103,7 +1114,7 @@ async def test_time_limit_add_group_tags(
                 OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
             ),
         )
-        == 4
+        == 7
     )
     assert (
         await db_count(
@@ -1113,7 +1124,7 @@ async def test_time_limit_add_group_tags(
                 OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=8)),
             ),
         )
-        == 4
+        == 1
     )
     assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 1
     assert (
@@ -1149,6 +1160,10 @@ async def test_time_limit_add_app_tags(
     user: OktaUser,
     url_for: Any,
 ) -> None:
+    # A time-limited tag landing on a group now also caps the members of roles
+    # associated with that group. The role's own membership row therefore moves
+    # from the uncapped bucket into the capped one; the totals below are
+    # unchanged, one row simply counts on the other side.
     # Set primary tag constraint time limit to 3 days
     tags = TagFactory.batch(
         3,
@@ -1218,9 +1233,9 @@ async def test_time_limit_add_app_tags(
                 OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
             ),
         )
-        == 4
+        == 5
     )
-    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 3
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 2
     assert (
         await db_count(
             db.session,
@@ -1258,9 +1273,9 @@ async def test_time_limit_add_app_tags(
                 OktaUserGroupMember.ended_at < (datetime.now(UTC) + timedelta(days=4)),
             ),
         )
-        == 4
+        == 5
     )
-    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 3
+    assert await db_count(db.session, select(OktaUserGroupMember).where(OktaUserGroupMember.ended_at.is_(None))) == 2
     assert (
         await db_count(
             db.session,


### PR DESCRIPTION
# Summary

Adds `Tag.propagate_to_roles`, one switch governing whether a tag's constraints reach roles associated with a tagged group, and makes all six constraints propagate under it. Enforcement only — no new API surface, no UI.

**Urgency**: 1 week — this closes a SOX audit finding, with a one-time review wave scheduled behind it.
**Expected review effort**: HIGH — breaking change, security-adjacent, ~2000 lines.

> [!NOTE]
> Stacked on **#615** → **#594**. Review those first; this diff is against #615's branch and GitHub will retarget as they merge.
>
> Supersedes **#601**, which carried this work plus the read API and UI. Those are split out and will stack on this one.

# Motivation

A compliance tag such as `SOX` is applied to an app; its `AppGroup`s inherit it. A role that is a member of one of those groups grants its own members access to a SOX-scoped group — so that role's membership must respect the same limits, without an operator hand-tagging every such role and remembering to untag it when the role's associations change.

Today four of the six constraints already reach member roles: unconditionally, invisibly, and with no way to opt out. The two **time-limit** constraints do not reach them at all. That is the audit finding — renewing a role's access to a group restores every grant the role confers, without anyone reviewing whether those members should still be in the role.

<details>
<summary><h1>Description of Changes</h1></summary>

**The switch.** One boolean column on `tag`, beside `enabled`, defaulted on via `server_default` so every existing tag keeps behaving as it does today with no backfill. Deliberately not a seventh entry in `Tag.CONSTRAINTS`: it must never be coalesced across tags (each tag decides whether *its own* constraints propagate), and its default inverts relative to the five existing booleans. As a column both problems are structurally impossible rather than prevented by a comment.

**Computed, not materialized.** `RoleGroupMap` is time-bounded and bulk-ended by `UnmanageGroup` and `DeleteGroup`, both of which bypass `ModifyRoleGroups`. A materialized cache would need a trigger-completeness invariant and a repair cron — and under a single gate a missed trigger stops being "a time limit lands late" and becomes "a control is silently off". A computed set cannot drift.

**The propagation rule.** A role confers access on its *members*, so propagation always feeds the role's member side. What differs is which key is read on the associated group:

| Association | Members of the role receive | Role's member-side constraint reads |
|---|---|---|
| Role is a **member** of G | Membership of G | the same key on G's tags |
| Role is an **owner** of G | Ownership of G | the **owner-side counterpart** key |

`OWNER_SIDE_COUNTERPART` encodes both the pairing and, by its key set, which constraints propagate at all. Nothing reaches a role's owner side — owning a role confers none of its grants.

**One enforcement path.** `effective_constraint` replaces every hand-rolled traversal; the associated-group loops in `CheckForSelfAdd` / `CheckForReason` are deleted, including the **owner** loops they contained. Error messages still name the group that imposed the restriction, via `constraint_source_clause`.

**Time limits land in three places**, because they mutate state rather than veto:

1. Grant time, in `ModifyGroupUsers`.
2. A time-limited tag arriving on a group roles are already associated with, in `ModifyGroupsTimeLimit`.
3. A role being attached to such a group, or that attachment renewed, in `ModifyRoleGroups`. Without this the gap recurs on every renewal rather than only for grants predating the deploy.

All three go through `limit_access_conferred_by_roles` (from #615), so a capped role membership never leaves behind the access it confers. The `cap-role-memberships` CLI sweep covers pre-existing grants and uses the same helper for the same reason — assigning `ended_at` directly would shorten the membership while the rows actually holding the Okta groups stayed indefinite.

**Unmanaged roles.** Propagation is gated on the role's own `is_managed` inside `_propagated_sources`. Every enforcement path already checks that separately, so gating in one place is what keeps the computed set from advertising constraints nothing applies.

</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

- `make test` green: ruff, ty, 922 backend, 38 frontend.
- **Parity is the bar for the breaking change**: with propagation on, self-add and reason behave identically to `main`. The existing suites pass with no assertion edits except the two time-limit count tests, whose new numbers are the propagated caps.
- Both association axes covered for each constraint, plus the negative: nothing reaches a role's owner side from either direction.
- Gate coverage: off means none of the six reach associated roles while direct and app-group enforcement is untouched; and per-tag rather than global, so one opted-out tag on a group does not drag another's constraints along.
- Mutation-tested where a test's value depended on it — the unmanaged-role gate was removed and its test confirmed to fail.
- Verified against a live local stack in the previous incarnation of this work (#601): a SOX tag on `App-Foo-Admin` with `Role-Finance` a member and `Role-Auditor` an owner produced a 90-day member cap and a 30-day cap read from the group's *owner* limit respectively.

</details>

# Guidance for Reviewers

Three places most worth your judgement:

1. **`api/models/tag.py` — the propagation rule.** Everything calls into it. Worth checking the owner-side axis swap, and that `constraint_key in OWNER_SIDE_COUNTERPART` is the right test for "does this key propagate".
2. **Deleting the associated-group loops** makes `effective_constraint` the *sole* enforcement path for self-add and reason on associated roles. The full suite passing with no assertion edits was the parity bar.
3. **Eager loading.** `lazy="raise_on_sql"` makes a missing loader a 500 on a live endpoint rather than a test failure, and `effective_constraint` raises only for groups that actually carry a tag — so an untagged smoke test proves nothing. Worth confirming no call path into it lacks its loaders.

**Rollout note:** There's both a new opt-in capability (a tag *can now stop* propagating self-add and reason) and opt-out breaking behavior change: time limits reach roles for the first time, so new role memberships begin getting shortened immediately. Capping existing memberships requires manual action, as `cap-role-memberships` is deliberately not wired to any cron.
