### PR TITLE
Allow appending a custom description to app owner groups

### DIFF
--- a/api/models/app_group.py
+++ b/api/models/app_group.py
@@ -1,9 +1,24 @@
+import re
 from typing import List
 
 from sqlalchemy import func, or_, select
 
 from api.extensions import db
 from api.models.core_models import App, AppGroup, OktaGroup, OktaUser, OktaUserGroupMember
+
+_LEADING_BLANK_LINES_RE = re.compile(r"^(?:[ \t]*\n)+")
+
+
+def _trim_free_text(text: str) -> str:
+    """Strip leading blank lines and trailing whitespace, preserving indentation on the first line of real content.
+
+    Leading spaces/tabs on a non-blank line are meaningful markdown (an indented list item or
+    code block), so unlike `str.strip()` this does not treat a run of leading whitespace and
+    newlines as one unit to discard -- only whole blank lines ahead of the first real content are
+    removed. Trailing whitespace carries no such meaning and is stripped in full. Mirrors
+    `firstParagraph`'s leading-blank-line handling in `src/components/MarkdownDescription.tsx`.
+    """
+    return _LEADING_BLANK_LINES_RE.sub("", text).rstrip()
 
 
 async def get_app_managers(app_id: str) -> List[OktaUser]:
@@ -91,7 +106,7 @@ def app_owners_group_description(app_name: str, additional_description: str | No
         The base line alone, or the base line, a blank line, and the free text.
     """
     base = f"Owners of the {app_name} application"
-    additional = (additional_description or "").strip()
+    additional = _trim_free_text(additional_description or "")
     if not additional:
         return base
     return f"{base}\n\n{additional}"
@@ -118,5 +133,5 @@ def app_owners_group_description_remainder(description: str, app_name: str) -> s
     if normalized.strip() == base:
         return ""
     if normalized.startswith(base):
-        return normalized[len(base) :].strip()
-    return normalized.strip()
+        return _trim_free_text(normalized[len(base) :])
+    return _trim_free_text(normalized)

--- a/api/models/app_group.py
+++ b/api/models/app_group.py
@@ -19,6 +19,10 @@ def _trim_free_text(text: str) -> str:
     `firstParagraph`'s leading-blank-line handling in `src/components/MarkdownDescription.tsx`.
 
     `\\r\\n` is normalized to `\\n` first, since a browser textarea submits CRLF line endings.
+
+    Mirrored in the frontend by `trimFreeText`, a private helper in
+    `src/pages/groups/appOwnerGroupDescription.ts`; both are pinned by tests that name
+    each other.
     """
     return _LEADING_BLANK_LINES_RE.sub("", text.replace("\r\n", "\n")).rstrip()
 

--- a/api/models/app_group.py
+++ b/api/models/app_group.py
@@ -17,8 +17,10 @@ def _trim_free_text(text: str) -> str:
     newlines as one unit to discard -- only whole blank lines ahead of the first real content are
     removed. Trailing whitespace carries no such meaning and is stripped in full. Mirrors
     `firstParagraph`'s leading-blank-line handling in `src/components/MarkdownDescription.tsx`.
+
+    `\\r\\n` is normalized to `\\n` first, since a browser textarea submits CRLF line endings.
     """
-    return _LEADING_BLANK_LINES_RE.sub("", text).rstrip()
+    return _LEADING_BLANK_LINES_RE.sub("", text.replace("\r\n", "\n")).rstrip()
 
 
 async def get_app_managers(app_id: str) -> List[OktaUser]:

--- a/api/models/app_group.py
+++ b/api/models/app_group.py
@@ -72,5 +72,51 @@ async def get_access_owners() -> List[OktaUser]:
     return []
 
 
-def app_owners_group_description(app_name: str) -> str:
-    return f"Owners of the {app_name} application"
+def app_owners_group_description(app_name: str, additional_description: str | None = None) -> str:
+    """Compose an app owner group's description.
+
+    The base line is fixed; free text, when given, follows it after a blank line so the
+    two render as separate paragraphs (group descriptions are rendered as markdown).
+
+    This format string is mirrored in the frontend by `appOwnerGroupDescriptionPrefix`
+    (`src/pages/groups/appOwnerGroupDescription.ts`), which needs the base line to seed
+    its edit field. Change one and you must change the other; both are pinned by tests.
+
+    Args:
+        app_name: The owning app's name.
+        additional_description: Free text to append. Empty or whitespace-only is treated
+            as absent.
+
+    Returns:
+        The base line alone, or the base line, a blank line, and the free text.
+    """
+    base = f"Owners of the {app_name} application"
+    additional = (additional_description or "").strip()
+    if not additional:
+        return base
+    return f"{base}\n\n{additional}"
+
+
+def app_owners_group_description_remainder(description: str, app_name: str) -> str:
+    """Extract the free-text remainder from an app owner group's description.
+
+    The reseat rule, shared with the edit form: a description that starts with the base
+    line for `app_name` splits into base + remainder; one that does not becomes the
+    remainder in its entirety. The second branch is what makes a description written
+    before this convention (or written directly to the database) recoverable rather than
+    discarded -- the caller composes it back onto a correct base line.
+
+    Args:
+        description: The stored description. May be empty.
+        app_name: The app name whose base line is expected.
+
+    Returns:
+        The remainder, or an empty string when there is none.
+    """
+    normalized = (description or "").replace("\r\n", "\n")
+    base = app_owners_group_description(app_name)
+    if normalized.strip() == base:
+        return ""
+    if normalized.startswith(base):
+        return normalized[len(base) :].strip()
+    return normalized.strip()

--- a/api/models/app_group.py
+++ b/api/models/app_group.py
@@ -101,7 +101,8 @@ def app_owners_group_description(app_name: str, additional_description: str | No
 
     This format string is mirrored in the frontend by `appOwnerGroupDescriptionPrefix`
     (`src/pages/groups/appOwnerGroupDescription.ts`), which needs the base line to seed
-    its edit field. Change one and you must change the other; both are pinned by tests.
+    its edit field. `test_frontend_prefix_template_matches_backend`
+    (`tests/test_app_group_description.py`) enforces that the two agree.
 
     Args:
         app_name: The owning app's name.

--- a/api/operations/create_app.py
+++ b/api/operations/create_app.py
@@ -8,6 +8,7 @@ from api.context import get_request_context
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import with_polymorphic
 
+from api.exceptions import InvalidRequestError
 from api.extensions import db
 from api.models import App, AppGroup, AppTagMap, OktaGroup, OktaGroupTagMap, OktaUser, RoleGroup, Tag
 from api.models.app_group import app_owners_group_description, app_owners_group_description_remainder
@@ -17,6 +18,7 @@ from api.operations.modify_group_type import ModifyGroupType
 from api.operations.modify_group_users import ModifyGroupUsers
 from api.operations.modify_role_groups import ModifyRoleGroups
 from api.schemas import AuditLogSchema, EventType
+from api.schemas.requests_schemas import _GROUP_DESC_MAX_LENGTH
 
 
 class AppDict(TypedDict):
@@ -117,6 +119,29 @@ class CreateApp:
         if existing_app is not None:
             return existing_app
 
+        # A pre-existing group at the owner-group name is promoted below rather than
+        # replaced, and its description is reseated onto the new base line (matching the
+        # app-rename path). Composing can push the result past _GROUP_DESC_MAX_LENGTH --
+        # checked here, before anything is created or committed, so a refusal leaves no
+        # partial app, no promoted group, and no Okta call.
+        existing_owner_group = (
+            await db.session.scalars(
+                select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
+                .where(func.lower(OktaGroup.name) == func.lower(self.owner_group_name))
+                .where(OktaGroup.deleted_at.is_(None))
+            )
+        ).first()
+        if existing_owner_group is not None:
+            remainder = app_owners_group_description_remainder(existing_owner_group.description or "", self.app.name)
+            composed = app_owners_group_description(self.app.name, remainder)
+            if len(composed) > _GROUP_DESC_MAX_LENGTH:
+                raise InvalidRequestError(
+                    f'Creating this app would make the description of "{existing_owner_group.name}" '
+                    f"{len(composed)} characters, over the {_GROUP_DESC_MAX_LENGTH} limit. "
+                    f"Shorten that group's description by "
+                    f"{len(composed) - _GROUP_DESC_MAX_LENGTH} characters and try again."
+                )
+
         # Audit logging
         email = None
         if current_user_id is not None:
@@ -142,14 +167,6 @@ class CreateApp:
         await db.session.commit()
 
         app_id = self.app.id
-
-        existing_owner_group = (
-            await db.session.scalars(
-                select(with_polymorphic(OktaGroup, [AppGroup, RoleGroup]))
-                .where(func.lower(OktaGroup.name) == func.lower(self.owner_group_name))
-                .where(OktaGroup.deleted_at.is_(None))
-            )
-        ).first()
 
         if existing_owner_group is None:
             owner_app_group = AppGroup(

--- a/api/operations/create_app.py
+++ b/api/operations/create_app.py
@@ -10,8 +10,9 @@ from sqlalchemy.orm import with_polymorphic
 
 from api.extensions import db
 from api.models import App, AppGroup, AppTagMap, OktaGroup, OktaGroupTagMap, OktaUser, RoleGroup, Tag
-from api.models.app_group import app_owners_group_description
+from api.models.app_group import app_owners_group_description, app_owners_group_description_remainder
 from api.operations.create_group import CreateGroup, GroupDict
+from api.operations.modify_group_details import ModifyGroupDetails
 from api.operations.modify_group_type import ModifyGroupType
 from api.operations.modify_group_users import ModifyGroupUsers
 from api.operations.modify_role_groups import ModifyRoleGroups
@@ -171,6 +172,20 @@ class CreateApp:
             owner_app_group.app_id = app_id
             owner_app_group.is_owner = True
             await db.session.commit()
+
+            # A promoted group keeps whatever it already had for a description: the
+            # reseat rule (shared with app rename, in `put_app`) composes the base line
+            # onto the existing text as a remainder rather than discarding it. Routed
+            # through ModifyGroupDetails, not a bare attribute assignment, so the Okta
+            # side of this pre-existing group is pushed to match -- unlike `app_id` and
+            # `is_owner` above, `description` is a real Okta group field, and this branch
+            # has no later step that would otherwise sync it.
+            remainder = app_owners_group_description_remainder(owner_app_group.description or "", self.app.name)
+            await ModifyGroupDetails(
+                group=owner_app_group,
+                description=app_owners_group_description(self.app.name, remainder),
+                current_user_id=current_user_id,
+            ).execute()
 
         if owner_id is not None:
             # Add the app owner to the app owner group as members and owners

--- a/api/operations/modify_group_details.py
+++ b/api/operations/modify_group_details.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import with_polymorphic
 
 from api.extensions import db
 from api.models import App, AppGroup, OktaGroup, OktaUser, RoleGroup
+from api.models.app_group import app_owners_group_description
 from api.operations._lifecycle_fan_out import defer_or_invoke_lifecycle_hook
 from api.plugins.app_group_lifecycle import AppGroupLifecycleHook
 from api.services import okta
@@ -86,6 +87,25 @@ class ModifyGroupDetails:
                         self.name, app_group_name_prefix
                     )
                 )
+
+        # An app owner group's description keeps its base line: "Owners of the {app name}
+        # application", optionally followed by a blank line and free text. Enforced here
+        # rather than in the router so it also holds for the plugin `set_group_description`
+        # capability and any other caller that bypasses the route.
+        if self.description is not None and type(self.group) is AppGroup and self.group.is_owner:
+            description = self.description.replace("\r\n", "\n")
+            owner_app = (
+                await db.session.scalars(select(App).where(App.id == self.group.app_id).where(App.deleted_at.is_(None)))
+            ).first()
+            if owner_app is None:
+                raise ValueError("App for AppGroup does not exist")
+            base = app_owners_group_description(owner_app.name)
+            if description != base and not description.startswith(f"{base}\n\n"):
+                raise ValueError(
+                    f'An app owner group description must begin with "{base}", optionally '
+                    "followed by a blank line and additional text."
+                )
+            self.description = description
 
         if self.name is not None:
             self.group.name = self.name

--- a/api/plugins/app_group_lifecycle.py
+++ b/api/plugins/app_group_lifecycle.py
@@ -660,6 +660,12 @@ class AppGroupLifecycleContext:
         idempotent and re-enforce on the next pass; the alternative -- committing here -- breaks
         the lock.
 
+        An app owner group constrains what it accepts: the description must keep its
+        "Owners of the {app name} application" base line, optionally followed by a blank
+        line and free text. A non-conforming value raises, and because a failing hook is
+        logged and swallowed, it fails quietly -- compose the base line back on rather
+        than replacing it wholesale.
+
         Args:
             group: The app group to describe.
             description: The description to set, replacing whatever is there.

--- a/api/routers/apps.py
+++ b/api/routers/apps.py
@@ -283,9 +283,13 @@ async def put_app(
 
     from api.auth.permissions import is_access_admin
     from api.models import AppGroup as _AppGroup
-    from api.models.app_group import app_owners_group_description
+    from api.models.app_group import (
+        app_owners_group_description,
+        app_owners_group_description_remainder,
+    )
     from api.operations import ModifyAppTags, ModifyGroupDetails
     from api.plugins.app_group_lifecycle import merge_app_lifecycle_plugin_data, validate_app_plugin_config_or_raise
+    from api.schemas.requests_schemas import _GROUP_DESC_MAX_LENGTH
 
     fields_set = body.model_fields_set
     description = (body.description if body.description is not None else "") if "description" in fields_set else None
@@ -374,13 +378,38 @@ async def put_app(
         old_prefix = f"{_AppGroup.APP_GROUP_NAME_PREFIX}{old_app_name}{_AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}"
         new_prefix = f"{_AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}{_AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}"
         app_groups = (await db.scalars(select(_AppGroup).where(_AppGroup.app_id == app_obj.id))).all()
+
+        # An owner group's description keeps whatever free text sits below its base line,
+        # so the new base line is composed onto the old remainder rather than replacing it.
+        #
+        # Composing can grow the string past the 1024-character column -- a longer app
+        # name, or a description that predates the convention and reseats whole -- so the
+        # length is checked here, before the loop. ModifyGroupDetails pushes to Okta and
+        # commits on every call, so raising from inside the loop would leave earlier
+        # groups renamed and the app rename itself already published.
+        owner_descriptions: dict[str, str] = {}
+        for ag in app_groups:
+            if not ag.is_owner:
+                continue
+            remainder = app_owners_group_description_remainder(ag.description or "", old_app_name)
+            composed = app_owners_group_description(app_obj.name, remainder)
+            if len(composed) > _GROUP_DESC_MAX_LENGTH:
+                raise HTTPException(
+                    400,
+                    f'Renaming this app would make the description of "{ag.name}" '
+                    f"{len(composed)} characters, over the {_GROUP_DESC_MAX_LENGTH} limit. "
+                    f"Shorten that group's description by "
+                    f"{len(composed) - _GROUP_DESC_MAX_LENGTH} characters and try again.",
+                )
+            owner_descriptions[ag.id] = composed
+
         for ag in app_groups:
             if ag.name.startswith(old_prefix):
                 suffix = ag.name[len(old_prefix) :]
                 new_group_name = f"{new_prefix}{suffix}"
             else:
                 new_group_name = f"{new_prefix}{ag.name}"
-            new_description = app_owners_group_description(app_obj.name) if ag.is_owner else None
+            new_description = owner_descriptions.get(ag.id) if ag.is_owner else None
             await ModifyGroupDetails(group=ag, name=new_group_name, description=new_description).execute()
 
     await db.commit()

--- a/api/routers/apps.py
+++ b/api/routers/apps.py
@@ -382,14 +382,18 @@ async def put_app(
         # An owner group's description keeps whatever free text sits below its base line,
         # so the new base line is composed onto the old remainder rather than replacing it.
         #
-        # Composing can grow the string past the 1024-character column -- a longer app
-        # name, or a description that predates the convention and reseats whole -- so the
-        # length is checked here, before the loop. ModifyGroupDetails pushes to Okta and
-        # commits on every call, so raising from inside the loop would leave earlier
-        # groups renamed and the app rename itself already published.
+        # Composing can grow the string past _GROUP_DESC_MAX_LENGTH -- a longer app name,
+        # or a description that predates the convention and reseats whole -- so the length
+        # is checked here, before the loop. ModifyGroupDetails pushes to Okta and commits
+        # on every call, so raising from inside the loop would leave earlier groups renamed
+        # and the app rename itself already published.
+        #
+        # Soft-deleted owner groups are skipped: they aren't visible in the UI, so a user
+        # can't shorten their description to unblock the rename, and the rename loop below
+        # renames them without touching their description regardless.
         owner_descriptions: dict[str, str] = {}
         for ag in app_groups:
-            if not ag.is_owner:
+            if not ag.is_owner or ag.deleted_at is not None:
                 continue
             remainder = app_owners_group_description_remainder(ag.description or "", old_app_name)
             composed = app_owners_group_description(app_obj.name, remainder)
@@ -409,7 +413,7 @@ async def put_app(
                 new_group_name = f"{new_prefix}{suffix}"
             else:
                 new_group_name = f"{new_prefix}{ag.name}"
-            new_description = owner_descriptions.get(ag.id) if ag.is_owner else None
+            new_description = owner_descriptions.get(ag.id)
             await ModifyGroupDetails(group=ag, name=new_group_name, description=new_description).execute()
 
     await db.commit()

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -234,10 +234,14 @@ async def put_group(
     if group is None:
         raise HTTPException(404, "Not Found")
 
-    # Capture the pre-update name/description so the single, consolidated group_updated fire
-    # (below) can report them.
+    # Capture the pre-update name/description/app_id so the single, consolidated
+    # group_updated fire (below) can report them, and so the app-owner-group guard
+    # further down can detect a rebind even after the rebind-authorization block
+    # (which runs first, unconditionally on AppGroup, not just owner groups) has
+    # already applied `group.app_id = target_app.id` in memory.
     old_name = group.name
     old_description = group.description or ""
+    original_app_id = getattr(group, "app_id", None)
     # Length + REQUIRE_DESCRIPTIONS-when-set are enforced by the schema; this
     # just normalises a `None` (only possible when the client explicitly sent
     # `null`) to an empty string for ModifyGroupDetails.
@@ -308,8 +312,27 @@ async def put_group(
     tags_to_add = body.tags_to_add or []
     tags_to_remove = body.tags_to_remove or []
 
-    # App owner groups: only tag changes allowed
+    # App owner groups: only tag and description changes are allowed. The description is
+    # itself constrained -- it must keep its "Owners of the {app name} application" base
+    # line -- which ModifyGroupDetails enforces for every caller.
+    #
+    # `type` is the discriminator and is present in `fields_set` on every request, so the
+    # structural fields are compared by value rather than by presence.
     if type(group) is AppGroup and group.is_owner:
+        renaming = "name" in fields_set and body.name is not None and body.name != group.name
+        retyping = body.type != group.type
+        rebinding = isinstance(body, _AppGroupUpdateBody) and "app_id" in fields_set and body.app_id != original_app_id
+        if renaming or retyping or rebinding:
+            raise HTTPException(400, "Only tags and the description can be modified for application owner groups")
+
+        if description is not None:
+            try:
+                await ModifyGroupDetails(
+                    group=group, description=description, current_user_id=current_user_id
+                ).execute()
+            except ValueError as e:
+                raise HTTPException(400, str(e)) from e
+
         if len(tags_to_add) > 0 or len(tags_to_remove) > 0:
             await ModifyGroupTags(
                 group=group,
@@ -317,9 +340,9 @@ async def put_group(
                 tags_to_remove=tags_to_remove,
                 current_user_id=current_user_id,
             ).execute()
-            refreshed = await _load_group_with_options(db, group.id)
-            return _group_adapter.validate_python(refreshed, from_attributes=True)
-        raise HTTPException(400, "Only tags can be modifed for application owner groups")
+
+        refreshed = await _load_group_with_options(db, group.id)
+        return _group_adapter.validate_python(refreshed, from_attributes=True)
 
     # Block renaming to a reserved prefix unless the final group type matches.
     # Computed using the target type since a legitimate

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -235,10 +235,12 @@ async def put_group(
         raise HTTPException(404, "Not Found")
 
     # Capture the pre-update name/description/app_id so the single, consolidated
-    # group_updated fire (below) can report them, and so the app-owner-group guard
-    # further down can detect a rebind even after the rebind-authorization block
-    # (which runs first, unconditionally on AppGroup, not just owner groups) has
-    # already applied `group.app_id = target_app.id` in memory.
+    # group_updated fire (below) can report them. The rebind-authorization block
+    # further down only mutates `group.app_id` in memory for non-owner AppGroups;
+    # the owner-group guard still compares against this captured value rather
+    # than the live attribute as defence in depth, so a future edit that widens
+    # the rebind block's condition can't silently reach an owner group's app_id
+    # before the guard has a chance to reject the change.
     old_name = group.name
     old_description = group.description or ""
     original_app_id = getattr(group, "app_id", None)
@@ -266,7 +268,8 @@ async def put_group(
     new_plugin_data = (
         body.plugin_data if isinstance(body, _AppGroupUpdateBody) and "plugin_data" in fields_set else None
     )
-    if new_plugin_data is not None and new_plugin_data != (group.plugin_data or {}):
+    plugin_data_changing = new_plugin_data is not None and new_plugin_data != (group.plugin_data or {})
+    if plugin_data_changing:
         if not (
             await is_access_admin(db, current_user_id)
             or (type(group) is AppGroup and await is_app_owner_group_owner(db, current_user_id, app_group=group))
@@ -284,9 +287,12 @@ async def put_group(
     # Prevent rebinding an AppGroup to a different app without owning the
     # target app. Access admins can always rebind. Apply the rebind here when
     # the group type isn't also changing — type-change rebinds are wired into
-    # ModifyGroupType below.
+    # ModifyGroupType below. Owner groups are structural (membership confers
+    # app-owner permissions), so they're excluded here and rejected outright
+    # by the owner-group guard further down instead of being rebound.
     if (
         type(group) is AppGroup
+        and not group.is_owner
         and isinstance(body, _AppGroupUpdateBody)
         and "app_id" in fields_set
         and body.app_id != group.app_id
@@ -314,7 +320,10 @@ async def put_group(
 
     # App owner groups: only tag and description changes are allowed. The description is
     # itself constrained -- it must keep its "Owners of the {app name} application" base
-    # line -- which ModifyGroupDetails enforces for every caller.
+    # line -- which ModifyGroupDetails enforces for every caller. Plugin configuration is
+    # rejected separately below rather than silently dropped -- owner groups do participate
+    # in lifecycle plugins, so a discarded `plugin_data` write would be meaningful config
+    # loss, not a cosmetic no-op.
     #
     # `type` is the discriminator and is present in `fields_set` on every request, so the
     # structural fields are compared by value rather than by presence.
@@ -324,6 +333,8 @@ async def put_group(
         rebinding = isinstance(body, _AppGroupUpdateBody) and "app_id" in fields_set and body.app_id != original_app_id
         if renaming or retyping or rebinding:
             raise HTTPException(400, "Only tags and the description can be modified for application owner groups")
+        if plugin_data_changing:
+            raise HTTPException(400, "Plugin configuration cannot be modified for application owner groups")
 
         if description is not None:
             try:

--- a/examples/plugins/app_group_lifecycle_google/plugin.py
+++ b/examples/plugins/app_group_lifecycle_google/plugin.py
@@ -882,7 +882,17 @@ class GoogleGroupManagerPlugin:
                 return f"Live Google group email '{google_email}' is not in domain {self._domain}"
             ctx.set_config(group, CONFIG_EMAIL, inferred_email_prefix)
             ctx.set_config(group, CONFIG_DISPLAY_NAME, google_group.get("displayName", "") or "")
-            if not (group.description or "") and google_description:
+            # An owner group's description is governed by Access's own fixed base line
+            # ("Owners of the {app name} application"), not by whatever free text Google
+            # holds, so it is never a backfill target here: adopting Google's raw text
+            # wholesale would not conform, and `set_group_description` raises on a
+            # non-conforming value -- a failure that rolls back the `set_config` calls
+            # just above and reproduces on every later reconcile. Access itself keeps a
+            # freshly created or promoted owner group's description conforming and
+            # non-empty (see `CreateApp`/`CreateGroup`), so this guard only matters for a
+            # group that was already an empty-description owner group before that
+            # invariant existed.
+            if not group.is_owner and not (group.description or "") and google_description:
                 logger.info(f"Backfilling group description from Google to Access for {group.name}...")
                 # Route the Access-side description change through the plugin interface, which
                 # updates the ORM and syncs to Okta without committing or re-firing this hook.

--- a/examples/plugins/app_group_lifecycle_google/test_plugin.py
+++ b/examples/plugins/app_group_lifecycle_google/test_plugin.py
@@ -306,6 +306,7 @@ def _group(
     group_config: dict[str, Any] | None = None,
     status: dict[str, Any] | None = None,
     description: str = "",
+    is_owner: bool = False,
 ) -> Mock:
     app = Mock(spec=App)
     app.plugin_data = {PLUGIN_ID: {"configuration": app_config or {"enabled": True}, "status": {}}}
@@ -313,6 +314,7 @@ def _group(
     group.id = "grp-1"
     group.name = "App-Google-Platform-Security"
     group.description = description
+    group.is_owner = is_owner
     group.app = app
     group.plugin_data = {PLUGIN_ID: {"configuration": group_config or {}, "status": status or {}}}
     return group
@@ -706,6 +708,48 @@ async def test_reconcile_adopts_missing_config_from_live_group(
     # updates Access + syncs Okta); the group_updated hook is suppressed to avoid re-entering this
     # plugin, and Google itself is not mutated.
     modify.assert_awaited_once_with(group, "Adopted desc")
+    patch.assert_not_called()
+
+
+async def test_reconcile_does_not_backfill_description_onto_an_owner_group(
+    plugin_instance: GoogleGroupManagerPlugin, mocker: MockerFixture, ctx_mock: MagicMock
+) -> None:
+    """An owner group's description is governed by Access's fixed base line, not by
+    whatever free text Google holds -- adopting it wholesale would not conform, and
+    `set_group_description` raising on that would roll back the `set_config` calls this
+    same adoption pass just made. Config (email/display name) is still adopted; only the
+    description backfill is skipped."""
+    group = _group(mocker, group_config={}, description="", is_owner=True)  # no config, no description
+    ctx_mock.get_config.side_effect = lambda obj, key, default=None: {
+        "enabled": True,
+    }.get(key, default)
+    ctx_mock.get_status.side_effect = lambda *_a, **_k: None
+    ctx_mock.discover_existing_push_mapping_and_target_group_external_id.return_value = (
+        "map-1",
+        "adopted@test-company.com",
+    )
+    mocker.patch.object(plugin_instance, "_look_up_google_group_id", return_value="ggid-1")
+    mocker.patch.object(
+        plugin_instance,
+        "_get_google_group",
+        return_value={
+            "name": "groups/ggid-1",
+            "groupKey": {"id": "adopted@test-company.com"},
+            "displayName": "Adopted Name",
+            "description": "Adopted desc",
+        },
+    )
+    ctx_mock.create_push_mapping_for_existing_group.return_value = "map-existing"
+    ctx_mock.find_groups_by_status.return_value = []  # not owned elsewhere
+    seed = ctx_mock.set_config
+    modify = ctx_mock.set_group_description
+    patch = mocker.patch.object(plugin_instance, "_patch_google_group")
+
+    await plugin_instance._reconcile(ctx_mock, group)
+
+    seed.assert_any_call(group, CONFIG_EMAIL, "adopted")
+    seed.assert_any_call(group, CONFIG_DISPLAY_NAME, "Adopted Name")
+    modify.assert_not_awaited()
     patch.assert_not_called()
 
 

--- a/src/pages/groups/CreateUpdate.test.tsx
+++ b/src/pages/groups/CreateUpdate.test.tsx
@@ -14,6 +14,18 @@ vi.mock('../../api/apiComponents', () => ({
   useGroupsCreate: () => ({mutate: createMutate}),
   useGroupByIdPut: () => ({mutate: updateMutate}),
 }));
+// REQUIRE_DESCRIPTIONS is a build-time global sourced from an untracked local `.env`; CI runs
+// without it set, so `requireDescriptions` is false there regardless of this developer's
+// environment. Mocking the config module makes tests that depend on it true independent of
+// both, rather than passing only on a machine with the right `.env`.
+vi.mock('../../config/accessConfig', () => ({
+  default: {
+    NAME_VALIDATION_PATTERN: '^[A-Z][A-Za-z0-9-]*$',
+    NAME_VALIDATION_ERROR: 'Name must start capitalized and contain only alphanumeric characters or hyphens.',
+  },
+  appName: 'Access',
+  requireDescriptions: true,
+}));
 
 import CreateUpdateGroup from './CreateUpdate';
 
@@ -90,6 +102,17 @@ describe('creating an app group from an app page', () => {
 
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
     expect(typeSelect).toHaveTextContent('App Group');
+  });
+
+  // A non-owner group's Description has no owner-group remainder budget to protect, so it must
+  // not carry the DOM-level cap: the field's own `maxLength` rule (1024, same figure) is what
+  // enforces the limit, and it fails visibly instead of silently truncating input.
+  it('does not cap the Description field at the DOM level', async () => {
+    render(<CreateUpdateGroup currentUser={ACCESS_ADMIN} defaultGroupType="app_group" app={APP} />);
+
+    await openDialog('Create App Group');
+
+    expect(screen.getByLabelText(/^Description/)).not.toHaveAttribute('maxlength');
   });
 });
 
@@ -195,6 +218,52 @@ describe('editing an app owner group description', () => {
       'maxlength',
       String(1024 - BASE.length - 2),
     );
+  });
+
+  it('seeds an empty field and submits the bare base line for a description that is the base line plus trailing whitespace', async () => {
+    render(
+      <CreateUpdateGroup
+        currentUser={ACCESS_ADMIN}
+        defaultGroupType="app_group"
+        group={ownerGroupWith(`${BASE}\n\n   `)}
+      />,
+    );
+    await openDialog('edit');
+
+    expect(screen.getByLabelText(/^Additional description/)).toHaveValue('');
+
+    await submitDialog('Update');
+
+    expect(updateMutate.mock.calls[0][0].body).toMatchObject({description: BASE});
+  });
+
+  it('round-trips a remainder containing a blank line unchanged through seed and submit', async () => {
+    const remainder = 'Also grants billing\n\nSecond paragraph';
+    render(
+      <CreateUpdateGroup
+        currentUser={ACCESS_ADMIN}
+        defaultGroupType="app_group"
+        group={ownerGroupWith(`${BASE}\n\n${remainder}`)}
+      />,
+    );
+    await openDialog('edit');
+
+    expect(screen.getByLabelText(/^Additional description/)).toHaveValue(remainder);
+
+    await submitDialog('Update');
+
+    expect(updateMutate.mock.calls[0][0].body).toMatchObject({description: `${BASE}\n\n${remainder}`});
+  });
+
+  it('round-trips a conforming description byte-identical when submitted without touching the field', async () => {
+    const original = `${BASE}\n\nAlso grants billing access`;
+    render(
+      <CreateUpdateGroup currentUser={ACCESS_ADMIN} defaultGroupType="app_group" group={ownerGroupWith(original)} />,
+    );
+    await openDialog('edit');
+    await submitDialog('Update');
+
+    expect(updateMutate.mock.calls[0][0].body).toMatchObject({description: original});
   });
 
   it('leaves the field disabled when the app name is unavailable', async () => {

--- a/src/pages/groups/CreateUpdate.test.tsx
+++ b/src/pages/groups/CreateUpdate.test.tsx
@@ -94,10 +94,13 @@ describe('creating an app group from an app page', () => {
 });
 
 describe('editing an app owner group', () => {
-  // Type, name and description are all locked for an owner group. Only `type` has to be
-  // submitted -- it discriminates the update body. Name and description are immutable,
-  // so they are left out of the partial update entirely.
-  it('submits the locked type and omits the immutable name and description', async () => {
+  // Type and name are locked for an owner group. Only `type` has to be submitted -- it
+  // discriminates the update body -- and the immutable name is left out of the partial
+  // update entirely. The description is different: only its base line is fixed, and the
+  // free text below it is user-editable (see "editing an app owner group description" below).
+  // OWNER_APP_GROUP's stored description does not match the base line for its app, so the
+  // reseat rule treats it as divergent and repairs it under the current base line on save.
+  it('submits the locked type and omits the immutable name, but recomposes the description', async () => {
     render(<CreateUpdateGroup currentUser={ACCESS_ADMIN} defaultGroupType="app_group" group={OWNER_APP_GROUP} />);
 
     await openDialog('edit');
@@ -107,12 +110,13 @@ describe('editing an app owner group', () => {
     const body = updateMutate.mock.calls[0][0].body;
     expect(body).toMatchObject({type: 'app_group'});
     expect(body.name).toBeUndefined();
-    expect(body.description).toBeUndefined();
+    expect(body.description).toBe('Owners of the HammerAndChiselZendeskSandbox application\n\nOwners of the sandbox');
   });
 
-  // An owner group whose description is empty must still be editable -- validating a
-  // `required` description the user cannot reach would leave the form with no way out.
-  it('submits when the immutable description is empty', async () => {
+  // An owner group's additional description is always optional -- the fixed base line
+  // alone always satisfies a `require description` tag constraint, so leaving the free
+  // text empty must still submit.
+  it('submits when the additional description is empty', async () => {
     const emptyDescription = {...OWNER_APP_GROUP, description: ''} as GroupDetail;
     render(<CreateUpdateGroup currentUser={ACCESS_ADMIN} defaultGroupType="app_group" group={emptyDescription} />);
 
@@ -120,5 +124,91 @@ describe('editing an app owner group', () => {
     await submitDialog('Update');
 
     expect(updateMutate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('editing an app owner group description', () => {
+  const ownerGroupWith = (description: string) => ({...OWNER_APP_GROUP, description}) as unknown as GroupDetail;
+
+  const BASE = 'Owners of the HammerAndChiselZendeskSandbox application';
+
+  it('seeds the field with the remainder, not the whole description', async () => {
+    render(
+      <CreateUpdateGroup
+        currentUser={ACCESS_ADMIN}
+        defaultGroupType="app_group"
+        group={ownerGroupWith(`${BASE}\n\nAlso grants billing access`)}
+      />,
+    );
+    await openDialog('edit');
+
+    expect(screen.getByLabelText(/^Additional description/)).toHaveValue('Also grants billing access');
+    expect(screen.getByText(BASE)).toBeInTheDocument();
+  });
+
+  it('seeds the whole description when it does not match the base line', async () => {
+    render(
+      <CreateUpdateGroup
+        currentUser={ACCESS_ADMIN}
+        defaultGroupType="app_group"
+        group={ownerGroupWith('Owners of the sandbox')}
+      />,
+    );
+    await openDialog('edit');
+
+    // Divergent text stays visible and editable, so saving repairs the description.
+    expect(screen.getByLabelText(/^Additional description/)).toHaveValue('Owners of the sandbox');
+  });
+
+  it('submits the base line rejoined with the edited remainder', async () => {
+    render(<CreateUpdateGroup currentUser={ACCESS_ADMIN} defaultGroupType="app_group" group={ownerGroupWith(BASE)} />);
+    await openDialog('edit');
+    await userEvent.type(screen.getByLabelText(/^Additional description/), 'Also grants billing access');
+    await submitDialog('Update');
+
+    expect(updateMutate).toHaveBeenCalledTimes(1);
+    expect(updateMutate.mock.calls[0][0].body).toMatchObject({
+      description: `${BASE}\n\nAlso grants billing access`,
+    });
+  });
+
+  it('submits the bare base line when the remainder is cleared', async () => {
+    render(
+      <CreateUpdateGroup
+        currentUser={ACCESS_ADMIN}
+        defaultGroupType="app_group"
+        group={ownerGroupWith(`${BASE}\n\nAlso grants billing access`)}
+      />,
+    );
+    await openDialog('edit');
+    await userEvent.clear(screen.getByLabelText(/^Additional description/));
+    await submitDialog('Update');
+
+    expect(updateMutate.mock.calls[0][0].body).toMatchObject({description: BASE});
+  });
+
+  it('caps the remainder so the composed description fits 1024 characters', async () => {
+    render(<CreateUpdateGroup currentUser={ACCESS_ADMIN} defaultGroupType="app_group" group={ownerGroupWith(BASE)} />);
+    await openDialog('edit');
+
+    expect(screen.getByLabelText(/^Additional description/)).toHaveAttribute(
+      'maxlength',
+      String(1024 - BASE.length - 2),
+    );
+  });
+
+  it('leaves the field disabled when the app name is unavailable', async () => {
+    const groupWithoutApp = {...OWNER_APP_GROUP, description: BASE, app: undefined};
+    render(
+      <CreateUpdateGroup
+        currentUser={ACCESS_ADMIN}
+        defaultGroupType="app_group"
+        group={groupWithoutApp as unknown as GroupDetail}
+      />,
+    );
+    await openDialog('edit');
+
+    // Better no edit than a wrong prefix built from a missing name.
+    expect(screen.getByLabelText(/^Description/)).toBeDisabled();
   });
 });

--- a/src/pages/groups/CreateUpdate.tsx
+++ b/src/pages/groups/CreateUpdate.tsx
@@ -42,6 +42,11 @@ import {
 import {canManageGroup, isAccessAdmin, isAppOwnerGroupOwner} from '../../authorization';
 import accessConfig, {requireDescriptions} from '../../config/accessConfig';
 import AppGroupLifecyclePluginConfigurationForm from '../../components/AppGroupLifecyclePluginConfigurationForm';
+import {
+  appOwnerGroupDescriptionPrefix,
+  appOwnerGroupDescriptionRemainder,
+  composeAppOwnerGroupDescription,
+} from './appOwnerGroupDescription';
 
 interface GroupButtonProps {
   defaultGroupType: 'okta_group' | 'app_group' | 'role_group';
@@ -107,6 +112,17 @@ function GroupDialog(props: GroupDialogProps) {
   const [appName, setAppName] = React.useState(initialAppName);
   const [requestError, setRequestError] = React.useState('');
   const [submitting, setSubmitting] = React.useState(false);
+
+  // An owner group's description is the fixed base line plus optional free text. The form
+  // edits only the free text -- the same split the name field uses, where the field holds
+  // the suffix and submit() re-adds the prefix. Without an app name there is no correct
+  // prefix to show, so the description stays locked as it is for every other owner field.
+  const ownerDescriptionPrefix = props.app_owner_group && appName ? appOwnerGroupDescriptionPrefix(appName) : null;
+  const ownerDescriptionRemainder = ownerDescriptionPrefix
+    ? appOwnerGroupDescriptionRemainder(props.group?.description ?? '', appName)
+    : '';
+  const descriptionMaxLength =
+    ownerDescriptionPrefix != null ? Math.max(0, 1024 - ownerDescriptionPrefix.length - 2) : 1024;
 
   const appGroupLifecyclePluginId = React.useMemo(() => {
     if (groupType !== 'app_group') return null;
@@ -174,6 +190,12 @@ function GroupDialog(props: GroupDialogProps) {
       group.tags_to_add = selectedTags.map((tag: TagSummary) => tag.id);
     }
 
+    // The description field holds the free text only; the fixed base line is added back
+    // here, mirroring how the name field's prefix is re-added below.
+    if (ownerDescriptionPrefix != null) {
+      group.description = composeAppOwnerGroupDescription(appName, group.description ?? '');
+    }
+
     // The name field holds the suffix only; the type-derived prefix is added back here.
     // Locked-and-immutable names (an owner group's) are absent from the form data, and a
     // partial update must leave them alone rather than prefix an undefined suffix.
@@ -219,7 +241,7 @@ function GroupDialog(props: GroupDialogProps) {
                   props.group?.name.substring(
                     (APP_GROUP_PREFIX + initialAppName + APP_NAME_APP_GROUP_SEPARATOR).length,
                   ) ?? '',
-                description: props.group?.description ?? '',
+                description: ownerDescriptionPrefix ? ownerDescriptionRemainder : props.group?.description ?? '',
               }
             : {
                 type: defaultGroupType,
@@ -227,7 +249,7 @@ function GroupDialog(props: GroupDialogProps) {
                   props.group?.type == 'role_group'
                     ? props.group?.name.substring(ROLE_GROUP_PREFIX.length)
                     : props.group?.name ?? '',
-                description: props.group?.description ?? '',
+                description: ownerDescriptionPrefix ? ownerDescriptionRemainder : props.group?.description ?? '',
               }
         }
         onSuccess={(formData) => submit(formData)}>
@@ -341,25 +363,39 @@ function GroupDialog(props: GroupDialogProps) {
             </Box>
           </FormControl>
           <FormControl margin="normal" fullWidth>
+            {ownerDescriptionPrefix != null && (
+              <Typography variant="body2" color="text.secondary" sx={{mb: 1, whiteSpace: 'pre-wrap'}}>
+                {ownerDescriptionPrefix}
+              </Typography>
+            )}
             <TextFieldElement
-              label="Description"
+              label={ownerDescriptionPrefix != null ? 'Additional description' : 'Description'}
               name="description"
               multiline
               rows={4}
-              rules={{maxLength: 1024}}
-              // `disabled`, like the name above: immutable for an owner group, so it is left out
-              // of the partial update rather than submitted unchanged.
-              disabled={props.app_owner_group}
+              rules={{maxLength: descriptionMaxLength}}
+              // MUI v6: the HTML attribute goes through slotProps.htmlInput, not the deprecated
+              // inputProps. `rules` drives the react-hook-form message; this drives the browser cap.
+              slotProps={{htmlInput: {maxLength: descriptionMaxLength}}}
+              helperText={
+                ownerDescriptionPrefix != null ? 'Shown as a second paragraph below the line above.' : undefined
+              }
+              // `disabled`, like the name above: an owner group with no resolvable app name has no
+              // correct prefix to show, so its description stays immutable and is left out of the
+              // partial update rather than submitted unchanged.
+              disabled={props.app_owner_group && ownerDescriptionPrefix == null}
               parseError={(error) => {
                 if (error?.message != '') {
                   return error?.message ?? '';
                 }
                 if (error.type == 'maxLength') {
-                  return 'Description can be at most 1024 characters in length';
+                  return `Description can be at most ${descriptionMaxLength} characters in length`;
                 }
                 return '';
               }}
-              required={requireDescriptions}
+              // The base line always satisfies REQUIRE_DESCRIPTIONS, so the free text below it is
+              // always optional.
+              required={ownerDescriptionPrefix != null ? false : requireDescriptions}
             />
           </FormControl>
           <FormControl margin="normal" fullWidth>

--- a/src/pages/groups/CreateUpdate.tsx
+++ b/src/pages/groups/CreateUpdate.tsx
@@ -45,6 +45,7 @@ import AppGroupLifecyclePluginConfigurationForm from '../../components/AppGroupL
 import {
   appOwnerGroupDescriptionPrefix,
   appOwnerGroupDescriptionRemainder,
+  appOwnerGroupDescriptionRemainderMaxLength,
   composeAppOwnerGroupDescription,
 } from './appOwnerGroupDescription';
 
@@ -122,7 +123,7 @@ function GroupDialog(props: GroupDialogProps) {
     ? appOwnerGroupDescriptionRemainder(props.group?.description ?? '', appName)
     : '';
   const descriptionMaxLength =
-    ownerDescriptionPrefix != null ? Math.max(0, 1024 - ownerDescriptionPrefix.length - 2) : 1024;
+    ownerDescriptionPrefix != null ? appOwnerGroupDescriptionRemainderMaxLength(appName) : 1024;
 
   const appGroupLifecyclePluginId = React.useMemo(() => {
     if (groupType !== 'app_group') return null;
@@ -376,7 +377,11 @@ function GroupDialog(props: GroupDialogProps) {
               rules={{maxLength: descriptionMaxLength}}
               // MUI v6: the HTML attribute goes through slotProps.htmlInput, not the deprecated
               // inputProps. `rules` drives the react-hook-form message; this drives the browser cap.
-              slotProps={{htmlInput: {maxLength: descriptionMaxLength}}}
+              // Applied only on the owner-group path: there, `descriptionMaxLength` is a remainder
+              // budget the user cannot otherwise see, so capping input at the DOM level prevents
+              // typing past it. Elsewhere the cap is a validation rule the user should see fail
+              // (with the message below) rather than have their input silently truncated.
+              slotProps={ownerDescriptionPrefix != null ? {htmlInput: {maxLength: descriptionMaxLength}} : undefined}
               helperText={
                 ownerDescriptionPrefix != null ? 'Shown as a second paragraph below the line above.' : undefined
               }

--- a/src/pages/groups/appOwnerGroupDescription.test.ts
+++ b/src/pages/groups/appOwnerGroupDescription.test.ts
@@ -1,0 +1,66 @@
+import {describe, it, expect} from 'vitest';
+
+import {
+  appOwnerGroupDescriptionPrefix,
+  appOwnerGroupDescriptionRemainder,
+  composeAppOwnerGroupDescription,
+} from './appOwnerGroupDescription';
+
+describe('appOwnerGroupDescriptionPrefix', () => {
+  // Pinned literal. The backend owns this format string in
+  // `app_owners_group_description` (api/models/app_group.py); if you change the
+  // wording there, change it here and update both tests.
+  it('matches the backend base line exactly', () => {
+    expect(appOwnerGroupDescriptionPrefix('Zendesk')).toBe('Owners of the Zendesk application');
+  });
+});
+
+describe('appOwnerGroupDescriptionRemainder', () => {
+  it('returns the text after a matching base line', () => {
+    expect(
+      appOwnerGroupDescriptionRemainder('Owners of the Zendesk application\n\nAlso grants billing', 'Zendesk'),
+    ).toBe('Also grants billing');
+  });
+
+  it('returns an empty string for a bare base line', () => {
+    expect(appOwnerGroupDescriptionRemainder('Owners of the Zendesk application', 'Zendesk')).toBe('');
+  });
+
+  it('returns the whole description when the base line does not match', () => {
+    expect(appOwnerGroupDescriptionRemainder('Hand-written legacy text', 'Zendesk')).toBe('Hand-written legacy text');
+  });
+
+  it('does not false-match a similarly named app', () => {
+    expect(appOwnerGroupDescriptionRemainder('Owners of the FooBar application', 'Foo')).toBe(
+      'Owners of the FooBar application',
+    );
+  });
+
+  it('normalises CRLF', () => {
+    expect(appOwnerGroupDescriptionRemainder('Owners of the Zendesk application\r\n\r\nExtra', 'Zendesk')).toBe(
+      'Extra',
+    );
+  });
+
+  it('returns an empty string for an empty description', () => {
+    expect(appOwnerGroupDescriptionRemainder('', 'Zendesk')).toBe('');
+  });
+});
+
+describe('composeAppOwnerGroupDescription', () => {
+  it('returns the bare base line for an empty remainder', () => {
+    expect(composeAppOwnerGroupDescription('Zendesk', '')).toBe('Owners of the Zendesk application');
+    expect(composeAppOwnerGroupDescription('Zendesk', '   ')).toBe('Owners of the Zendesk application');
+  });
+
+  it('joins the base line and the remainder with a blank line', () => {
+    expect(composeAppOwnerGroupDescription('Zendesk', 'Also grants billing')).toBe(
+      'Owners of the Zendesk application\n\nAlso grants billing',
+    );
+  });
+
+  it('round-trips with the remainder helper', () => {
+    const composed = composeAppOwnerGroupDescription('Zendesk', 'Also grants billing');
+    expect(appOwnerGroupDescriptionRemainder(composed, 'Zendesk')).toBe('Also grants billing');
+  });
+});

--- a/src/pages/groups/appOwnerGroupDescription.test.ts
+++ b/src/pages/groups/appOwnerGroupDescription.test.ts
@@ -64,3 +64,41 @@ describe('composeAppOwnerGroupDescription', () => {
     expect(appOwnerGroupDescriptionRemainder(composed, 'Zendesk')).toBe('Also grants billing');
   });
 });
+
+// Mirrors tests/test_app_group_description.py one-for-one so the two can be diffed.
+describe('markdown indentation parity with the backend', () => {
+  // test_remainder_preserves_indentation_on_a_conforming_description
+  it('preserves indentation on the remainder of a conforming description', () => {
+    const description = 'Owners of the Zendesk application\n\n    - nested item\n    - another item';
+    expect(appOwnerGroupDescriptionRemainder(description, 'Zendesk')).toBe('    - nested item\n    - another item');
+  });
+
+  // test_remainder_preserves_indentation_on_a_non_conforming_description
+  it('preserves indentation on a non-conforming description', () => {
+    const description = '    - nested item\n    - another item';
+    expect(appOwnerGroupDescriptionRemainder(description, 'Zendesk')).toBe('    - nested item\n    - another item');
+  });
+
+  // Covers composeAppOwnerGroupDescription's own use of the same helper.
+  it('preserves indentation when composing with an indented remainder', () => {
+    expect(composeAppOwnerGroupDescription('Zendesk', '    - nested item\n    - another item')).toBe(
+      'Owners of the Zendesk application\n\n    - nested item\n    - another item',
+    );
+  });
+
+  // test_compose_and_split_round_trip_preserves_indentation
+  it('round-trips an indented remainder through compose and remainder exactly', () => {
+    const composed = composeAppOwnerGroupDescription('Zendesk', '    - nested item\n    - another item');
+    expect(appOwnerGroupDescriptionRemainder(composed, 'Zendesk')).toBe('    - nested item\n    - another item');
+    expect(composeAppOwnerGroupDescription('Zendesk', appOwnerGroupDescriptionRemainder(composed, 'Zendesk'))).toBe(
+      composed,
+    );
+  });
+
+  // test_composing_after_a_crlf_normalises_the_separator
+  it('still removes leading blank lines, including a CRLF blank-line separator', () => {
+    expect(
+      appOwnerGroupDescriptionRemainder('Owners of the Zendesk application\n\n\n\n   \nActual text', 'Zendesk'),
+    ).toBe('Actual text');
+  });
+});

--- a/src/pages/groups/appOwnerGroupDescription.test.ts
+++ b/src/pages/groups/appOwnerGroupDescription.test.ts
@@ -3,6 +3,7 @@ import {describe, it, expect} from 'vitest';
 import {
   appOwnerGroupDescriptionPrefix,
   appOwnerGroupDescriptionRemainder,
+  appOwnerGroupDescriptionRemainderMaxLength,
   composeAppOwnerGroupDescription,
 } from './appOwnerGroupDescription';
 
@@ -44,6 +45,16 @@ describe('appOwnerGroupDescriptionRemainder', () => {
 
   it('returns an empty string for an empty description', () => {
     expect(appOwnerGroupDescriptionRemainder('', 'Zendesk')).toBe('');
+  });
+});
+
+describe('appOwnerGroupDescriptionRemainderMaxLength', () => {
+  it('caps the remainder so a description composed at that length is exactly 1024 characters', () => {
+    const appName = 'Zendesk';
+    const maxLength = appOwnerGroupDescriptionRemainderMaxLength(appName);
+    const remainderAtLimit = 'x'.repeat(maxLength);
+
+    expect(composeAppOwnerGroupDescription(appName, remainderAtLimit)).toHaveLength(1024);
   });
 });
 

--- a/src/pages/groups/appOwnerGroupDescription.ts
+++ b/src/pages/groups/appOwnerGroupDescription.ts
@@ -1,8 +1,9 @@
 // The base line of an app owner group's description. The backend owns this format in
 // `app_owners_group_description` (api/models/app_group.py) and validates against it; the
 // form needs it here to split the stored description into an immutable prefix and an
-// editable remainder. Both copies are pinned by tests that name each other -- if you
-// change the wording, change it in both places.
+// editable remainder. `test_frontend_prefix_template_matches_backend`
+// (tests/test_app_group_description.py) enforces that this template literal agrees with
+// the backend's format string -- if you change the wording, change it in both places.
 //
 // This mirrors how the group name is handled in this directory: APP_GROUP_PREFIX and
 // ROLE_GROUP_PREFIX in CreateUpdate.tsx are the same kind of client-side copy.

--- a/src/pages/groups/appOwnerGroupDescription.ts
+++ b/src/pages/groups/appOwnerGroupDescription.ts
@@ -10,6 +10,24 @@ export function appOwnerGroupDescriptionPrefix(appName: string): string {
   return `Owners of the ${appName} application`;
 }
 
+const LEADING_BLANK_LINES_RE = /^(?:[ \t]*\n)+/;
+
+/**
+ * Strip leading blank lines and trailing whitespace, preserving indentation on the first
+ * line of real content.
+ *
+ * Leading spaces/tabs on a non-blank line are meaningful markdown (an indented list item
+ * or code block), so unlike `String.trim()` this does not treat a run of leading
+ * whitespace and newlines as one unit to discard; only whole blank lines ahead of the
+ * first real content are removed. Trailing whitespace carries no such meaning and is
+ * stripped in full. Mirrors `_trim_free_text` in `api/models/app_group.py`.
+ *
+ * `\r\n` is normalized to `\n` first, since a browser textarea submits CRLF line endings.
+ */
+function trimFreeText(text: string): string {
+  return text.replace(/\r\n/g, '\n').replace(LEADING_BLANK_LINES_RE, '').trimEnd();
+}
+
 /**
  * The free text below an app owner group's base line.
  *
@@ -26,14 +44,14 @@ export function appOwnerGroupDescriptionRemainder(description: string, appName: 
     return '';
   }
   if (normalized.startsWith(prefix)) {
-    return normalized.slice(prefix.length).trim();
+    return trimFreeText(normalized.slice(prefix.length));
   }
-  return normalized.trim();
+  return trimFreeText(normalized);
 }
 
 /** The base line, plus a blank line and `remainder` when there is any. */
 export function composeAppOwnerGroupDescription(appName: string, remainder: string): string {
   const prefix = appOwnerGroupDescriptionPrefix(appName);
-  const trimmed = (remainder ?? '').trim();
+  const trimmed = trimFreeText(remainder ?? '');
   return trimmed.length > 0 ? `${prefix}\n\n${trimmed}` : prefix;
 }

--- a/src/pages/groups/appOwnerGroupDescription.ts
+++ b/src/pages/groups/appOwnerGroupDescription.ts
@@ -1,0 +1,39 @@
+// The base line of an app owner group's description. The backend owns this format in
+// `app_owners_group_description` (api/models/app_group.py) and validates against it; the
+// form needs it here to split the stored description into an immutable prefix and an
+// editable remainder. Both copies are pinned by tests that name each other -- if you
+// change the wording, change it in both places.
+//
+// This mirrors how the group name is handled in this directory: APP_GROUP_PREFIX and
+// ROLE_GROUP_PREFIX in CreateUpdate.tsx are the same kind of client-side copy.
+export function appOwnerGroupDescriptionPrefix(appName: string): string {
+  return `Owners of the ${appName} application`;
+}
+
+/**
+ * The free text below an app owner group's base line.
+ *
+ * A description starting with the expected base line splits into base + remainder; one
+ * that does not becomes the remainder whole, so text written before the group conformed
+ * stays visible and editable rather than being hidden behind a prefix that does not
+ * match it. Mirrors `app_owners_group_description_remainder` on the backend.
+ */
+export function appOwnerGroupDescriptionRemainder(description: string, appName: string): string {
+  const normalized = (description ?? '').replace(/\r\n/g, '\n');
+  const prefix = appOwnerGroupDescriptionPrefix(appName);
+
+  if (normalized.trim() === prefix) {
+    return '';
+  }
+  if (normalized.startsWith(prefix)) {
+    return normalized.slice(prefix.length).trim();
+  }
+  return normalized.trim();
+}
+
+/** The base line, plus a blank line and `remainder` when there is any. */
+export function composeAppOwnerGroupDescription(appName: string, remainder: string): string {
+  const prefix = appOwnerGroupDescriptionPrefix(appName);
+  const trimmed = (remainder ?? '').trim();
+  return trimmed.length > 0 ? `${prefix}\n\n${trimmed}` : prefix;
+}

--- a/src/pages/groups/appOwnerGroupDescription.ts
+++ b/src/pages/groups/appOwnerGroupDescription.ts
@@ -11,6 +11,9 @@ export function appOwnerGroupDescriptionPrefix(appName: string): string {
   return `Owners of the ${appName} application`;
 }
 
+// The blank line composeAppOwnerGroupDescription joins the base line and remainder with.
+const BASE_LINE_SEPARATOR = '\n\n';
+
 const LEADING_BLANK_LINES_RE = /^(?:[ \t]*\n)+/;
 
 /**
@@ -54,5 +57,18 @@ export function appOwnerGroupDescriptionRemainder(description: string, appName: 
 export function composeAppOwnerGroupDescription(appName: string, remainder: string): string {
   const prefix = appOwnerGroupDescriptionPrefix(appName);
   const trimmed = trimFreeText(remainder ?? '');
-  return trimmed.length > 0 ? `${prefix}\n\n${trimmed}` : prefix;
+  return trimmed.length > 0 ? `${prefix}${BASE_LINE_SEPARATOR}${trimmed}` : prefix;
+}
+
+/**
+ * The longest `remainder` composeAppOwnerGroupDescription can accept for `appName` without the
+ * composed description exceeding the backend's 1024-character description limit.
+ *
+ * Derived from the base line's length and the separator composeAppOwnerGroupDescription joins
+ * with, rather than a hardcoded figure, so a change to either does not silently open a gap
+ * between this cap and the limit it exists to enforce. Floored at zero, which is unreachable in
+ * practice since `App.name` is capped at 255 characters.
+ */
+export function appOwnerGroupDescriptionRemainderMaxLength(appName: string): number {
+  return Math.max(0, 1024 - appOwnerGroupDescriptionPrefix(appName).length - BASE_LINE_SEPARATOR.length);
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1015,12 +1015,14 @@ async def test_create_app_succeeds_with_empty_preexisting_owner_group(
     )
     mocker.patch.object(okta, "add_user_to_group")
     mocker.patch.object(okta, "add_owner_to_group")
+    mocker.patch.object(okta, "update_group")
 
     owner_group_name = (
         f"{AppGroup.APP_GROUP_NAME_PREFIX}Payments"
         f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
     )
-    await OktaGroupFactory.create_async(name=owner_group_name)
+    preexisting_group = await OktaGroupFactory.create_async(name=owner_group_name)
+    preexisting_group_id = preexisting_group.id
 
     apps_url = url_for("api-apps.apps")
     rep = await client.post(apps_url, json={"name": "Payments"})
@@ -1031,6 +1033,50 @@ async def test_create_app_succeeds_with_empty_preexisting_owner_group(
     assert (
         await db.session.scalars(select(App).where(App.name == "Payments").where(App.deleted_at.is_(None)))
     ).first() is not None
+
+    # The promoted owner group's empty description becomes the bare base line, not left
+    # empty -- an empty owner group description previously reached a non-conforming state
+    # that later crashed any plugin trying to reconcile it (see the app-group-lifecycle
+    # docs on `set_group_description`).
+    promoted = await db.session.get(AppGroup, preexisting_group_id)
+    assert promoted is not None
+    assert promoted.description == app_owners_group_description("Payments")
+
+
+async def test_create_app_preserves_a_preexisting_owner_group_description(
+    client: AsyncClient,
+    db: Db,
+    mocker: MockerFixture,
+    faker: Faker,  # type: ignore[type-arg]
+    url_for: Any,
+) -> None:
+    """Promoting a pre-existing group with its own free text keeps that text below the
+    new base line rather than discarding it -- the same reseat rule an app rename uses."""
+    mocker.patch.object(
+        okta,
+        "create_group",
+        side_effect=lambda name, desc: Group.from_dict({"id": cast(FakerWithPyStr, faker).pystr()}),
+    )
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
+    mocker.patch.object(okta, "update_group")
+
+    owner_group_name = (
+        f"{AppGroup.APP_GROUP_NAME_PREFIX}Payments"
+        f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
+    )
+    preexisting_group = await OktaGroupFactory.create_async(
+        name=owner_group_name, description="Hand-written legacy text"
+    )
+    preexisting_group_id = preexisting_group.id
+
+    apps_url = url_for("api-apps.apps")
+    rep = await client.post(apps_url, json={"name": "Payments"})
+    assert rep.status_code == 201
+
+    promoted = await db.session.get(AppGroup, preexisting_group_id)
+    assert promoted is not None
+    assert promoted.description == app_owners_group_description("Payments", "Hand-written legacy text")
 
 
 async def test_create_app_succeeds_with_members_only_preexisting_owner_group(
@@ -1051,6 +1097,7 @@ async def test_create_app_succeeds_with_members_only_preexisting_owner_group(
     )
     mocker.patch.object(okta, "add_user_to_group")
     mocker.patch.object(okta, "add_owner_to_group")
+    mocker.patch.object(okta, "update_group")
 
     owner_group_name = (
         f"{AppGroup.APP_GROUP_NAME_PREFIX}Payments"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1181,6 +1181,35 @@ async def _app_with_owner_and_non_owner_groups(
     return app, owner_group, non_owner_group
 
 
+async def _app_with_non_owner_group_created_before_owner_group(
+    mocker: MockerFixture, app_name: str = "Zendesk"
+) -> tuple[App, AppGroup, AppGroup, Any]:
+    """An app whose non-owner group is created before its owner group, so the
+    unordered query the rename endpoint runs returns the non-owner group first. Used to
+    discriminate a length pre-flight that runs before the rename loop (correct) from one
+    that runs inside it (a regression): with the owner group first, a per-iteration check
+    would raise on the very first row, before mutating anything, and the two behaviors
+    would be indistinguishable. Returns the `okta.update_group` mock alongside the app and
+    groups so callers can assert Okta was never reached."""
+    update_group_mock = mocker.patch.object(okta, "update_group")
+    app = await AppFactory.create_async(name=app_name, description="")
+    non_owner_group = await AppGroupFactory.create_async(
+        app_id=app.id,
+        is_owner=False,
+        name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}Admin",
+    )
+    owner_group = await AppGroupFactory.create_async(
+        app_id=app.id,
+        is_owner=True,
+        name=(
+            f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_name}"
+            f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
+        ),
+        description=app_owners_group_description(app_name),
+    )
+    return app, owner_group, non_owner_group, update_group_mock
+
+
 async def test_rename_preserves_the_owner_group_free_text(
     client: AsyncClient, db: Db, mocker: MockerFixture, url_for: Any
 ) -> None:
@@ -1218,12 +1247,24 @@ async def test_rename_reseats_a_divergent_description_rather_than_discarding_it(
 async def test_rename_fails_when_the_composed_description_would_overflow(
     client: AsyncClient, db: Db, mocker: MockerFixture, url_for: Any
 ) -> None:
-    """Over 1024 characters, the rename fails loudly instead of truncating."""
-    app, owner_group, non_owner_group = await _app_with_owner_and_non_owner_groups(mocker, "Zendesk")
+    """Over 1024 characters, the rename fails loudly instead of truncating -- and it fails
+    before anything is renamed, not merely before a response is returned."""
+    app, owner_group, non_owner_group, update_group_mock = await _app_with_non_owner_group_created_before_owner_group(
+        mocker, "Zendesk"
+    )
     # 1010 chars of remainder + a longer base line pushes the composition over 1024.
     owner_group.description = app_owners_group_description(app.name, "x" * 1010)
     db.session.add(owner_group)
     await db.session.commit()
+
+    # This test only discriminates a pre-flight (correct) from a per-iteration check
+    # inside the rename loop (a regression) if the non-owner group sorts before the
+    # overflowing owner group in the unordered query the endpoint runs -- otherwise a
+    # per-iteration check would raise on the very first row, before mutating anything,
+    # and look identical to the pre-flight. Assert that ordering directly rather than
+    # assuming SQLite returns rows by insertion order.
+    ordered = (await db.session.scalars(select(AppGroup).where(AppGroup.app_id == app.id))).all()
+    assert [g.id for g in ordered] == [non_owner_group.id, owner_group.id]
 
     original_app_name = app.name
     original_owner_group_name = owner_group.name
@@ -1246,6 +1287,7 @@ async def test_rename_fails_when_the_composed_description_would_overflow(
     assert owner_group.name == original_owner_group_name
     assert non_owner_group.name == original_non_owner_group_name
     assert owner_group.description == original_owner_description
+    assert update_group_mock.call_count == 0
 
 
 async def test_rename_leaves_non_owner_app_group_descriptions_alone(
@@ -1262,3 +1304,38 @@ async def test_rename_leaves_non_owner_app_group_descriptions_alone(
     assert rep.status_code == 200
     await db.session.refresh(non_owner_group)
     assert non_owner_group.description == "Grants the Admin role"
+
+
+async def test_rename_succeeds_despite_a_soft_deleted_owner_group_with_overlong_description(
+    client: AsyncClient, db: Db, mocker: MockerFixture, url_for: Any
+) -> None:
+    """A soft-deleted owner group isn't shown in the UI, so its description can't be
+    shortened to unblock a rename -- the length pre-flight skips deleted groups rather
+    than permanently blocking the app's rename on a group nobody can act on."""
+    app, owner_group, non_owner_group = await _app_with_owner_and_non_owner_groups(mocker, "Zendesk")
+    # Over 1024 once composed onto the new base line; would 400 if the pre-flight
+    # evaluated this group like a live one.
+    original_owner_description = app_owners_group_description(app.name, "x" * 1010)
+    owner_group.description = original_owner_description
+    owner_group.deleted_at = datetime.now(timezone.utc)
+    db.session.add(owner_group)
+    await db.session.commit()
+
+    app_url = url_for("api-apps.app_by_id", app_id=app.id)
+    rep = await client.put(app_url, json={"name": "ZendeskSupport"})
+
+    assert rep.status_code == 200
+    await db.session.refresh(app)
+    await db.session.refresh(owner_group)
+    await db.session.refresh(non_owner_group)
+    assert app.name == "ZendeskSupport"
+    assert non_owner_group.name == (
+        f"{AppGroup.APP_GROUP_NAME_PREFIX}ZendeskSupport{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}Admin"
+    )
+    # The rename loop still renames the deleted group, same as before this change, but
+    # its description -- skipped in the pre-flight -- is left untouched.
+    assert owner_group.name == (
+        f"{AppGroup.APP_GROUP_NAME_PREFIX}ZendeskSupport"
+        f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
+    )
+    assert owner_group.description == original_owner_description

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -22,6 +22,7 @@ from api.models import (
     RoleGroupMap,
     Tag,
 )
+from api.models.app_group import app_owners_group_description
 from api.operations import ModifyGroupUsers, ModifyRoleGroups
 from api.services import okta
 from tests.factories import (
@@ -1154,3 +1155,110 @@ async def test_get_apps_q_via_http(client: AsyncClient, db: Db, url_for: Any) ->
     names = [a["name"] for a in rep.json()["items"]]
     assert "ZelaPaymentsApp" in names
     assert "LoggingApp" not in names
+
+
+async def _app_with_owner_and_non_owner_groups(
+    mocker: MockerFixture, app_name: str = "Zendesk"
+) -> tuple[App, AppGroup, AppGroup]:
+    """An app with a conforming owner group and a plain (non-owner) app group,
+    ready to exercise a rename PUT. Mirrors what CreateApp produces."""
+    mocker.patch.object(okta, "update_group")
+    app = await AppFactory.create_async(name=app_name, description="")
+    owner_group = await AppGroupFactory.create_async(
+        app_id=app.id,
+        is_owner=True,
+        name=(
+            f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_name}"
+            f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
+        ),
+        description=app_owners_group_description(app_name),
+    )
+    non_owner_group = await AppGroupFactory.create_async(
+        app_id=app.id,
+        is_owner=False,
+        name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_name}{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}Admin",
+    )
+    return app, owner_group, non_owner_group
+
+
+async def test_rename_preserves_the_owner_group_free_text(
+    client: AsyncClient, db: Db, mocker: MockerFixture, url_for: Any
+) -> None:
+    """Renaming an app rewrites the base line and keeps the text below it."""
+    app, owner_group, _ = await _app_with_owner_and_non_owner_groups(mocker, "Zendesk")
+    owner_group.description = "Owners of the Zendesk application\n\nAlso grants billing"
+    db.session.add(owner_group)
+    await db.session.commit()
+
+    app_url = url_for("api-apps.app_by_id", app_id=app.id)
+    rep = await client.put(app_url, json={"name": "ZendeskSupport"})
+
+    assert rep.status_code == 200
+    await db.session.refresh(owner_group)
+    assert owner_group.description == "Owners of the ZendeskSupport application\n\nAlso grants billing"
+
+
+async def test_rename_reseats_a_divergent_description_rather_than_discarding_it(
+    client: AsyncClient, db: Db, mocker: MockerFixture, url_for: Any
+) -> None:
+    """A description that does not match the old base line becomes the remainder whole."""
+    app, owner_group, _ = await _app_with_owner_and_non_owner_groups(mocker, "Zendesk")
+    owner_group.description = "Hand-written legacy text"
+    db.session.add(owner_group)
+    await db.session.commit()
+
+    app_url = url_for("api-apps.app_by_id", app_id=app.id)
+    rep = await client.put(app_url, json={"name": "ZendeskSupport"})
+
+    assert rep.status_code == 200
+    await db.session.refresh(owner_group)
+    assert owner_group.description == "Owners of the ZendeskSupport application\n\nHand-written legacy text"
+
+
+async def test_rename_fails_when_the_composed_description_would_overflow(
+    client: AsyncClient, db: Db, mocker: MockerFixture, url_for: Any
+) -> None:
+    """Over 1024 characters, the rename fails loudly instead of truncating."""
+    app, owner_group, non_owner_group = await _app_with_owner_and_non_owner_groups(mocker, "Zendesk")
+    # 1010 chars of remainder + a longer base line pushes the composition over 1024.
+    owner_group.description = app_owners_group_description(app.name, "x" * 1010)
+    db.session.add(owner_group)
+    await db.session.commit()
+
+    original_app_name = app.name
+    original_owner_group_name = owner_group.name
+    original_non_owner_group_name = non_owner_group.name
+    original_owner_description = owner_group.description
+
+    app_url = url_for("api-apps.app_by_id", app_id=app.id)
+    rep = await client.put(app_url, json={"name": "AVeryMuchLongerApplicationName"})
+
+    assert rep.status_code == 400
+    assert "1024" in rep.json()["detail"]
+
+    # The pre-flight must run before ANY mutation: ModifyGroupDetails pushes to Okta and
+    # commits per call, so a check inside the loop would leave earlier groups renamed and
+    # the app rename already published.
+    await db.session.refresh(app)
+    await db.session.refresh(owner_group)
+    await db.session.refresh(non_owner_group)
+    assert app.name == original_app_name
+    assert owner_group.name == original_owner_group_name
+    assert non_owner_group.name == original_non_owner_group_name
+    assert owner_group.description == original_owner_description
+
+
+async def test_rename_leaves_non_owner_app_group_descriptions_alone(
+    client: AsyncClient, db: Db, mocker: MockerFixture, url_for: Any
+) -> None:
+    app, _, non_owner_group = await _app_with_owner_and_non_owner_groups(mocker, "Zendesk")
+    non_owner_group.description = "Grants the Admin role"
+    db.session.add(non_owner_group)
+    await db.session.commit()
+
+    app_url = url_for("api-apps.app_by_id", app_id=app.id)
+    rep = await client.put(app_url, json={"name": "ZendeskSupport"})
+
+    assert rep.status_code == 200
+    await db.session.refresh(non_owner_group)
+    assert non_owner_group.description == "Grants the Admin role"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,7 +4,7 @@ from typing import Any, Protocol, cast
 import pytest
 from faker import Faker
 from httpx import AsyncClient
