### PR TITLE
[frontend] Bugfix: Submit locked form fields the API needs

### DIFF
--- a/src/pages/apps/CreateUpdate.tsx
+++ b/src/pages/apps/CreateUpdate.tsx
@@ -166,6 +166,10 @@ function AppDialog(props: AppDialogProps) {
                 maxLength: 255,
                 pattern: new RegExp(accessConfig.NAME_VALIDATION_PATTERN),
               }}
+              // `disabled`, so react-hook-form omits the field: the Access app's name is
+              // immutable, and a partial update should leave it alone rather than resubmit it.
+              // Do not switch this to `readOnly` -- `rules` would then run against a value the
+              // user cannot correct, leaving the tag-only edit with no way to submit.
               disabled={props.access_app}
               parseError={(error) => {
                 if (error?.message != '') {
@@ -192,6 +196,7 @@ function AppDialog(props: AppDialogProps) {
               multiline
               rows={4}
               rules={{maxLength: 1024}}
+              // `disabled`, like the name above: immutable, so left out of the partial update.
               disabled={props.access_app}
               parseError={(error) => {
                 if (error?.message != '') {

--- a/src/pages/group_requests/Read.test.tsx
+++ b/src/pages/group_requests/Read.test.tsx
@@ -1,0 +1,95 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {AppDetail, GroupRequestDetail, OktaUserDetail} from '../../api/apiSchemas';
+
+const resolveMutate = vi.fn();
+
+const APP = {id: 'zendesk-sandbox-0000', name: 'HammerAndChiselZendeskSandbox'} as unknown as AppDetail;
+
+// An app owner, not an Access admin: ownership of the app's owner group is what lets
+// them approve, and it is what locks the Type select.
+const APP_OWNER = {
+  id: 'appowner-0000000000',
+  email: 'owner@example.com',
+  active_group_memberships: [],
+  active_group_ownerships: [
+    {
+      active_group: {
+        id: 'owner-group-00000000',
+        type: 'app_group',
+        name: 'App-HammerAndChiselZendeskSandbox-Owners',
+        is_owner: true,
+        app: APP,
+      },
+    },
+  ],
+} as unknown as OktaUserDetail;
+
+const PENDING_APP_GROUP_REQUEST = {
+  id: 'request-000000000000',
+  status: 'PENDING',
+  created_at: '2026-09-01T00:00:00Z',
+  requester: {id: 'requester-0000000000', email: 'requester@example.com'},
+  requested_group_type: 'app_group',
+  requested_group_name: 'App-HammerAndChiselZendeskSandbox-Admin',
+  requested_group_description: 'Grants the Admin role',
+  requested_app_id: APP.id,
+  requested_group_tags: [],
+} as unknown as GroupRequestDetail;
+
+vi.mock('react-router-dom', async () => {
+  const React = await import('react');
+  return {
+    useNavigate: () => vi.fn(),
+    useParams: () => ({id: PENDING_APP_GROUP_REQUEST.id}),
+    Link: ({children}: {children?: React.ReactNode}) => children,
+  };
+});
+
+vi.mock('../../authentication', () => ({useCurrentUser: () => APP_OWNER}));
+
+vi.mock('../../api/apiComponents', () => ({
+  useGroupRequestById: () => ({data: PENDING_APP_GROUP_REQUEST, isError: false, isLoading: false}),
+  useGroupRequestByIdPut: () => ({mutate: resolveMutate}),
+  useAppById: () => ({data: APP, isLoading: false}),
+  useApps: () => ({data: {items: [APP]}}),
+  useTags: () => ({data: {items: []}}),
+}));
+
+import ReadGroupRequest from './Read';
+
+beforeEach(() => resolveMutate.mockClear());
+
+describe('an app owner approving an app group request', () => {
+  // The Type select is locked for a non-admin approver. `submit` derives the resolved
+  // group name and app id from that type, so it has to survive into the payload --
+  // otherwise the request resolves to an unprefixed group with no app.
+  it('resolves to the prefixed group name and the requested app', async () => {
+    render(<ReadGroupRequest />);
+
+    const approve = await screen.findByRole('button', {name: /Approve/});
+    await userEvent.click(approve);
+
+    await waitFor(() => expect(resolveMutate).toHaveBeenCalledTimes(1));
+    // `approved` is deliberately not asserted: the approve/reject choice is React state
+    // set from the button's onClick, and jsdom dispatches submit before React flushes that
+    // discrete update, so it reads as false here for either button. Browsers flush first.
+    expect(resolveMutate.mock.calls[0][0].body).toMatchObject({
+      resolved_group_type: 'app_group',
+      resolved_group_name: 'App-HammerAndChiselZendeskSandbox-Admin',
+      resolved_app_id: APP.id,
+    });
+  });
+
+  it('still refuses to let the type be changed', async () => {
+    render(<ReadGroupRequest />);
+
+    const typeSelect = await screen.findByRole('combobox', {name: 'Type'});
+    await userEvent.click(typeSelect);
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(typeSelect).toHaveTextContent('App Group');
+  });
+});

--- a/src/pages/group_requests/Read.tsx
+++ b/src/pages/group_requests/Read.tsx
@@ -780,7 +780,13 @@ export default function ReadGroupRequest() {
                                           setAppName('');
                                         }}
                                         required
-                                        disabled={!admin}
+                                        // `readOnly`, not `disabled`: react-hook-form omits a
+                                        // disabled field from the submitted data, and rhf-mui
+                                        // forwards `SelectElement`'s `disabled` into
+                                        // `useController`. `submit` derives the resolved group
+                                        // name and app id from this type, so dropping it resolves
+                                        // the request to an unprefixed, app-less group.
+                                        slotProps={{select: {readOnly: !admin}}}
                                       />
                                     </FormControl>
                                   </Grid>

--- a/src/pages/groups/CreateUpdate.test.tsx
+++ b/src/pages/groups/CreateUpdate.test.tsx
@@ -1,0 +1,124 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import {AppDetail, GroupDetail, OktaUserDetail} from '../../api/apiSchemas';
+
+const createMutate = vi.fn();
+const updateMutate = vi.fn();
+
+vi.mock('react-router-dom', () => ({useNavigate: () => vi.fn()}));
+vi.mock('../../api/apiComponents', () => ({
+  useApps: () => ({data: {items: []}}),
+  useTags: () => ({data: {items: []}}),
+  useGroupsCreate: () => ({mutate: createMutate}),
+  useGroupByIdPut: () => ({mutate: updateMutate}),
+}));
+
+import CreateUpdateGroup from './CreateUpdate';
+
+const ACCESS_OWNER_GROUP = {
+  id: 'access-owners-000000',
+  type: 'app_group',
+  name: 'App-Access-Owners',
+  is_owner: true,
+  app: {id: 'access-app-0000000000', name: 'Access'},
+};
+
+// The Access admin tier is membership in the Access app's owner group.
+const ACCESS_ADMIN = {
+  id: 'admin-00000000000000',
+  email: 'admin@example.com',
+  active_group_memberships: [{active_group: ACCESS_OWNER_GROUP}],
+  active_group_ownerships: [],
+} as unknown as OktaUserDetail;
+
+const APP = {id: 'zendesk-sandbox-0000', name: 'HammerAndChiselZendeskSandbox'} as unknown as AppDetail;
+
+const OWNER_APP_GROUP = {
+  id: 'owner-group-00000000',
+  type: 'app_group',
+  name: 'App-HammerAndChiselZendeskSandbox-Owners',
+  description: 'Owners of the sandbox',
+  is_owner: true,
+  is_managed: true,
+  app: APP,
+  active_group_tags: [],
+} as unknown as GroupDetail;
+
+beforeEach(() => {
+  createMutate.mockClear();
+  updateMutate.mockClear();
+});
+
+const openDialog = async (label: string) => {
+  await userEvent.click(screen.getByRole('button', {name: label}));
+};
+
+const submitDialog = async (label: string) => {
+  await userEvent.click(screen.getByRole('button', {name: label}));
+};
+
+describe('creating an app group from an app page', () => {
+  // The Type select and App autocomplete are locked to the app being viewed. A lock
+  // must not drop the value: react-hook-form omits `disabled` fields from submitted
+  // data, and the API discriminates CreateGroupBody on `type`, so a dropped `type`
+  // fails validation with "Unable to extract tag using discriminator 'type'".
+  it('submits the locked type and app alongside the typed name', async () => {
+    render(<CreateUpdateGroup currentUser={ACCESS_ADMIN} defaultGroupType="app_group" app={APP} />);
+
+    await openDialog('Create App Group');
+    await userEvent.type(screen.getByLabelText(/^Name/), 'Admin');
+    await userEvent.type(screen.getByLabelText(/^Description/), 'Grants the Admin role');
+    await submitDialog('Create');
+
+    expect(createMutate).toHaveBeenCalledTimes(1);
+    expect(createMutate.mock.calls[0][0].body).toMatchObject({
+      type: 'app_group',
+      app_id: APP.id,
+      name: 'App-HammerAndChiselZendeskSandbox-Admin',
+      description: 'Grants the Admin role',
+    });
+  });
+
+  it('still refuses to let the type be changed', async () => {
+    render(<CreateUpdateGroup currentUser={ACCESS_ADMIN} defaultGroupType="app_group" app={APP} />);
+
+    await openDialog('Create App Group');
+    const typeSelect = screen.getByRole('combobox', {name: 'Type'});
+    await userEvent.click(typeSelect);
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(typeSelect).toHaveTextContent('App Group');
+  });
+});
+
+describe('editing an app owner group', () => {
+  // Type, name and description are all locked for an owner group. Only `type` has to be
+  // submitted -- it discriminates the update body. Name and description are immutable,
+  // so they are left out of the partial update entirely.
+  it('submits the locked type and omits the immutable name and description', async () => {
+    render(<CreateUpdateGroup currentUser={ACCESS_ADMIN} defaultGroupType="app_group" group={OWNER_APP_GROUP} />);
+
+    await openDialog('edit');
+    await submitDialog('Update');
+
+    expect(updateMutate).toHaveBeenCalledTimes(1);
+    const body = updateMutate.mock.calls[0][0].body;
+    expect(body).toMatchObject({type: 'app_group'});
+    expect(body.name).toBeUndefined();
+    expect(body.description).toBeUndefined();
+  });
+
+  // An owner group whose description is empty must still be editable -- validating a
+  // `required` description the user cannot reach would leave the form with no way out.
+  it('submits when the immutable description is empty', async () => {
+    const emptyDescription = {...OWNER_APP_GROUP, description: ''} as GroupDetail;
+    render(<CreateUpdateGroup currentUser={ACCESS_ADMIN} defaultGroupType="app_group" group={emptyDescription} />);
+
+    await openDialog('edit');
+    await submitDialog('Update');
+
+    expect(updateMutate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/pages/groups/CreateUpdate.tsx
+++ b/src/pages/groups/CreateUpdate.tsx
@@ -174,16 +174,23 @@ function GroupDialog(props: GroupDialogProps) {
       group.tags_to_add = selectedTags.map((tag: TagSummary) => tag.id);
     }
 
+    // The name field holds the suffix only; the type-derived prefix is added back here.
+    // Locked-and-immutable names (an owner group's) are absent from the form data, and a
+    // partial update must leave them alone rather than prefix an undefined suffix.
     switch (group.type) {
       case 'okta_group':
         break;
       case 'role_group':
-        group.name = ROLE_GROUP_PREFIX + group.name;
+        if (group.name != null) {
+          group.name = ROLE_GROUP_PREFIX + group.name;
+        }
         break;
       case 'app_group':
         const appGroup = group as AppGroupDetail;
         appGroup.app_id = appGroup.app?.id ?? '';
-        appGroup.name = APP_GROUP_PREFIX + (appGroup.app?.name ?? '') + APP_NAME_APP_GROUP_SEPARATOR + appGroup.name;
+        if (appGroup.name != null) {
+          appGroup.name = APP_GROUP_PREFIX + (appGroup.app?.name ?? '') + APP_NAME_APP_GROUP_SEPARATOR + appGroup.name;
+        }
         break;
     }
     delete (group as AppGroupDetail).app;
@@ -235,7 +242,16 @@ function GroupDialog(props: GroupDialogProps) {
               name="type"
               options={GROUP_TYPE_OPTIONS}
               onChange={(value) => setGroupType(value)}
-              disabled={props.app != null || !isAccessAdmin(props.currentUser) || props.app_owner_group}
+              // `readOnly`, not `disabled`: react-hook-form omits a disabled field from the
+              // submitted data, and rhf-mui forwards `SelectElement`'s `disabled` into
+              // `useController`. The API discriminates the group body on `type`, so dropping it
+              // fails validation ("Unable to extract tag using discriminator 'type'") and also
+              // skips the prefixing in `submit`.
+              slotProps={{
+                select: {
+                  readOnly: props.app != null || !isAccessAdmin(props.currentUser) || props.app_owner_group,
+                },
+              }}
               required
             />
           </FormControl>
@@ -282,6 +298,9 @@ function GroupDialog(props: GroupDialogProps) {
                 label="Name"
                 name="name"
                 variant="outlined"
+                // `disabled`, unlike the Type select above: an owner group's name is structural
+                // and immutable, so omitting it from the partial update is what we want. It also
+                // keeps `rules`/`required` from running against a value the user cannot correct.
                 disabled={props.app_owner_group}
                 rules={{
                   maxLength: 255,
@@ -328,6 +347,8 @@ function GroupDialog(props: GroupDialogProps) {
               multiline
               rows={4}
               rules={{maxLength: 1024}}
+              // `disabled`, like the name above: immutable for an owner group, so it is left out
+              // of the partial update rather than submitted unchanged.
               disabled={props.app_owner_group}
               parseError={(error) => {
                 if (error?.message != '') {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -75,6 +75,14 @@ export default defineConfig(({mode}) => {
       alias: {
         '@mui/styled-engine': '@mui/styled-engine-sc',
       },
+      // Test-only field order. Vitest resolves bare dependencies through Node, which
+      // picks MUI's CJS `main` (`node/index.js`); that build `require`s
+      // '@mui/styled-engine' itself, bypassing the alias above and demanding
+      // @emotion/styled, which this app does not install (it renders through
+      // styled-components). Preferring `module` keeps MUI on its ESM build so the
+      // alias applies and component tests can render real MUI instead of mocking it.
+      // The app build keeps Vite's default order.
+      ...(mode === 'test' ? {mainFields: ['module', 'browser', 'main']} : {}),
     },
     define: {
       ACCESS_CONFIG: accessConfig,
@@ -107,6 +115,9 @@ export default defineConfig(({mode}) => {
       // *this* checkout's node_modules, reporting failures that belong to some
       // other branch. Every frontend test lives under src/.
       include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
+      // Inline MUI and react-hook-form-mui so Vite transforms them (and applies the
+      // styled-engine alias) rather than handing them to Node's CJS loader.
+      server: {deps: {inline: [/@mui/, /react-hook-form-mui/]}},
     },
   };
 });


### PR DESCRIPTION
# Summary

Locked form fields whose value the API needs were being dropped from the request body, breaking app group creation with `body: Unable to extract tag using discriminator 'type'`. Lock those fields with `readOnly` instead of `disabled` so react-hook-form keeps the value.

**Urgency**: today — app group creation is broken for anyone creating from an app page.
**Expected review effort**: LOW

# Motivation

Users reported being unable to create app groups; the dialog returns `body: Unable to extract tag using discriminator 'type'`.

<img width="600" height="654" alt="image" src="https://github.com/user-attachments/assets/8d4e2538-6c02-49cc-82c5-e27b5152e6db" />

`react-hook-form-mui` 7 (#607) forwards an element's `disabled` prop into `useController`, and react-hook-form deliberately omits disabled fields from submitted data:

```
6.7.3  useController({name, rules, control})                          ← disabled not forwarded
7.6.2  useController({name, rules, disabled: P.disabled, control})
```

Every field the UI locks because its value is not the user's to choose therefore vanished from the payload. #631 already hit this on `AutocompleteElement` and fixed it with `readOnly` — which is why the report shows both an empty App field and the error. #631 fixed the App field; the Type select was left behind.

<details>
<summary><h1>Description & Screenshots of Changes</h1></summary>

### Create App Group, from an app page

Access admin, creating from the Zztestapp page, so the Type select is locked to `app_group`.

| Before | After |
|---|---|
| <!-- paste 01-create-app-group-BEFORE.png --> | <!-- paste 03-create-app-group-AFTER-success.png --> |
| `body: Unable to extract tag using discriminator 'type'`. Note the App field is also blank. | `App-Zztestapp-Zzscreenshot` created, correctly prefixed and linked to the app. |

### Resolving an app group request, as a non-admin app owner

The Type select is locked because the approver is not an Access admin.

| Before | After |
|---|---|
| <!-- paste 04-resolve-request-BEFORE.png --> | <!-- paste 05-resolve-request-AFTER.png --> |
| `App Group name "Admin" should be prefixed with App name. For example: "App-Zztestapp-"` -- the approver cannot approve at all. | Approved; resolved to `App-Zztestapp-Admin` against the requested app. |


**One rule, two idioms.** `readOnly` is not a blanket replacement for `disabled`, so each locked field is now labelled with which it wants and why:

- **`readOnly`** when the server needs the value: `type` discriminates the group body, and `app` becomes `app_id`. The value belongs in the request; the user just may not change it.
- **`disabled`** when the field is genuinely immutable and a partial update should omit it: an owner group's structural name, the Access app's name and description. Switching these to `readOnly` would start validating `required` against a value the user cannot reach — an owner group with an empty description becomes uneditable under `REQUIRE_DESCRIPTIONS`.

**Three sites, two distinct failures.**

1. `groups/CreateUpdate.tsx` — the reported 422. The Type select is locked when creating from an app page, when a non-admin app owner creates, and when editing an owner group.
2. `groups/CreateUpdate.tsx` `submit()` — a quieter defect the first fix would have exposed. The name is rebuilt from its type-derived prefix unconditionally, so an owner group edit would have submitted `App-<app>-undefined`, silently renaming the group rather than failing. Now only a name that was actually submitted gets prefixed.
3. `group_requests/Read.tsx` — same root cause, worse outcome. `submit` derives both the resolved group name and the resolved app id from `resolved_group_type`, so an app owner approving an app group request resolved it to an unprefixed, app-less group; the API then fell back to the requested type, leaving an app group whose name breaks the `App-<app>-` convention.

**Test infrastructure.** Component tests could not render MUI at all: vitest resolves bare deps through Node, picking MUI's CJS `main`, which `require`s `@mui/styled-engine` itself and so bypasses the styled-engine alias and demands `@emotion/styled` (not installed — this app renders through styled-components). Existing tests worked around it by mocking every MUI import, which limits coverage to pure helpers. Preferring the `module` field and inlining MUI under `mode === 'test'` lets tests render the real forms and assert what actually gets submitted. The app build keeps Vite's default field order.

</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

- 6 new tests render the **real** locked forms, assert the submitted payload, and assert the locks still lock (the dropdown does not open, the inputs stay read-only)
- One test covers the `REQUIRE_DESCRIPTIONS` dead-end directly: an owner group with an empty description must still be submittable
- 44/44 frontend tests pass; `tsc --noEmit` clean; prettier clean; production `vite build` succeeds
- Closed the loop against the real backend schema rather than only the frontend's view of it:

  ```
  BEFORE (type dropped)   -> Unable to extract tag using discriminator 'type'
  AFTER  (type submitted) -> OK
  ```

- Both flows exercised against a local stack (SQLite + the Okta sandbox), before and after, with the screenshots above. Confirmed in the database rather than only on screen:
  - creating from the app page yields `('App-Zztestapp-Zzscreenshot', 'app_group', app_id='qestnJkr6BLd7R6XWeNb')`
  - approving as a non-admin app owner yields `resolved_group_type='app_group'`, `resolved_group_name='App-Zztestapp-Admin'`

</details>

# Guidance for Reviewers

Commit-by-commit; the three commits are the test infrastructure, the group dialog, and the resolve form.

Two calls worth a second opinion for later follow-up:

- **The `readOnly` / `disabled` split.** The alternative was `readOnly` everywhere for consistency with #631, which is what I tried first — it makes an owner group with an empty description permanently uneditable. If you'd rather the locked description not be `required` at all, that's a different and arguably cleaner fix. I may take a stab at this cleanup later, as part of making it possible to add to the default description for owner groups.
- **UX.** A `readOnly` MUI field is not greyed out (it gets `Mui-readOnly`, which the default theme does not dim), so the Type select now looks editable but refuses to open. This matches what #631 already did to the App field beside it, so the dialog is internally consistent, but it is a visible change and worth styling deliberately if we care.