### PR TITLE
Record both halves of why a role-derived grant exists

### DIFF
--- a/api/integrity.py
+++ b/api/integrity.py
@@ -3,6 +3,7 @@ import logging
 from sqlalchemy import func, or_, select, update
 from api.extensions import db
 from api.models import OktaGroup, OktaUserGroupMember, RoleGroupMap
+from api.operations._derived_reason import role_derived_reason
 from api.operations import UnmanageGroup
 from api.services import okta
 
@@ -107,6 +108,14 @@ async def verify_and_fix_role_memberships(dry_run: bool = False) -> None:
                             is_owner=active_role_group_map.is_owner,
                             role_group_map_id=active_role_group_map.id,
                             ended_at=associated_users_ended_at,
+                            # A repaired row is reconstructed from the two
+                            # records that justify it, so it carries the same
+                            # provenance as one written by the operations --
+                            # rather than the blank it used to default to.
+                            created_reason=role_derived_reason(
+                                role_group_membership.created_reason,
+                                active_role_group_map.created_reason,
+                            ),
                         )
                     )
                 await db.session.commit()

--- a/api/integrity.py
+++ b/api/integrity.py
@@ -115,6 +115,7 @@ async def verify_and_fix_role_memberships(dry_run: bool = False) -> None:
                             created_reason=role_derived_reason(
                                 role_group_membership.created_reason,
                                 active_role_group_map.created_reason,
+                                is_owner=active_role_group_map.is_owner,
                             ),
                         )
                     )

