### PR TITLE
Report a group's effective constraints on its detail endpoint

### DIFF
--- a/api/models/tag.py
+++ b/api/models/tag.py
@@ -390,12 +390,30 @@ def constraint_source_clause(constraint_key: str, group: OktaGroup) -> str:
 
 def _constraint_entry(
     constraint_key: str, constraint: TagConstraint, sources: list[ConstraintSource]
-) -> dict[str, Any]:
-    """One constraint's coalesced value and the sources that produced it."""
+) -> Optional[dict[str, Any]]:
+    """One constraint's coalesced value and the sources that produced it.
+
+    A source setting a flag to `False` imposes nothing -- the tag form writes
+    all four boolean keys on every save, so most tags carry several -- and a
+    constraint every source turns off is not in force at all. Both are dropped,
+    so a reader is never told a restriction applies when it does not, and a tag
+    is never named as the reason for one it explicitly declines to impose.
+    `constraint_source_clause` filters the same way for the same reason.
+
+    Discriminated on `is not False` rather than on truthiness: only a boolean
+    flag can be switched off, and a falsy *number* is the tightest possible
+    limit rather than the absence of one.
+
+    Returns:
+        The entry, or None when nothing is left contributing.
+    """
+    contributing = [source for source in sources if source.value is not False]
+    if not contributing:
+        return None
     return {
         "constraint": constraint_key,
         "name": constraint.name,
-        "value": _fold(constraint, sources),
+        "value": _fold(constraint, contributing),
         "sources": [
             {
                 "tag_id": source.tag.id,
@@ -404,7 +422,7 @@ def _constraint_entry(
                 "source_id": source.source_id,
                 "source_name": source.source_name,
             }
-            for source in sources
+            for source in contributing
         ],
     }
 
@@ -425,8 +443,10 @@ def effective_constraints(group: OktaGroup) -> list[dict[str, Any]]:
         name), `value` (coalesced across every source under that constraint's
         own rule), and `sources`. A source names the tag, how it reached the
         group (`origin`), and the app or group it came from -- `source_id` and
-        `source_name`, both None for a `DIRECT` origin. Constraints nothing
-        sets are omitted, so an untagged group returns an empty list.
+        `source_name`, both None for a `DIRECT` origin. A constraint nothing
+        sets, and a flag every tag setting it turns off, are both omitted --
+        so an untagged group returns an empty list, and so does one whose only
+        tag declines every constraint.
 
     Raises:
         InvalidRequestError: If a relationship this reads was not eager-loaded.
@@ -437,7 +457,7 @@ def effective_constraints(group: OktaGroup) -> list[dict[str, Any]]:
     entries = []
     for constraint_key, constraint in Tag.CONSTRAINTS.items():
         sources = constraint_sources(constraint_key, group, include_provenance=True)
-        if not sources:
-            continue
-        entries.append(_constraint_entry(constraint_key, constraint, sources))
+        entry = _constraint_entry(constraint_key, constraint, sources)
+        if entry is not None:
+            entries.append(entry)
     return entries

