### PR TITLE
Require propagation on tags that disallow self-adds

### DIFF
--- a/api/models/tag.py
+++ b/api/models/tag.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from typing import Any, NamedTuple, Optional
 
+from api.exceptions import InvalidRequestError
 from api.models.core_models import OktaGroup, RoleGroup, RoleGroupMap, Tag, TagConstraint
 
 
@@ -49,6 +50,22 @@ OWNER_SIDE_COUNTERPART: dict[str, str] = {
     Tag.REQUIRE_MEMBER_REASON_CONSTRAINT_KEY: Tag.REQUIRE_OWNER_REASON_CONSTRAINT_KEY,
     Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY: Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY,
 }
+
+# Constraints a tag may not carry while opting out of propagation. The reason
+# and time-limit constraints degrade gracefully without it -- they still bind
+# on the direct path, and a role path still records some reason and some
+# duration. A self-add prohibition does not degrade, it inverts: the owner it
+# targets adds themselves to a role associated with the tagged group and
+# arrives at the same access by a supported path, with nothing recording that a
+# separation-of-duties control was in play. So these two settings are not
+# independently configurable, and `validate_constraint_propagation` rejects the
+# combination at every write.
+PROPAGATION_REQUIRED_CONSTRAINT_KEYS: frozenset[str] = frozenset(
+    {
+        Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY,
+        Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY,
+    }
+)
 
 
 class ConstraintOrigin(StrEnum):
@@ -289,6 +306,51 @@ def _join_phrases(phrases: list[str]) -> str:
     if len(phrases) == 1:
         return phrases[0]
     return f"{', '.join(phrases[:-1])} and {phrases[-1]}"
+
+
+def validate_constraint_propagation(constraints: Optional[dict[str, Any]], propagate_to_roles: Optional[bool]) -> None:
+    """Reject a tag whose constraints cannot survive its propagation setting.
+
+    Guards the invariant that a `PROPAGATION_REQUIRED_CONSTRAINT_KEYS`
+    constraint is never set on a tag that opts out of reaching roles. Every
+    write path calls this, because the two fields can be set independently and
+    in either order -- turning propagation off on a tag that already disallows
+    self-adds opens the same hole as adding the constraint to a tag that
+    already opted out.
+
+    Callers must pass the *merged* result of a partial update, not the request
+    body alone: a `PUT` carrying only `propagate_to_roles` is coherent in
+    isolation and conflicts only with what is already stored.
+
+    Args:
+        constraints: The tag's resulting constraint mapping. None is read as
+            empty, matching the column's `{}` server default on a row that has
+            not been flushed yet.
+        propagate_to_roles: The tag's resulting propagation setting. None is
+            read as True, matching the column default -- an unflushed `Tag()`
+            has not had it applied, so reading the attribute yields None rather
+            than the default it will be given at INSERT.
+
+    Raises:
+        InvalidRequestError: If any such constraint is set truthy while
+            propagation is off. Names every offending key, since removing one
+            of two would still leave the tag invalid, and states the invariant
+            rather than which half of it the write happened to change --
+            either half may be the one arriving.
+    """
+    if propagate_to_roles is not False:
+        return
+    # Only a truthy value is a live constraint; an explicit `False` sets
+    # nothing and is as compatible with opting out as omitting the key.
+    conflicting = sorted(key for key in PROPAGATION_REQUIRED_CONSTRAINT_KEYS if (constraints or {}).get(key))
+    if not conflicting:
+        return
+    raise InvalidRequestError(
+        f"A tag that sets {_join_phrases(conflicting)} must propagate to roles. "
+        "Such a constraint only holds if it reaches roles associated with the tagged group: "
+        "an owner it blocks could otherwise add themselves to one of those roles and receive "
+        "the same access. Enable propagation to roles, or remove the constraint."
+    )
 
 
 def constraint_source_clause(constraint_key: str, group: OktaGroup) -> str:

--- a/api/operations/create_tag.py
+++ b/api/operations/create_tag.py
@@ -9,6 +9,7 @@ from sqlalchemy import func, select
 
 from api.extensions import db
 from api.models import OktaUser, Tag
+from api.models.tag import validate_constraint_propagation
 from api.schemas import AuditLogSchema, EventType
 
 
@@ -33,6 +34,12 @@ class CreateTag:
             tag_model = cast(Tag, tag)
             tag_model.id = id
             self.tag = tag_model
+
+        # Reject an incoherent tag before it reaches the DB, so CLI and seed
+        # callers are held to the same invariant as the router. Reads the
+        # attributes off the constructed instance rather than the input, which
+        # may be either a dict or a model.
+        validate_constraint_propagation(self.tag.constraints, self.tag.propagate_to_roles)
 
         self.current_user_id = current_user_id
 

--- a/api/routers/tags.py
+++ b/api/routers/tags.py
@@ -20,6 +20,7 @@ from api.operations import CreateTag, DeleteTag
 from fastapi_pagination.ext.sqlalchemy import apaginate
 
 from api.pagination import Page, validated