--- a/api/operations/_derived_reason.py
+++ b/api/operations/_derived_reason.py
@@ -1,0 +1,91 @@
+"""The two-part justification behind a role-derived grant.
+
+When user U has access to group G because U is a member of role R and R is
+associated with G, the `OktaUserGroupMember` materialized in G is not the
+record of a decision anyone made about G directly. It exists because of two
+separate decisions: someone put U in R, and someone attached R to G. Either one
+alone is half the story, and a reader of G's audit log could not tell which
+half they were looking at.
+
+Each of the three sites that materializes such a row holds one half directly
+and can reach the other, but each holds a *different* half -- `ModifyRoleGroups`
+knows why the role was attached, `ModifyGroupUsers` knows why the user joined
+the role, and `api.integrity` is repairing rows it did not create. Composing
+here keeps the stored shape identical across all three.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from api.models import OktaUserGroupMember
+
+USER_IN_ROLE_PREFIX = "User in role because: "
+ROLE_IN_GROUP_PREFIX = "Role in group because: "
+
+#: Stands in for a half that was never recorded. A blank half is itself worth
+#: seeing -- dropping the label instead would make a one-sided reason
+#: indistinguishable from a row written before this composition existed.
+MISSING_REASON_PLACEHOLDER = "(no reason given)"
+
+_ELLIPSIS = "…"
+
+# Read off the column rather than restated, so widening `created_reason` widens
+# what fits here without a second edit. `TypeEngine.length` is Optional in
+# SQLAlchemy's typing and the column declares `Unicode(1024)`, so the fallback
+# is unreachable in practice -- it is there so an unbounded column would not
+# put `None` into the arithmetic below.
+_MAX_LENGTH: int = getattr(OktaUserGroupMember.__table__.c.created_reason.type, "length", None) or 1024
+
+
+def _trim(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    if limit <= len(_ELLIPSIS):
+        return text[:limit]
+    return text[: limit - len(_ELLIPSIS)] + _ELLIPSIS
+
+
+def _fit(user_half: str, role_half: str, budget: int) -> tuple[str, str]:
+    """Trim the halves to `budget` characters between them.
+
+    Hands each half whatever slack the other leaves, so a short half never
+    forces a long one down to an even split. Only when both exceed their share
+    is the budget divided.
+    """
+    if len(user_half) + len(role_half) <= budget:
+        return user_half, role_half
+    share = budget // 2
+    if len(user_half) <= share:
+        return user_half, _trim(role_half, budget - len(user_half))
+    if len(role_half) <= share:
+        return _trim(user_half, budget - len(role_half)), role_half
+    return _trim(user_half, share), _trim(role_half, budget - share)
+
+
+def role_derived_reason(user_in_role_reason: Optional[str], role_in_group_reason: Optional[str]) -> str:
+    """Compose the reason stored on a membership a role confers.
+
+    Args:
+        user_in_role_reason: Why the user is a member of the role.
+        role_in_group_reason: Why the role is associated with the group.
+
+    Returns:
+        Both halves on their own labelled lines, trimmed to fit
+        `OktaUserGroupMember.created_reason`. Empty when neither half was
+        recorded -- two labels around two blanks is noise, not provenance.
+    """
+    user_half = (user_in_role_reason or "").strip()
+    role_half = (role_in_group_reason or "").strip()
+    if not user_half and not role_half:
+        return ""
+
+    user_half = user_half or MISSING_REASON_PLACEHOLDER
+    role_half = role_half or MISSING_REASON_PLACEHOLDER
+
+    # The labels and the separating newline are not negotiable; only the two
+    # reasons compete for what is left.
+    overhead = len(USER_IN_ROLE_PREFIX) + len(ROLE_IN_GROUP_PREFIX) + len("\n")
+    user_half, role_half = _fit(user_half, role_half, _MAX_LENGTH - overhead)
+
+    return f"{USER_IN_ROLE_PREFIX}{user_half}\n{ROLE_IN_GROUP_PREFIX}{role_half}"

--- a/api/operations/_derived_reason.py
+++ b/api/operations/_derived_reason.py
@@ -22,6 +22,9 @@ from api.models import OktaUserGroupMember
 
 USER_IN_ROLE_PREFIX = "User in role because: "
 ROLE_IN_GROUP_PREFIX = "Role in group because: "
+#: The association's own side. A role that owns a group confers ownership of
+#: it, and "in group" would describe the wrong relationship.
+ROLE_OWNS_GROUP_PREFIX = "Role owns group because: "
 
 #: Stands in for a half that was never recorded. A blank half is itself worth
 #: seeing -- dropping the label instead would make a one-sided reason
@@ -63,12 +66,19 @@ def _fit(user_half: str, role_half: str, budget: int) -> tuple[str, str]:
     return _trim(user_half, share), _trim(role_half, budget - share)
 
 
-def role_derived_reason(user_in_role_reason: Optional[str], role_in_group_reason: Optional[str]) -> str:
-    """Compose the reason stored on a membership a role confers.
+def role_derived_reason(
+    user_in_role_reason: Optional[str], role_in_group_reason: Optional[str], *, is_owner: bool = False
+) -> str:
+    """Compose the reason stored on a membership or ownership a role confers.
 
     Args:
-        user_in_role_reason: Why the user is a member of the role.
+        user_in_role_reason: Why the user is a member of the role. Always a
+            membership: only a role's members receive what it confers, so this
+            label does not vary.
         role_in_group_reason: Why the role is associated with the group.
+        is_owner: Whether the association makes the role an owner of the group
+            rather than a member, taken from the `RoleGroupMap`. It selects the
+            second label, since a role that owns a group is not in it.
 
     Returns:
         Both halves on their own labelled lines, trimmed to fit
@@ -83,9 +93,12 @@ def role_derived_reason(user_in_role_reason: Optional[str], role_in_group_reason
     user_half = user_half or MISSING_REASON_PLACEHOLDER
     role_half = role_half or MISSING_REASON_PLACEHOLDER
 
+    role_prefix = ROLE_OWNS_GROUP_PREFIX if is_owner else ROLE_IN_GROUP_PREFIX
+
     # The labels and the separating newline are not negotiable; only the two
-    # reasons compete for what is left.
-    overhead = len(USER_IN_ROLE_PREFIX) + len(ROLE_IN_GROUP_PREFIX) + len("\n")
+    # reasons compete for what is left. Measured off the selected label, which
+    # is the longer of the two when the role owns the group.
+    overhead = len(USER_IN_ROLE_PREFIX) + len(role_prefix) + len("\n")
     user_half, role_half = _fit(user_half, role_half, _MAX_LENGTH - overhead)
 
-    return f"{USER_IN_ROLE_PREFIX}{user_half}\n{ROLE_IN_GROUP_PREFIX}{role_half}"
+    return f"{USER_IN_ROLE_PREFIX}{user_half}\n{role_prefix}{role_half}"

--- a/api/operations/_derived_reason.py
+++ b/api/operations/_derived_reason.py
@@ -2,7 +2,7 @@
 
 When user U has access to group G because U is a member of role R and R is
 associated with G, the `OktaUserGroupMember` materialized in G is not the
-record of a decision anyone made about G directly. It exists because of two
+record of a decision anyone made about U and G directly. It exists because of two
 separate decisions: someone put U in R, and someone attached R to G. Either one
 alone is half the story, and a reader of G's audit log could not tell which
 half they were looking at.

--- a/api/operations/modify_group_users.py
+++ b/api/operations/modify_group_users.py
@@ -674,7 +674,9 @@ class ModifyGroupUsers:
                             # association mapping supplies why the role reaches
                             # this group.
                             created_reason=role_derived_reason(
-                                self.created_reason, role_associated_group_map.created_reason
+                                self.created_reason,
+                                role_associated_group_map.created_reason,
+                                is_owner=role_associated_group_map.is_owner,
                             ),
                             created_actor_id=self.current_user_id,
                             ended_actor_id=self.current_user_id if associated_users_ended_at is not None else None,

--- a/api/operations/modify_group_users.py
+++ b/api/operations/modify_group_users.py
@@ -9,6 +9,7 @@ from api.context import get_request_context
 from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload
 
 from api.extensions import db
+from api.operations._derived_reason import role_derived_reason
 from api.operations._fan_out import defer_or_drain_fan_out, prepare_notification_task
 from api.models import (
     AccessRequest,
@@ -668,7 +669,13 @@ class ModifyGroupUsers:
                             is_owner=role_associated_group_map.is_owner,
                             role_group_map_id=role_associated_group_map.id,
                             ended_at=associated_users_ended_at,
-                            created_reason=self.created_reason,
+                            # The mirror of `ModifyRoleGroups`: this operation
+                            # supplies why the user joined the role, and the
+                            # association mapping supplies why the role reaches
+                            # this group.
+                            created_reason=role_derived_reason(
+                                self.created_reason, role_associated_group_map.created_reason
+                            ),
                             created_actor_id=self.current_user_id,
                             ended_actor_id=self.current_user_id if associated_users_ended_at is not None else None,
                         )

--- a/api/operations/modify_role_groups.py
+++ b/api/operations/modify_role_groups.py
@@ -9,6 +9,7 @@ from api.context import get_request_context
 from sqlalchemy.orm import joinedload, selectin_polymorphic, selectinload
 
 from api.extensions import db
+from api.operations._derived_reason import role_derived_reason
 from api.operations._fan_out import defer_or_drain_fan_out, prepare_notification_task
 from api.models import (
     AccessRequest,
@@ -510,7 +511,10 @@ class ModifyRoleGroups:
                         ended_at=associated_users_ended_at,
                         created_actor_id=self.current_user_id,
                         ended_actor_id=self.current_user_id if self.groups_added_ended_at is not None else None,
-                        created_reason=self.created_reason,
+                        # This operation supplies why the role was attached;
+                        # `member` is the user's role membership and supplies
+                        # why they are in the role to begin with.
+                        created_reason=role_derived_reason(member.created_reason, self.created_reason),
                     )
                     role_associated_membership_added[member.user_id] = membership_to_add
                     db.session.add(membership_to_add)
@@ -545,7 +549,7 @@ class ModifyRoleGroups:
                         ended_at=associated_users_ended_at,
                         created_actor_id=self.current_user_id,
                         ended_actor_id=self.current_user_id if self.groups_added_ended_at is not None else None,
-                        created_reason=self.created_reason,
+                        created_reason=role_derived_reason(member.created_reason, self.created_reason),
                     )
                     role_associated_ownership_added[member.user_id] = ownership_to_add
                     db.session.add(ownership_to_add)

--- a/api/operations/modify_role_groups.py
+++ b/api/operations/modify_role_groups.py
@@ -514,7 +514,11 @@ class ModifyRoleGroups:
                         # This operation supplies why the role was attached;
                         # `member` is the user's role membership and supplies
                         # why they are in the role to begin with.
-                        created_reason=role_derived_reason(member.created_reason, self.created_reason),
+                        created_reason=role_derived_reason(
+                            member.created_reason,
+                            self.created_reason,
+                            is_owner=role_associated_group_map.is_owner,
+                        ),
                     )
                     role_associated_membership_added[member.user_id] = membership_to_add
                     db.session.add(membership_to_add)
@@ -549,7 +553,11 @@ class ModifyRoleGroups:
                         ended_at=associated_users_ended_at,
                         created_actor_id=self.current_user_id,
                         ended_actor_id=self.current_user_id if self.groups_added_ended_at is not None else None,
-                        created_reason=role_derived_reason(member.created_reason, self.created_reason),
+                        created_reason=role_derived_reason(
+                            member.created_reason,
+                            self.created_reason,
+                            is_owner=role_associated_group_map.is_owner,
+                        ),
                     )
                     role_associated_ownership_added[member.user_id] = ownership_to_add
                     db.session.add(ownership_to_add)

--- a/src/components/CreatedReason.tsx
+++ b/src/components/CreatedReason.tsx
@@ -28,7 +28,10 @@ function CreatedReasonDialog(props: CreatedReasonDialogProps) {
   return (
     <Dialog open fullWidth onClose={() => props.setOpen(false)}>
       <DialogTitle sx={{paddingBottom: '0px'}}>Justification</DialogTitle>
-      <DialogContent>{props.created_reason}</DialogContent>
+      {/* `pre-line` so a role-derived justification keeps its two labelled
+          lines; HTML would otherwise collapse the newline to a space and
+          run both halves together. Spaces still collapse normally. */}
+      <DialogContent sx={{whiteSpace: 'pre-line'}}>{props.created_reason}</DialogContent>
       <DialogActions>
         <Button onClick={() => props.setOpen(false)}>Close</Button>
       </DialogActions>

--- a/src/components/InlineReason.tsx
+++ b/src/components/InlineReason.tsx
@@ -20,6 +20,10 @@ export default function InlineReason({reason}: InlineReasonProps) {
       <Typography
         variant="body2"
         sx={{
+          // A role-derived justification is two labelled lines; without this
+          // they render as one run-on sentence. The clamp below still bounds
+          // the height.
+          whiteSpace: 'pre-line',
           wordBreak: 'break-word',
           overflow: 'hidden',
           textOverflow: 'ellipsis',

--- a/tests/test_role_derived_reason.py
+++ b/tests/test_role_derived_reason.py
@@ -1,0 +1,229 @@
+"""A role-derived grant records both halves of why it exists.
+
+When user U has access to group G because U is a member of role R and R is
+associated with G, the `OktaUserGroupMember` materialized in G used to carry
+whichever single reason happened to be in hand at the operation that created
+it -- the reason U was added to R, or the reason R was attached to G, depending
+on which came second. Each is half the justification, and a reader of G's audit
+log had no way to tell which half they were looking at.
+"""
+
+from pytest_mock import MockerFixture
+from sqlalchemy import select
+
+from api.extensions import Db
+from api.models import OktaGroup, OktaUser, OktaUserGroupMember, RoleGroup
+from api.integrity import verify_and_fix_role_memberships
+from api.operations import ModifyGroupUsers, ModifyRoleGroups
+from api.operations._derived_reason import (
+    MISSING_REASON_PLACEHOLDER,
+    ROLE_IN_GROUP_PREFIX,
+    USER_IN_ROLE_PREFIX,
+    role_derived_reason,
+)
+from api.services import okta
+from tests.factories import OktaUserGroupMemberFactory, RoleGroupMapFactory
+
+USER_IN_ROLE = "Q3 audit rotation"
+ROLE_IN_GROUP = "role needs ledger export"
+COMPOSED = f"{USER_IN_ROLE_PREFIX}{USER_IN_ROLE}\n{ROLE_IN_GROUP_PREFIX}{ROLE_IN_GROUP}"
+
+
+async def _derived_row(db: Db, group_id: str, user_id: str) -> OktaUserGroupMember:
+    return (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == group_id)
+            .where(OktaUserGroupMember.user_id == user_id)
+            .where(OktaUserGroupMember.role_group_map_id.is_not(None))
+        )
+    ).one()
+
+
+# --- The helper ------------------------------------------------------------
+
+
+def test_role_derived_reason_composes_both_halves() -> None:
+    assert role_derived_reason(USER_IN_ROLE, ROLE_IN_GROUP) == COMPOSED
+
+
+def test_role_derived_reason_is_empty_when_neither_half_was_given() -> None:
+    """Two labels around two blanks is noise, not provenance."""
+    assert role_derived_reason("", "") == ""
+    assert role_derived_reason(None, None) == ""
+
+
+def test_role_derived_reason_marks_a_missing_half_rather_than_dropping_it() -> None:
+    """A blank half is itself a finding, so it stays visible: dropping the
+    label would make a one-sided reason indistinguishable from an
+    uncomposed one."""
+    assert role_derived_reason(USER_IN_ROLE, "") == (
+        f"{USER_IN_ROLE_PREFIX}{USER_IN_ROLE}\n{ROLE_IN_GROUP_PREFIX}{MISSING_REASON_PLACEHOLDER}"
+    )
+    assert role_derived_reason("", ROLE_IN_GROUP) == (
+        f"{USER_IN_ROLE_PREFIX}{MISSING_REASON_PLACEHOLDER}\n{ROLE_IN_GROUP_PREFIX}{ROLE_IN_GROUP}"
+    )
+
+
+def test_role_derived_reason_fits_the_column_when_both_halves_are_long() -> None:
+    """Each half can already be column-length on its own, so the composition
+    can overflow. Both labels must survive the trim -- a truncation that ate
+    the second half would silently restore the one-sided reason this change
+    exists to remove."""
+    composed = role_derived_reason("a" * 900, "b" * 900)
+
+    assert len(composed) <= OktaUserGroupMember.__table__.c.created_reason.type.length
+    assert composed.startswith(USER_IN_ROLE_PREFIX)
+    assert ROLE_IN_GROUP_PREFIX in composed
+    assert "a" in composed and "b" in composed
+
+
+def test_role_derived_reason_gives_a_long_half_the_slack_a_short_one_leaves() -> None:
+    """Splitting the budget evenly would truncate a long half while a short
+    one left room unused."""
+    composed = role_derived_reason("a" * 2000, "short")
+
+    assert len(composed) <= OktaUserGroupMember.__table__.c.created_reason.type.length
+    assert composed.endswith(f"{ROLE_IN_GROUP_PREFIX}short")
+    # Well past an even split of the ~980 available characters.
+    assert composed.count("a") > 700
+
+
+def test_role_derived_reason_leaves_a_short_composition_untouched() -> None:
+    assert role_derived_reason("x", "y") == f"{USER_IN_ROLE_PREFIX}x\n{ROLE_IN_GROUP_PREFIX}y"
+
+
+# --- ModifyRoleGroups: the role is attached to the group second ------------
+
+
+async def test_attaching_a_role_composes_the_reason_for_existing_role_members(
+    db: Db, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser
+) -> None:
+    db.session.add_all([user, role_group, okta_group])
+    await db.session.commit()
+
+    await ModifyGroupUsers(
+        group=role_group.id, members_to_add=[user.id], created_reason=USER_IN_ROLE, sync_to_okta=False
+    ).execute()
+    await ModifyRoleGroups(
+        role_group=role_group.id, groups_to_add=[okta_group.id], created_reason=ROLE_IN_GROUP, sync_to_okta=False
+    ).execute()
+
+    assert (await _derived_row(db, okta_group.id, user.id)).created_reason == COMPOSED
+
+
+async def test_attaching_a_role_as_owner_composes_the_reason(
+    db: Db, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser
+) -> None:
+    """The ownership branch materializes its own rows and needs the same
+    composition; only the member branch would be covered otherwise."""
+    db.session.add_all([user, role_group, okta_group])
+    await db.session.commit()
+
+    await ModifyGroupUsers(
+        group=role_group.id, members_to_add=[user.id], created_reason=USER_IN_ROLE, sync_to_okta=False
+    ).execute()
+    await ModifyRoleGroups(
+        role_group=role_group.id, owner_groups_to_add=[okta_group.id], created_reason=ROLE_IN_GROUP, sync_to_okta=False
+    ).execute()
+
+    derived = await _derived_row(db, okta_group.id, user.id)
+    assert derived.is_owner is True
+    assert derived.created_reason == COMPOSED
+
+
+async def test_attaching_a_role_leaves_the_direct_role_membership_reason_alone(
+    db: Db, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser
+) -> None:
+    """Only the derived row tells a two-part story. U's membership of R is a
+    direct grant with a single reason and must stay verbatim."""
+    db.session.add_all([user, role_group, okta_group])
+    await db.session.commit()
+
+    await ModifyGroupUsers(
+        group=role_group.id, members_to_add=[user.id], created_reason=USER_IN_ROLE, sync_to_okta=False
+    ).execute()
+    await ModifyRoleGroups(
+        role_group=role_group.id, groups_to_add=[okta_group.id], created_reason=ROLE_IN_GROUP, sync_to_okta=False
+    ).execute()
+
+    direct = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == role_group.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+        )
+    ).one()
+    assert direct.created_reason == USER_IN_ROLE
+
+
+# --- ModifyGroupUsers: the user joins the role second ----------------------
+
+
+async def test_adding_a_user_to_an_attached_role_composes_the_reason(
+    db: Db, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser
+) -> None:
+    """The mirror image of the case above: here the role association already
+    exists and supplies the half the operation does not hold."""
+    db.session.add_all([user, role_group, okta_group])
+    await db.session.commit()
+
+    await ModifyRoleGroups(
+        role_group=role_group.id, groups_to_add=[okta_group.id], created_reason=ROLE_IN_GROUP, sync_to_okta=False
+    ).execute()
+    await ModifyGroupUsers(
+        group=role_group.id, members_to_add=[user.id], created_reason=USER_IN_ROLE, sync_to_okta=False
+    ).execute()
+
+    assert (await _derived_row(db, okta_group.id, user.id)).created_reason == COMPOSED
+
+
+async def test_adding_a_user_to_a_group_directly_keeps_a_single_reason(
+    db: Db, okta_group: OktaGroup, user: OktaUser
+) -> None:
+    """A direct grant has one half and must not gain the two-part shape."""
+    db.session.add_all([user, okta_group])
+    await db.session.commit()
+
+    await ModifyGroupUsers(
+        group=okta_group.id, members_to_add=[user.id], created_reason="direct grant", sync_to_okta=False
+    ).execute()
+
+    membership = (
+        await db.session.scalars(
+            select(OktaUserGroupMember)
+            .where(OktaUserGroupMember.group_id == okta_group.id)
+            .where(OktaUserGroupMember.user_id == user.id)
+        )
+    ).one()
+    assert membership.created_reason == "direct grant"
+
+
+# --- The integrity repair job ----------------------------------------------
+
+
+async def test_repairing_a_missing_role_membership_records_both_halves(
+    db: Db, mocker: MockerFixture, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser
+) -> None:
+    """`verify_and_fix_role_memberships` materializes rows the operations
+    failed to write, and recorded no reason at all for them. Both halves are
+    on hand there -- the user's role membership and the association mapping --
+    so a repaired row carries the same provenance as one written normally."""
+    db.session.add_all([user, role_group, okta_group])
+    await OktaUserGroupMemberFactory.create_async(user_id=user.id, group_id=role_group.id, created_reason=USER_IN_ROLE)
+    role_group_map = await RoleGroupMapFactory.create_async(
+        role_group_id=role_group.id, group_id=okta_group.id, is_owner=False, created_reason=ROLE_IN_GROUP
+    )
+    await db.session.commit()
+
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
+
+    await verify_and_fix_role_memberships()
+
+    repaired = (
+        await db.session.scalars(
+            select(OktaUserGroupMember).where(OktaUserGroupMember.role_group_map_id == role_group_map.id)
+        )
+    ).one()
+    assert repaired.created_reason == COMPOSED

--- a/tests/test_role_derived_reason.py
+++ b/tests/test_role_derived_reason.py
@@ -17,7 +17,9 @@ from api.integrity import verify_and_fix_role_memberships
 from api.operations import ModifyGroupUsers, ModifyRoleGroups
 from api.operations._derived_reason import (
     MISSING_REASON_PLACEHOLDER,
+    _MAX_LENGTH,
     ROLE_IN_GROUP_PREFIX,
+    ROLE_OWNS_GROUP_PREFIX,
     USER_IN_ROLE_PREFIX,
     role_derived_reason,
 )
@@ -27,6 +29,7 @@ from tests.factories import OktaUserGroupMemberFactory, RoleGroupMapFactory
 USER_IN_ROLE = "Q3 audit rotation"
 ROLE_IN_GROUP = "role needs ledger export"
 COMPOSED = f"{USER_IN_ROLE_PREFIX}{USER_IN_ROLE}\n{ROLE_IN_GROUP_PREFIX}{ROLE_IN_GROUP}"
+COMPOSED_AS_OWNER = f"{USER_IN_ROLE_PREFIX}{USER_IN_ROLE}\n{ROLE_OWNS_GROUP_PREFIX}{ROLE_IN_GROUP}"
 
 
 async def _derived_row(db: Db, group_id: str, user_id: str) -> OktaUserGroupMember:
@@ -93,6 +96,22 @@ def test_role_derived_reason_leaves_a_short_composition_untouched() -> None:
     assert role_derived_reason("x", "y") == f"{USER_IN_ROLE_PREFIX}x\n{ROLE_IN_GROUP_PREFIX}y"
 
 
+def test_the_owner_side_names_ownership_rather_than_membership() -> None:
+    # Only the association's own side changes. The user half stays a
+    # membership: only a role's members receive what it confers.
+    assert role_derived_reason("x", "y", is_owner=True) == f"{USER_IN_ROLE_PREFIX}x\n{ROLE_OWNS_GROUP_PREFIX}y"
+
+
+def test_the_owner_side_budget_accounts_for_its_longer_label() -> None:
+    # "Role owns group because: " is longer than "Role in group because: ", so
+    # a composition that just fits as a membership must trim as an ownership.
+    long_half = "z" * 4000
+    composed = role_derived_reason(long_half, long_half, is_owner=True)
+    assert len(composed) <= _MAX_LENGTH
+    assert composed.startswith(USER_IN_ROLE_PREFIX)
+    assert f"\n{ROLE_OWNS_GROUP_PREFIX}" in composed
+
+
 # --- ModifyRoleGroups: the role is attached to the group second ------------
 
 
@@ -116,7 +135,10 @@ async def test_attaching_a_role_as_owner_composes_the_reason(
     db: Db, role_group: RoleGroup, okta_group: OktaGroup, user: OktaUser
 ) -> None:
     """The ownership branch materializes its own rows and needs the same
