### PR TITLE
Fix two form regressions and stop reporting cancelled requests as errors

### DIFF
--- a/src/api/apiFetcher.ts
+++ b/src/api/apiFetcher.ts
@@ -90,9 +90,16 @@ export async function apiFetch<
       return (await response.blob()) as unknown as TData;
     }
   } catch (e) {
-    // Genuine network/abort failures arrive here as `Error` instances; the
-    // re-thrown problem-detail above is already in `{status, payload}` shape,
-    // so pass it through untouched.
+    // React Query aborts the signal whenever a query is cancelled -- a navigation, or a
+    // search keystroke superseding the request in flight. `DOMException` extends `Error`,
+    // so without this the abort would be rewritten as a network failure below and React
+    // Query would never see the cancellation it asked for.
+    if (e instanceof Error && e.name === 'AbortError') {
+      throw e;
+    }
+    // Genuine network failures arrive here as `Error` instances; the re-thrown
+    // problem-detail above is already in `{status, payload}` shape, so pass it
+    // through untouched.
     if (e instanceof Error) {
       throw {
         status: 'unknown' as const,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,6 +36,11 @@ if (['production', 'staging'].includes(import.meta.env.MODE)) {
     dsn: 'https://user@example.ingest.sentry.io/1234567',
     release: import.meta.env.VITE_SENTRY_RELEASE,
     integrations: [Sentry.replayIntegration()],
+    // React Query cancels in-flight requests when the last observer goes away, which
+    // aborts their signal. That is the intended behaviour, not a fault, and the resulting
+    // rejection reports with no application frames in it. Matched on the exception type
+    // so genuine failures still come through.
+    ignoreErrors: ['AbortError'],
     replaysSessionSampleRate: 0,
     replaysOnErrorSampleRate: 1.0,
     tunnel: '/api/bugs/sentry',

--- a/src/pages/group_requests/Read.tsx
+++ b/src/pages/group_requests/Read.tsx
@@ -800,7 +800,10 @@ export default function ReadGroupRequest() {
                                               setAppSearchInput(newInputValue),
                                             onChange: (_event: React.SyntheticEvent, value: AppDetail | null) =>
                                               setAppName(value?.name ?? ''),
-                                            disabled: !admin,
+                                            // `readOnly`, not `disabled`: react-hook-form clears a disabled field's value, and
+                                            // rhf-mui forwards `autocompleteProps.disabled` into `useController`, so disabling
+                                            // this would drop the app from the submitted form.
+                                            readOnly: !admin,
                                           }}
                                         />
                                       </FormControl>

--- a/src/pages/groups/CreateUpdate.tsx
+++ b/src/pages/groups/CreateUpdate.tsx
@@ -247,11 +247,14 @@ function GroupDialog(props: GroupDialogProps) {
                 options={appSearchOptions}
                 required
                 autocompleteProps={{
-                  disabled: props.app != null || !isAccessAdmin(props.currentUser) || props.app_owner_group,
+                  // `readOnly`, not `disabled`: react-hook-form clears a disabled field's value, and
+                  // rhf-mui forwards `autocompleteProps.disabled` into `useController`, so disabling
+                  // this would drop the app from the submitted form.
+                  readOnly: props.app != null || !isAccessAdmin(props.currentUser) || props.app_owner_group,
                   getOptionLabel: (option) => option.name,
                   isOptionEqualToValue: (option, value) => option.id == value?.id,
                   onInputChange: (event, newInputValue) => setAppSearchInput(newInputValue),
-                  onChange: (event, value) => setAppName(value!.name),
+                  onChange: (event, value) => setAppName(value?.name ?? ''),
                 }}
               />
             </FormControl>

--- a/src/pages/requests/Create.tsx
+++ b/src/pages/requests/Create.tsx
@@ -363,7 +363,11 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
                 updateUntil(value);
               },
               inputValue: groupSearchInput,
-              disabled: props.group != null,
+              // `readOnly`, not `disabled`: react-hook-form clears a disabled field's value, and
+              // rhf-mui forwards `autocompleteProps.disabled` straight into `useController`, so
+              // disabling this would submit the group as `undefined`. readOnly fixes the value
+              // without dropping it.
+              readOnly: props.group != null,
               renderOption: (props, option, state) => {
                 return (
                   <li {...props}>

--- a/src/pages/role_requests/Create.tsx
+++ b/src/pages/role_requests/Create.tsx
@@ -334,7 +334,11 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
                 }
               },
               inputValue: roleSearchInput,
-              disabled: props.group != null,
+              // `readOnly`, not `disabled`: react-hook-form clears a disabled field's value, and
+              // rhf-mui forwards `autocompleteProps.disabled` straight into `useController`, so
+              // disabling this would submit the group as `undefined`. readOnly fixes the value
+              // without dropping it.
+              readOnly: props.group != null,
               renderOption: (props, option, state) => {
                 return (
                   <li {...props}>
@@ -375,7 +379,11 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
                 updateUntil(value);
               },
               inputValue: groupSearchInput,
-              disabled: props.group != null,
+              // `readOnly`, not `disabled`: react-hook-form clears a disabled field's value, and
+              // rhf-mui forwards `autocompleteProps.disabled` straight into `useController`, so
+              // disabling this would submit the group as `undefined`. readOnly fixes the value
+              // without dropping it.
+              readOnly: props.group != null,
               renderOption: (props, option, state) => {
                 return (
                   <li {...props}>


### PR DESCRIPTION
Fixes a production regression from [#607](https://github.com/discord/access/pull/607): **creating an access request or a role request from a group page throws and never submits.** Two related silent failures, one older crash, and a noisy Sentry issue go with it. Each is its own commit.

## What broke

These dialogs fix the group field by disabling it when the page already implies the target. react-hook-form treats a disabled field as having no value ([`disabled` sets the input value to `undefined`](https://react-hook-form.com/docs/usecontroller)), and react-hook-form-mui v7 now forwards `autocompleteProps.disabled` into `useController`. v6 called it with only `{name, control, rules}`, so the value survived.

The group therefore reaches `submit()` as `undefined`, and reading its id throws an unhandled rejection. Nothing looks wrong beforehand: the input still shows the group name, because that text comes from separate search state rather than from the form value.

`readOnly` expresses the same intent without the side effect. The field still cannot be edited, and react-hook-form keeps its value, so `required` stays meaningful too.

## The two that did not crash

Worth flagging for review, because these are the more dangerous half. The app group create/edit form and the group request approval form disable their **app** field on the same pattern, but read it back through `?? ''` instead of dereferencing it. Rather than throwing, they would have submitted an empty `resolved_app_id`/`app_id` and built a malformed `App--<name>` group name. That path is reachable by any non-admin, and by anyone acting from an app page.

## Unrelated older bug, same field

Clearing that app autocomplete with the X hands `onChange` a `null`, and `value!.name` asserted it away, so the click threw `Cannot read properties of null (reading 'name')`. It predates #607. Clearing now resets the name preview to the placeholder it showed before an app was chosen.

## Cancelled requests reported as failures

Separate issue, also predating #607, found while chasing an `AbortError` in Sentry.

React Query aborts a query's signal whenever its last observer goes away, which happens on every navigation and whenever a search keystroke supersedes the request in flight. `DOMException` extends `Error`, so the fetcher's catch-all was rewriting those aborts into `Network error (signal is aborted without reason)` -- React Query never saw the cancellation it had just initiated, and a request the user discarded was reported as a failure. AbortError now propagates untouched; genuine network failures still wrap as before.

The abort also reaches Sentry as an unhandled rejection whose stack sits entirely inside the query cache's teardown, with no application frames to act on, so it is ignored there too. I could not reproduce that rejection locally even with cancellation forced against delayed responses, so the ignore is deliberate noise suppression rather than a claimed fix; it is matched on the exception type rather than a message, since browsers word it differently.

## Verifying

Reproduced the crash against the deployed behaviour locally and confirmed the fix on the same flow: with `disabled`, submitting from a group page throws `Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'id')` through react-hook-form, matching the Sentry mechanism and message; with `readOnly` the field reports `readOnly: true, disabled: false`, keeps the group, and the request is created. The fetcher change was checked both ways: an aborted request now propagates its `AbortError`, and a genuine failure still wraps as `Network error (Failed to fetch)`.

Re-ran the codegen to confirm the fetcher edit survives it, so the client drift check stays green.

A rendering regression test would be the right guard for the form bugs, but the frontend test setup mocks MUI out rather than rendering it (see the note atop `AppGroupLifecyclePluginConfigurationForm.test.tsx`), so there is no harness for one yet. Left alone rather than reworked under an incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)