### PR TITLE
Dedupe approver lookups so a double-owner gets one notification, not two

### DIFF
--- a/api/models/app_group.py
+++ b/api/models/app_group.py
@@ -17,8 +17,13 @@ async def get_app_managers(app_id: str) -> List[OktaUser]:
 
     if ((await db.session.scalar(select(func.count()).select_from(owner_app_groups_stmt.subquery()))) or 0) > 0:
         owner_app_group_ids = [ag.id for ag in await db.session.scalars(owner_app_groups_stmt)]
+        # A user can hold two concurrent active OktaUserGroupMember owner rows
+        # for the same app-owner group at once (a direct grant plus one via a
+        # role mapping, per the access-grant-precedence rules) -- distinct()
+        # so such a user is returned once, not once per row.
         result = await db.session.scalars(
             select(OktaUser)
+            .distinct()
             .join(OktaUser.all_group_memberships_and_ownerships)
             .where(OktaUserGroupMember.group_id.in_(owner_app_group_ids))
             .where(OktaUserGroupMember.is_owner.is_(True))
@@ -55,8 +60,11 @@ async def get_access_owners() -> List[OktaUser]:
 
     if ((await db.session.scalar(select(func.count()).select_from(owner_app_groups_stmt.subquery()))) or 0) > 0:
         owner_app_group_ids = [ag.id for ag in await db.session.scalars(owner_app_groups_stmt)]
+        # See the distinct() note in get_app_managers above -- same concurrent
+        # direct-plus-role-grant case applies to members of this group.
         result = await db.session.scalars(
             select(OktaUser)
+            .distinct()
             .join(OktaUser.all_group_memberships_and_ownerships)
             .where(OktaUserGroupMember.group_id.in_(owner_app_group_ids))
             .where(OktaUserGroupMember.is_owner.is_(False))

--- a/api/models/okta_group.py
+++ b/api/models/okta_group.py
@@ -7,8 +7,13 @@ from api.models.core_models import OktaUser, OktaUserGroupMember
 
 
 async def get_group_managers(group_id: str) -> List[OktaUser]:
+    # A user can hold two concurrent active OktaUserGroupMember owner rows for
+    # the same group at once (a direct grant plus one via a role mapping,
+    # per the access-grant-precedence rules) -- distinct() so such a user is
+    # returned once, not once per row.
     result = await db.session.scalars(
         select(OktaUser)
+        .distinct()
         .join(OktaUserGroupMember, OktaUser.id == OktaUserGroupMember.user_id)
         .where(OktaUserGroupMember.group_id == group_id)
         .where(OktaUserGroupMember.is_owner.is_(True))

--- a/tests/test_group_owner_lookups_dedup.py
+++ b/tests/test_group_owner_lookups_dedup.py
@@ -1,0 +1,109 @@
+"""A user can hold two concurrent active OktaUserGroupMember owner rows for the
+same group at once -- a direct grant plus one via a role mapping, per the
+access-grant-precedence rules -- and those rows are never collapsed into one.
+The approver lookups used to notify a single access request must still return
+such a user once, not once per row, or the notification plugin sends one DM
+per list entry for what is really one owner.
+"""
+
+from sqlalchemy import select
+
+from api.models import App, AppGroup, OktaUser, RoleGroup
+from api.models.app_group import get_access_owners, get_app_managers
+from api.models.okta_group import get_group_managers
+from tests.factories import (
+    AppFactory,
+    AppGroupFactory,
+    OktaGroupFactory,
+    OktaUserGroupMemberFactory,
+    RoleGroupFactory,
+    RoleGroupMapFactory,
+)
+
+
+async def _double_owner(group_id: str, owner: OktaUser, role: RoleGroup) -> None:
+    """Grant `owner` ownership of `group_id` both directly and via `role`."""
+    role_group_map = await RoleGroupMapFactory.create_async(
+        role_group_id=role.id,
+        group_id=group_id,
+        is_owner=True,
+    )
+    await OktaUserGroupMemberFactory.create_async(
+        user_id=owner.id,
+        group_id=group_id,
+        is_owner=True,
+        role_group_map_id=role_group_map.id,
+    )
+    await OktaUserGroupMemberFactory.create_async(
+        user_id=owner.id,
+        group_id=group_id,
+        is_owner=True,
+        role_group_map_id=None,
+    )
+
+
+async def test_get_group_managers_dedupes_direct_and_role_ownership(db, user: OktaUser) -> None:
+    db.session.add(user)
+    await db.session.commit()
+
+    group = await OktaGroupFactory.create_async()
+    role = await RoleGroupFactory.create_async()
+    await _double_owner(group.id, user, role)
+
+    managers = await get_group_managers(group.id)
+
+    assert [m.id for m in managers] == [user.id]
+
+
+async def test_get_app_managers_dedupes_direct_and_role_ownership(db, user: OktaUser) -> None:
+    db.session.add(user)
+    await db.session.commit()
+
+    app = await AppFactory.create_async()
+    owner_group = await AppGroupFactory.create_async(app_id=app.id, is_owner=True)
+    role = await RoleGroupFactory.create_async()
+    await _double_owner(owner_group.id, user, role)
+
+    managers = await get_app_managers(app.id)
+
+    assert [m.id for m in managers] == [user.id]
+
+
+async def test_get_access_owners_dedupes_direct_and_role_membership(db, user: OktaUser) -> None:
+    db.session.add(user)
+    await db.session.commit()
+
+    # The `db` fixture already seeds the bootstrap Access app + its owner
+    # group; reuse it rather than creating a second app with the reserved name.
+    access_app = (await db.session.scalars(select(App).where(App.name == App.ACCESS_APP_RESERVED_NAME))).one()
+    owner_group = (
+        await db.session.scalars(
+            select(AppGroup).where(AppGroup.app_id == access_app.id).where(AppGroup.is_owner.is_(True))
+        )
+    ).one()
+    role = await RoleGroupFactory.create_async()
+    role_group_map = await RoleGroupMapFactory.create_async(
+        role_group_id=role.id,
+        group_id=owner_group.id,
+        is_owner=False,
+    )
+    await OktaUserGroupMemberFactory.create_async(
+        user_id=user.id,
+        group_id=owner_group.id,
+        is_owner=False,
+        role_group_map_id=role_group_map.id,
+    )
+    await OktaUserGroupMemberFactory.create_async(
+        user_id=user.id,
+        group_id=owner_group.id,
+        is_owner=False,
+        role_group_map_id=None,
+    )
+
+    owners = await get_access_owners()
+    owner_ids = [o.id for o in owners]
+
+    # The bootstrap admin (seeded by the `db` fixture) is also a member of
+    # this group, so `user` is one of (at least) two owners -- the point is
+    # that `user` appears exactly once despite its two active membership rows.
+    assert owner_ids.count(user.id) == 1


### PR DESCRIPTION
# Summary
A group/app owner who holds two concurrent active ownership rows for the same group (a direct grant plus one granted via a role mapping) was being returned twice by the approver lookup helpers, so they received duplicate DMs for a single access request.
**Urgency**: 3
**Expected review effort**: LOW

# Motivation
Reported in an internal thread: a user's notification count climbed rapidly, with pairs of identical "has requested membership to [App-X]" DMs for the same request. Traced to `get_group_managers`, `get_app_managers`, and `get_access_owners` returning the same `OktaUser` more than once when that user has multiple active `OktaUserGroupMember` rows granting ownership of the same group (e.g. one direct row plus one via a role mapping) — a state the data model explicitly allows and never collapses (see the access-grant-precedence rules). `CreateAccessRequest` passes that list straight through to the notification hook with no dedup, so the notification plugin sends one message per list entry.

# Description of Changes
- Added `.distinct()` to the `OktaUser` queries in `get_group_managers` (`api/models/okta_group.py`) and `get_app_managers`/`get_access_owners` (`api/models/app_group.py`) so a user with multiple active ownership rows for the same group is returned once.
- Added regression tests covering all three lookups with a user granted ownership both directly and via a role.

# Validation of Changes
- Added `tests/test_group_owner_lookups_dedup.py`, verified it fails on `main` (each lookup returns the user twice) and passes with the fix.
- Full test suite passes (`uv run pytest`).
- `ruff check`, `ruff format --check`, and `ty check` pass on the changed files.

# Guidance for Reviewers
Single logical change across two files plus one test file — fine to review as one diff. The core question is whether `.distinct()` on `select(OktaUser)...` is the right fix point vs. deduping at each call site (e.g. `create_access_request.py`); I chose the query-level fix so every current and future caller of these three helpers gets the same guarantee.