-    composition; only the member branch would be covered otherwise."""
+    composition; only the member branch would be covered otherwise.
+
+    It also labels its second half differently: a role that owns a group is not
+    in it, so "Role in group because" would describe the wrong relationship."""
     db.session.add_all([user, role_group, okta_group])
     await db.session.commit()
 
@@ -129,7 +151,7 @@ async def test_attaching_a_role_as_owner_composes_the_reason(
 
     derived = await _derived_row(db, okta_group.id, user.id)
     assert derived.is_owner is True
-    assert derived.created_reason == COMPOSED
+    assert derived.created_reason == COMPOSED_AS_OWNER
 
 
 async def test_attaching_a_role_leaves_the_direct_role_membership_reason_alone(


### PR DESCRIPTION
**Urgency**: 5 days
**Expected review effort**: LOW, mostly tests

## Motivation

Create a more robust audit trail.

When user U has access to group G because U is a member of role R and R is associated with G, the `OktaUserGroupMember` row materialized in G is not the record of a decision anyone made about U and G. It exists because of **two** decisions: someone put U in R, and someone attached R to G.

The stored `created_reason` carried only one of them — and which one depended on which decision happened second. `ModifyRoleGroups` wrote why the role was attached; `ModifyGroupUsers` wrote why the user joined the role. So a reader of G's audit log saw half the justification, with nothing marking it as a half, and no way to tell which half they were looking at.

## What's Changing

Both halves are recorded, on their own labelled lines:

```
User in role because: needs ledger access for the Q3 close
Role {in|owns} group because: finance job function covers payment config
```

Three sites materialize these rows — `ModifyGroupUsers`, `ModifyRoleGroups`, and `verify_and_fix_role_memberships` — and each holds a *different* half while being able to reach the other. Composing in one helper is what keeps the stored shape identical across all three, including repaired rows, which previously defaulted to blank.

<img width="1123" height="425" alt="image" src="https://github.com/user-attachments/assets/bc384e0e-fe70-4194-9f49-ba9240f2b2ae" />

<details>
<summary><h2>Details worth a look</h2></summary>

- **A missing half still gets its label.** `(no reason given)` stands in, rather than dropping the line. Otherwise a one-sided reason is indistinguishable from a row written before this existed, which is exactly the ambiguity being fixed.
- **Both halves blank produces an empty string**, not two placeholder lines — nothing was recorded, and saying so twice is noise.
- **Truncation is budget-aware.** The limit is read off `OktaUserGroupMember.created_reason` rather than restated, so widening the column widens what fits without a second edit. Each half gets whatever slack the other leaves, so a short half never forces a long one into an even split; only when both exceed their share is the budget divided.
- The two frontend components that render a stored reason handle the multi-line shape.

</details>

<details>
<summary><h2>Validation of Changes</h2></summary>

`tests/test_role_derived_reason.py` covers the composition directly and through all three writers: both halves present, either half missing, both missing, the exact stored shape, and the truncation cases including the asymmetric-slack behaviour and the boundary where both halves exceed their share.

921 backend / 38 frontend passing; `ruff`, `ty`, `tsc`, and prettier clean.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