--- a/api/models/tag.py
+++ b/api/models/tag.py
@@ -404,10 +404,22 @@ def _constraint_entry(
     flag can be switched off, and a falsy *number* is the tightest possible
     limit rather than the absence of one.
 
+    Sources are ordered by ascending value, then tag name, then source name.
+    Ascending value puts the tag that actually decided the answer first, which
+    for a `min` constraint is the shortest limit; the reader wants to know which
+    tag is binding them, not which happened to be traversed first. Flags all
+    tie -- every one left is `True` -- so they fall through to the name keys.
+    `bool` subclasses `int`, so one comparator covers both kinds of constraint.
+    The two name keys are what make the order independent of traversal, since
+    one tag can reach a role from two different groups and tie on the first two.
+
     Returns:
         The entry, or None when nothing is left contributing.
     """
-    contributing = [source for source in sources if source.value is not False]
+    contributing = sorted(
+        (source for source in sources if source.value is not False),
+        key=lambda source: (source.value, source.tag.name, source.source_name or ""),
+    )
     if not contributing:
         return None
     return {
@@ -443,10 +455,11 @@ def effective_constraints(group: OktaGroup) -> list[dict[str, Any]]:
         name), `value` (coalesced across every source under that constraint's
         own rule), and `sources`. A source names the tag, how it reached the
         group (`origin`), and the app or group it came from -- `source_id` and
-        `source_name`, both None for a `DIRECT` origin. A constraint nothing
-        sets, and a flag every tag setting it turns off, are both omitted --
-        so an untagged group returns an empty list, and so does one whose only
-        tag declines every constraint.
+        `source_name`, both None for a `DIRECT` origin. Sources are ordered by
+        ascending value, so the tag imposing the coalesced value comes first.
+        A constraint nothing sets, and a flag every tag setting it turns off,
+        are both omitted -- so an untagged group returns an empty list, and so
+        does one whose only tag declines every constraint.
 
     Raises:
         InvalidRequestError: If a relationship this reads was not eager-loaded.

--- a/api/models/tag.py
+++ b/api/models/tag.py
@@ -386,3 +386,41 @@ def constraint_source_clause(constraint_key: str, group: OktaGroup) -> str:
     if not phrases:
         return "due to tags on this group"
     return f"due to {_join_phrases(phrases)}"
+
+
+def _constraint_entry(
+    constraint_key: str, constraint: TagConstraint, sources: list[ConstraintSource]
+) -> dict[str, Any]:
+    """One constraint's coalesced value and the sources that produced it."""
+    return {
+        "constraint": constraint_key,
+        "name": constraint.name,
+        "value": _fold(constraint, sources),
+        "sources": [
+            {
+                "tag_id": source.tag.id,
+                "tag_name": source.tag.name,
+                "origin": source.origin,
+                "source_id": source.source_id,
+                "source_name": source.source_name,
+            }
+            for source in sources
+        ],
+    }
+
+
+def effective_constraints(group: OktaGroup) -> list[dict[str, Any]]:
+    """Every constraint in force on `group`, with its coalesced value and sources.
+
+    Backs the API response the UI reads, so display and enforcement answer from
+    the same code. Unlike `effective_constraint`, this reads
+    `OktaGroupTagMap.active_app_tag_mapping` for provenance -- callers must
+    eager-load it (`group_tag_map_options()` in `api/routers/_eager.py` does).
+    """
+    entries = []
+    for constraint_key, constraint in Tag.CONSTRAINTS.items():
+        sources = constraint_sources(constraint_key, group, include_provenance=True)
+        if not sources:
+            continue
+        entries.append(_constraint_entry(constraint_key, constraint, sources))
+    return entries

--- a/api/models/tag.py
+++ b/api/models/tag.py
@@ -413,9 +413,26 @@ def effective_constraints(group: OktaGroup) -> list[dict[str, Any]]:
     """Every constraint in force on `group`, with its coalesced value and sources.
 
     Backs the API response the UI reads, so display and enforcement answer from
-    the same code. Unlike `effective_constraint`, this reads
-    `OktaGroupTagMap.active_app_tag_mapping` for provenance -- callers must
-    eager-load it (`group_tag_map_options()` in `api/routers/_eager.py` does).
+    the same code.
+
+    Args:
+        group: The group to evaluate. Association reads only happen when this
+            is a `RoleGroup`.
+
+    Returns:
+        One entry per constraint that anything sets, in `Tag.CONSTRAINTS`
+        order, each a mapping of `constraint` (the key), `name` (its display
+        name), `value` (coalesced across every source under that constraint's
+        own rule), and `sources`. A source names the tag, how it reached the
+        group (`origin`), and the app or group it came from -- `source_id` and
+        `source_name`, both None for a `DIRECT` origin. Constraints nothing
+        sets are omitted, so an untagged group returns an empty list.
+
+    Raises:
+        InvalidRequestError: If a relationship this reads was not eager-loaded.
+            Provenance means this reads one relationship more than
+            `effective_constraint` does -- `OktaGroupTagMap.active_app_tag_mapping`,
+            supplied by `group_tag_map_options()` in `api/routers/_eager.py`.
     """
     entries = []
     for constraint_key, constraint in Tag.CONSTRAINTS.items():

--- a/api/models/tag.py
+++ b/api/models/tag.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from typing import Any, NamedTuple, Optional
 
+from api.exceptions import InvalidRequestError
 from api.models.core_models import OktaGroup, RoleGroup, RoleGroupMap, Tag, TagConstraint
 
 
@@ -49,6 +50,22 @@ OWNER_SIDE_COUNTERPART: dict[str, str] = {
     Tag.REQUIRE_MEMBER_REASON_CONSTRAINT_KEY: Tag.REQUIRE_OWNER_REASON_CONSTRAINT_KEY,
     Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY: Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY,
 }
+
+# Constraints a tag may not carry while opting out of propagation. The reason
+# and time-limit constraints degrade gracefully without it -- they still bind
+# on the direct path, and a role path still records some reason and some
+# duration. A self-add prohibition does not degrade, it inverts: the owner it
+# targets adds themselves to a role associated with the tagged group and
+# arrives at the same access by a supported path, with nothing recording that a
+# separation-of-duties control was in play. So these two settings are not
+# independently configurable, and `validate_constraint_propagation` rejects the
+# combination at every write.
+PROPAGATION_REQUIRED_CONSTRAINT_KEYS: frozenset[str] = frozenset(
+    {
+        Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY,
+        Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY,
+    }
+)
 
 
 class ConstraintOrigin(StrEnum):
@@ -289,6 +306,51 @@ def _join_phrases(phrases: list[str]) -> str:
     if len(phrases) == 1:
         return phrases[0]
     return f"{', '.join(phrases[:-1])} and {phrases[-1]}"
+
+
+def validate_constraint_propagation(constraints: Optional[dict[str, Any]], propagate_to_roles: Optional[bool]) -> None:
+    """Reject a tag whose constraints cannot survive its propagation setting.
+
+    Guards the invariant that a `PROPAGATION_REQUIRED_CONSTRAINT_KEYS`
+    constraint is never set on a tag that opts out of reaching roles. Every
+    write path calls this, because the two fields can be set independently and
+    in either order -- turning propagation off on a tag that already disallows
+    self-adds opens the same hole as adding the constraint to a tag that
+    already opted out.
+
+    Callers must pass the *merged* result of a partial update, not the request
+    body alone: a `PUT` carrying only `propagate_to_roles` is coherent in
+    isolation and conflicts only with what is already stored.
+
+    Args:
+        constraints: The tag's resulting constraint mapping. None is read as
+            empty, matching the column's `{}` server default on a row that has
+            not been flushed yet.
+        propagate_to_roles: The tag's resulting propagation setting. None is
+            read as True, matching the column default -- an unflushed `Tag()`
+            has not had it applied, so reading the attribute yields None rather
+            than the default it will be given at INSERT.
+
+    Raises:
+        InvalidRequestError: If any such constraint is set truthy while
+            propagation is off. Names every offending key, since removing one
+            of two would still leave the tag invalid, and states the invariant
+            rather than which half of it the write happened to change --
+            either half may be the one arriving.
+    """
+    if propagate_to_roles is not False:
+        return
+    # Only a truthy value is a live constraint; an explicit `False` sets
+    # nothing and is as compatible with opting out as omitting the key.
+    conflicting = sorted(key for key in PROPAGATION_REQUIRED_CONSTRAINT_KEYS if (constraints or {}).get(key))
+    if not conflicting:
+        return
+    raise InvalidRequestError(
+        f"A tag that sets {_join_phrases(conflicting)} must propagate to roles. "
+        "Such a constraint only holds if it reaches roles associated with the tagged group: "
+        "an owner it blocks could otherwise add themselves to one of those roles and receive "
+        "the same access. Enable propagation to roles, or remove the constraint."
+    )
 
 
 def constraint_source_clause(constraint_key: str, group: OktaGroup) -> str:

--- a/api/models/tag.py
+++ b/api/models/tag.py
@@ -1,12 +1,16 @@
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
-from typing import Any, NamedTuple, Optional
+from typing import Any, NamedTuple, Optional, TypedDict
 
 from api.exceptions import InvalidRequestError
 from api.models.core_models import OktaGroup, RoleGroup, RoleGroupMap, Tag, TagConstraint
 
+#: What a constraint resolves to: a seconds count for the two time limits, a
+#: flag for the other four. `Tag.CONSTRAINTS` carries the full set.
+ConstraintValue = int | bool
 
-def coalesce_constraints(constraint_key: str, tags: list[Tag]) -> Any:
+
+def coalesce_constraints(constraint_key: str, tags: list[Tag]) -> Optional[ConstraintValue]:
     coalesced_constraint_value = None
     constraint = Tag.CONSTRAINTS[constraint_key]
     for tag in tags:
@@ -91,13 +95,39 @@ class ConstraintSource(NamedTuple):
     """One tag contributing a value for a constraint, and where it came from."""
 
     tag: Tag
-    value: Any
+    value: ConstraintValue
     origin: ConstraintOrigin
     #: The App for an `APP` origin, the source group for an association origin,
     #: and None for a `DIRECT` one. Named without "group" because it is not
     #: always a group.
     source_id: Optional[str]
     source_name: Optional[str]
+
+
+class ConstraintSourceEntry(TypedDict):
+    """One source of a constraint, as the API serializes it.
+
+    Mirrored by `EffectiveConstraintSourceDetail` in
+    `api/schemas/core_schemas.py`, which is what validates it on the way out.
+    """
+
+    tag_id: str
+    tag_name: str
+    origin: ConstraintOrigin
+    source_id: Optional[str]
+    source_name: Optional[str]
+
+
+class EffectiveConstraintEntry(TypedDict):
+    """One constraint in force, as the API serializes it.
+
+    Mirrored by `EffectiveConstraintDetail` in `api/schemas/core_schemas.py`.
+    """
+
+    constraint: str
+    name: str
+    value: ConstraintValue
+    sources: list[ConstraintSourceEntry]
 
 
 def _own_tag_sources(constraint_key: str, group: OktaGroup, include_provenance: bool) -> list[ConstraintSource]:
@@ -187,16 +217,21 @@ def _propagated_sources(constraint_key: str, group: OktaGroup) -> list[Constrain
     return sources
 
 
-def _fold(constraint: TagConstraint, sources: list[ConstraintSource]) -> Any:
+def _fold(constraint: TagConstraint, sources: list[ConstraintSource]) -> ConstraintValue:
     """Coalesce `sources`' values pairwise under `constraint.coalesce`.
 
-    Seeded on `is None`, not on truthiness: a first source contributing a falsy
-    value (`False`, or a `0`-second time limit) is a real contribution and must
-    seed the fold rather than be skipped.
+    Seeded from the first source rather than from a sentinel, so a falsy
+    contribution (`False`, or a `0`-second time limit) seeds the fold like any
+    other instead of being mistaken for "nothing yet".
+
+    Args:
+        constraint: The constraint being folded, which carries the rule.
+        sources: Must not be empty; a constraint with no sources is not in
+            force, which is a distinction its caller makes.
     """
-    value = None
-    for source in sources:
-        value = source.value if value is None else constraint.coalesce(value, source.value)
+    value = sources[0].value
+    for source in sources[1:]:
+        value = constraint.coalesce(value, source.value)
     return value
 
 
@@ -239,7 +274,7 @@ def constraint_sources(
     return _own_tag_sources(constraint_key, group, include_provenance) + _propagated_sources(constraint_key, group)
 
 
-def effective_constraint(constraint_key: str, group: OktaGroup) -> Any:
+def effective_constraint(constraint_key: str, group: OktaGroup) -> Optional[ConstraintValue]:
     """Resolve the value of `constraint_key` actually in force on `group`.
 
     Coalesces every contributing tag under that constraint's own rule -- the
@@ -256,7 +291,8 @@ def effective_constraint(constraint_key: str, group: OktaGroup) -> Any:
     Raises:
         InvalidRequestError: If a relationship this reads was not eager-loaded.
     """
-    return _fold(Tag.CONSTRAINTS[constraint_key], constraint_sources(constraint_key, group))
+    sources = constraint_sources(constraint_key, group)
+    return _fold(Tag.CONSTRAINTS[constraint_key], sources) if sources else None
 
 
 def effective_ended_at(
@@ -391,7 +427,7 @@ def constraint_source_clause(constraint_key: str, group: OktaGroup) -> str:
 
 def _constraint_entry(
     constraint_key: str, constraint: TagConstraint, sources: list[ConstraintSource]
-) -> Optional[dict[str, Any]]:
+) -> Optional[EffectiveConstraintEntry]:
     """One constraint's coalesced value and the sources that produced it.
 
     A source setting a flag to `False` imposes nothing -- the tag form writes
@@ -440,7 +476,7 @@ def _constraint_entry(
     }
 
 
-def effective_constraints(group: OktaGroup) -> list[dict[str, Any]]:
+def effective_constraints(group: OktaGroup) -> list[EffectiveConstraintEntry]:
     """Every constraint in force on `group`, with its coalesced value and sources.
 
     Backs the API response the UI reads, so display and enforcement answer from

--- a/api/models/tag.py
+++ b/api/models/tag.py
@@ -140,13 +140,6 @@ def _propagated_sources(constraint_key: str, group: OktaGroup) -> list[Constrain
     """
     if type(group) is not RoleGroup:
         return []
-    # An unmanaged role enforces nothing, so nothing should propagate onto it.
-    # Gating here rather than at each caller keeps display and enforcement
-    # agreeing: every enforcement path already checks `is_managed` separately,
-    # and without this the read surface would advertise constraints that
-    # nothing applies.
-    if not group.is_managed:
-        return []
     # Owner-side keys never propagate onto a role.
     if constraint_key not in OWNER_SIDE_COUNTERPART:
         return []
@@ -213,9 +206,10 @@ def constraint_sources(
     """Collect every tag contributing a value for `constraint_key` to `group`.
 
     Covers tags on the group itself and, when `group` is a role, tags reaching
-    it from the groups it is associated with. Only enabled tags contribute, and
-    a propagated tag contributes only if it has `propagate_to_roles` set, its
-    source group is managed, and the role itself is managed.
+    it from the groups it is associated with. An unmanaged group has no sources
+    at all. Otherwise only enabled tags contribute, and a propagated tag
+    contributes only if it has `propagate_to_roles` set and its source group is
+    managed.
 
     Args:
         constraint_key: A key from `Tag.CONSTRAINTS`.
@@ -235,6 +229,13 @@ def constraint_sources(
             All of them are `lazy="raise_on_sql"`; see
             `api/routers/_eager.py`.
     """
+    # An unmanaged group enforces nothing, so nothing is in force on it -- not
+    # its own tags, not its app's, and nothing propagated to it. Gating here
+    # rather than at each caller keeps display and enforcement agreeing: every
+    # enforcement path already checks `is_managed` separately, and without this
+    # the read surface would advertise constraints that nothing applies.
+    if not group.is_managed:
+        return []
     return _own_tag_sources(constraint_key, group, include_provenance) + _propagated_sources(constraint_key, group)
 
 

--- a/api/operations/create_tag.py
+++ b/api/operations/create_tag.py
@@ -9,6 +9,7 @@ from sqlalchemy import func, select
 
 from api.extensions import db
 from api.models import OktaUser, Tag
+from api.models.tag import validate_constraint_propagation
 from api.schemas import AuditLogSchema, EventType
 
 
@@ -33,6 +34,12 @@ class CreateTag:
             tag_model = cast(Tag, tag)
             tag_model.id = id
             self.tag = tag_model
+
+        # Reject an incoherent tag before it reaches the DB, so CLI and seed
+        # callers are held to the same invariant as the router. Reads the
+        # attributes off the constructed instance rather than the input, which
+        # may be either a dict or a model.
+        validate_constraint_propagation(self.tag.constraints, self.tag.propagate_to_roles)
 
         self.current_user_id = current_user_id
 

--- a/api/routers/_eager.py
+++ b/api/routers/_eager.py
@@ -138,6 +138,12 @@ def effective_constraint_options() -> tuple:
     `polymorphic_group_options()`) so the `RoleGroup` paths resolve; a query
     selecting `RoleGroup` directly needs no such pairing.
 
+    The plural `effective_constraints(group)` reads one relationship more --
+    `OktaGroupTagMap.active_app_tag_mapping`, to tell a tag applied to the
+    group apart from one inherited via its app. That path belongs to
+    `group_tag_map_options()`, which detail routes already nest under
+    `active_group_tags`; pair the two when you need provenance.
+
     Uses `selectinload` (not `joinedload`) for `RoleGroupMap.active_group` to
     match the strategy `role_group_map_options()` already declares for that
     path in `groups.py`'s `DEFAULT_LOAD_OPTIONS` -- mixing strategies on the

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -31,6 +31,7 @@ from api.auth.permissions import (
 )
 from api.database import DbSession
 from api.models import App, AppGroup, OktaGroup, OktaUser, OktaUserGroupMember, RoleGroup
+from api.models.tag import effective_constraints
 from api.operations import (
     CreateGroup,
     DeleteGroup,
@@ -45,6 +46,7 @@ from api.pagination import Page, validated
 from api.plugins.app_group_lifecycle import validate_group_plugin_config_or_raise
 from api.routers._eager import (
     bind_role_group_map_own_groups,
+    effective_constraint_options,
     group_tag_map_options,
     role_group_map_options,
     role_group_map_options_for_own_group,
@@ -54,6 +56,7 @@ from api.routers._fan_out import defer_fan_out
 from api.schemas import (
     CreateGroupBody,
     DeleteMessage,
+    EffectiveConstraintDetail,
     GroupDetail,
     GroupMembersSummary,
     GroupSummary,
@@ -80,6 +83,7 @@ DEFAULT_LOAD_OPTIONS = (
     selectinload(RoleGroup.active_role_associated_group_owner_mappings).options(*role_group_map_options()),
     joinedload(AppGroup.app),
     selectinload(OktaGroup.active_group_tags).options(*group_tag_map_options()),
+    *effective_constraint_options(),
 )
 
 # `GroupDetail` is a discriminated union (`Annotated[Union[...], Field(discriminator="type")]`),
@@ -142,7 +146,11 @@ async def get_group(group_id: str, db: DbSession, current_user_id: CurrentUserId
     group = await _load_group_with_options(db, group_id)
     if group is None:
         raise HTTPException(status_code=404, detail="Not Found")
-    return _group_adapter.validate_python(group, from_attributes=True)
+    detail = _group_adapter.validate_python(group, from_attributes=True)
+    detail.effective_constraints = [
+        EffectiveConstraintDetail.model_validate(entry) for entry in effective_constraints(group)
+    ]
+    return detail
 
 
 @router.post("", name="groups_create", status_code=201)

--- a/api/routers/tags.py
+++ b/api/routers/tags.py
@@ -20,6 +20,7 @@ from api.operations import CreateTag, DeleteTag
 from fastapi_pagination.ext.sqlalchemy import apaginate
 
 from api.pagination import Page, validated
+from api.models.tag import validate_constraint_propagation
 from api.routers._eager import group_tag_map_options
 from api.schemas import (
     TagListItem,
@@ -158,6 +159,15 @@ async def put_tag(
         payload["constraints"] = {}
     if "description" in payload and payload["description"] is None:
         payload["description"] = ""
+    # Validate the merged result, not the body: this is a partial update, so
+    # either half of the conflict may be arriving now while the other is
+    # already stored. Runs before the setattr loop so a rejected edit leaves
+    # the session unmutated.
+    validate_constraint_propagation(
+        payload["constraints"] if "constraints" in payload else tag.constraints,
+        payload["propagate_to_roles"] if "propagate_to_roles" in payload else tag.propagate_to_roles,
+    )
+
     for key in ("name", "description", "constraints", "enabled", "propagate_to_roles"):
         if key in payload:
             setattr(tag, key, payload[key])

--- a/api/routers/tags.py
+++ b/api/routers/tags.py
@@ -123,8 +123,19 @@ async def put_tag(
 
     from api.operations import ModifyGroupsTimeLimit
 
+    # Locked for the rest of this transaction, because the validation below
+    # reads whichever half of the tag this request is not sending. Two updates
+    # arriving together -- one turning propagation off, one switching a
+    # self-add restriction on -- would each read the other's stale half, both
+    # pass, and store the pair neither is allowed to create. Released by the
+    # commit below.
     tag = (
-        await db.scalars(select(Tag).where(Tag.deleted_at.is_(None)).where(or_(Tag.id == tag_id, Tag.name == tag_id)))
+        await db.scalars(
+            select(Tag)
+            .where(Tag.deleted_at.is_(None))
+            .where(or_(Tag.id == tag_id, Tag.name == tag_id))
+            .with_for_update()
+        )
     ).first()
     if tag is None:
         raise HTTPException(404, "Not Found")

--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -20,6 +20,8 @@ from api.schemas.core_schemas import (  # noqa: F401
     AppIdRef,
     AppSummary,
     AppTagMapDetail,
+    EffectiveConstraintDetail,
+    EffectiveConstraintSourceDetail,
     GroupDetail,
     GroupMembersSummary,
     GroupRef,

--- a/api/schemas/core_schemas.py
+++ b/api/schemas/core_schemas.py
@@ -332,9 +332,16 @@ class _GroupBase(BaseModel):
     active_group_tags: list[OktaGroupTagMapDetail] = Field(default_factory=list)
     # Populated explicitly by `get_group` from `api.models.tag.effective_constraints`
     # -- not an ORM attribute, so `from_attributes=True` cannot pick it up on its
-    # own. `post_group`/`put_group` leave this at its default `[]`; the group page
-    # re-fetches the detail after a mutation, so it is populated on the read.
-    effective_constraints: list[EffectiveConstraintDetail] = Field(default_factory=list)
+    # own. Only `get_group` does so; `post_group`/`put_group` return the group
+    # without it, and the group page re-fetches the detail after a mutation.
+    #
+    # Null rather than `[]` on those responses, because the two mean different
+    # things to a reader: `[]` is the answer "nothing constrains this group",
+    # while null is "this payload does not carry the answer". The frontend's
+    # `carriedConstraints` fails its gates closed on null and open on `[]`, so
+    # defaulting to `[]` here would have a mutation response quietly assert
+    # that a constrained group has no constraints.
+    effective_constraints: Optional[list[EffectiveConstraintDetail]] = None
 
 
 class OktaGroupDetail(_GroupBase):

--- a/api/schemas/core_schemas.py
+++ b/api/schemas/core_schemas.py
@@ -297,9 +297,9 @@ class EffectiveConstraintSourceDetail(BaseModel):
     tag_id: str
     tag_name: str
     origin: ConstraintOrigin
-    # Deliberately not `source_group_*`: an "app" origin's source is an App,
-    # not a group. Both fields are None for a "direct" origin, which has no
-    # source beyond the group itself.
+    # The site where the source tag was directly applied, from which the
+    # constraint is inherited: an app, another group, or None if applied
+    # directly.
     source_id: Optional[str] = None
     source_name: Optional[str] = None
 

--- a/api/schemas/core_schemas.py
+++ b/api/schemas/core_schemas.py
@@ -23,6 +23,7 @@ from typing import Annotated, Any, Literal, Optional, Union
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing_extensions import TypeAliasType
 
+from api.models.tag import ConstraintOrigin
 from api.schemas.datetimes import FlexibleDatetime
 
 
@@ -291,6 +292,29 @@ class RoleGroupMapDetail(BaseModel):
 # request-body unions live in `requests_schemas.py`.
 
 
+class EffectiveConstraintSourceDetail(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    tag_id: str
+    tag_name: str
+    origin: ConstraintOrigin
+    # Deliberately not `source_group_*`: an "app" origin's source is an App,
+    # not a group. Both fields are None for a "direct" origin, which has no
+    # source beyond the group itself.
+    source_id: Optional[str] = None
+    source_name: Optional[str] = None
+
+
+class EffectiveConstraintDetail(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    constraint: str
+    name: str
+    # Every constraint in `Tag.CONSTRAINTS` is either a seconds count or a
+    # flag. Spelling the union out (rather than `Any`) keeps the generated
+    # TypeScript client from rendering this as `void`.
+    value: int | bool
+    sources: list[EffectiveConstraintSourceDetail] = Field(default_factory=list)
+
+
 class _GroupBase(BaseModel):
     model_config = ConfigDict(from_attributes=True)
     id: str
@@ -306,6 +330,11 @@ class _GroupBase(BaseModel):
     # group of an app) materialize unbounded member rows. They are served by
     # the paginated `GET /api/groups/{id}/member-details` endpoint instead.
     active_group_tags: list[OktaGroupTagMapDetail] = Field(default_factory=list)
+    # Populated explicitly by `get_group` from `api.models.tag.effective_constraints`
+    # -- not an ORM attribute, so `from_attributes=True` cannot pick it up on its
+    # own. `post_group`/`put_group` leave this at its default `[]`; the group page
+    # re-fetches the detail after a mutation, so it is populated on the read.
+    effective_constraints: list[EffectiveConstraintDetail] = Field(default_factory=list)
 
 
 class OktaGroupDetail(_GroupBase):

--- a/src/api/apiSchemas.ts
+++ b/src/api/apiSchemas.ts
@@ -135,7 +135,7 @@ export type AppGroupDetail = {
   updated_at: string | null;
   deleted_at?: string | null;
   active_group_tags?: OktaGroupTagMapDetail[];
-  effective_constraints?: EffectiveConstraintDetail[];
+  effective_constraints?: EffectiveConstraintDetail[] | null;
   /**
    * @default app_group
    */
@@ -585,7 +585,7 @@ export type OktaGroupDetail = {
   updated_at: string | null;
   deleted_at?: string | null;
   active_group_tags?: OktaGroupTagMapDetail[];
-  effective_constraints?: EffectiveConstraintDetail[];
+  effective_constraints?: EffectiveConstraintDetail[] | null;
   /**
    * @default okta_group
    */
@@ -1084,7 +1084,7 @@ export type RoleGroupDetail = {
   updated_at: string | null;
   deleted_at?: string | null;
   active_group_tags?: OktaGroupTagMapDetail[];
-  effective_constraints?: EffectiveConstraintDetail[];
+  effective_constraints?: EffectiveConstraintDetail[] | null;
   /**
    * @default role_group
    */

--- a/src/api/apiSchemas.ts
+++ b/src/api/apiSchemas.ts
@@ -135,6 +135,7 @@ export type AppGroupDetail = {
   updated_at: string | null;
   deleted_at?: string | null;
   active_group_tags?: OktaGroupTagMapDetail[];
+  effective_constraints?: EffectiveConstraintDetail[];
   /**
    * @default app_group
    */
@@ -357,6 +358,16 @@ export type AuditUserGroupRow = {
   ended_actor?: UserSummaryForAudit | null;
 };
 
+/**
+ * How a tag reaches the group a constraint is being evaluated for.
+ *
+ * A `StrEnum` so it serializes as the bare string it always was: the JSON
+ * contract is unchanged, but the OpenAPI schema now carries the value set,
+ * and the generated TypeScript client gets a literal union instead of
+ * `string`.
+ */
+export type ConstraintOrigin = 'direct' | 'app' | 'member_association' | 'owner_association';
+
 export type CreateAccessRequestBody = {
   group_id: string;
   /**
@@ -426,6 +437,21 @@ export type CreateTagBody = {
 
 export type DeleteMessage = {
   deleted: boolean;
+};
+
+export type EffectiveConstraintDetail = {
+  constraint: string;
+  name: string;
+  value: number | boolean;
+  sources?: EffectiveConstraintSourceDetail[];
+};
+
+export type EffectiveConstraintSourceDetail = {
+  tag_id: string;
+  tag_name: string;
+  origin: ConstraintOrigin;
+  source_id?: string | null;
+  source_name?: string | null;
 };
 
 export type GroupDetail =
@@ -559,6 +585,7 @@ export type OktaGroupDetail = {
   updated_at: string | null;
   deleted_at?: string | null;
   active_group_tags?: OktaGroupTagMapDetail[];
+  effective_constraints?: EffectiveConstraintDetail[];
   /**
    * @default okta_group
    */
@@ -1057,6 +1084,7 @@ export type RoleGroupDetail = {
   updated_at: string | null;
   deleted_at?: string | null;
   active_group_tags?: OktaGroupTagMapDetail[];
+  effective_constraints?: EffectiveConstraintDetail[];
   /**
    * @default role_group
    */

--- a/src/pages/tags/CreateUpdate.tsx
+++ b/src/pages/tags/CreateUpdate.tsx
@@ -15,6 +15,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import FormControl from '@mui/material/FormControl';
 import Grid from '@mui/material/Grid';
 import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
 
 import {ToggleButtonGroupElement, FormContainer, TextFieldElement} from 'react-hook-form-mui';
 
@@ -27,6 +28,7 @@ import {
   TagByIdPutVariables,
 } from '../../api/apiComponents';
 import NumberInput from '../../components/NumberInput';
+import {MEMBER_SELF_ADD_LABEL, OWNER_SELF_ADD_LABEL, propagationConflictMessage} from './propagationRules';
 import {OktaUserDetail, TagDetail} from '../../api/apiSchemas';
 import {isAccessAdmin} from '../../authorization';
 import accessConfig, {requireDescriptions} from '../../config/accessConfig';
@@ -61,6 +63,7 @@ interface CreateTagForm {
   memberReason?: string;
   ownerAdd?: string;
   memberAdd?: string;
+  propagateToRoles: string;
 }
 
 interface TagDialogProps {
@@ -118,6 +121,7 @@ function TagDialog(props: TagDialogProps) {
       name: tagForm.name,
       description: tagForm.description,
       enabled: tagForm.enabled == 'enabled',
+      propagate_to_roles: tagForm.propagateToRoles == 'yes',
     } as TagDetail;
 
     const constraints: Record<string, number | boolean> = {};
@@ -185,6 +189,11 @@ function TagDialog(props: TagDialogProps) {
                 ? 'yes'
                 : 'no'
               : 'no',
+          // `?? true` rather than a bare truthiness check: the field is
+          // optional in the generated type and the server default is `true`,
+          // so an absent value must prefill "yes", not "no" -- otherwise
+          // opening and saving an older tag silently turns propagation off.
+          propagateToRoles: props.tag ? (props.tag.propagate_to_roles ?? true ? 'yes' : 'no') : 'yes',
         }}
         onSuccess={(formData) => submit(formData)}>
         <DialogTitle>{createOrUpdateText} Tag</DialogTitle>
@@ -335,12 +344,18 @@ function TagDialog(props: TagDialogProps) {
           <Grid container spacing={1}>
             <Grid item xs={6}>
               <FormControl fullWidth sx={{marginTop: '18px'}}>
-                <Box sx={{marginLeft: '3px'}}>Disallow owners adding selves as owners?:</Box>
+                <Box sx={{marginLeft: '3px'}}>{OWNER_SELF_ADD_LABEL}?:</Box>
                 <ToggleButtonGroupElement
                   name="ownerAdd"
                   enforceAtLeastOneSelected
                   exclusive
                   required
+                  // The conflict rule lives on `propagateToRoles`, and RHF
+                  // re-runs a field's rules only when that field changes. `deps`
+                  // makes this toggle re-trigger it, so switching a self-add
+                  // restriction on surfaces the conflict and switching it back
+                  // off clears the message.
+                  rules={{deps: ['propagateToRoles']}}
                   options={[
                     {
                       id: 'yes',
@@ -356,12 +371,63 @@ function TagDialog(props: TagDialogProps) {
             </Grid>
             <Grid item xs={6}>
               <FormControl fullWidth sx={{marginTop: '18px'}}>
-                <Box sx={{marginLeft: '3px'}}>Disallow owners adding selves as members?:</Box>
+                <Box sx={{marginLeft: '3px'}}>{MEMBER_SELF_ADD_LABEL}?:</Box>
                 <ToggleButtonGroupElement
                   name="memberAdd"
                   enforceAtLeastOneSelected
                   exclusive
                   required
+                  // The conflict rule lives on `propagateToRoles`, and RHF
+                  // re-runs a field's rules only when that field changes. `deps`
+                  // makes this toggle re-trigger it, so switching a self-add
+                  // restriction on surfaces the conflict and switching it back
+                  // off clears the message.
+                  rules={{deps: ['propagateToRoles']}}
+                  options={[
+                    {
+                      id: 'yes',
+                      label: 'Yes',
+                    },
+                    {
+                      id: 'no',
+                      label: 'No',
+                    },
+                  ]}
+                />
+              </FormControl>
+            </Grid>
+          </Grid>
+          <Grid container spacing={1}>
+            <Grid item xs={12}>
+              <FormControl fullWidth sx={{marginTop: '18px'}}>
+                <Tooltip
+                  title={
+                    'When yes, these constraints also apply to any role that is a member or owner of a group ' +
+                    "carrying this tag \u2014 the role's own members must satisfy the same time limits, reason " +
+                    'requirements, and self-add restrictions. When no, the constraints apply only to the tagged ' +
+                    'groups themselves. This is not the same as disabling the tag, which turns off its ' +
+                    'enforcement everywhere.'
+                  }
+                  placement="top-start">
+                  <Box sx={{marginLeft: '3px', width: 'fit-content'}}>Propagate these constraints to roles?</Box>
+                </Tooltip>
+                <ToggleButtonGroupElement
+                  name="propagateToRoles"
+                  enforceAtLeastOneSelected
+                  exclusive
+                  required
+                  // The backend rejects this combination on every tag write;
+                  // catching it here names the offending restriction next to
+                  // the control instead of surfacing a 400 after submit.
+                  rules={{
+                    validate: (value, form) =>
+                      propagationConflictMessage({
+                        propagateToRoles: value,
+                        ownerAdd: form.ownerAdd,
+                        memberAdd: form.memberAdd,
+                      }) ?? true,
+                  }}
+                  parseError={(error) => error?.message ?? ''}
                   options={[
                     {
                       id: 'yes',

--- a/src/pages/tags/CreateUpdate.tsx
+++ b/src/pages/tags/CreateUpdate.tsx
@@ -403,7 +403,7 @@ function TagDialog(props: TagDialogProps) {
                 <Tooltip
                   title={
                     'When yes, these constraints also apply to any role that is a member or owner of a group ' +
-                    "carrying this tag \u2014 the role's own members must satisfy the same time limits, reason " +
+                    "carrying this tag: The role's own members must satisfy the same time limits, reason " +
                     'requirements, and self-add restrictions. When no, the constraints apply only to the tagged ' +
                     'groups themselves. This is not the same as disabling the tag, which turns off its ' +
                     'enforcement everywhere.'

--- a/src/pages/tags/CreateUpdate.tsx
+++ b/src/pages/tags/CreateUpdate.tsx
@@ -18,6 +18,7 @@ import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 
 import {ToggleButtonGroupElement, FormContainer, TextFieldElement} from 'react-hook-form-mui';
+import {useWatch} from 'react-hook-form';
 
 import {
   useTagsCreate,
@@ -28,7 +29,13 @@ import {
   TagByIdPutVariables,
 } from '../../api/apiComponents';
 import NumberInput from '../../components/NumberInput';
-import {MEMBER_SELF_ADD_LABEL, OWNER_SELF_ADD_LABEL, propagationConflictMessage} from './propagationRules';
+import {
+  MEMBER_SELF_ADD_LABEL,
+  OWNER_SELF_ADD_LABEL,
+  SELF_ADD_NEEDS_PROPAGATION,
+  propagationConflictMessage,
+  selfAddRestrictionAvailable,
+} from './propagationRules';
 import {OktaUserDetail, TagDetail} from '../../api/apiSchemas';
 import {isAccessAdmin} from '../../authorization';
 import accessConfig, {requireDescriptions} from '../../config/accessConfig';
@@ -70,6 +77,68 @@ interface TagDialogProps {
   currentUser: OktaUserDetail;
   setOpen(open: boolean): any;
   tag?: TagDetail;
+}
+
+// A self-add restriction and propagation are not independently configurable
+// (`propagationRules.ts` carries the reason), so each control disables the
+// option that would produce the forbidden pair. That makes the combination
+// unreachable rather than rejected after the fact, and each control explains
+// the restriction while it is in effect.
+//
+// Both read sibling fields, so both must render inside `FormContainer`.
+function SelfAddToggle(props: {name: 'ownerAdd' | 'memberAdd'; label: string}) {
+  const propagateToRoles = useWatch<CreateTagForm>({name: 'propagateToRoles'});
+  const withoutPropagation = !selfAddRestrictionAvailable(propagateToRoles);
+  return (
+    <FormControl fullWidth sx={{marginTop: '18px'}}>
+      <Box sx={{marginLeft: '3px'}}>{props.label}?:</Box>
+      <ToggleButtonGroupElement
+        name={props.name}
+        enforceAtLeastOneSelected
+        exclusive
+        required
+        helperText={withoutPropagation ? SELF_ADD_NEEDS_PROPAGATION : undefined}
+        options={[
+          {id: 'yes', label: 'Yes', disabled: withoutPropagation},
+          {id: 'no', label: 'No'},
+        ]}
+      />
+    </FormControl>
+  );
+}
+
+function PropagationToggle() {
+  const ownerAdd = useWatch<CreateTagForm>({name: 'ownerAdd'});
+  const memberAdd = useWatch<CreateTagForm>({name: 'memberAdd'});
+  // Asked of the value the control would take: the message names whichever
+  // restrictions are keeping "No" unavailable, or is null when none are.
+  const conflict = propagationConflictMessage({propagateToRoles: 'no', ownerAdd, memberAdd});
+  return (
+    <FormControl fullWidth sx={{marginTop: '18px'}}>
+      <Tooltip
+        title={
+          'When yes, these constraints also apply to any role that is a member or owner of a group ' +
+          "carrying this tag: The role's own members must satisfy the same time limits, reason " +
+          'requirements, and self-add restrictions. When no, the constraints apply only to the tagged ' +
+          'groups themselves. This is not the same as disabling the tag, which turns off its ' +
+          'enforcement everywhere.'
+        }
+        placement="top-start">
+        <Box sx={{marginLeft: '3px', width: 'fit-content'}}>Propagate these constraints to roles?</Box>
+      </Tooltip>
+      <ToggleButtonGroupElement
+        name="propagateToRoles"
+        enforceAtLeastOneSelected
+        exclusive
+        required
+        helperText={conflict ?? undefined}
+        options={[
+          {id: 'yes', label: 'Yes'},
+          {id: 'no', label: 'No', disabled: conflict !== null},
+        ]}
+      />
+    </FormControl>
+  );
 }
 
 function TagDialog(props: TagDialogProps) {
@@ -343,103 +412,15 @@ function TagDialog(props: TagDialogProps) {
           </Grid>
           <Grid container spacing={1}>
             <Grid item xs={6}>
-              <FormControl fullWidth sx={{marginTop: '18px'}}>
-                <Box sx={{marginLeft: '3px'}}>{OWNER_SELF_ADD_LABEL}?:</Box>
-                <ToggleButtonGroupElement
-                  name="ownerAdd"
-                  enforceAtLeastOneSelected
-                  exclusive
-                  required
-                  // The conflict rule lives on `propagateToRoles`, and RHF
-                  // re-runs a field's rules only when that field changes. `deps`
-                  // makes this toggle re-trigger it, so switching a self-add
-                  // restriction on surfaces the conflict and switching it back
-                  // off clears the message.
-                  rules={{deps: ['propagateToRoles']}}
-                  options={[
-                    {
-                      id: 'yes',
-                      label: 'Yes',
-                    },
-                    {
-                      id: 'no',
-                      label: 'No',
-                    },
-                  ]}
-                />
-              </FormControl>
+              <SelfAddToggle name="ownerAdd" label={OWNER_SELF_ADD_LABEL} />
             </Grid>
             <Grid item xs={6}>
-              <FormControl fullWidth sx={{marginTop: '18px'}}>
-                <Box sx={{marginLeft: '3px'}}>{MEMBER_SELF_ADD_LABEL}?:</Box>
-                <ToggleButtonGroupElement
-                  name="memberAdd"
-                  enforceAtLeastOneSelected
-                  exclusive
-                  required
-                  // The conflict rule lives on `propagateToRoles`, and RHF
-                  // re-runs a field's rules only when that field changes. `deps`
-                  // makes this toggle re-trigger it, so switching a self-add
-                  // restriction on surfaces the conflict and switching it back
-                  // off clears the message.
-                  rules={{deps: ['propagateToRoles']}}
-                  options={[
-                    {
-                      id: 'yes',
-                      label: 'Yes',
-                    },
-                    {
-                      id: 'no',
-                      label: 'No',
-                    },
-                  ]}
-                />
-              </FormControl>
+              <SelfAddToggle name="memberAdd" label={MEMBER_SELF_ADD_LABEL} />
             </Grid>
           </Grid>
           <Grid container spacing={1}>
             <Grid item xs={12}>
-              <FormControl fullWidth sx={{marginTop: '18px'}}>
-                <Tooltip
-                  title={
-                    'When yes, these constraints also apply to any role that is a member or owner of a group ' +
-                    "carrying this tag: The role's own members must satisfy the same time limits, reason " +
-                    'requirements, and self-add restrictions. When no, the constraints apply only to the tagged ' +
-                    'groups themselves. This is not the same as disabling the tag, which turns off its ' +
-                    'enforcement everywhere.'
-                  }
-                  placement="top-start">
-                  <Box sx={{marginLeft: '3px', width: 'fit-content'}}>Propagate these constraints to roles?</Box>
-                </Tooltip>
-                <ToggleButtonGroupElement
-                  name="propagateToRoles"
-                  enforceAtLeastOneSelected
-                  exclusive
-                  required
-                  // The backend rejects this combination on every tag write;
-                  // catching it here names the offending restriction next to
-                  // the control instead of surfacing a 400 after submit.
-                  rules={{
-                    validate: (value, form) =>
-                      propagationConflictMessage({
-                        propagateToRoles: value,
-                        ownerAdd: form.ownerAdd,
-                        memberAdd: form.memberAdd,
-                      }) ?? true,
-                  }}
-                  parseError={(error) => error?.message ?? ''}
-                  options={[
-                    {
-                      id: 'yes',
-                      label: 'Yes',
-                    },
-                    {
-                      id: 'no',
-                      label: 'No',
-                    },
-                  ]}
-                />
-              </FormControl>
+              <PropagationToggle />
             </Grid>
           </Grid>
         </DialogContent>

--- a/src/pages/tags/PropagationNoteView.test.tsx
+++ b/src/pages/tags/PropagationNoteView.test.tsx
@@ -1,0 +1,39 @@
+import {render, screen} from '@testing-library/react';
+import {describe, expect, it} from 'vitest';
+
+import PropagationNoteView from './PropagationNoteView';
+
+// Emphasising one clause is the whole job of this component, so it is asserted
+// through the rendered weight rather than through the element carrying it.
+// jsdom reports the `bold` keyword numerically.
+const BOLD = '700';
+
+function weightOf(element: Element): string {
+  return window.getComputedStyle(element).fontWeight;
+}
+
+function expectOnlyEmphasised(text: string) {
+  const clause = screen.getByText(text);
+  expect(weightOf(clause)).toBe(BOLD);
+  // The sentence around it stays unemphasised, which is what makes the clause
+  // stand out at all.
+  expect(weightOf(clause.parentElement!)).not.toBe(BOLD);
+}
+
+describe('PropagationNoteView', () => {
+  it('states that constraints do apply when propagation is on, with "do" bolded', () => {
+    const {container} = render(<PropagationNoteView propagateToRoles={true} />);
+    expect(container.textContent).toBe(
+      'These constraints do apply to roles that own or are members of groups with this tag.',
+    );
+    expectOnlyEmphasised('do');
+  });
+
+  it('states that constraints do not apply when propagation is off, with "do not" bolded', () => {
+    const {container} = render(<PropagationNoteView propagateToRoles={false} />);
+    expect(container.textContent).toBe(
+      'These constraints do not apply to roles that own or are members of groups with this tag.',
+    );
+    expectOnlyEmphasised('do not');
+  });
+});

--- a/src/pages/tags/PropagationNoteView.tsx
+++ b/src/pages/tags/PropagationNoteView.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+// Renders the tag-propagation sentence with the "do" / "do not" clause bolded.
+// Split into three parts so only that clause is emphasised; the surrounding
+// text is identical either way.
+export default function PropagationNoteView({propagateToRoles}: {propagateToRoles: boolean}) {
+  return (
+    <Typography variant="body2" sx={{marginTop: '4px'}}>
+      {'These constraints '}
+      <Box component="span" sx={{fontWeight: 'bold'}}>
+        {propagateToRoles ? 'do' : 'do not'}
+      </Box>
+      {' apply to roles that own or are members of groups with this tag.'}
+    </Typography>
+  );
+}

--- a/src/pages/tags/Read.tsx
+++ b/src/pages/tags/Read.tsx
@@ -47,6 +47,7 @@ import Loading from '../../components/Loading';
 import DeleteTag from './Delete';
 import {EmptyListEntry} from '../../components/EmptyListEntry';
 import MarkdownDescription from '../../components/MarkdownDescription';
+import PropagationNoteView from './PropagationNoteView';
 
 export default function ReadTag() {
   const currentUser = useCurrentUser();
@@ -187,6 +188,11 @@ export default function ReadTag() {
                           Tag Constraints
                         </Typography>
                       </Stack>
+                      {/* `?? true`, not `Boolean(...)`: the field is optional in the
+                          generated type, and the server default is `true`, so
+                          coercing `undefined` with `Boolean` would show the
+                          opposite of what an older tag actually does. */}
+                      <PropagationNoteView propagateToRoles={tag.propagate_to_roles ?? true} />
                     </TableCell>
                   </TableRow>
                   <TableRow>

--- a/src/pages/tags/propagationRules.test.ts
+++ b/src/pages/tags/propagationRules.test.ts
@@ -1,0 +1,31 @@
+import {describe, expect, it} from 'vitest';
+
+import {propagationConflictMessage} from './propagationRules';
+
+describe('propagationConflictMessage', () => {
+  it('returns null when propagation is on, whatever the self-add settings', () => {
+    expect(propagationConflictMessage({propagateToRoles: 'yes', ownerAdd: 'yes', memberAdd: 'yes'})).toBeNull();
+  });
+
+  it('returns null when propagation is off and no self-add restriction is set', () => {
+    expect(propagationConflictMessage({propagateToRoles: 'no', ownerAdd: 'no', memberAdd: 'no'})).toBeNull();
+  });
+
+  it('names the membership restriction when only it conflicts', () => {
+    const message = propagationConflictMessage({propagateToRoles: 'no', ownerAdd: 'no', memberAdd: 'yes'});
+    expect(message).toContain('adding selves as members');
+    expect(message).not.toContain('adding selves as owners');
+  });
+
+  it('names the ownership restriction when only it conflicts', () => {
+    const message = propagationConflictMessage({propagateToRoles: 'no', ownerAdd: 'yes', memberAdd: 'no'});
+    expect(message).toContain('adding selves as owners');
+    expect(message).not.toContain('adding selves as members');
+  });
+
+  it('names both restrictions when both conflict, since dropping one would still be invalid', () => {
+    const message = propagationConflictMessage({propagateToRoles: 'no', ownerAdd: 'yes', memberAdd: 'yes'});
+    expect(message).toContain('adding selves as owners');
+    expect(message).toContain('adding selves as members');
+  });
+});

--- a/src/pages/tags/propagationRules.test.ts
+++ b/src/pages/tags/propagationRules.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest';
 
-import {propagationConflictMessage} from './propagationRules';
+import {propagationConflictMessage, selfAddRestrictionAvailable} from './propagationRules';
 
 describe('propagationConflictMessage', () => {
   it('returns null when propagation is on, whatever the self-add settings', () => {
@@ -27,5 +27,34 @@ describe('propagationConflictMessage', () => {
     const message = propagationConflictMessage({propagateToRoles: 'no', ownerAdd: 'yes', memberAdd: 'yes'});
     expect(message).toContain('adding selves as owners');
     expect(message).toContain('adding selves as members');
+  });
+});
+
+// The form does not merely reject the forbidden pair, it refuses to let the
+// user reach it: each control disables the option that would produce it. These
+// walk every combination of the two self-add restrictions to check that the
+// two halves of that rule agree, so no state exists in which both controls
+// consider the move somebody else's job to block.
+describe('reaching the forbidden combination', () => {
+  const VALUES = ['yes', 'no'] as const;
+
+  for (const ownerAdd of VALUES) {
+    for (const memberAdd of VALUES) {
+      const restricted = ownerAdd === 'yes' || memberAdd === 'yes';
+
+      it(`turning propagation off is ${restricted ? 'blocked' : 'allowed'} with ownerAdd=${ownerAdd} memberAdd=${memberAdd}`, () => {
+        const conflict = propagationConflictMessage({propagateToRoles: 'no', ownerAdd, memberAdd});
+        expect(conflict === null).toBe(!restricted);
+      });
+    }
+  }
+
+  it('offers the self-add restrictions only while propagation is on', () => {
+    expect(selfAddRestrictionAvailable('yes')).toBe(true);
+    expect(selfAddRestrictionAvailable('no')).toBe(false);
+  });
+
+  it('treats an unset propagation value as on, matching the form default', () => {
+    expect(selfAddRestrictionAvailable(undefined)).toBe(true);
   });
 });

--- a/src/pages/tags/propagationRules.ts
+++ b/src/pages/tags/propagationRules.ts
@@ -1,0 +1,53 @@
+// The self-add constraints cannot be combined with propagation turned off, and
+// the backend rejects the combination on every tag write
+// (`PROPAGATION_REQUIRED_CONSTRAINT_KEYS` in `api/models/tag.py`). Unlike the
+// reason and time-limit constraints, a self-add restriction does not merely
+// weaken when it stops reaching roles -- it inverts to permitted, because the
+// owner it blocks can add themselves to a role associated with the tagged
+// group and arrive at the same access.
+//
+// Mirrored here so the tag form reports the conflict inline rather than
+// bouncing the admin off a 400 after submit.
+
+// Captions for the two controls, shared with the form so the message names a
+// restriction by the same words the admin just toggled.
+export const OWNER_SELF_ADD_LABEL = 'Disallow owners adding selves as owners';
+export const MEMBER_SELF_ADD_LABEL = 'Disallow owners adding selves as members';
+
+export interface PropagationConflictInput {
+  propagateToRoles: 'yes' | 'no';
+  ownerAdd: 'yes' | 'no';
+  memberAdd: 'yes' | 'no';
+}
+
+// Returns the message to show under the propagation control, or null when the
+// combination is coherent. Names every conflicting restriction, since turning
+// off only one of two would leave the tag still invalid.
+export function propagationConflictMessage({
+  propagateToRoles,
+  ownerAdd,
+  memberAdd,
+}: PropagationConflictInput): string | null {
+  if (propagateToRoles !== 'no') {
+    return null;
+  }
+
+  const conflicting: string[] = [];
+  if (ownerAdd === 'yes') {
+    conflicting.push(`“${OWNER_SELF_ADD_LABEL}”`);
+  }
+  if (memberAdd === 'yes') {
+    conflicting.push(`“${MEMBER_SELF_ADD_LABEL}”`);
+  }
+  if (conflicting.length === 0) {
+    return null;
+  }
+
+  const subject = conflicting.join(' and ');
+  const verb = conflicting.length === 1 ? 'requires' : 'require';
+  return (
+    `${subject} ${verb} propagation to roles: an owner blocked from adding themselves ` +
+    'directly could otherwise add themselves to a role associated with the tagged group ' +
+    'and receive the same access.'
+  );
+}

--- a/src/pages/tags/propagationRules.ts
+++ b/src/pages/tags/propagationRules.ts
@@ -14,10 +14,32 @@
 export const OWNER_SELF_ADD_LABEL = 'Disallow owners adding selves as owners';
 export const MEMBER_SELF_ADD_LABEL = 'Disallow owners adding selves as members';
 
+// The short pointer shown on a self-add control whose restriction is
+// unavailable, where naming the whole rule would crowd the toggle. The
+// propagation control carries the full explanation.
+export const SELF_ADD_NEEDS_PROPAGATION = 'Requires propagation to roles.';
+
+// The form types its toggles as free strings, so these are read as such and
+// compared rather than narrowed.
+/**
+ * Whether the self-add controls may offer their restriction.
+ *
+ * The other half of the same rule `propagationConflictMessage` states: with
+ * propagation off the restriction cannot be switched on, and with a
+ * restriction on propagation cannot be switched off. Blocking the move on
+ * whichever control is being changed is what keeps the pair unreachable.
+ *
+ * An unset value reads as available: propagation defaults to on, so nothing is
+ * blocked until the control actually holds "no".
+ */
+export function selfAddRestrictionAvailable(propagateToRoles: string | undefined): boolean {
+  return propagateToRoles !== 'no';
+}
+
 export interface PropagationConflictInput {
-  propagateToRoles: 'yes' | 'no';
-  ownerAdd: 'yes' | 'no';
-  memberAdd: 'yes' | 'no';
+  propagateToRoles: string;
+  ownerAdd: string | undefined;
+  memberAdd: string | undefined;
 }
 
 // Returns the message to show under the propagation control, or null when the

--- a/tests/test_effective_constraints.py
+++ b/tests/test_effective_constraints.py
@@ -7,6 +7,9 @@ from api.extensions import Db
 from api.models import AppTagMap, OktaGroup, OktaGroupTagMap, RoleGroup, RoleGroupMap, Tag
 from api.routers._eager import effective_constraint_options
 from api.models.tag import (
+    ConstraintOrigin,
+    ConstraintSource,
+    _constraint_entry,
     constraint_source_clause,
     constraint_sources,
     effective_constraint,
@@ -290,6 +293,66 @@ async def test_effective_constraints_omits_unset_constraints(db: Db) -> None:
     assert [entry["constraint"] for entry in result] == [Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY]
     assert result[0]["value"] == 86400
     assert result[0]["name"] == Tag.CONSTRAINTS[Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY].name
+
+
+async def test_effective_constraints_omits_a_flag_every_tag_turns_off(db: Db) -> None:
+    """The tag form writes all four boolean keys on every save, so a tag whose
+    only real setting is a time limit still carries four `False` flags. Those
+    set nothing, and reporting them would tell a reader that a
+    separation-of-duties control is in force when it is switched off."""
+    group = OktaGroupFactory.build()
+    tag = TagFactory.build(
+        constraints={
+            Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400,
+            Tag.REQUIRE_MEMBER_REASON_CONSTRAINT_KEY: False,
+            Tag.REQUIRE_OWNER_REASON_CONSTRAINT_KEY: False,
+            Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY: False,
+            Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY: False,
+        }
+    )
+    db.session.add_all([group, tag])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    await db.session.commit()
+
+    loaded = await _load_group_with_provenance(db, group.id)
+    assert [entry["constraint"] for entry in effective_constraints(loaded)] == [Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY]
+
+
+async def test_effective_constraints_omits_a_tag_that_declines_the_flag(db: Db) -> None:
+    """One tag turning a flag on and another turning it off leaves it in force,
+    but only the first is the reason. Naming the second would send a reader to
+    edit a tag that already says `False`."""
+    group = OktaGroupFactory.build()
+    strict = TagFactory.build(name="Strict", constraints={Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY: True})
+    lax = TagFactory.build(name="Lax", constraints={Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY: False})
+    db.session.add_all([group, strict, lax])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=strict.id))
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=lax.id))
+    await db.session.commit()
+
+    loaded = await _load_group_with_provenance(db, group.id)
+    (entry,) = effective_constraints(loaded)
+    assert entry["value"] is True
+    assert [source["tag_name"] for source in entry["sources"]] == ["Strict"]
+
+
+async def test_effective_constraints_keeps_a_falsy_numeric_limit(db: Db) -> None:
+    """The `False` filter is discriminated on the boolean, not on truthiness: a
+    zero-second limit is the tightest possible constraint, not the absence of
+    one. The API validator rejects it, so this guards the helper directly."""
+    constraint = Tag.CONSTRAINTS[Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY]
+    source = ConstraintSource(
+        tag=TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 0}),
+        value=0,
+        origin=ConstraintOrigin.DIRECT,
+        source_id=None,
+        source_name=None,
+    )
+    entry = _constraint_entry(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, constraint, [source])
+    assert entry is not None
+    assert entry["value"] == 0
 
 
 async def test_effective_constraints_reports_association_source(db: Db) -> None:

--- a/tests/test_effective_constraints.py
+++ b/tests/test_effective_constraints.py
@@ -10,9 +10,13 @@ from api.models.tag import (
     constraint_source_clause,
     constraint_sources,
     effective_constraint,
+    effective_constraints,
     effective_ended_at,
 )
 from tests.factories import (
+    AppFactory,
+    AppGroupFactory,
+    AppTagMapFactory,
     OktaGroupFactory,
     OktaGroupTagMapFactory,
     RoleGroupFactory,
@@ -278,3 +282,123 @@ async def test_nothing_propagates_onto_an_unmanaged_role(db: Db) -> None:
     assert effective_constraint(Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY, loaded) is None
     # Enforcement agrees, which is the point -- the two must not diverge.
     assert effective_ended_at(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, loaded, None) is None
+
+
+async def test_effective_constraints_omits_unset_constraints(db: Db) -> None:
+    role = await _setup(db, constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400}, is_owner=False)
+    result = effective_constraints(role)
+    assert [entry["constraint"] for entry in result] == [Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY]
+    assert result[0]["value"] == 86400
+    assert result[0]["name"] == Tag.CONSTRAINTS[Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY].name
+
+
+async def test_effective_constraints_reports_association_source(db: Db) -> None:
+    role = await _setup(db, constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400}, is_owner=False)
+    (entry,) = effective_constraints(role)
+    (source,) = entry["sources"]
+    assert source["origin"] == "member_association"
+    assert source["source_name"] is not None
+
+
+async def test_effective_constraints_is_empty_when_nothing_applies(db: Db) -> None:
+    role = RoleGroupFactory.build()
+    db.session.add(role)
+    await db.session.commit()
+    loaded = await _load_role(db, role.id)
+    assert effective_constraints(loaded) == []
+
+
+async def test_effective_constraints_direct_tag_has_direct_origin(db: Db) -> None:
+    """A tag applied straight to a group (no `AppTagMap` linkage) is reported
+    with `origin == "direct"` -- the `_own_tag_sources` branch where
+    `tag_map.active_app_tag_mapping is None`."""
+    group = OktaGroupFactory.build()
+    tag = TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400})
+    db.session.add_all([group, tag])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    await db.session.commit()
+    loaded = await _load_group_with_provenance(db, group.id)
+    (entry,) = effective_constraints(loaded)
+    (source,) = entry["sources"]
+    assert source["origin"] == "direct"
+
+
+async def test_effective_constraints_app_tag_has_app_origin(db: Db) -> None:
+    """A tag applied to an `App` and inherited by one of its `AppGroup`s is
+    reported with `origin == "app"` -- the `_own_tag_sources` branch where
+    `tag_map.active_app_tag_mapping is not None`. The inherited group-tag row
+    (`OktaGroupTagMap`) points at the `AppTagMap` row via `app_tag_map_id`;
+    that linkage is what makes `active_app_tag_mapping` non-null.
+
+    The source also carries the app's name in `source_name` -- for an
+    "app" origin the "source" is the App itself, not a group -- hence the
+    origin-agnostic field names -- so `source_id` stays `None` while
+    the name is still meaningful to show in the UI."""
+    app = AppFactory.build()
+    app_group = AppGroupFactory.build()
+    app_group.app_id = app.id
+    tag = TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400})
+    db.session.add_all([app, app_group, tag])
+    await db.session.commit()
+    app_tag_map = AppTagMapFactory.build(app_id=app.id, tag_id=tag.id)
+    db.session.add(app_tag_map)
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=app_group.id, tag_id=tag.id, app_tag_map_id=app_tag_map.id))
+    await db.session.commit()
+    loaded = await _load_group_with_provenance(db, app_group.id)
+    (entry,) = effective_constraints(loaded)
+    (source,) = entry["sources"]
+    assert source["origin"] == "app"
+    assert source["source_name"] == app.name
+    assert source["source_id"] == app.id
+
+
+async def test_effective_constraints_tolerates_a_soft_deleted_app(db: Db) -> None:
+    """`AppTagMap.active_app` filters `App.deleted_at`, so it resolves to
+    `None` once the app is soft-deleted while an inherited `OktaGroupTagMap`
+    row survives. Reading `.name` off it unguarded raises `AttributeError`
+    (a 500); the source must instead report the "app" origin with no name.
+
+    Loaded with `selectinload` deliberately. `group_tag_map_options()` uses
+    `joinedload`, and `active_app` is `innerjoin=True`, so there the deleted
+    app collapses the whole `active_app_tag_mapping` chain to `None` and the
+    source degrades to "direct" instead -- which is why the unguarded read is
+    not reachable through the production loader today. `selectinload` issues a
+    separate SELECT per relationship, so `active_app_tag_mapping` survives
+    while `active_app` comes back `None`: exactly the shape the guard exists
+    for, and the shape any future switch to `selectinload` would produce."""
+    app = AppFactory.build()
+    app_group = AppGroupFactory.build()
+    app_group.app_id = app.id
+    tag = TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400})
+    db.session.add_all([app, app_group, tag])
+    await db.session.commit()
+    app_tag_map = AppTagMapFactory.build(app_id=app.id, tag_id=tag.id)
+    db.session.add(app_tag_map)
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=app_group.id, tag_id=tag.id, app_tag_map_id=app_tag_map.id))
+    await db.session.commit()
+
+    app.deleted_at = datetime.now(UTC) - timedelta(days=1)
+    db.session.add(app)
+    await db.session.commit()
+    app_group_id = app_group.id
+
+    db.session.expire_all()
+    loaded = (
+        await db.session.scalars(
+            select(OktaGroup)
+            .options(
+                selectinload(OktaGroup.active_group_tags).joinedload(OktaGroupTagMap.active_tag),
+                selectinload(OktaGroup.active_group_tags)
+                .selectinload(OktaGroupTagMap.active_app_tag_mapping)
+                .selectinload(AppTagMap.active_app),
+            )
+            .where(OktaGroup.id == app_group_id)
+        )
+    ).one()
+    (entry,) = effective_constraints(loaded)
+    (source,) = entry["sources"]
+    assert source["origin"] == "app"
+    assert source["source_name"] is None

--- a/tests/test_effective_constraints.py
+++ b/tests/test_effective_constraints.py
@@ -355,6 +355,65 @@ async def test_effective_constraints_keeps_a_falsy_numeric_limit(db: Db) -> None
     assert entry["value"] == 0
 
 
+async def test_effective_constraints_lists_the_binding_tag_first(db: Db) -> None:
+    """For a `min` constraint the shortest limit is the one actually binding,
+    so it leads. The reader's question is which tag is stopping them, not which
+    happened to be traversed first."""
+    group = OktaGroupFactory.build()
+    # Named so alphabetical order is the opposite of value order, which is what
+    # makes this test about the value key rather than the name key.
+    lenient = TagFactory.build(name="Aardvark", constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 999_999})
+    strict = TagFactory.build(name="Zebra", constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 3600})
+    db.session.add_all([group, lenient, strict])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=lenient.id))
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=strict.id))
+    await db.session.commit()
+
+    loaded = await _load_group_with_provenance(db, group.id)
+    (entry,) = effective_constraints(loaded)
+    assert entry["value"] == 3600
+    assert [source["tag_name"] for source in entry["sources"]] == ["Zebra", "Aardvark"]
+
+
+async def test_effective_constraints_breaks_value_ties_alphabetically(db: Db) -> None:
+    """Flags all coalesce to True, so nothing distinguishes them by value. The
+    name keys make the order deterministic rather than dependent on traversal."""
+    group = OktaGroupFactory.build()
+    later = TagFactory.build(name="Yak", constraints={Tag.REQUIRE_MEMBER_REASON_CONSTRAINT_KEY: True})
+    earlier = TagFactory.build(name="Badger", constraints={Tag.REQUIRE_MEMBER_REASON_CONSTRAINT_KEY: True})
+    db.session.add_all([group, later, earlier])
+    await db.session.commit()
+    # Added in the order that would put "Yak" first without the name key.
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=later.id))
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=earlier.id))
+    await db.session.commit()
+
+    loaded = await _load_group_with_provenance(db, group.id)
+    (entry,) = effective_constraints(loaded)
+    assert entry["value"] is True
+    assert [source["tag_name"] for source in entry["sources"]] == ["Badger", "Yak"]
+
+
+async def test_effective_constraints_orders_one_tag_reaching_from_two_groups(db: Db) -> None:
+    """One tag can reach a role from two associated groups, tying on value and
+    tag name. The source name is the tiebreak that keeps the order stable."""
+    strict_group = OktaGroupFactory.build(name="Aardvark-Group")
+    lenient_group = OktaGroupFactory.build(name="Zebra-Group")
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(name="SOX", constraints={Tag.REQUIRE_MEMBER_REASON_CONSTRAINT_KEY: True})
+    db.session.add_all([strict_group, lenient_group, role, tag])
+    await db.session.commit()
+    for group in (lenient_group, strict_group):
+        db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+        db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False))
+    await db.session.commit()
+
+    loaded = await _load_role(db, role.id)
+    (entry,) = effective_constraints(loaded)
+    assert [source["source_name"] for source in entry["sources"]] == ["Aardvark-Group", "Zebra-Group"]
+
+
 async def test_effective_constraints_reports_association_source(db: Db) -> None:
     role = await _setup(db, constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400}, is_owner=False)
     (entry,) = effective_constraints(role)

--- a/tests/test_effective_constraints.py
+++ b/tests/test_effective_constraints.py
@@ -263,7 +263,7 @@ async def test_nothing_propagates_onto_an_unmanaged_role(db: Db) -> None:
     """An unmanaged role enforces nothing, so nothing may propagate onto it.
 
     Every enforcement path gates on `is_managed` separately. Without the gate
-    inside `_propagated_sources` the read surface would advertise a limit and a
+    in `constraint_sources` the read surface would advertise a limit and a
     self-add prohibition that nothing applies, and the two would disagree.
     """
     group = OktaGroupFactory.build()
@@ -281,6 +281,38 @@ async def test_nothing_propagates_onto_an_unmanaged_role(db: Db) -> None:
     await db.session.commit()
 
     loaded = await _load_role(db, role.id)
+    assert effective_constraint(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, loaded) is None
+    assert effective_constraint(Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY, loaded) is None
+    # Enforcement agrees, which is the point -- the two must not diverge.
+    assert effective_ended_at(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, loaded, None) is None
+
+
+async def test_an_unmanaged_group_reports_none_of_its_own_tags(db: Db) -> None:
+    """An unmanaged group enforces nothing, so its own tags are not in force.
+
+    Covers both ways a tag reaches a group directly: applied to it, and
+    inherited from its app. Tag rows survive a group being switched to
+    unmanaged, so without the gate the group page would list controls Access no
+    longer applies.
+    """
+    app = AppFactory.build()
+    app_group = AppGroupFactory.build(is_managed=False)
+    app_group.app_id = app.id
+    direct = TagFactory.build(constraints={Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY: True})
+    inherited = TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400})
+    db.session.add_all([app, app_group, direct, inherited])
+    await db.session.commit()
+    app_tag_map = AppTagMapFactory.build(app_id=app.id, tag_id=inherited.id)
+    db.session.add(app_tag_map)
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=app_group.id, tag_id=direct.id))
+    db.session.add(
+        OktaGroupTagMapFactory.build(group_id=app_group.id, tag_id=inherited.id, app_tag_map_id=app_tag_map.id)
+    )
+    await db.session.commit()
+
+    loaded = await _load_group_with_provenance(db, app_group.id)
+    assert effective_constraints(loaded) == []
     assert effective_constraint(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, loaded) is None
     assert effective_constraint(Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY, loaded) is None
     # Enforcement agrees, which is the point -- the two must not diverge.

--- a/tests/test_effective_constraints.py
+++ b/tests/test_effective_constraints.py
@@ -4,7 +4,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from api.extensions import Db
-from api.models import AppTagMap, OktaGroup, OktaGroupTagMap, RoleGroup, RoleGroupMap, Tag
+from api.models import AppTagMap, OktaGroup, OktaGroupTagMap, RoleGroup, Tag
 from api.routers._eager import effective_constraint_options
 from api.models.tag import (
     ConstraintOrigin,
@@ -23,6 +23,7 @@ from tests.factories import (
     OktaGroupFactory,
     OktaGroupTagMapFactory,
     RoleGroupFactory,
+    RoleGroupMapFactory,
     TagFactory,
 )
 
@@ -74,7 +75,7 @@ async def _setup(db: Db, *, constraints: dict, is_owner: bool, propagate: bool =
     db.session.add_all([group, role, tag])
     await db.session.commit()
     db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
-    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=is_owner))
+    db.session.add(RoleGroupMapFactory.build(group_id=group.id, role_group_id=role.id, is_owner=is_owner))
     await db.session.commit()
     return await _load_role(db, role.id)
 
@@ -118,7 +119,7 @@ async def test_disabled_tag_contributes_nothing(db: Db) -> None:
     db.session.add_all([group, role, tag])
     await db.session.commit()
     db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
-    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False))
+    db.session.add(RoleGroupMapFactory.build(group_id=group.id, role_group_id=role.id, is_owner=False))
     await db.session.commit()
     loaded = await _load_role(db, role.id)
     assert effective_constraint(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, loaded) is None
@@ -131,7 +132,7 @@ async def test_unmanaged_source_group_contributes_nothing(db: Db) -> None:
     db.session.add_all([group, role, tag])
     await db.session.commit()
     db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
-    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False))
+    db.session.add(RoleGroupMapFactory.build(group_id=group.id, role_group_id=role.id, is_owner=False))
     await db.session.commit()
     loaded = await _load_role(db, role.id)
     assert effective_constraint(Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY, loaded) is None
@@ -156,7 +157,7 @@ async def test_per_tag_not_global(db: Db) -> None:
     await db.session.commit()
     db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=propagating.id))
     db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=blocked.id))
-    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False))
+    db.session.add(RoleGroupMapFactory.build(group_id=group.id, role_group_id=role.id, is_owner=False))
     await db.session.commit()
     loaded = await _load_role(db, role.id)
     # 60 would win a `min` coalesce -- it must not be considered at all.
@@ -206,8 +207,8 @@ async def test_constraint_source_clause_names_every_blocking_source(db: Db) -> N
         [
             OktaGroupTagMapFactory.build(group_id=group_a.id, tag_id=tag.id),
             OktaGroupTagMapFactory.build(group_id=group_b.id, tag_id=tag.id),
-            RoleGroupMap(group_id=group_a.id, role_group_id=role.id, is_owner=False),
-            RoleGroupMap(group_id=group_b.id, role_group_id=role.id, is_owner=False),
+            RoleGroupMapFactory.build(group_id=group_a.id, role_group_id=role.id, is_owner=False),
+            RoleGroupMapFactory.build(group_id=group_b.id, role_group_id=role.id, is_owner=False),
         ]
     )
     await db.session.commit()
@@ -244,7 +245,7 @@ async def test_soft_deleted_source_group_contributes_nothing(db: Db) -> None:
     db.session.add_all([group, role, tag])
     await db.session.commit()
     db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
-    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False))
+    db.session.add(RoleGroupMapFactory.build(group_id=group.id, role_group_id=role.id, is_owner=False))
     await db.session.commit()
 
     group.deleted_at = datetime.now(UTC) - timedelta(days=1)
@@ -277,7 +278,7 @@ async def test_nothing_propagates_onto_an_unmanaged_role(db: Db) -> None:
     db.session.add_all([group, role, tag])
     await db.session.commit()
     db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
-    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False))
+    db.session.add(RoleGroupMapFactory.build(group_id=group.id, role_group_id=role.id, is_owner=False))
     await db.session.commit()
 
     loaded = await _load_role(db, role.id)
@@ -438,7 +439,7 @@ async def test_effective_constraints_orders_one_tag_reaching_from_two_groups(db:
     await db.session.commit()
     for group in (lenient_group, strict_group):
         db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
-        db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False))
+        db.session.add(RoleGroupMapFactory.build(group_id=group.id, role_group_id=role.id, is_owner=False))
     await db.session.commit()
 
     loaded = await _load_role(db, role.id)

--- a/tests/test_effective_constraints_api.py
+++ b/tests/test_effective_constraints_api.py
@@ -39,6 +39,29 @@ async def test_group_detail_exposes_effective_constraints(
     assert constraints[0]["sources"][0]["origin"] == "member_association"
 
 
+async def test_group_create_response_omits_effective_constraints(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any, mocker: Any
+) -> None:
+    """`[]` and null are different answers: `[]` says nothing constrains this
+    group, null says this payload does not carry the answer. Only `get_group`
+    resolves them, so every other response must say null -- the frontend fails
+    its gates closed on null and open on `[]`."""
+    from okta.models.group import Group as OktaGroupModel
+
+    from api.services import okta
+
+    mocker.patch.object(okta, "create_group", return_value=OktaGroupModel.from_dict({"id": "okta-id-eff"}))
+
+    response = await client.post(url_for("groups_create"), json={"type": "okta_group", "name": "Constraintless"})
+    assert response.status_code == 201
+    assert response.json()["effective_constraints"] is None
+
+    created_id = response.json()["id"]
+    detail = await client.get(url_for("group_by_id", group_id=created_id))
+    assert detail.status_code == 200
+    assert detail.json()["effective_constraints"] == []
+
+
 async def test_group_detail_effective_constraints_empty_when_untagged(
     app: FastAPI, client: AsyncClient, db: Db, url_for: Any
 ) -> None:

--- a/tests/test_effective_constraints_api.py
+++ b/tests/test_effective_constraints_api.py
@@ -1,0 +1,107 @@
+from typing import Any
+
+from httpx import AsyncClient
+
+from fastapi import FastAPI
+
+from api.extensions import Db
+from api.models import RoleGroupMap, Tag
+from tests.factories import (
+    AppFactory,
+    AppGroupFactory,
+    AppTagMapFactory,
+    OktaGroupFactory,
+    OktaGroupTagMapFactory,
+    RoleGroupFactory,
+    TagFactory,
+)
+
+
+async def test_group_detail_exposes_effective_constraints(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any
+) -> None:
+    group = OktaGroupFactory.build()
+    role = RoleGroupFactory.build()
+    tag = TagFactory.build(name="SOX", constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400})
+    db.session.add_all([group, role, tag])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    db.session.add(RoleGroupMap(group_id=group.id, role_group_id=role.id, is_owner=False))
+    await db.session.commit()
+
+    response = await client.get(url_for("group_by_id", group_id=role.id))
+    assert response.status_code == 200
+    constraints = response.json()["effective_constraints"]
+    assert len(constraints) == 1
+    assert constraints[0]["constraint"] == Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY
+    assert constraints[0]["value"] == 86400
+    assert constraints[0]["sources"][0]["tag_name"] == "SOX"
+    assert constraints[0]["sources"][0]["origin"] == "member_association"
+
+
+async def test_group_detail_effective_constraints_empty_when_untagged(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any
+) -> None:
+    group = OktaGroupFactory.build()
+    db.session.add(group)
+    await db.session.commit()
+
+    response = await client.get(url_for("group_by_id", group_id=group.id))
+    assert response.status_code == 200
+    assert response.json()["effective_constraints"] == []
+
+
+async def test_group_detail_direct_tag_has_direct_origin(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any
+) -> None:
+    """A tag applied straight to the *fetched* group (no `AppTagMap` linkage)
+    is reported with `origin == "direct"`. This walks `_own_tag_sources` on
+    the group `GET /api/groups/{id}` actually loads -- unlike
+    `test_group_detail_exposes_effective_constraints` above, which fetches a
+    *role* and only ever reads tags via `_propagated_sources` on the
+    associated group, a path that never touches
+    `OktaGroupTagMap.active_app_tag_mapping`. Removing
+    `joinedload(OktaGroupTagMap.active_app_tag_mapping)` from
+    `group_tag_map_options()` should make this raise `InvalidRequestError`."""
+    group = OktaGroupFactory.build()
+    tag = TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400})
+    db.session.add_all([group, tag])
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=group.id, tag_id=tag.id))
+    await db.session.commit()
+
+    response = await client.get(url_for("group_by_id", group_id=group.id))
+    assert response.status_code == 200
+    constraints = response.json()["effective_constraints"]
+    assert len(constraints) == 1
+    assert constraints[0]["sources"][0]["origin"] == "direct"
+
+
+async def test_group_detail_app_tag_has_app_origin(app: FastAPI, client: AsyncClient, db: Db, url_for: Any) -> None:
+    """A tag applied to an `App` and inherited by one of its `AppGroup`s is
+    reported with `origin == "app"` when the `AppGroup` itself is fetched --
+    the `_own_tag_sources` branch where `tag_map.active_app_tag_mapping is
+    not None`. Setup mirrors
+    `test_effective_constraints_app_tag_has_app_origin` in
+    `tests/test_effective_constraints.py`: the inherited group-tag row
+    (`OktaGroupTagMap`) points at the `AppTagMap` row via `app_tag_map_id`,
+    which is what makes `active_app_tag_mapping` non-null. Removing
+    `joinedload(OktaGroupTagMap.active_app_tag_mapping)` from
+    `group_tag_map_options()` should make this raise `InvalidRequestError`."""
+    app_row = AppFactory.build()
+    app_group = AppGroupFactory.build()
+    app_group.app_id = app_row.id
+    tag = TagFactory.build(constraints={Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400})
+    db.session.add_all([app_row, app_group, tag])
+    await db.session.commit()
+    app_tag_map = AppTagMapFactory.build(app_id=app_row.id, tag_id=tag.id)
+    db.session.add(app_tag_map)
+    await db.session.commit()
+    db.session.add(OktaGroupTagMapFactory.build(group_id=app_group.id, tag_id=tag.id, app_tag_map_id=app_tag_map.id))
+    await db.session.commit()
+
+    response = await client.get(url_for("group_by_id", group_id=app_group.id))
+    assert response.status_code == 200
+    constraints = response.json()["effective_constraints"]
+    assert len(constraints) == 1
+    assert constraints[0]["sources"][0]["origin"] == "app"

--- a/tests/test_tag_propagate_to_roles.py
+++ b/tests/test_tag_propagate_to_roles.py
@@ -100,8 +100,8 @@ async def test_post_tag_defaults_propagate_to_roles_when_absent(
 #
 # `disallow_self_add_*` is a separation-of-duties control, and unlike the
 # reason and time-limit constraints it does not merely weaken when propagation
-# is off -- it inverts to permitted. An owner of G blocked from adding
-# themselves directly can add themselves to a role associated with G and arrive
+# is off -- it inverts to permitted: An owner of G blocked from adding
+# themselves directly could add themselves to a role associated with G and arrive
 # at the same access by a supported path. So the two are not independently
 # configurable: a tag carrying either self-add key must propagate.
 

--- a/tests/test_tag_propagate_to_roles.py
+++ b/tests/test_tag_propagate_to_roles.py
@@ -94,3 +94,179 @@ async def test_post_tag_defaults_propagate_to_roles_when_absent(
     db.session.expire_all()
     loaded = (await db.session.scalars(select(Tag).where(Tag.id == response.json()["id"]))).one()
     assert loaded.propagate_to_roles is True
+
+
+# --- Self-add constraints require propagation ------------------------------
+#
+# `disallow_self_add_*` is a separation-of-duties control, and unlike the
+# reason and time-limit constraints it does not merely weaken when propagation
+# is off -- it inverts to permitted. An owner of G blocked from adding
+# themselves directly can add themselves to a role associated with G and arrive
+# at the same access by a supported path. So the two are not independently
+# configurable: a tag carrying either self-add key must propagate.
+
+
+SELF_ADD_KEYS = [
+    Tag.DISALLOW_SELF_ADD_MEMBERSHIP_CONSTRAINT_KEY,
+    Tag.DISALLOW_SELF_ADD_OWNERSHIP_CONSTRAINT_KEY,
+]
+
+
+@pytest.mark.parametrize("constraint_key", SELF_ADD_KEYS)
+async def test_post_tag_rejects_self_add_without_propagation(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any, constraint_key: str
+) -> None:
+    response = await client.post(
+        url_for("tags_create"),
+        json={
+            "name": f"SOX-post-{constraint_key}",
+            "description": "test tag",
+            "constraints": {constraint_key: True},
+            "propagate_to_roles": False,
+        },
+    )
+    assert response.status_code == 400
+    assert constraint_key in response.json()["detail"]
+
+    db.session.expire_all()
+    assert (await db.session.scalars(select(Tag).where(Tag.name == f"SOX-post-{constraint_key}"))).first() is None
+
+
+@pytest.mark.parametrize("constraint_key", SELF_ADD_KEYS)
+async def test_post_tag_allows_self_add_with_propagation(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any, constraint_key: str
+) -> None:
+    response = await client.post(
+        url_for("tags_create"),
+        json={
+            "name": f"SOX-ok-{constraint_key}",
+            "description": "test tag",
+            "constraints": {constraint_key: True},
+            "propagate_to_roles": True,
+        },
+    )
+    assert response.status_code == 201
+
+
+async def test_post_tag_allows_disabled_propagation_without_self_add(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any
+) -> None:
+    """Reason and time-limit constraints degrade rather than invert, so they
+    remain freely combinable with propagation turned off."""
+    response = await client.post(
+        url_for("tags_create"),
+        json={
+            "name": "SOX-reason-only",
+            "description": "test tag",
+            "constraints": {
+                Tag.REQUIRE_MEMBER_REASON_CONSTRAINT_KEY: True,
+                Tag.MEMBER_TIME_LIMIT_CONSTRAINT_KEY: 86400,
+            },
+            "propagate_to_roles": False,
+        },
+    )
+    assert response.status_code == 201
+
+
+@pytest.mark.parametrize("constraint_key", SELF_ADD_KEYS)
+async def test_put_tag_rejects_turning_off_propagation_on_a_self_add_tag(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any, constraint_key: str
+) -> None:
+    """The conflict comes from the stored constraints, which a body carrying
+    only `propagate_to_roles` cannot see -- so this cannot be caught in the
+    request schema."""
+    tag = TagFactory.build(name=f"SOX-put-{constraint_key}", constraints={constraint_key: True})
+    db.session.add(tag)
+    await db.session.commit()
+    tag_id = tag.id
+
+    response = await client.put(
+        url_for("tag_by_id_put", tag_id=tag_id),
+        json={"propagate_to_roles": False},
+    )
+    assert response.status_code == 400
+
+    db.session.expire_all()
+    loaded = (await db.session.scalars(select(Tag).where(Tag.id == tag_id))).one()
+    assert loaded.propagate_to_roles is True
+
+
+@pytest.mark.parametrize("constraint_key", SELF_ADD_KEYS)
+async def test_put_tag_rejects_adding_self_add_to_a_non_propagating_tag(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any, constraint_key: str
+) -> None:
+    """The mirror image: the body supplies the constraint and the stored row
+    supplies the propagation setting."""
+    tag = TagFactory.build(name=f"SOX-put-rev-{constraint_key}", propagate_to_roles=False)
+    db.session.add(tag)
+    await db.session.commit()
+    tag_id = tag.id
+
+    response = await client.put(
+        url_for("tag_by_id_put", tag_id=tag_id),
+        json={"constraints": {constraint_key: True}},
+    )
+    assert response.status_code == 400
+
+    db.session.expire_all()
+    loaded = (await db.session.scalars(select(Tag).where(Tag.id == tag_id))).one()
+    assert loaded.constraints == {}
+
+
+@pytest.mark.parametrize("constraint_key", SELF_ADD_KEYS)
+async def test_put_tag_allows_clearing_both_halves_together(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any, constraint_key: str
+) -> None:
+    """Validation reads the merged result, not either half alone: dropping the
+    constraint in the same request that turns propagation off is coherent."""
+    tag = TagFactory.build(name=f"SOX-put-both-{constraint_key}", constraints={constraint_key: True})
+    db.session.add(tag)
+    await db.session.commit()
+    tag_id = tag.id
+
+    response = await client.put(
+        url_for("tag_by_id_put", tag_id=tag_id),
+        json={"constraints": {}, "propagate_to_roles": False},
+    )
+    assert response.status_code == 200
+
+    db.session.expire_all()
+    loaded = (await db.session.scalars(select(Tag).where(Tag.id == tag_id))).one()
+    assert loaded.propagate_to_roles is False
+    assert loaded.constraints == {}
+
+
+@pytest.mark.parametrize("constraint_key", SELF_ADD_KEYS)
+async def test_post_tag_rejects_self_add_without_propagation_even_when_disabled(
+    app: FastAPI, client: AsyncClient, db: Db, url_for: Any, constraint_key: str
+) -> None:
+    """A disabled tag enforces nothing today, but enabling it later goes
+    through a body that need not mention either field. Validating regardless of
+    `enabled` keeps that later flip from being the moment the hole opens."""
+    response = await client.post(
+        url_for("tags_create"),
+        json={
+            "name": f"SOX-disabled-{constraint_key}",
+            "description": "test tag",
+            "constraints": {constraint_key: True},
+            "propagate_to_roles": False,
+            "enabled": False,
+        },
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.parametrize("constraint_key", SELF_ADD_KEYS)
+async def test_create_tag_operation_rejects_self_add_without_propagation(db: Db, constraint_key: str) -> None:
+    """The operation guards the invariant too, so CLI and seed callers that
+    never touch the router cannot write the combination either."""
+    from api.exceptions import InvalidRequestError
+    from api.operations import CreateTag
+
+    tag = TagFactory.build(
+        name=f"SOX-op-{constraint_key}",
+        constraints={constraint_key: True},
+        propagate_to_roles=False,
+    )
+    with pytest.raises(InvalidRequestError):
+        await CreateTag(tag=tag).execute()


### PR DESCRIPTION
> **Stacked on #617** (`brynna/require_propagation_for_self_add_tags`). Review only the last commit; GitHub retargets this as the stack merges.

**Urgency**: 3 days
**Expected review effort**: MEDIUM

## Motivation

Make the constraints in force per group obvious in the UI, without having to replicate constraint coalescing logic in the frontend.

## What's Changing 

Which constraints bind a group, and why, was only ever answered *inside* enforcement. Anything wanting to show it had to re-derive coalescing and propagation for itself — and any drift between the two surfaces as the UI promising something enforcement does not do.

`effective_constraints(group)` in `api/models/tag.py` returns every constraint in force, with its coalesced value and the sources that produced it. It is built on the same `constraint_sources` walk enforcement already uses, so the two cannot disagree. `GET /api/groups/{id}` serves it as `effective_constraints`.

A source carries the tag plus **how the tag reached the group**:

| `origin` | Meaning |
|---|---|
| `direct` | The tag sits on this group |
| `app` | Inherited from the group's `App` |
| `member_association` | Propagated onto this role from a group it is a member of |
| `owner_association` | Propagated onto this role from a group it owns |

That distinction is the point: it separates a constraint the reader can lift by untagging this group from one they cannot.

Backend only. No UI reads it yet — that lands in the dialogs and the group-page panel further up the stack.

<details>
<summary><h3>Two shape decisions worth a look</h3></summary>

**`source_id` / `source_name`, not `source_group_*`.** An `app` origin's source is an `App`, not a group. Naming the fields after the origin keeps one shape across all four cases; a `direct` origin leaves both `None`, having no source beyond the group itself.

**Populated in the handler, not by `from_attributes`.** `effective_constraints` is derived, not an ORM attribute, so `validate_python(..., from_attributes=True)` cannot pick it up. `get_group` sets it after validating. `post_group`/`put_group` leave it at `[]` — the group page re-fetches the detail after a mutation, so the read is where it is populated.

Also worth flagging for the reviewer: the plural `effective_constraints` reads one relationship more than the singular `effective_constraint` — `OktaGroupTagMap.active_app_tag_mapping`, which is what tells `direct` from `app`. That path belongs to `group_tag_map_options()`, which detail routes already nest under `active_group_tags`, so `groups.py` gets it by composing the two helpers. `effective_constraint_options()`'s docstring now says so, since a caller that took only that helper and then asked for provenance would hit `raise_on_sql`.
</details>

<details>
<summary><h2>Validation of Changes</h2></summary>

Ten new tests. Six in `tests/test_effective_constraints.py` cover the helper directly: unset constraints omitted, association source reported, empty when nothing applies, and one per origin branch — `direct`, `app`, and a soft-deleted app.

That last one is deliberately loaded with `selectinload` rather than the production `joinedload`. `AppTagMap.active_app` is `innerjoin=True`, so under `joinedload` a deleted app collapses the whole `active_app_tag_mapping` chain to `None` and the source degrades to `direct` — meaning the unguarded `.name` read is not reachable through today's loader. `selectinload` issues a separate SELECT per relationship, so the mapping survives while `active_app` comes back `None`: exactly the shape the guard exists for, and the shape any future switch to `selectinload` would produce.

Four in `tests/test_effective_constraints_api.py` go through `GET /api/groups/{id}`: a propagated constraint appears, an untagged group reports `[]`, and the `direct` / `app` origins round-trip through the schema.

Adding `*effective_constraint_options()` to `DEFAULT_LOAD_OPTIONS` sits alongside an existing `selectinload(OktaGroup.active_group_tags)`, so it was worth proving no `Loader strategies ... conflict` at query-compile time — the 427 group-touching tests pass.

`src/api/apiSchemas.ts` regenerated (`ConstraintOrigin` as a literal union, the two new types, the field on all three group-detail variants). `apiComponents.ts` regenerated to no new content — a full regen also collapses a number of unrelated object literals that the committed file has expanded, which the `openapi-client-drift` check treats as drift — so it is reverted.

947 backend / 45 frontend passing; `ruff`, `ty`, and `tsc` clean.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