-from sqlalchemy import select
+from sqlalchemy import func, select
 from okta.models.group import Group
 from pytest_mock import MockerFixture
 from fastapi import FastAPI
@@ -15,6 +15,7 @@ from api.models import (
     App,
     AppGroup,
     AppTagMap,
+    OktaGroup,
     OktaGroupTagMap,
     OktaUser,
     OktaUserGroupMember,
@@ -1077,6 +1078,53 @@ async def test_create_app_preserves_a_preexisting_owner_group_description(
     promoted = await db.session.get(AppGroup, preexisting_group_id)
     assert promoted is not None
     assert promoted.description == app_owners_group_description("Payments", "Hand-written legacy text")
+
+
+async def test_create_app_fails_when_the_composed_description_would_overflow(
+    client: AsyncClient,
+    db: Db,
+    mocker: MockerFixture,
+    url_for: Any,
+) -> None:
+    """Promoting a pre-existing group whose composed description would exceed 1024
+    characters fails loudly instead of truncating -- and it fails before anything is
+    created, not merely before a response is returned."""
+    create_group_mock = mocker.patch.object(okta, "create_group")
+    add_user_to_group_mock = mocker.patch.object(okta, "add_user_to_group")
+    add_owner_to_group_mock = mocker.patch.object(okta, "add_owner_to_group")
+    update_group_mock = mocker.patch.object(okta, "update_group")
+
+    owner_group_name = (
+        f"{AppGroup.APP_GROUP_NAME_PREFIX}Payments"
+        f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
+    )
+    # 1010 chars of remainder pushes the composition (base line + remainder) over 1024.
+    original_description = app_owners_group_description("Payments", "x" * 1010)
+    preexisting_group = await OktaGroupFactory.create_async(name=owner_group_name, description=original_description)
+    preexisting_group_id = preexisting_group.id
+
+    apps_url = url_for("api-apps.apps")
+    rep = await client.post(apps_url, json={"name": "Payments"})
+
+    assert rep.status_code == 400
+    assert "1024" in rep.json()["detail"]
+
+    # Nothing was created or changed: no App row, the pre-existing group's type and
+    # description untouched, and no Okta call made.
+    assert (
+        await db.session.scalars(select(App).where(func.lower(App.name) == "payments").where(App.deleted_at.is_(None)))
+    ).first() is None
+
+    refreshed_group = await db.session.get(OktaGroup, preexisting_group_id)
+    assert refreshed_group is not None
+    await db.session.refresh(refreshed_group)
+    assert type(refreshed_group) is OktaGroup
+    assert refreshed_group.description == original_description
+
+    assert create_group_mock.call_count == 0
+    assert add_user_to_group_mock.call_count == 0
+    assert add_owner_to_group_mock.call_count == 0
+    assert update_group_mock.call_count == 0
 
 
 async def test_create_app_succeeds_with_members_only_preexisting_owner_group(

--- a/tests/test_app_group_description.py
+++ b/tests/test_app_group_description.py
@@ -1,0 +1,67 @@
+from api.models.app_group import (
+    app_owners_group_description,
+    app_owners_group_description_remainder,
+)
+
+
+# Pinned literal. The frontend mirrors this format string in
+# `appOwnerGroupDescriptionPrefix` (src/pages/groups/appOwnerGroupDescription.ts);
+# if you change the wording here, change it there and update both tests.
+def test_base_line_literal_is_pinned() -> None:
+    assert app_owners_group_description("Zendesk") == "Owners of the Zendesk application"
+
+
+def test_composes_additional_text_after_a_blank_line() -> None:
+    assert app_owners_group_description("Zendesk", "Also grants billing access") == (
+        "Owners of the Zendesk application\n\nAlso grants billing access"
+    )
+
+
+def test_treats_empty_and_whitespace_additional_text_as_absent() -> None:
+    base = "Owners of the Zendesk application"
+    assert app_owners_group_description("Zendesk", None) == base
+    assert app_owners_group_description("Zendesk", "") == base
+    assert app_owners_group_description("Zendesk", "   \n  ") == base
+
+
+def test_remainder_is_the_text_after_a_matching_base_line() -> None:
+    assert (
+        app_owners_group_description_remainder(
+            "Owners of the Zendesk application\n\nAlso grants billing access", "Zendesk"
+        )
+        == "Also grants billing access"
+    )
+
+
+def test_remainder_is_empty_for_a_bare_base_line() -> None:
+    assert app_owners_group_description_remainder("Owners of the Zendesk application", "Zendesk") == ""
+
+
+def test_remainder_is_the_whole_description_when_the_base_line_does_not_match() -> None:
+    # The reseat rule: divergent text is preserved as remainder rather than dropped.
+    assert app_owners_group_description_remainder("Legacy hand-written text", "Zendesk") == ("Legacy hand-written text")
+    assert app_owners_group_description_remainder("Owners of the Jira application", "Zendesk") == (
+        "Owners of the Jira application"
+    )
+
+
+def test_remainder_normalises_crlf() -> None:
+    assert (
+        app_owners_group_description_remainder("Owners of the Zendesk application\r\n\r\nExtra", "Zendesk") == "Extra"
+    )
+
+
+def test_remainder_of_an_empty_description_is_empty() -> None:
+    assert app_owners_group_description_remainder("", "Zendesk") == ""
+
+
+def test_a_similarly_named_app_is_not_a_false_match() -> None:
+    # "Owners of the Foo application" must not be seen as a prefix of the FooBar line.
+    assert app_owners_group_description_remainder("Owners of the FooBar application", "Foo") == (
+        "Owners of the FooBar application"
+    )
+
+
+def test_compose_and_split_round_trip() -> None:
+    composed = app_owners_group_description("Zendesk", "Also grants billing access")
+    assert app_owners_group_description_remainder(composed, "Zendesk") == "Also grants billing access"

--- a/tests/test_app_group_description.py
+++ b/tests/test_app_group_description.py
@@ -11,6 +11,7 @@ from api.models.app_group import (
     app_owners_group_description_remainder,
 )
 from api.operations import ModifyGroupDetails
+from api.schemas.requests_schemas import _GROUP_DESC_MAX_LENGTH
 from api.services import okta
 from tests.factories import AppFactory, AppGroupFactory
 
@@ -57,6 +58,39 @@ def test_frontend_prefix_template_matches_backend() -> None:
         "has it been renamed or restructured?"
     )
     assert match.group(1) == expected_template
+
+
+def test_frontend_length_limit_matches_backend() -> None:
+    """The frontend's remainder length budget must match the backend's `_GROUP_DESC_MAX_LENGTH`.
+
+    `appOwnerGroupDescriptionRemainderMaxLength` (`src/pages/groups/appOwnerGroupDescription.ts`)
+    hardcodes the same 1024-character description column limit as
+    `_GROUP_DESC_MAX_LENGTH` (`api/schemas/requests_schemas.py`), rather than importing it --
+    there is no shared-constant channel between the two languages. Reads the TypeScript
+    source and compares the literal against the backend constant, the same way
+    `test_frontend_prefix_template_matches_backend` pins the base-line format string
+    above. Without this, the two figures could drift apart silently: too high a client
+    cap lets a user type text the API then rejects with a 400; too low one blocks text
+    the API would have accepted. Skipped if the frontend file is absent, e.g. a
+    backend-only checkout.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    frontend_path = repo_root / "src" / "pages" / "groups" / "appOwnerGroupDescription.ts"
+    if not frontend_path.exists():
+        pytest.skip(f"{frontend_path} not present; backend-only checkout")
+
+    source = frontend_path.read_text()
+    match = re.search(
+        r"export function appOwnerGroupDescriptionRemainderMaxLength\(appName: string\): number \{\s*"
+        r"return Math\.max\(0, (\d+) - appOwnerGroupDescriptionPrefix\(appName\)\.length - "
+        r"BASE_LINE_SEPARATOR\.length\);\s*\}",
+        source,
+    )
+    assert match is not None, (
+        "could not find appOwnerGroupDescriptionRemainderMaxLength's return statement in "
+        f"{frontend_path}; has it been renamed or restructured?"
+    )
+    assert int(match.group(1)) == _GROUP_DESC_MAX_LENGTH
 
 
 def test_composes_additional_text_after_a_blank_line() -> None:
@@ -199,7 +233,7 @@ async def test_rejects_text_appended_on_the_same_line(db: Db, mocker: MockerFixt
     group = await _owner_group(db)
     mocker.patch.object(okta, "update_group")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Owners of the Zendesk application"):
         await ModifyGroupDetails(
             group=group, description="Owners of the Zendesk application and also billing"
         ).execute()
@@ -209,7 +243,7 @@ async def test_rejects_a_single_newline_separator(db: Db, mocker: MockerFixture)
     group = await _owner_group(db)
     mocker.patch.object(okta, "update_group")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Owners of the Zendesk application"):
         await ModifyGroupDetails(
             group=group, description="Owners of the Zendesk application\nAlso grants billing"
         ).execute()

--- a/tests/test_app_group_description.py
+++ b/tests/test_app_group_description.py
@@ -1,7 +1,15 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from api.extensions import Db
+from api.models import AppGroup
 from api.models.app_group import (
     app_owners_group_description,
     app_owners_group_description_remainder,
 )
+from api.operations import ModifyGroupDetails
+from api.services import okta
+from tests.factories import AppFactory, AppGroupFactory
 
 
 # Pinned literal. The frontend mirrors this format string in
@@ -86,3 +94,91 @@ def test_compose_and_split_round_trip_preserves_indentation() -> None:
     assert (
         app_owners_group_description("Zendesk", app_owners_group_description_remainder(composed, "Zendesk")) == composed
     )
+
+
+def test_composing_after_a_crlf_normalises_the_separator() -> None:
+    # A CRLF blank-line separator (e.g. from a browser textarea) must not survive verbatim --
+    # otherwise compose -> remainder -> compose is not stable for that input.
+    assert app_owners_group_description("Zendesk", "\r\n\r\nExtra text") == (
+        "Owners of the Zendesk application\n\nExtra text"
+    )
+
+
+async def _owner_group(db: Db, app_name: str = "Zendesk") -> AppGroup:
+    """Create an app and its owner group with a conforming description, mirroring what CreateApp produces."""
+    app = await AppFactory.create_async(name=app_name, description="")
+    return await AppGroupFactory.create_async(
+        app_id=app.id,
+        is_owner=True,
+        name=(
+            f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_name}"
+            f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
+        ),
+        description=app_owners_group_description(app_name),
+    )
+
+
+async def test_accepts_the_bare_base_line(db: Db, mocker: MockerFixture) -> None:
+    group = await _owner_group(db)
+    mocker.patch.object(okta, "update_group")
+
+    await ModifyGroupDetails(group=group, description="Owners of the Zendesk application").execute()
+    assert group.description == "Owners of the Zendesk application"
+
+
+async def test_accepts_the_base_line_followed_by_a_blank_line_and_text(db: Db, mocker: MockerFixture) -> None:
+    group = await _owner_group(db)
+    mocker.patch.object(okta, "update_group")
+
+    await ModifyGroupDetails(
+        group=group, description="Owners of the Zendesk application\n\nAlso grants billing"
+    ).execute()
+    assert group.description == "Owners of the Zendesk application\n\nAlso grants billing"
+
+
+async def test_normalises_crlf_before_checking(db: Db, mocker: MockerFixture) -> None:
+    group = await _owner_group(db)
+    mocker.patch.object(okta, "update_group")
+
+    await ModifyGroupDetails(
+        group=group, description="Owners of the Zendesk application\r\n\r\nAlso grants billing"
+    ).execute()
+    assert group.description == "Owners of the Zendesk application\n\nAlso grants billing"
+
+
+async def test_rejects_a_description_that_drops_the_base_line(db: Db, mocker: MockerFixture) -> None:
+    group = await _owner_group(db)
+    mocker.patch.object(okta, "update_group")
+
+    with pytest.raises(ValueError, match="Owners of the Zendesk application"):
+        await ModifyGroupDetails(group=group, description="Something else entirely").execute()
+
+
+async def test_rejects_text_appended_on_the_same_line(db: Db, mocker: MockerFixture) -> None:
+    # One paragraph is not the requested format; it must be a blank line.
+    group = await _owner_group(db)
+    mocker.patch.object(okta, "update_group")
+
+    with pytest.raises(ValueError):
+        await ModifyGroupDetails(
+            group=group, description="Owners of the Zendesk application and also billing"
+        ).execute()
+
+
+async def test_rejects_a_single_newline_separator(db: Db, mocker: MockerFixture) -> None:
+    group = await _owner_group(db)
+    mocker.patch.object(okta, "update_group")
+
+    with pytest.raises(ValueError):
+        await ModifyGroupDetails(
+            group=group, description="Owners of the Zendesk application\nAlso grants billing"
+        ).execute()
+
+
+async def test_a_non_owner_app_group_description_is_unconstrained(db: Db, mocker: MockerFixture) -> None:
+    app = await AppFactory.create_async(name="Zendesk", description="")
+    group = await AppGroupFactory.create_async(app_id=app.id, is_owner=False, description="anything")
+    mocker.patch.object(okta, "update_group")
+
+    await ModifyGroupDetails(group=group, description="literally anything").execute()
+    assert group.description == "literally anything"

--- a/tests/test_app_group_description.py
+++ b/tests/test_app_group_description.py
@@ -1,3 +1,6 @@
+import re
+from pathlib import Path
+
 import pytest
 from pytest_mock import MockerFixture
 
@@ -14,9 +17,46 @@ from tests.factories import AppFactory, AppGroupFactory
 
 # Pinned literal. The frontend mirrors this format string in
 # `appOwnerGroupDescriptionPrefix` (src/pages/groups/appOwnerGroupDescription.ts);
-# if you change the wording here, change it there and update both tests.
+# `test_frontend_prefix_template_matches_backend` below is what enforces that the two
+# stay in agreement -- this pin only guards the backend's own wording.
 def test_base_line_literal_is_pinned() -> None:
     assert app_owners_group_description("Zendesk") == "Owners of the Zendesk application"
+
+
+def test_frontend_prefix_template_matches_backend() -> None:
+    """The frontend's returned template literal must match the backend's format string.
+
+    Reads `src/pages/groups/appOwnerGroupDescription.ts` from disk (resolved relative to
+    the repository root, not the working directory pytest was invoked from) and compares
+    the exact template literal returned by `appOwnerGroupDescriptionPrefix` against a
+    template derived from `app_owners_group_description`: the base line is generated for
+    a placeholder app name, then the placeholder is swapped for the TypeScript
+    interpolation syntax. Matching against the returned expression -- rather than
+    checking whether the backend's wording merely appears in the file somewhere -- means
+    a wording change that survives only in a comment, or an interpolation that is
+    restructured to produce different output, still fails here; a comment addition or
+    unrelated reformatting elsewhere in the file does not. Skipped if the frontend file
+    is absent, e.g. a backend-only checkout.
+    """
+    placeholder = "___APP_NAME_PLACEHOLDER___"
+    expected_template = app_owners_group_description(placeholder).replace(placeholder, "${appName}")
+
+    repo_root = Path(__file__).resolve().parent.parent
+    frontend_path = repo_root / "src" / "pages" / "groups" / "appOwnerGroupDescription.ts"
+    if not frontend_path.exists():
+        pytest.skip(f"{frontend_path} not present; backend-only checkout")
+
+    source = frontend_path.read_text()
+    match = re.search(
+        r"export function appOwnerGroupDescriptionPrefix\(appName: string\): string \{\s*"
+        r"return\s*`([^`]*)`;\s*\}",
+        source,
+    )
+    assert match is not None, (
+        f"could not find appOwnerGroupDescriptionPrefix's return statement in {frontend_path}; "
+        "has it been renamed or restructured?"
+    )
+    assert match.group(1) == expected_template
 
 
 def test_composes_additional_text_after_a_blank_line() -> None:

--- a/tests/test_app_group_description.py
+++ b/tests/test_app_group_description.py
@@ -65,3 +65,24 @@ def test_a_similarly_named_app_is_not_a_false_match() -> None:
 def test_compose_and_split_round_trip() -> None:
     composed = app_owners_group_description("Zendesk", "Also grants billing access")
     assert app_owners_group_description_remainder(composed, "Zendesk") == "Also grants billing access"
+
+
+def test_remainder_preserves_indentation_on_a_conforming_description() -> None:
+    # The remainder is markdown; leading spaces on its first content line are a nested list
+    # item, not incidental whitespace to discard.
+    description = "Owners of the Zendesk application\n\n    - nested item\n    - another item"
+    assert app_owners_group_description_remainder(description, "Zendesk") == ("    - nested item\n    - another item")
+
+
+def test_remainder_preserves_indentation_on_a_non_conforming_description() -> None:
+    # Same principle for the whole-description (non-matching-base-line) branch.
+    description = "    - nested item\n    - another item"
+    assert app_owners_group_description_remainder(description, "Zendesk") == ("    - nested item\n    - another item")
+
+
+def test_compose_and_split_round_trip_preserves_indentation() -> None:
+    composed = app_owners_group_description("Zendesk", "    - nested item\n    - another item")
+    assert app_owners_group_description_remainder(composed, "Zendesk") == "    - nested item\n    - another item"
+    assert (
+        app_owners_group_description("Zendesk", app_owners_group_description_remainder(composed, "Zendesk")) == composed
+    )

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -26,6 +26,7 @@ from api.models import (
     RoleGroup,
     Tag,
 )
+from api.models.app_group import app_owners_group_description
 from api.operations import CreateAccessRequest, ModifyGroupUsers, ModifyRoleGroups
 from api.services import okta
 from tests.factories import (
@@ -307,7 +308,8 @@ async def test_put_group(
         url_for=url_for,
     )
 
-    # Updating the name of the built-in app owners group should fail
+    # Renaming or retyping the built-in app owners group should fail, even when
+    # combined with a tag change -- those structural fields stay rejected.
     builtin_access_owners_group_name = (
         f"{AppGroup.APP_GROUP_NAME_PREFIX}{App.ACCESS_APP_RESERVED_NAME}"
         + f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
@@ -327,14 +329,11 @@ async def test_put_group(
     rep = await client.put(group_url, json=data)
     assert rep.status_code == 400
 
-    # Updating tags is allowed, but nothing else
+    # Updating tags is allowed, but a structural field (name/type/app_id) is not.
+    # `type` must match the group's actual type -- "app_group" -- to isolate the
+    # tags-only case from the rename/retype rejected above.
     update_group_spy.reset_mock()
-    data.update(
-        {
-            "tags_to_add": [tag_id],
-        }
-    )
-    rep = await client.put(group_url, json=data)
+    rep = await client.put(group_url, json={"type": "app_group", "tags_to_add": [tag_id]})
     assert rep.status_code == 200
     assert update_group_spy.call_count == 0
 
@@ -346,12 +345,7 @@ async def test_put_group(
     assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 1
 
     update_group_spy.reset_mock()
-    data.update(
-        {
-            "tags_to_remove": [tag_id],
-        }
-    )
-    rep = await client.put(group_url, json=data)
+    rep = await client.put(group_url, json={"type": "app_group", "tags_to_remove": [tag_id]})
     assert rep.status_code == 200
     assert update_group_spy.call_count == 0
 
@@ -476,6 +470,116 @@ async def test_put_app_group_rebind_authorization(
     rep = await client.put(group_url, json=rebind_data)
     assert rep.status_code == 200
     assert rep.json()["app_id"] == target_app_id
+
+
+async def _make_owner_group(db: Db, access_app: App, app_group: AppGroup) -> AppGroup:
+    """Wire access_app/app_group into an app owner group with a conforming description."""
+    app_group.app_id = access_app.id
+    app_group.is_owner = True
+    app_group.name = (
+        f"{AppGroup.APP_GROUP_NAME_PREFIX}{access_app.name}"
+        f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
+    )
+    app_group.description = app_owners_group_description(access_app.name)
+    db.session.add(access_app)
+    db.session.add(app_group)
+    await db.session.commit()
+    return app_group
+
+
+async def test_owner_group_accepts_a_conforming_description(
+    client: AsyncClient,
+    db: Db,
+    mocker: MockerFixture,
+    access_app: App,
+    app_group: AppGroup,
+    url_for: Any,
+) -> None:
+    """An app owner group's description may carry free text below its base line."""
+    owner_group = await _make_owner_group(db, access_app, app_group)
+    mocker.patch.object(okta, "update_group")
+
+    base = app_owners_group_description(access_app.name)
+    group_url = url_for("api-groups.group_by_id", group_id=owner_group.id)
+    response = await client.put(
+        group_url,
+        json={"type": "app_group", "description": f"{base}\n\nAlso grants billing access"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["description"] == f"{base}\n\nAlso grants billing access"
+
+
+async def test_owner_group_rejects_a_description_without_the_base_line(
+    client: AsyncClient,
+    db: Db,
+    access_app: App,
+    app_group: AppGroup,
+    url_for: Any,
+) -> None:
+    owner_group = await _make_owner_group(db, access_app, app_group)
+
+    group_url = url_for("api-groups.group_by_id", group_id=owner_group.id)
+    response = await client.put(group_url, json={"type": "app_group", "description": "Something else"})
+
+    assert response.status_code == 400
+    # RFC 9457 envelope: the human-readable message is in `detail`.
+    assert "Owners of the" in response.json()["detail"]
+
+
+async def test_owner_group_still_rejects_a_rename(
+    client: AsyncClient,
+    db: Db,
+    access_app: App,
+    app_group: AppGroup,
+    url_for: Any,
+) -> None:
+    owner_group = await _make_owner_group(db, access_app, app_group)
+
+    group_url = url_for("api-groups.group_by_id", group_id=owner_group.id)
+    response = await client.put(
+        group_url,
+        json={"type": "app_group", "name": f"{AppGroup.APP_GROUP_NAME_PREFIX}Renamed"},
+    )
+
+    assert response.status_code == 400
+
+
+async def test_owner_group_still_rejects_a_type_change(
+    client: AsyncClient,
+    db: Db,
+    access_app: App,
+    app_group: AppGroup,
+    url_for: Any,
+) -> None:
+    owner_group = await _make_owner_group(db, access_app, app_group)
+
+    group_url = url_for("api-groups.group_by_id", group_id=owner_group.id)
+    response = await client.put(group_url, json={"type": "okta_group"})
+
+    assert response.status_code == 400
+
+
+async def test_owner_group_still_rejects_an_app_rebind(
+    client: AsyncClient,
+    db: Db,
+    access_app: App,
+    app_group: AppGroup,
+    url_for: Any,
+) -> None:
+    owner_group = await _make_owner_group(db, access_app, app_group)
+    other_app = AppFactory.build()
+    db.session.add(other_app)
+    await db.session.commit()
+    other_app_id = other_app.id
+
+    group_url = url_for("api-groups.group_by_id", group_id=owner_group.id)
+    response = await client.put(
+        group_url,
+        json={"type": "app_group", "app_id": other_app_id},
+    )
+
+    assert response.status_code == 400
 
 
 async def test_put_group_members(

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -613,6 +613,47 @@ async def test_owner_group_still_rejects_a_plugin_data_change(
     assert refreshed.plugin_data == {"existing_plugin": {"key": "value"}}
 
 
+async def test_owner_group_echoing_identical_plugin_data_succeeds(
+    client: AsyncClient,
+    db: Db,
+    mocker: MockerFixture,
+    access_app: App,
+    app_group: AppGroup,
+    url_for: Any,
+) -> None:
+    """CreateUpdate.tsx seeds the owner-group edit dialog's plugin config form from the
+    group's current `plugin_data` and resubmits it on every save, so a description or tag
+    edit on a plugin-managed app always echoes an unchanged `plugin_data` value back. That
+    echo must not trip the "Plugin configuration cannot be modified" guard -- only an
+    actual change to the value should. This is a value comparison
+    (`new_plugin_data != (group.plugin_data or {})`), not a presence check, precisely so
+    this echo succeeds."""
+    owner_group = await _make_owner_group(db, access_app, app_group)
+    owner_group.plugin_data = {"existing_plugin": {"key": "value"}}
+    db.session.add(owner_group)
+    await db.session.commit()
+    owner_group_id = owner_group.id
+    mocker.patch.object(okta, "update_group")
+
+    base = app_owners_group_description(access_app.name)
+    group_url = url_for("api-groups.group_by_id", group_id=owner_group_id)
+    response = await client.put(
+        group_url,
+        json={
+            "type": "app_group",
+            "description": f"{base}\n\nAlso grants billing access",
+            "plugin_data": {"existing_plugin": {"key": "value"}},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["description"] == f"{base}\n\nAlso grants billing access"
+
+    refreshed = await db.session.get(AppGroup, owner_group_id)
+    assert refreshed is not None
+    assert refreshed.plugin_data == {"existing_plugin": {"key": "value"}}
+
+
 async def test_put_group_members(
     client: AsyncClient,
     db: Db,

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -321,13 +321,16 @@ async def test_put_group(
     ).first()
     update_group_spy.reset_mock()
 
-    data: dict[str, Any] = OktaGroupUpdateBodyFactory.json(name="Updated", description="new description")
+    data: dict[str, Any] = OktaGroupUpdateBodyFactory.json(
+        name="Updated", description="new description", tags_to_add=[tag_id]
+    )
     # Capture the id once before any requests — the failed PUT below rolls back
     # the shared session and expires the fixture-loaded object.
     group_id = builtin_access_owners_group.id
     group_url = url_for("api-groups.group_by_id", group_id=group_id)
     rep = await client.put(group_url, json=data)
     assert rep.status_code == 400
+    assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 0
 
     # Updating tags is allowed, but a structural field (name/type/app_id) is not.
     # `type` must match the group's actual type -- "app_group" -- to isolate the
@@ -580,6 +583,34 @@ async def test_owner_group_still_rejects_an_app_rebind(
     )
 
     assert response.status_code == 400
+
+
+async def test_owner_group_still_rejects_a_plugin_data_change(
+    client: AsyncClient,
+    db: Db,
+    access_app: App,
+    app_group: AppGroup,
+    url_for: Any,
+) -> None:
+    """Owner groups participate in lifecycle plugins, so a `plugin_data` edit is
+    refused with 400 rather than silently discarded."""
+    owner_group = await _make_owner_group(db, access_app, app_group)
+    owner_group.plugin_data = {"existing_plugin": {"key": "value"}}
+    db.session.add(owner_group)
+    await db.session.commit()
+    owner_group_id = owner_group.id
+
+    group_url = url_for("api-groups.group_by_id", group_id=owner_group_id)
+    response = await client.put(
+        group_url,
+        json={"type": "app_group", "plugin_data": {"existing_plugin": {"key": "new_value"}}},
+    )
+
+    assert response.status_code == 400
+
+    refreshed = await db.session.get(AppGroup, owner_group_id)
+    assert refreshed is not None
+    assert refreshed.plugin_data == {"existing_plugin": {"key": "value"}}
 
 
 async def test_put_group_members(


### PR DESCRIPTION
# Summary
An app owner group's description can now carry free text below the fixed `Owners of the {app name} application` line, rendering as a second markdown paragraph. No new column, no migration, no API field.

**Urgency**: 5 days
**Expected review effort**: MEDIUM

# Motivation
Owner groups sometimes carry app-level permissions beyond "owns this app", and there was nowhere to record that: the description was composed at app creation and rewritten on every app rename, and `PUT /api/groups/{id}` rejected every non-tag edit for owner groups.

Stacked on #635, which fixes inline markdown rendering. That PR must merge first: this one is what starts producing two-paragraph descriptions, and without it list views render the two paragraphs run together.

<details>
<summary><h1>Description of Changes</h1></summary>

The composed string stays in `okta_group.description` — it is already stored, already synced to Okta, and already rendered everywhere. Two ideas carry the design:

**One invariant, enforced in one place.** A description is either exactly the base line, or the base line + `\n\n` + free text. The check lives in `ModifyGroupDetails.execute()` rather than a router, because every writer already routes through it — `put_group` and the plugin `set_group_description` capability both do — so one site covers the API, plugins, and any future caller, and lands as a 400 through the existing `except ValueError`.

**One reseat rule, shared by both readers.** A description starting with the expected base line splits into base + remainder; one that does *not* becomes the remainder in its entirety. Both the edit form (seeding its field) and the app-rename path (recomposing) use it, so a description written before this convention is repaired rather than discarded, and repaired identically by either.

The rename path refuses with a 400 when recomposition would exceed the 1024-character column, checked in a **pre-flight before its loop**: `ModifyGroupDetails` pushes to Okta and commits per call, and the app name is assigned before the loop, so a check inside it would leave earlier groups renamed and the app half-renamed. `CreateApp` carries the same guard for the same reason.

**On the frontend duplicating a backend format string.** The form builds the expected prefix from the app name rather than splitting on the first blank line. Splitting on structure cannot tell a conforming description from a divergent one, so it would show wrong text as immutable and leave a divergent description unrepairable through the UI. The duplication is contained by a test that reads the TypeScript source and asserts it agrees with the Python — for both the format string and the length budget. This is also not unprecedented: `CreateUpdate.tsx` already keeps `APP_GROUP_PREFIX` and `ROLE_GROUP_PREFIX` as client-side copies.

Nothing changes for non-owner app groups, role groups, or plain Okta groups; `name`, `type`, `app_id`, and plugin config remain rejected for owner groups.

TODO: screenshots of the edit dialog not yet attached.
</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

- Backend **984 passed**; frontend **82 passed**; `make ruff`, `make ty`, `tsc --noEmit` all clean.
- `tests/test_spa.py::test_missing_asset_returns_404_not_the_spa_shell` fails on this branch **and at its base commit**; it needs a frontend build. This branch touches neither `tests/test_spa.py` nor `api/app.py`.
- Every fix in this branch was mutation-verified: the fix was made inert, the covering test confirmed to fail, then restored. That includes the rename pre-flight (moving the check into the loop fails the overflow test), the indentation handling on both sides, and the guard against structural edits.
- A differential fuzz of 940 inputs compared the Python and TypeScript trimming; a 7-case HTTP round trip (store → GET → seed → submit → validate → store → rename → store) confirmed free text is byte-identical throughout.

**Reviewer-facing note on one gap:** SQLite does not enforce the description column width, so an overflow stores silently in tests and would surface as a 500 only on PostgreSQL. The two overflow guards are therefore load-bearing in production in a way the suite alone would not demonstrate.
</details>

# Guidance for Reviewers
Read file-by-file; the 14 commits include review-fix passes and do not reflect final state cleanly.

Three things most merit a second opinion:

1. **`api/routers/apps.py`** — the rename pre-flight's position. It is correct only because it runs before the loop; the reasoning is in the comment and I would like it checked.
2. **`api/routers/groups.py`** — the owner-group guard compares structural fields by *value* against `original_app_id` captured at load, not against the live attribute, because an earlier block in the same handler mutates `group.app_id` in memory first. An early draft compared against the live value and would have silently permitted rebinding an owner group to another app.
3. **`api/operations/create_app.py`** — promotion of a pre-existing group now reformats its description. This fixes a silent, permanent failure in the in-repo Google lifecycle plugin: its adoption branch fired on an empty owner-group description, the new constraint raised, a failing hook rolls back the transaction, and the error was logged and swallowed, so the group would never adopt and would retry identically forever.

Accepted and not fixed, all deliberate: `rstrip`/`trimEnd` disagree on a few exotic Unicode whitespace characters (cosmetic, no rejection possible either way); `ModifyGroupDetails` does not trim, so a stored value is not canonical until a later rename normalizes it; a combined rename-plus-description call issues two identical `App` lookups; and the form now submits a composed description on every owner-group save, so a tags-only edit issues an Okta update it previously did not and silently reseats a divergent description onto the base line.
