### PR TITLE
[frontend] Bugfix: Stop the Create App Group dialog looping on /api/apps

### DIFF
--- a/src/pages/groups/CreateUpdate.loop.test.tsx
+++ b/src/pages/groups/CreateUpdate.loop.test.tsx
@@ -1,0 +1,138 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+
+import {AppDetail, OktaUserDetail} from '../../api/apiSchemas';
+import CreateUpdateGroup from './CreateUpdate';
+
+vi.mock('react-router-dom', () => ({useNavigate: () => vi.fn()}));
+
+const ACCESS_OWNER_GROUP = {
+  id: 'access-owners-000000',
+  type: 'app_group',
+  name: 'App-Access-Owners',
+  is_owner: true,
+  app: {id: 'access-app-0000000000', name: 'Access'},
+};
+
+// The Access admin tier is membership in the Access app's owner group.
+const ACCESS_ADMIN = {
+  id: 'admin-00000000000000',
+  email: 'admin@example.com',
+  active_group_memberships: [{active_group: ACCESS_OWNER_GROUP}],
+  active_group_ownerships: [],
+} as unknown as OktaUserDetail;
+
+const APP_NAME = 'HammerAndChiselZendeskSandbox';
+
+// The app the dialog is opened from, as the app page holds it: an AppDetail, a
+// different object from the summary GET /api/apps returns for the same app.
+const APP = {
+  id: 'zendesk-sandbox-0000',
+  name: APP_NAME,
+  description: 'Zendesk sandbox',
+  plugin_data: {},
+  active_app_tags: [],
+} as unknown as AppDetail;
+
+const APP_SUMMARY = {id: APP.id, name: APP.name, description: APP.description};
+
+/** Apps that crowd out the target app on the first page of an empty search. */
+const OTHER_APPS = [
+  'Airtable',
+  'Asana',
+  'Datadog',
+  'Figma',
+  'Github',
+  'Jira',
+  'Linear',
+  'Notion',
+  'Sentry',
+  'Slack',
+].map((name, i) => ({id: `other-app-${i}`, name, description: name}));
+
+let appQueries: string[] = [];
+
+/**
+ * Serves GET /api/apps from `page`, answering on a later tick and honouring the
+ * abort signal. Both matter: a real round-trip leaves the query with no data
+ * while it is in flight, and React Query cancels a request whose key is
+ * superseded, so a cancelled key never populates the cache.
+ */
+const stubApps = (page: (q: string) => unknown[]) => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: string, init?: RequestInit) => {
+      const url = new URL(input, 'http://localhost');
+      const q = url.searchParams.get('q') ?? '';
+      const items = url.pathname === '/api/apps' ? (appQueries.push(q), page(q)) : [];
+      const body = JSON.stringify({items, total: items.length, page: 1, size: 10, pages: 1});
+
+      return new Promise<Response>((resolve, reject) => {
+        const timer = setTimeout(
+          () => resolve(new Response(body, {headers: {'Content-Type': 'application/json'}})),
+          10,
+        );
+        init?.signal?.addEventListener('abort', () => {
+          clearTimeout(timer);
+          reject(Object.assign(new Error('aborted'), {name: 'AbortError'}));
+        });
+      });
+    }),
+  );
+};
+
+const searchByName = (q: string) =>
+  [APP_SUMMARY, ...OTHER_APPS].filter((app) => app.name.toLowerCase().includes(q.toLowerCase()));
+
+beforeEach(() => {
+  appQueries = [];
+  // The runaway needs the app present for some searches and absent for others,
+  // which is what an ordinary search does as the query changes.
+  stubApps(searchByName);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const openDialog = async () => {
+  const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
+  render(
+    <QueryClientProvider client={queryClient}>
+      <CreateUpdateGroup currentUser={ACCESS_ADMIN} defaultGroupType="app_group" app={APP} />
+    </QueryClientProvider>,
+  );
+  await userEvent.click(screen.getByRole('button', {name: 'Create App Group'}));
+  return screen.getByRole('combobox', {name: /App/});
+};
+
+describe('the App field of the Create App Group dialog', () => {
+  // The field's input feeds the /api/apps search that supplies its own options, so
+  // anything that re-derives the displayed value from those options makes the two
+  // chase each other: the search in flight has no options yet, so the value reads as
+  // empty, which resets the input, which starts another search. That spun thousands
+  // of requests a second and exhausted the backend's ports.
+  it('settles after a bounded number of app searches', async () => {
+    await openDialog();
+
+    // Give any feedback loop room to run away before counting.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(appQueries.length).toBeLessThanOrEqual(2);
+  });
+
+  // The dialog is opened from an app page, so the app is already known and the field
+  // is locked to it. What the field shows has to come from the form value, not from
+  // whichever apps the current search happens to return -- an app past the first page
+  // of results is absent from every search the field runs on its own, and the user is
+  // left staring at an empty required "App" dropdown.
+  it('shows the app it is locked to even when the search does not return it', async () => {
+    stubApps(() => OTHER_APPS);
+
+    const appField = await openDialog();
+
+    await waitFor(() => expect(appField).toHaveValue(APP_NAME));
+  });
+});

--- a/src/pages/groups/CreateUpdate.tsx
+++ b/src/pages/groups/CreateUpdate.tsx
@@ -262,6 +262,13 @@ function GroupDialog(props: GroupDialogProps) {
                 name="app"
                 options={appSearchOptions}
                 required
+                // Show the app the form actually holds. Left to itself, rhf-mui displays
+                // whichever entry of `options` matches the form value, and `options` here is
+                // the result of a search this field's own input drives: an app past the first
+                // page of results matches nothing and the field renders blank, and a search in
+                // flight has no options at all, so the value reads as empty, the input resets,
+                // and the reset starts another search -- a loop that outran the backend.
+                transform={{input: (app) => app ?? null}}
                 autocompleteProps={{
                   // `readOnly`, not `disabled`: react-hook-form clears a disabled field's value, and
                   // rhf-mui forwards `autocompleteProps.disabled` into `useController`, so disabling


### PR DESCRIPTION
# Summary

The Create App Group dialog put its App autocomplete into an infinite re-render loop, hammering `GET /api/apps?page=1&size=10&q=…` with the query alternating between `q=` and `q=<app name>`. Locally this generated thousands of requests in seconds and took the uvicorn backend down with port exhaustion; in staging it showed up as `ERR_HTTP2_PROTOCOL_ERROR`, a DoS defense. A one-line change breaks the feedback loop and also fixes a blank App field that shares the same root cause.

**Urgency**: 2 days; doesn't block form submission
**Expected review effort**: LOW - One commit, two files, mostly tests.

# Motivation

Reproduces on `main` today: visit `/apps/<AppName>` as an Access admin and click "Create App Group". The console fills with React's "Maximum update depth exceeded" and the backend falls over. A user also sees an empty required "App \*" dropdown even though the form is holding the app — the `App-<AppName>-` prefix beside the Name field renders correctly from the same data.

<img width="618" height="625" alt="image" src="https://github.com/user-attachments/assets/49b7c8fb-810d-4330-9572-e113d4ff7641" />

Which of the two symptoms you get depends on the app, so pick deliberately when reproducing: the loop needs the app to be on **page 1 of the empty search** (`/api/apps?page=1&size=10&q=`) so the value flickers in and out of `options`. An app that is *never* in those results pins the value to `null` instead — permanently blank field, no loop, no console noise. On a locally seeded 19-app instance, a page-1 app produced **588 requests in 2 seconds** while an off-page-1 app produced 2 requests and an empty field.

This is **not** a regression from #631 or #632. Reverting the App autocomplete to `disabled` (its pre-#631 form) still loops identically; the behaviour this depends on came in with the react-hook-form-mui 7 upgrade in #607.

<details>
<summary><h1>Description of Changes</h1></summary>

`react-hook-form-mui`'s `AutocompleteElement` does not hand the form value to MUI. It looks the value up in `options` and displays whichever entry matches, falling back to `null`:

```ts
matchOptionByValue(newValue) ?? null   // options.find(o => isOptionEqualToValue(o, value))
```

That is fine for a static option list. But this field's `options` are the results of a search that the field's own input drives:

```
onInputChange → appSearchInput → useApps({q}) → options → value → onInputChange
```

React Query has no data for a query key that is in flight, so `options` is empty for the whole round-trip. The value therefore reads as `null`, and MUI resets the input to the empty string to match it. That reset arrives back as `onInputChange` (with `reason: 'reset'`), which sets the search back to `q=` — whose results *do* contain the app — so the value reappears, the input resets to the app name, the search becomes `q=<app name>`, and the two keys ping-pong.

Nothing breaks the cycle on its own: React Query cancels the request whose key was superseded, so neither key ever populates the cache. Every request in the browser network log is `ERR_ABORTED`.

The fix passes `transform.input` so the field displays the value the form actually holds, independent of whatever the current search returns:

```tsx
transform={{input: (app) => app ?? null}}
```

This also fixes the blank App field, which is the same root cause seen from the other side: an app past the first page of `/api/apps` results matches no option, so the dialog renders an empty required dropdown while holding the app the whole time.

The regression test needs to render real MUI, which #632 made possible; this branch is rebased on that and carries only the fix.

</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

- New regression test, `src/pages/groups/CreateUpdate.loop.test.tsx`, covering both symptoms. It renders the real dialog with real MUI, a real `QueryClient`, and a stubbed `fetch` that answers on a later tick and honours the abort signal — both are needed, since the loop depends on a query having no data while in flight and on a superseded key being cancelled before it can cache.
  - Without the fix: ~50 app searches in 300ms, and a blank App field.
  - With the fix: 2 searches, field populated. Verified red → green in both directions.
- Verified in the running app against a locally seeded DB: reopening the dialog now issues 2 requests and settles, and the App field shows the app. Before: unbounded alternating `q=` / `q=<app name>`.
- Confirmed the bug predates #631 by checking out `cb33c30`'s version of the dialog into the running stack — it still loops.
- Checked the structurally similar `resolved_app` field on the group-request resolve page by seeding an app-group request and driving it: 0 app searches, field populated. Not affected, left alone.
- Full frontend suite (46 tests, including #632's) and `tsc --noEmit` clean.

</details>