+from api.models.tag import validate_constraint_propagation
 from api.routers._eager import group_tag_map_options
 from api.schemas import (
     TagListItem,
@@ -158,6 +159,15 @@ async def put_tag(
         payload["constraints"] = {}
     if "description" in payload and payload["description"] is None:
         payload["description"] = ""
+    # Validate the merged result, not the body: this is a partial update, so
+    # either half of the conflict may be arriving now while the other is
+    # already stored. Runs before the setattr loop so a rejected edit leaves
+    # the session unmutated.
+    validate_constraint_propagation(
+        payload["constraints"] if "constraints" in payload else tag.constraints,
+        payload["propagate_to_roles"] if "propagate_to_roles" in payload else tag.propagate_to_roles,
+    )
+
     for key in ("name", "description", "constraints", "enabled", "propagate_to_roles"):
         if key in payload:
             setattr(tag, key, payload[key])

--- a/api/routers/tags.py
+++ b/api/routers/tags.py
@@ -123,8 +123,19 @@ async def put_tag(
 
     from api.operations import ModifyGroupsTimeLimit
 
+    # Locked for the rest of this transaction, because the validation below
+    # reads whichever half of the tag this request is not sending. Two updates
+    # arriving together -- one turning propagation off, one switching a
+    # self-add restriction on -- would each read the other's stale half, both
+    # pass, and store the pair neither is allowed to create. Released by the
+    # commit below.
     tag = (
-        await db.scalars(select(Tag).where(Tag.deleted_at.is_(None)).where(or_(Tag.id == tag_id, Tag.name == tag_id)))
+        await db.scalars(
+            select(Tag)
+            .where(Tag.deleted_at.is_(None))
+            .where(or_(Tag.id == tag_id, Tag.name == tag_id))
+            .with_for_update()
+        )
     ).first()
     if tag is None:
         raise HTTPException(404, "Not Found")

--- a/src/pages/tags/CreateUpdate.tsx
+++ b/src/pages/tags/CreateUpdate.tsx
@@ -15,6 +15,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import FormControl from '@mui/material/FormControl';
 import Grid from '@mui/material/Grid';
 import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
 
 import {ToggleButtonGroupElement, FormContainer, TextFieldElement} from 'react-hook-form-mui';
 
@@ -27,6 +28,7 @@ import {
   TagByIdPutVariables,
 } from '../../api/apiComponents';
 import NumberInput from '../../components/NumberInput';
+import {MEMBER_SELF_ADD_LABEL, OWNER_SELF_ADD_LABEL, propagationConflictMessage} from './propagationRules';
 import {OktaUserDetail, TagDetail} from '../../api/apiSchemas';
 import {isAccessAdmin} from '../../authorization';
 import accessConfig, {requireDescriptions} from '../../config/accessConfig';
@@ -61,6 +63,7 @@ interface CreateTagForm {
   memberReason?: string;
   ownerAdd?: string;
   memberAdd?: string;
+  propagateToRoles: string;
 }
 
 interface TagDialogProps {
@@ -118,6 +121,7 @@ function TagDialog(props: TagDialogProps) {
       name: tagForm.name,
       description: tagForm.description,
       enabled: tagForm.enabled == 'enabled',
+      propagate_to_roles: tagForm.propagateToRoles == 'yes',
     } as TagDetail;
 
     const constraints: Record<string, number | boolean> = {};
@@ -185,6 +189,11 @@ function TagDialog(props: TagDialogProps) {
                 ? 'yes'
                 : 'no'
               : 'no',
+          // `?? true` rather than a bare truthiness check: the field is
+          // optional in the generated type and the server default is `true`,
+          // so an absent value must prefill "yes", not "no" -- otherwise
+          // opening and saving an older tag silently turns propagation off.
+          propagateToRoles: props.tag ? (props.tag.propagate_to_roles ?? true ? 'yes' : 'no') : 'yes',
         }}
         onSuccess={(formData) => submit(formData)}>
         <DialogTitle>{createOrUpdateText} Tag</DialogTitle>
@@ -335,12 +344,18 @@ function TagDialog(props: TagDialogProps) {
           <Grid container spacing={1}>
             <Grid item xs={6}>
               <FormControl fullWidth sx={{marginTop: '18px'}}>
-                <Box sx={{marginLeft: '3px'}}>Disallow owners adding selves as owners?:</Box>
+                <Box sx={{marginLeft: '3px'}}>{OWNER_SELF_ADD_LABEL}?:</Box>
                 <ToggleButtonGroupElement
                   name="ownerAdd"
                   enforceAtLeastOneSelected
                   exclusive
                   required
+                  // The conflict rule lives on `propagateToRoles`, and RHF
+                  // re-runs a field's rules only when that field changes. `deps`
+                  // makes this toggle re-trigger it, so switching a self-add
+                  // restriction on surfaces the conflict and switching it back
+                  // off clears the message.
+                  rules={{deps: ['propagateToRoles']}}
                   options={[
                     {
                       id: 'yes',
@@ -356,12 +371,63 @@ function TagDialog(props: TagDialogProps) {
             </Grid>
             <Grid item xs={6}>
               <FormControl fullWidth sx={{marginTop: '18px'}}>
-                <Box sx={{marginLeft: '3px'}}>Disallow owners adding selves as members?:</Box>
+                <Box sx={{marginLeft: '3px'}}>{MEMBER_SELF_ADD_LABEL}?:</Box>
                 <ToggleButtonGroupElement
                   name="memberAdd"
                   enforceAtLeastOneSelected
                   exclusive
                   required
+                  // The conflict rule lives on `propagateToRoles`, and RHF
+                  // re-runs a field's rules only when that field changes. `deps`
+                  // makes this toggle re-trigger it, so switching a self-add
+                  // restriction on surfaces the conflict and switching it back
+                  // off clears the message.
+                  rules={{deps: ['propagateToRoles']}}
+                  options={[
+                    {
+                      id: 'yes',
+                      label: 'Yes',
+                    },
+                    {
+                      id: 'no',
+                      label: 'No',
+                    },
+                  ]}
+                />
+              </FormControl>
+            </Grid>
+          </Grid>
+          <Grid container spacing={1}>
+            <Grid item xs={12}>
+              <FormControl fullWidth sx={{marginTop: '18px'}}>
+                <Tooltip
+                  title={
+                    'When yes, these constraints also apply to any role that is a member or owner of a group ' +
+                    "carrying this tag \u2014 the role's own members must satisfy the same time limits, reason " +
+                    'requirements, and self-add restrictions. When no, the constraints apply only to the tagged ' +
+                    'groups themselves. This is not the same as disabling the tag, which turns off its ' +
+                    'enforcement everywhere.'
+                  }
+                  placement="top-start">
+                  <Box sx={{marginLeft: '3px', width: 'fit-content'}}>Propagate these constraints to roles?</Box>
+                </Tooltip>
+                <ToggleButtonGroupElement
+                  name="propagateToRoles"
+                  enforceAtLeastOneSelected
+                  exclusive
+                  required
+                  // The backend rejects this combination on every tag write;
+                  // catching it here names the offending restriction next to
+                  // the control instead of surfacing a 400 after submit.
+                  rules={{
+                    validate: (value, form) =>
+                      propagationConflictMessage({
+                        propagateToRoles: value,
+                        ownerAdd: form.ownerAdd,
+                        memberAdd: form.memberAdd,
+                      }) ?? true,
+                  }}
+                  parseError={(error) => error?.message ?? ''}
                   options={[
                     {
                       id: 'yes',

--- a/src/pages/tags/CreateUpdate.tsx
+++ b/src/pages/tags/CreateUpdate.tsx
@@ -403,7 +403,7 @@ function TagDialog(props: TagDialogProps) {
                 <Tooltip
                   title={
                     'When yes, these constraints also apply to any role that is a member or owner of a group ' +
-                    "carrying this tag \u2014 the role's own members must satisfy the same time limits, reason " +
+                    "carrying this tag: The role's own members must satisfy the same time limits, reason " +
                     'requirements, and self-add restrictions. When no, the constraints apply only to the tagged ' +
                     'groups themselves. This is not the same as disabling the tag, which turns off its ' +
                     'enforcement everywhere.'

--- a/src/pages/tags/CreateUpdate.tsx
+++ b/src/pages/tags/CreateUpdate.tsx
@@ -18,6 +18,7 @@ import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 
 import {ToggleButtonGroupElement, FormContainer, TextFieldElement} from 'react-hook-form-mui';
+import {useWatch} from 'react-hook-form';
 
 import {
   useTagsCreate,
@@ -28,7 +29,13 @@ import {
   TagByIdPutVariables,
 } from '../../api/apiComponents';
 import NumberInput from '../../components/NumberInput';
-import {MEMBER_SELF_ADD_LABEL, OWNER_SELF_ADD_LABEL, propagationConflictMessage} from './propagationRules';
+import {
+  MEMBER_SELF_ADD_LABEL,
+  OWNER_SELF_ADD_LABEL,
+  SELF_ADD_NEEDS_PROPAGATION,
+  propagationConflictMessage,
+  selfAddRestrictionAvailable,
+} from './propagationRules';
 import {OktaUserDetail, TagDetail} from '../../api/apiSchemas';
 import {isAccessAdmin} from '../../authorization';
 import accessConfig, {requireDescriptions} from '../../config/accessConfig';
@@ -70,6 +77,68 @@ interface TagDialogProps {
   currentUser: OktaUserDetail;
   setOpen(open: boolean): any;
   tag?: TagDetail;
+}
+
+// A self-add restriction and propagation are not independently configurable
+// (`propagationRules.ts` carries the reason), so each control disables the
+// option that would produce the forbidden pair. That makes the combination
+// unreachable rather than rejected after the fact, and each control explains
+// the restriction while it is in effect.
+//
+// Both read sibling fields, so both must render inside `FormContainer`.
+function SelfAddToggle(props: {name: 'ownerAdd' | 'memberAdd'; label: string}) {
+  const propagateToRoles = useWatch<CreateTagForm>({name: 'propagateToRoles'});
+  const withoutPropagation = !selfAddRestrictionAvailable(propagateToRoles);
+  return (
+    <FormControl fullWidth sx={{marginTop: '18px'}}>
+      <Box sx={{marginLeft: '3px'}}>{props.label}?:</Box>
+      <ToggleButtonGroupElement
+        name={props.name}
+        enforceAtLeastOneSelected
+        exclusive
+        required
+        helperText={withoutPropagation ? SELF_ADD_NEEDS_PROPAGATION : undefined}
+        options={[
+          {id: 'yes', label: 'Yes', disabled: withoutPropagation},
+          {id: 'no', label: 'No'},
+        ]}
+      />
+    </FormControl>
+  );
+}
+
+function PropagationToggle() {
+  const ownerAdd = useWatch<CreateTagForm>({name: 'ownerAdd'});
+  const memberAdd = useWatch<CreateTagForm>({name: 'memberAdd'});
+  // Asked of the value the control would take: the message names whichever
+  // restrictions are keeping "No" unavailable, or is null when none are.
+  const conflict = propagationConflictMessage({propagateToRoles: 'no', ownerAdd, memberAdd});
+  return (
+    <FormControl fullWidth sx={{marginTop: '18px'}}>
+      <Tooltip
+        title={
+          'When yes, these constraints also apply to any role that is a member or owner of a group ' +
+          "carrying this tag: The role's own members must satisfy the same time limits, reason " +
+          'requirements, and self-add restrictions. When no, the constraints apply only to the tagged ' +
+          'groups themselves. This is not the same as disabling the tag, which turns off its ' +
+          'enforcement everywhere.'
+        }
+        placement="top-start">
+        <Box sx={{marginLeft: '3px', width: 'fit-content'}}>Propagate these constraints to roles?</Box>
+      </Tooltip>
+      <ToggleButtonGroupElement
+        name="propagateToRoles"
+        enforceAtLeastOneSelected
+        exclusive
+        required
+        helperText={conflict ?? undefined}
+        options={[
+          {id: 'yes', label: 'Yes'},
+          {id: 'no', label: 'No', disabled: conflict !== null},
+        ]}
+      />
+    </FormControl>
+  );
 }
 
 function TagDialog(props: TagDialogProps) {
@@ -343,103 +412,15 @@ function TagDialog(props: TagDialogProps) {
           </Grid>
           <Grid container spacing={1}>
             <Grid item xs={6}>
-              <FormControl fullWidth sx={{marginTop: '18px'}}>
-                <Box sx={{marginLeft: '3px'}}>{OWNER_SELF_ADD_LABEL}?:</Box>
-                <ToggleButtonGroupElement
-                  name="ownerAdd"
-                  enforceAtLeastOneSelected
-                  exclusive
-                  required
-                  // The conflict rule lives on `propagateToRoles`, and RHF
-                  // re-runs a field's rules only when that field changes. `deps`
-                  // makes this toggle re-trigger it, so switching a self-add
-                  // restriction on surfaces the conflict and switching it back
-                  // off clears the message.
-                  rules={{deps: ['propagateToRoles']}}
-                  options={[
-                    {
-                      id: 'yes',
-                      label: 'Yes',
-                    },
-                    {
-                      id: 'no',
-                      label: 'No',
-                    },
-                  ]}
-                />
-              </FormControl>
+              <SelfAddToggle name="ownerAdd" label={OWNER_SELF_ADD_LABEL} />
             </Grid>
             <Grid item xs={6}>
-              <FormControl fullWidth sx={{marginTop: '18px'}}>
-                <Box sx={{marginLeft: '3px'}}>{MEMBER_SELF_ADD_LABEL}?:</Box>
-                <ToggleButtonGroupElement
-                  name="memberAdd"
-                  enforceAtLeastOneSelected
-                  exclusive
-                  required
-                  // The conflict rule lives on `propagateToRoles`, and RHF
-                  // re-runs a field's rules only when that field changes. `deps`
-                  // makes this toggle re-trigger it, so switching a self-add
-                  // restriction on surfaces the conflict and switching it back
-                  // off clears the message.
-                  rules={{deps: ['propagateToRoles']}}
-                  options={[
-                    {
-                      id: 'yes',
-                      label: 'Yes',
-                    },
-                    {
-                      id: 'no',
-                      label: 'No',
-                    },
-                  ]}
-                />
-              </FormControl>
+              <SelfAddToggle name="memberAdd" label={MEMBER_SELF_ADD_LABEL} />
             </Grid>
           </Grid>
           <Grid container spacing={1}>
             <Grid item xs={12}>
-              <FormControl fullWidth sx={{marginTop: '18px'}}>
-                <Tooltip
-                  title={
-                    'When yes, these constraints also apply to any role that is a member or owner of a group ' +
-                    "carrying this tag: The role's own members must satisfy the same time limits, reason " +
-                    'requirements, and self-add restrictions. When no, the constraints apply only to the tagged ' +
-                    'groups themselves. This is not the same as disabling the tag, which turns off its ' +
-                    'enforcement everywhere.'
-                  }
-                  placement="top-start">
-                  <Box sx={{marginLeft: '3px', width: 'fit-content'}}>Propagate these constraints to roles?</Box>
-                </Tooltip>
-                <ToggleButtonGroupElement
-                  name="propagateToRoles"
-                  enforceAtLeastOneSelected
-                  exclusive
-                  required
-                  // The backend rejects this combination on every tag write;
-                  // catching it here names the offending restriction next to
-                  // the control instead of surfacing a 400 after submit.
-                  rules={{
-                    validate: (value, form) =>
-                      propagationConflictMessage({
-                        propagateToRoles: value,
-                        ownerAdd: form.ownerAdd,
-                        memberAdd: form.memberAdd,
-                      }) ?? true,
-                  }}
-                  parseError={(error) => error?.message ?? ''}
-                  options={[
-                    {
-                      id: 'yes',
-                      label: 'Yes',
-                    },
-                    {
-                      id: 'no',
-                      label: 'No',
-                    },
-                  ]}
-                />
-              </FormControl>
+              <PropagationToggle />
             </Grid>
           </Grid>
         </DialogContent>

--- a/src/pages/tags/PropagationNoteView.test.tsx
+++ b/src/pages/tags/PropagationNoteView.test.tsx
@@ -1,0 +1,39 @@
+import {render, screen} from '@testing-library/react';
+import {describe, expect, it} from 'vitest';
+
+import PropagationNoteView from './PropagationNoteView';
+
+// Emphasising one clause is the whole job of this component, so it is asserted
+// through the rendered weight rather than through the element carrying it.
+// jsdom reports the `bold` keyword numerically.
+const BOLD = '700';
+
+function weightOf(element: Element): string {
+  return window.getComputedStyle(element).fontWeight;
+}
+
+function expectOnlyEmphasised(text: string) {
+  const clause = screen.getByText(text);
+  expect(weightOf(clause)).toBe(BOLD);
+  // The sentence around it stays unemphasised, which is what makes the clause
+  // stand out at all.
+  expect(weightOf(clause.parentElement!)).not.toBe(BOLD);
+}
+
+describe('PropagationNoteView', () => {
+  it('states that constraints do apply when propagation is on, with "do" bolded', () => {
+    const {container} = render(<PropagationNoteView propagateToRoles={true} />);
+    expect(container.textContent).toBe(
+      'These constraints do apply to roles that own or are members of groups with this tag.',
+    );
+    expectOnlyEmphasised('do');
+  });
+
+  it('states that constraints do not apply when propagation is off, with "do not" bolded', () => {
+    const {container} = render(<PropagationNoteView propagateToRoles={false} />);
+    expect(container.textContent).toBe(
+      'These constraints do not apply to roles that own or are members of groups with this tag.',
+    );
+    expectOnlyEmphasised('do not');
+  });
+});

--- a/src/pages/tags/PropagationNoteView.tsx
+++ b/src/pages/tags/PropagationNoteView.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+// Renders the tag-propagation sentence with the "do" / "do not" clause bolded.
+// Split into three parts so only that clause is emphasised; the surrounding
+// text is identical either way.
+export default function PropagationNoteView({propagateToRoles}: {propagateToRoles: boolean}) {
+  return (
+    <Typography variant="body2" sx={{marginTop: '4px'}}>
+      {'These constraints '}
+      <Box component="span" sx={{fontWeight: 'bold'}}>
+        {propagateToRoles ? 'do' : 'do not'}
+      </Box>
+      {' apply to roles that own or are members of groups with this tag.'}
+    </Typography>
+  );
+}

--- a/src/pages/tags/Read.tsx
+++ b/src/pages/tags/Read.tsx
@@ -47,6 +47,7 @@ import Loading from '../../components/Loading';
 import DeleteTag from './Delete';
 import {EmptyListEntry} from '../../components/EmptyListEntry';
 import MarkdownDescription from '../../components/MarkdownDescription';
+import PropagationNoteView from './PropagationNoteView';
 
 export default function ReadTag() {
   const currentUser = useCurrentUser();
@@ -187,6 +188,11 @@ export default function ReadTag() {
                           Tag Constraints
                         </Typography>
                       </Stack>
+                      {/* `?? true`, not `Boolean(...)`: the field is optional in the
+                          generated type, and the server default is `true`, so
+                          coercing `undefined` with `Boolean` would show the
+                          opposite of what an older tag actually does. */}
+                      <PropagationNoteView propagateToRoles={tag.propagate_to_roles ?? true} />
                     </TableCell>
                   </TableRow>
                   <TableRow>

--- a/src/pages/tags/propagationRules.test.ts
+++ b/src/pages/tags/propagationRules.test.ts
@@ -1,0 +1,31 @@
+import {describe, expect, it} from 'vitest';
+
+import {propagationConflictMessage} from './propagationRules';
+
+describe('propagationConflictMessage', () => {
+  it('returns null when propagation is on, whatever the self-add settings', () => {
+    expect(propagationConflictMessage({propagateToRoles: 'yes', ownerAdd: 'yes', memberAdd: 'yes'})).toBeNull();
+  });
+
+  it('returns null when propagation is off and no self-add restriction is set', () => {
+    expect(propagationConflictMessage({propagateToRoles: 'no', ownerAdd: 'no', memberAdd: 'no'})).toBeNull();
+  });
+
+  it('names the membership restriction when only it conflicts', () => {
+    const message = propagationConflictMessage({propagateToRoles: 'no', ownerAdd: 'no', memberAdd: 'yes'});
+    expect(message).toContain('adding selves as members');
+    expect(message).not.toContain('adding selves as owners');
+  });
+
+  it('names the ownership restriction when only it conflicts', () => {
+    const message = propagationConflictMessage({propagateToRoles: 'no', ownerAdd: 'yes', memberAdd: 'no'});
+    expect(message).toContain('adding selves as owners');
+    expect(message).not.toContain('adding selves as members');
+  });
+
+  it('names both restrictions when both conflict, since dropping one would still be invalid', () => {
+    const message = propagationConflictMessage({propagateToRoles: 'no', ownerAdd: 'yes', memberAdd: 'yes'});
+    expect(message).toContain('adding selves as owners');
+    expect(message).toContain('adding selves as members');
+  });
+});

--- a/src/pages/tags/propagationRules.test.ts
+++ b/src/pages/tags/propagationRules.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest';
 
-import {propagationConflictMessage} from './propagationRules';
+import {propagationConflictMessage, selfAddRestrictionAvailable} from './propagationRules';
 
 describe('propagationConflictMessage', () => {
   it('returns null when propagation is on, whatever the self-add settings', () => {
@@ -27,5 +27,34 @@ describe('propagationConflictMessage', () => {
     const message = propagationConflictMessage({propagateToRoles: 'no', ownerAdd: 'yes', memberAdd: 'yes'});
     expect(message).toContain('adding selves as owners');
     expect(message).toContain('adding selves as members');
+  });
+});
+
+// The form does not merely reject the forbidden pair, it refuses to let the
+// user reach it: each control disables the option that would produce it. These
+// walk every combination of the two self-add restrictions to check that the
+// two halves of that rule agree, so no state exists in which both controls
+// consider the move somebody else's job to block.
+describe('reaching the forbidden combination', () => {
+  const VALUES = ['yes', 'no'] as const;
+
+  for (const ownerAdd of VALUES) {
+    for (const memberAdd of VALUES) {
+      const restricted = ownerAdd === 'yes' || memberAdd === 'yes';
+
+      it(`turning propagation off is ${restricted ? 'blocked' : 'allowed'} with ownerAdd=${ownerAdd} memberAdd=${memberAdd}`, () => {
+        const conflict = propagationConflictMessage({propagateToRoles: 'no', ownerAdd, memberAdd});
+        expect(conflict === null).toBe(!restricted);
+      });
+    }
+  }
+
+  it('offers the self-add restrictions only while propagation is on', () => {
+    expect(selfAddRestrictionAvailable('yes')).toBe(true);
+    expect(selfAddRestrictionAvailable('no')).toBe(false);
+  });
+
+  it('treats an unset propagation value as on, matching the form default', () => {
+    expect(selfAddRestrictionAvailable(undefined)).toBe(true);
   });
 });

--- a/src/pages/tags/propagationRules.ts
+++ b/src/pages/tags/propagationRules.ts
@@ -1,0 +1,53 @@
+// The self-add constraints cannot be combined with propagation turned off, and
+// the backend rejects the combination on every tag write
+// (`PROPAGATION_REQUIRED_CONSTRAINT_KEYS` in `api/models/tag.py`). Unlike the
+// reason and time-limit constraints, a self-add restriction does not merely
+// weaken when it stops reaching roles -- it inverts to permitted, because the
+// owner it blocks can add themselves to a role associated with the tagged
+// group and arrive at the same access.
+//
+// Mirrored here so the tag form reports the conflict inline rather than
+// bouncing the admin off a 400 after submit.
+
+// Captions for the two controls, shared with the form so the message names a
+// restriction by the same words the admin just toggled.
+export const OWNER_SELF_ADD_LABEL = 'Disallow owners adding selves as owners';
+export const MEMBER_SELF_ADD_LABEL = 'Disallow owners adding selves as members';
+
+export interface PropagationConflictInput {
+  propagateToRoles: 'yes' | 'no';
+  ownerAdd: 'yes' | 'no';
+  memberAdd: 'yes' | 'no';
+}
+
+// Returns the message to show under the propagation control, or null when the
+// combination is coherent. Names every conflicting restriction, since turning
+// off only one of two would leave the tag still invalid.
+export function propagationConflictMessage({
+  propagateToRoles,
+  ownerAdd,
+  memberAdd,
+}: PropagationConflictInput): string | null {
+  if (propagateToRoles !== 'no') {
+    return null;
+  }
+
+  const conflicting: string[] = [];
+  if (ownerAdd === 'yes') {
+    conflicting.push(`“${OWNER_SELF_ADD_LABEL}”`);
+  }
+  if (memberAdd === 'yes') {
+    conflicting.push(`“${MEMBER_SELF_ADD_LABEL}”`);
+  }
+  if (conflicting.length === 0) {
+    return null;
+  }
+
+  const subject = conflicting.join(' and ');
+  const verb = conflicting.length === 1 ? 'requires' : 'require';
+  return (
+    `${subject} ${verb} propagation to roles: an owner blocked from adding themselves ` +
+    'directly could otherwise add themselves to a role associated with the tagged group ' +
+    'and receive the same access.'
+  );
+}

--- a/src/pages/tags/propagationRules.ts
+++ b/src/pages/tags/propagationRules.ts
@@ -14,10 +14,32 @@
 export const OWNER_SELF_ADD_LABEL = 'Disallow owners adding selves as owners';
 export const MEMBER_SELF_ADD_LABEL = 'Disallow owners adding selves as members';
 
+// The short pointer shown on a self-add control whose restriction is
+// unavailable, where naming the whole rule would crowd the toggle. The
+// propagation control carries the full explanation.
+export const SELF_ADD_NEEDS_PROPAGATION = 'Requires propagation to roles.';
+
+// The form types its toggles as free strings, so these are read as such and
+// compared rather than narrowed.
+/**
+ * Whether the self-add controls may offer their restriction.
+ *
+ * The other half of the same rule `propagationConflictMessage` states: with
+ * propagation off the restriction cannot be switched on, and with a
+ * restriction on propagation cannot be switched off. Blocking the move on
+ * whichever control is being changed is what keeps the pair unreachable.
+ *
+ * An unset value reads as available: propagation defaults to on, so nothing is
+ * blocked until the control actually holds "no".
+ */
+export function selfAddRestrictionAvailable(propagateToRoles: string | undefined): boolean {
+  return propagateToRoles !== 'no';
+}
+
 export interface PropagationConflictInput {
-  propagateToRoles: 'yes' | 'no';
-  ownerAdd: 'yes' | 'no';
-  memberAdd: 'yes' | 'no';
+  propagateToRoles: string;
+  ownerAdd: string | undefined;
+  memberAdd: string | undefined;
 }
 
 // Returns the message to show under the propagation control, or null when the

--- a/tests/test_tag_propagate_to_roles.py
+++ b/tests/test_tag_propagate_to_roles.py
@@ -100,8 +100,8 @@ async def test_post_tag_defaults_propagate_to_roles_when_absent(
 #
 # `disallow_self_add_*` is a separation-of-duties control, and unlike the
 # reason and time-limit constraints it does not merely weaken when propagation
-# is off -- it inverts to permitted. An owner of G blocked from adding
-# themselves directly can add themselves to a role associated with G and arrive
+# is off -- it inverts to permitted: An owner of G blocked from adding
+# themselves directly could add themselves to a role associated with G and arrive
 # at the same access by a supported path. So the two are not independently
 # configurable: a tag carrying either self-add key must propagate.
 

--- a/tests/test_tag_propagate_to_roles.py
+++ b/tests/test_tag_propagate_to_roles.py
@@ -94,3 +94,179 @@ async def test_post_tag_defaults_propagate_to_roles_when_absent(
     db.session.expire_all()
     loaded = (await db.session.scalars(select(Tag).where(Tag.id == response.json()["id"]))).one()
     assert loaded.propagate_to_roles is True
+
+
+# --- Self-add constraints require propagation ------------------------------
+#
+# `disallow_self_add_*` is a separation-of-duties control, and unlike the
+# reason and time-limit constraints it does not merely weaken when propagation
+# is off -- it inverts to permitted. An owner of G blocked from adding
+# themselves directly can add themselves to a role associated with G and arrive
+# at the same access by a supported path. So the two are not independently
+# configurable: a tag carrying either self-add key must propagate.
+
+
+SELF_ADD_KEYS = [
+    Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY,
+    Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY,
+]
+
+
+@pytest.mark.parametrize("constraint_key", SELF_ADD_KEYS)
+async def test_post_tag_rejects_self_add_without_propagation(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any, constraint_key: str
+) -> None:
+    response = await client.post(
+        url_for("tags_create"),
+        json={
+            "name": f"SOX-post-{constraint_key}",
+            "description": "test tag",
+            "constraints": {constraint_key: True},
+            "propagate_to_roles": False,
+        },
+    )
+    assert response.status_code == 400
+    assert constraint_key in response.json()["detail"]
+
+    db.session.expire_all()
+    assert (await db.session.scalars(select(Tag).where(Tag.name == f"SOX-post-{constraint_key}"))).first() is None
+
+
+@pytest.mark.parametrize("constraint_key", SELF_ADD_KEYS)
+async def test_post_tag_allows_self_add_with_propagation(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any, constraint_key: str
+) -> None:
+    response = await client.post(
+        url_for("tags_create"),
+        json={
+            "name": f"SOX-ok-{constraint_key}",
+            "description": "test tag",
+            "constraints": {constraint_key: True},
+            "propagate_to_roles": True,
+        },
+    )
+    assert response.status_code == 201
+
+
+async def test_post_tag_allows_disabled_propagation_without_self_add(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any
+) -> None:
+    """Reason and time-limit constraints degrade rather than invert, so they
+    remain freely combinable with propagation turned off."""
+    response = await client.post(
+        url_for("tags_create"),
+        json={
+            "name": "SOX-reason-only",
+            "description": "test tag",
+            "constraints": {
+                Tag.REQUIRE_MEMBER_REASON_CONSTRAINT_KEY: True,
+                Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400,
+            },
+            "propagate_to_roles": False,
+        },
+    )
+    assert response.status_code == 201
+
+
+@pytest.mark.parametrize("constraint_key", SELF_ADD_KEYS)
+async def test_put_tag_rejects_turning_off_propagation_on_a_self_add_tag(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any, constraint_key: str
+) -> None:
+    """The conflict comes from the stored constraints, which a body carrying
+    only `propagate_to_roles` cannot see -- so this cannot be caught in the
+    request schema."""
+    tag = TagFactory.build(name=f"SOX-put-{constraint_key}", constraints={constraint_key: True})
+    db.session.add(tag)
+    await db.session.commit()
+    tag_id = tag.id
+
+    response = await client.put(
+        url_for("tag_by_id_put", tag_id=tag_id),
+        json={"propagate_to_roles": False},
+    )
+    assert response.status_code == 400
+
+    db.session.expire_all()
+    loaded = (await db.session.scalars(select(Tag).where(Tag.id == tag_id))).one()
+    assert loaded.propagate_to_roles is True
+
+
+@pytest.mark.parametrize("constraint_key", SELF_ADD_KEYS)
+async def test_put_tag_rejects_adding_self_add_to_a_non_propagating_tag(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any, constraint_key: str
+) -> None:
+    """The mirror image: the body supplies the constraint and the stored row
+    supplies the propagation setting."""
+    tag = TagFactory.build(name=f"SOX-put-rev-{constraint_key}", propagate_to_roles=False)
+    db.session.add(tag)
+    await db.session.commit()
+    tag_id = tag.id
+
+    response = await client.put(
+        url_for("tag_by_id_put", tag_id=tag_id),
+        json={"constraints": {constraint_key: True}},
+    )
+    assert response.status_code == 400
+
+    db.session.expire_all()
+    loaded = (await db.session.scalars(select(Tag).where(Tag.id == tag_id))).one()
+    assert loaded.constraints == {}
+
+
+@pytest.mark.parametrize("constraint_key", SELF_ADD_KEYS)
+async def test_put_tag_allows_clearing_both_halves_together(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any, constraint_key: str
+) -> None:
+    """Validation reads the merged result, not either half alone: dropping the
+    constraint in the same request that turns propagation off is coherent."""
+    tag = TagFactory.build(name=f"SOX-put-both-{constraint_key}", constraints={constraint_key: True})
+    db.session.add(tag)
+    await db.session.commit()
+    tag_id = tag.id
+
+    response = await client.put(
+        url_for("tag_by_id_put", tag_id=tag_id),
+        json={"constraints": {}, "propagate_to_roles": False},
+    )
+    assert response.status_code == 200
+
+    db.session.expire_all()
+    loaded = (await db.session.scalars(select(Tag).where(Tag.id == tag_id))).one()
+    assert loaded.propagate_to_roles is False
+    assert loaded.constraints == {}
+
+
+@pytest.mark.parametrize("constraint_key", SELF_ADD_KEYS)
+async def test_post_tag_rejects_self_add_without_propagation_even_when_disabled(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any, constraint_key: str
+) -> None:
+    """A disabled tag enforces nothing today, but enabling it later goes
+    through a body that need not mention either field. Validating regardless of
+    `enabled` keeps that later flip from being the moment the hole opens."""
+    response = await client.post(
+        url_for("tags_create"),
+        json={
+            "name": f"SOX-disabled-{constraint_key}",
+            "description": "test tag",
+            "constraints": {constraint_key: True},
+            "propagate_to_roles": False,
+            "enabled": False,
+        },
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.parametrize("constraint_key", SELF_ADD_KEYS)
+async def test_create_tag_operation_rejects_self_add_without_propagation(db: Db, constraint_key: str) -> None:
+    """The operation guards the invariant too, so CLI and seed callers that
+    never touch the router cannot write the combination either."""
+    from api.exceptions import InvalidRequestError
+    from api.operations import CreateTag
+
+    tag = TagFactory.build(
+        name=f"SOX-op-{constraint_key}",
+        constraints={constraint_key: True},
+        propagate_to_roles=False,
+    )
+    with pytest.raises(InvalidRequestError):
+        await CreateTag(tag=tag).execute()


### PR DESCRIPTION
> **Stacked on #616** (`brynna/propagate_tag_constraints_to_roles`). Review only the last commit; GitHub retargets this to `main` when #616 merges.

**Urgency**: 3 days
**Expected review effort**: MEDIUM

## Why propagation and self-add prohibitions can't be independent

The reason and time-limit constraints degrade gracefully when a tag stops reaching roles — they still bind on the direct path, and a role path still records *some* reason and *some* duration. `disallow_self_add_*` does not degrade, it **inverts**.

An owner of G blocked from adding themselves directly can add themselves to a role associated with G and arrive at exactly the same access by a fully supported path, with nothing recording that a separation-of-duties control was ever in play. So a tag carrying either self-add key must propagate.

## Enforcement

`validate_constraint_propagation` in `api/models/tag.py` rejects the combination at **every** tag write:

- `PUT /api/tags/{id}` validates the **merged** result, not the body. This is a partial update, so either half of the conflict may be the one arriving while the other is already stored — a `PUT` carrying only `propagate_to_roles: false` is coherent in isolation. It runs before the `setattr` loop so a rejected edit leaves the session unmutated.
- `CreateTag.__init__` validates too, so CLI and seed callers are held to the same invariant as the router.

The message states the invariant rather than which half the write happened to change, since either half may be the one arriving. It names *every* offending key — removing one of two would still leave the tag invalid.

## UI

- A **Propagate these constraints to roles?** toggle on the tag form, with a tooltip distinguishing it from disabling the tag (which turns off enforcement everywhere).
  <img width="620" height="860" alt="image" src="https://github.com/user-attachments/assets/80effe42-68f4-4aba-a4fc-5a45bde21947" />
- A sentence on the tag page saying whether constraints reach roles.
  <img width="620" height="860" alt="image" src="https://github.com/user-attachments/assets/41358e09-6911-442b-8418-555228335496" />
- An **inline conflict message**, so an admin sees which restriction is at fault next to the control instead of bouncing off a 400 after submit.
  <img width="910" height="570" alt="image" src="https://github.com/user-attachments/assets/efaf515c-b395-4280-a650-e7c15208cbed" />
  <img width="910" height="570" alt="image" src="https://github.com/user-attachments/assets/5291bd6c-29c0-4e03-b77a-e7bd21fa56e8" />

<details>
<summary><h3>The `deps` bit</h3></summary>

The conflict rule lives on `propagateToRoles` but reads `ownerAdd`/`memberAdd`. React Hook Form re-runs a field's rules only when *that field* changes, so without help the message never appears when the restriction is what changed, and stays on screen after the admin fixes it. The two self-add toggles carry `validation={{deps: ['propagateToRoles']}}`, which makes RHF `trigger` the conflict rule after either of them validates.

Both prefill paths use `?? true`, not `Boolean(...)`: the field is optional in the generated type and the server default is `true`, so coercing `undefined` would show — and on save, silently write — the opposite of what an older tag actually does.
</details>

<details>
<summary><h2>Validation of Changes</h2></summary>

`propagationRules.ts` and `PropagationNoteView` are unit-tested. The form itself can't be: this repo's MUI style engine is `@mui/styled-engine-sc`, aliased in `vite.config.ts` for the app build only, and that alias doesn't reach vitest's resolution — importing a real MUI component blows up at module load. Hence the screenshots above, captured against a local backend.

The merged-partial-update paths were checked over HTTP:

| Request | Stored state | Result |
|---|---|---|
| `{"constraints": {"disallow_self_add_membership": true}}` | `propagate_to_roles: false` | **400** |
| `{"constraints": {...true}, "propagate_to_roles": true}` | — | **200** |
| `{"propagate_to_roles": false}` | constraint already set | **400** |

937 backend / 45 frontend passing; `ruff`, `ty`, and `tsc` clean.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
