### PR TITLE
Make app owner group descriptions editable

### DIFF
--- a/api/operations/create_app.py
+++ b/api/operations/create_app.py
@@ -170,6 +170,11 @@ class CreateApp:
             assert owner_app_group is not None
             owner_app_group.app_id = app_id
             owner_app_group.is_owner = True
+            # A group absorbed by app creation keeps whatever description it already had;
+            # only a group with none is seeded with the default, so an owner group is never
+            # left blank where an operator has REQUIRE_DESCRIPTIONS set.
+            if not (owner_app_group.description or ""):
+                owner_app_group.description = app_owners_group_description(self.app.name)
             await db.session.commit()
 
         if owner_id is not None:

--- a/api/routers/apps.py
+++ b/api/routers/apps.py
@@ -374,13 +374,23 @@ async def put_app(
         old_prefix = f"{_AppGroup.APP_GROUP_NAME_PREFIX}{old_app_name}{_AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}"
         new_prefix = f"{_AppGroup.APP_GROUP_NAME_PREFIX}{app_obj.name}{_AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}"
         app_groups = (await db.scalars(select(_AppGroup).where(_AppGroup.app_id == app_obj.id))).all()
+        # An owner group's description is seeded with a default naming the app and is
+        # editable afterwards, so the rename refreshes it only while it still holds that
+        # default verbatim. Anything else is text somebody chose, and a rename is not a
+        # reason to overwrite it. Non-owner groups pass `None`, which leaves the
+        # description untouched — owner groups now follow the same rule once edited.
+        seeded_owner_description = app_owners_group_description(old_app_name)
         for ag in app_groups:
             if ag.name.startswith(old_prefix):
                 suffix = ag.name[len(old_prefix) :]
                 new_group_name = f"{new_prefix}{suffix}"
             else:
                 new_group_name = f"{new_prefix}{ag.name}"
-            new_description = app_owners_group_description(app_obj.name) if ag.is_owner else None
+            new_description = (
+                app_owners_group_description(app_obj.name)
+                if ag.is_owner and (ag.description or "") == seeded_owner_description
+                else None
+            )
             await ModifyGroupDetails(group=ag, name=new_group_name, description=new_description).execute()
 
     await db.commit()

--- a/api/routers/groups.py
+++ b/api/routers/groups.py
@@ -234,10 +234,16 @@ async def put_group(
     if group is None:
         raise HTTPException(404, "Not Found")
 
-    # Capture the pre-update name/description so the single, consolidated group_updated fire
-    # (below) can report them.
+    # Capture the pre-update name/description/app_id so the single, consolidated
+    # group_updated fire (below) can report them. The rebind-authorization block
+    # further down only mutates `group.app_id` in memory for non-owner AppGroups;
+    # the owner-group guard still compares against this captured value rather
+    # than the live attribute as defence in depth, so a future edit that widens
+    # the rebind block's condition can't silently reach an owner group's app_id
+    # before the guard has a chance to reject the change.
     old_name = group.name
     old_description = group.description or ""
+    original_app_id = getattr(group, "app_id", None)
     # Length + REQUIRE_DESCRIPTIONS-when-set are enforced by the schema; this
     # just normalises a `None` (only possible when the client explicitly sent
     # `null`) to an empty string for ModifyGroupDetails.
@@ -280,9 +286,12 @@ async def put_group(
     # Prevent rebinding an AppGroup to a different app without owning the
     # target app. Access admins can always rebind. Apply the rebind here when
     # the group type isn't also changing — type-change rebinds are wired into
-    # ModifyGroupType below.
+    # ModifyGroupType below. Owner groups are structural (membership confers
+    # app-owner permissions), so they're excluded here and rejected outright
+    # by the owner-group guard further down instead of being rebound.
     if (
         type(group) is AppGroup
+        and not group.is_owner
         and isinstance(body, _AppGroupUpdateBody)
         and "app_id" in fields_set
         and body.app_id != group.app_id
@@ -308,8 +317,28 @@ async def put_group(
     tags_to_add = body.tags_to_add or []
     tags_to_remove = body.tags_to_remove or []
 
-    # App owner groups: only tag changes allowed
+    # App owner groups: only tag and description changes are allowed. The description is
+    # ordinary free text, seeded with a default at app creation and editable thereafter like
+    # any other group's. The group's name, type, and app binding are structural — membership
+    # in an owner group confers app-owner permissions — so those stay locked. Plugin
+    # configuration is rejected explicitly rather than silently dropped: owner groups do
+    # participate in lifecycle plugins, so a discarded `plugin_data` write would be
+    # meaningful config loss, not a cosmetic no-op.
+    #
+    # `type` is the discriminator and is present in `fields_set` on every request, so the
+    # structural fields are compared by value rather than by presence.
     if type(group) is AppGroup and group.is_owner:
+        renaming = "name" in fields_set and body.name is not None and body.name != group.name
+        retyping = body.type != group.type
+        rebinding = isinstance(body, _AppGroupUpdateBody) and "app_id" in fields_set and body.app_id != original_app_id
+        if renaming or retyping or rebinding:
+            raise HTTPException(400, "Only tags and the description can be modified for application owner groups")
+        if new_plugin_data is not None and new_plugin_data != (group.plugin_data or {}):
+            raise HTTPException(400, "Plugin configuration cannot be modified for application owner groups")
+
+        if description is not None:
+            await ModifyGroupDetails(group=group, description=description, current_user_id=current_user_id).execute()
+
         if len(tags_to_add) > 0 or len(tags_to_remove) > 0:
             await ModifyGroupTags(
                 group=group,
@@ -317,9 +346,9 @@ async def put_group(
                 tags_to_remove=tags_to_remove,
                 current_user_id=current_user_id,
             ).execute()
-            refreshed = await _load_group_with_options(db, group.id)
-            return _group_adapter.validate_python(refreshed, from_attributes=True)
-        raise HTTPException(400, "Only tags can be modifed for application owner groups")
+
+        refreshed = await _load_group_with_options(db, group.id)
+        return _group_adapter.validate_python(refreshed, from_attributes=True)
 
     # Block renaming to a reserved prefix unless the final group type matches.
     # Computed using the target type since a legitimate

--- a/src/pages/groups/CreateUpdate.test.tsx
+++ b/src/pages/groups/CreateUpdate.test.tsx
@@ -8,6 +8,13 @@ const createMutate = vi.fn();
 const updateMutate = vi.fn();
 
 vi.mock('react-router-dom', () => ({useNavigate: () => vi.fn()}));
+// Pinned rather than inherited from a developer's .env: REQUIRE_DESCRIPTIONS drives whether
+// the Description field is `required`, and CI and a local checkout disagree about it. Only
+// that one export is overridden; the rest of the config is the real thing.
+vi.mock('../../config/accessConfig', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../config/accessConfig')>()),
+  requireDescriptions: true,
+}));
 vi.mock('../../api/apiComponents', () => ({
   useApps: () => ({data: {items: []}}),
   useTags: () => ({data: {items: []}}),
@@ -94,10 +101,10 @@ describe('creating an app group from an app page', () => {
 });
 
 describe('editing an app owner group', () => {
-  // Type, name and description are all locked for an owner group. Only `type` has to be
-  // submitted -- it discriminates the update body. Name and description are immutable,
-  // so they are left out of the partial update entirely.
-  it('submits the locked type and omits the immutable name and description', async () => {
+  // Type and name are structural for an owner group and stay locked; only `type` has to be
+  // submitted, since it discriminates the update body. The description is ordinary free
+  // text, seeded with a default at app creation and editable here like any other group's.
+  it('keeps the name locked while submitting the description', async () => {
     render(<CreateUpdateGroup currentUser={ACCESS_ADMIN} defaultGroupType="app_group" group={OWNER_APP_GROUP} />);
 
     await openDialog('edit');
@@ -105,20 +112,40 @@ describe('editing an app owner group', () => {
 
     expect(updateMutate).toHaveBeenCalledTimes(1);
     const body = updateMutate.mock.calls[0][0].body;
-    expect(body).toMatchObject({type: 'app_group'});
+    expect(body).toMatchObject({type: 'app_group', description: 'Owners of the sandbox'});
     expect(body.name).toBeUndefined();
-    expect(body.description).toBeUndefined();
   });
 
-  // An owner group whose description is empty must still be editable -- validating a
-  // `required` description the user cannot reach would leave the form with no way out.
-  it('submits when the immutable description is empty', async () => {
+  it('submits an edited description', async () => {
+    render(<CreateUpdateGroup currentUser={ACCESS_ADMIN} defaultGroupType="app_group" group={OWNER_APP_GROUP} />);
+
+    await openDialog('edit');
+    const field = screen.getByLabelText(/^Description/);
+    await userEvent.clear(field);
+    await userEvent.type(field, 'Owners of the sandbox; also approve its quarterly review.');
+    await submitDialog('Update');
+
+    expect(updateMutate).toHaveBeenCalledTimes(1);
+    expect(updateMutate.mock.calls[0][0].body).toMatchObject({
+      description: 'Owners of the sandbox; also approve its quarterly review.',
+    });
+  });
+
+  // With the field editable, REQUIRE_DESCRIPTIONS applies to an owner group exactly as it
+  // does to every other group: an empty description is blocked, and filling it in submits.
+  // There is no trap here, because the user can reach the field to fix it.
+  it('blocks an empty description when descriptions are required, and submits once filled', async () => {
     const emptyDescription = {...OWNER_APP_GROUP, description: ''} as GroupDetail;
     render(<CreateUpdateGroup currentUser={ACCESS_ADMIN} defaultGroupType="app_group" group={emptyDescription} />);
 
     await openDialog('edit');
     await submitDialog('Update');
+    expect(updateMutate).not.toHaveBeenCalled();
+
+    await userEvent.type(screen.getByLabelText(/^Description/), 'Owners of the sandbox');
+    await submitDialog('Update');
 
     expect(updateMutate).toHaveBeenCalledTimes(1);
+    expect(updateMutate.mock.calls[0][0].body).toMatchObject({description: 'Owners of the sandbox'});
   });
 });

--- a/src/pages/groups/CreateUpdate.tsx
+++ b/src/pages/groups/CreateUpdate.tsx
@@ -347,9 +347,6 @@ function GroupDialog(props: GroupDialogProps) {
               multiline
               rows={4}
               rules={{maxLength: 1024}}
-              // `disabled`, like the name above: immutable for an owner group, so it is left out
-              // of the partial update rather than submitted unchanged.
-              disabled={props.app_owner_group}
               parseError={(error) => {
                 if (error?.message != '') {
                   return error?.message ?? '';

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -22,6 +22,7 @@ from api.models import (
     RoleGroupMap,
     Tag,
 )
+from api.models.app_group import app_owners_group_description
 from api.operations import ModifyGroupUsers, ModifyRoleGroups
 from api.services import okta
 from tests.factories import (
@@ -1154,3 +1155,111 @@ async def test_get_apps_q_via_http(client: AsyncClient, db: Db, url_for: Any) ->
     names = [a["name"] for a in rep.json()["items"]]
     assert "ZelaPaymentsApp" in names
     assert "LoggingApp" not in names
+
+
+async def test_put_app_rename_refreshes_an_unedited_owner_group_description(
+    client: AsyncClient, db: Db, mocker: MockerFixture, access_app: App, url_for: Any
+) -> None:
+    """A rename keeps the seeded default naming the app it belongs to."""
+    db.session.add(access_app)
+    await db.session.commit()
+    owner_group = AppGroupFactory.build(
+        app_id=access_app.id,
+        is_owner=True,
+        name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{access_app.name}"
+        f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
+        description=app_owners_group_description(access_app.name),
+    )
+    db.session.add(owner_group)
+    await db.session.commit()
+    owner_group_id = owner_group.id
+
+    mocker.patch.object(okta, "update_group")
+    rep = await client.put(
+        url_for("api-apps.app_by_id", app_id=access_app.id),
+        json=UpdateAppBodyFactory.json(name="RenamedApp", description=access_app.description),
+    )
+    assert rep.status_code == 200
+
+    db.session.expire_all()
+    refreshed = await db.session.get(AppGroup, owner_group_id)
+    assert refreshed is not None
+    assert refreshed.description == app_owners_group_description("RenamedApp")
+
+
+async def test_put_app_rename_leaves_an_edited_owner_group_description_alone(
+    client: AsyncClient, db: Db, mocker: MockerFixture, access_app: App, url_for: Any
+) -> None:
+    """Text somebody chose survives a rename; a rename is not a reason to overwrite it."""
+    db.session.add(access_app)
+    await db.session.commit()
+    edited = "Owners of the billing stack, and approvers for its quarterly access review."
+    owner_group = AppGroupFactory.build(
+        app_id=access_app.id,
+        is_owner=True,
+        name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{access_app.name}"
+        f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
+        description=edited,
+    )
+    db.session.add(owner_group)
+    await db.session.commit()
+    owner_group_id = owner_group.id
+
+    mocker.patch.object(okta, "update_group")
+    rep = await client.put(
+        url_for("api-apps.app_by_id", app_id=access_app.id),
+        json=UpdateAppBodyFactory.json(name="RenamedApp", description=access_app.description),
+    )
+    assert rep.status_code == 200
+
+    db.session.expire_all()
+    refreshed = await db.session.get(AppGroup, owner_group_id)
+    assert refreshed is not None
+    assert refreshed.description == edited
+    # The name is structural and still tracks the app.
+    assert refreshed.name.startswith(f"{AppGroup.APP_GROUP_NAME_PREFIX}RenamedApp")
+
+
+async def test_create_app_seeds_a_description_only_on_a_blank_absorbed_owner_group(
+    client: AsyncClient,
+    db: Db,
+    mocker: MockerFixture,
+    faker: Faker,  # type: ignore[type-arg]
+    url_for: Any,
+) -> None:
+    """Absorbing a pre-existing group keeps its description; a blank one gets the default.
+
+    The default matters where an operator has REQUIRE_DESCRIPTIONS set, since an absorbed
+    group would otherwise become an owner group with nothing in its description.
+    """
+    mocker.patch.object(
+        okta,
+        "create_group",
+        side_effect=lambda name, desc: Group.from_dict({"id": cast(FakerWithPyStr, faker).pystr()}),
+    )
+    mocker.patch.object(okta, "add_user_to_group")
+    mocker.patch.object(okta, "add_owner_to_group")
+    mocker.patch.object(okta, "update_group")
+
+    def owner_group_name(app_name: str) -> str:
+        return (
+            f"{AppGroup.APP_GROUP_NAME_PREFIX}{app_name}"
+            f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}"
+        )
+
+    existing_text = "Runs the payments on-call rotation."
+    await OktaGroupFactory.create_async(name=owner_group_name("Payments"), description=existing_text)
+    await OktaGroupFactory.create_async(name=owner_group_name("Billing"), description="")
+
+    apps_url = url_for("api-apps.apps")
+    assert (await client.post(apps_url, json={"name": "Payments"})).status_code == 201
+    assert (await client.post(apps_url, json={"name": "Billing"})).status_code == 201
+
+    db.session.expire_all()
+    kept = (await db.session.scalars(select(AppGroup).where(AppGroup.name == owner_group_name("Payments")))).first()
+    assert kept is not None
+    assert kept.description == existing_text
+
+    seeded = (await db.session.scalars(select(AppGroup).where(AppGroup.name == owner_group_name("Billing")))).first()
+    assert seeded is not None
+    assert seeded.description == app_owners_group_description("Billing")

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -38,9 +38,11 @@ from tests.factories import (
     OktaUserGroupMemberFactory,
     RoleGroupFactory,
 )
+from api.models.app_group import app_owners_group_description
 from tests.helpers import db_count
 from tests.request_factories import (
     AppGroupCreateBodyFactory,
+    AppGroupUpdateBodyFactory,
     GroupMemberFactory,
     OktaGroupCreateBodyFactory,
     OktaGroupUpdateBodyFactory,
@@ -327,14 +329,12 @@ async def test_put_group(
     rep = await client.put(group_url, json=data)
     assert rep.status_code == 400
 
-    # Updating tags is allowed, but nothing else
+    # Tags may be updated. The payload has to be type-correct and free of a rename: an
+    # owner group's type, name and app binding are structural, and a request carrying any
+    # of them is rejected outright rather than having them quietly ignored.
     update_group_spy.reset_mock()
-    data.update(
-        {
-            "tags_to_add": [tag_id],
-        }
-    )
-    rep = await client.put(group_url, json=data)
+    tags_only: dict[str, Any] = AppGroupUpdateBodyFactory.json(tags_to_add=[tag_id])
+    rep = await client.put(group_url, json=tags_only)
     assert rep.status_code == 200
     assert update_group_spy.call_count == 0
 
@@ -346,12 +346,8 @@ async def test_put_group(
     assert await db_count(db.session, select(OktaGroupTagMap).where(OktaGroupTagMap.ended_at.is_(None))) == 1
 
     update_group_spy.reset_mock()
-    data.update(
-        {
-            "tags_to_remove": [tag_id],
-        }
-    )
-    rep = await client.put(group_url, json=data)
+    tags_only = AppGroupUpdateBodyFactory.json(tags_to_remove=[tag_id])
+    rep = await client.put(group_url, json=tags_only)
     assert rep.status_code == 200
     assert update_group_spy.call_count == 0
 
@@ -2040,3 +2036,83 @@ async def test_get_group_member_details_search_paginates(client: AsyncClient, db
     assert set(emails1).isdisjoint(emails2)
     assert all(e.startswith("match-") for e in emails1 + emails2)
     assert sorted(emails1 + emails2) == [f"match-{i:02d}@example.com" for i in range(15)]
+
+
+async def test_put_group_app_owner_group_description_is_editable(
+    client: AsyncClient, db: Db, mocker: MockerFixture, url_for: Any
+) -> None:
+    """An owner group's description is ordinary free text, editable like any other group's."""
+    owner_app = AppFactory.build()
+    owner_group = AppGroupFactory.build(
+        app_id=owner_app.id,
+        is_owner=True,
+        name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{owner_app.name}"
+        f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
+        description=app_owners_group_description(owner_app.name),
+    )
+    db.session.add_all([owner_app, owner_group])
+    await db.session.commit()
+    owner_group_id = owner_group.id
+
+    mocker.patch.object(okta, "update_group")
+    edited = "Owners of the billing stack; also approvers for its quarterly access review."
+    rep = await client.put(
+        url_for("api-groups.group_by_id", group_id=owner_group_id),
+        json=AppGroupUpdateBodyFactory.json(description=edited),
+    )
+    assert rep.status_code == 200
+    assert rep.json()["description"] == edited
+
+    db.session.expire_all()
+    refreshed = await db.session.get(AppGroup, owner_group_id)
+    assert refreshed is not None
+    assert refreshed.description == edited
+
+
+async def test_put_group_app_owner_group_structural_fields_stay_locked(
+    client: AsyncClient, db: Db, mocker: MockerFixture, url_for: Any
+) -> None:
+    """Name, type, app binding and plugin config are structural for an owner group.
+
+    Membership in one confers app-owner permissions, so none of these may be changed
+    through the group endpoint even though the description now can be.
+    """
+    owner_app = AppFactory.build()
+    other_app = AppFactory.build()
+    owner_group = AppGroupFactory.build(
+        app_id=owner_app.id,
+        is_owner=True,
+        name=f"{AppGroup.APP_GROUP_NAME_PREFIX}{owner_app.name}"
+        f"{AppGroup.APP_NAME_GROUP_NAME_SEPARATOR}{AppGroup.APP_OWNERS_GROUP_NAME_SUFFIX}",
+        description=app_owners_group_description(owner_app.name),
+    )
+    db.session.add_all([owner_app, other_app, owner_group])
+    await db.session.commit()
+    owner_group_id = owner_group.id
+    original_name = owner_group.name
+    original_app_id = owner_group.app_id
+    other_app_id = other_app.id
+
+    mocker.patch.object(okta, "update_group")
+    group_url = url_for("api-groups.group_by_id", group_id=owner_group_id)
+
+    rename = await client.put(group_url, json=AppGroupUpdateBodyFactory.json(name="App-Whatever-Renamed"))
+    assert rename.status_code == 400
+
+    retype = await client.put(group_url, json=OktaGroupUpdateBodyFactory.json(name=original_name))
+    assert retype.status_code == 400
+
+    rebind = await client.put(group_url, json=AppGroupUpdateBodyFactory.json(app_id=other_app_id))
+    assert rebind.status_code == 400
+
+    plugin = await client.put(group_url, json=AppGroupUpdateBodyFactory.json(plugin_data={"some_plugin": {"a": 1}}))
+    assert plugin.status_code == 400
+
+    # Nothing was applied by any of the four rejected requests.
+    db.session.expire_all()
+    refreshed = await db.session.get(AppGroup, owner_group_id)
+    assert refreshed is not None
+    assert refreshed.name == original_name
+    assert refreshed.app_id == original_app_id
+    assert refreshed.type == "app_group"
+    assert not refreshed.plugin_data


### PR DESCRIPTION
# Summary
An app owner group's description is now ordinary free text, seeded with the existing `Owners of the {app name} application` default at app creation and editable afterwards like any other group's.

**Urgency**: LOW - 1 week?
**Expected review effort**: LOW

# Motivation
Owner groups sometimes carry app-level permissions beyond "owns this app", and there was nowhere to record that. The description was composed at app creation, rewritten on every app rename, and `PUT /api/groups/{id}` refused every non-tag edit for owner groups.

The boilerplate stays *stored* rather than becoming a read-time decoration, so it still reaches Okta and still satisfies `REQUIRE_DESCRIPTIONS` — it just stops being an invariant.

<details>
<summary><h1>Description of Changes</h1></summary>

**What stays locked.** Name, type, and app binding. Membership in an owner group confers app-owner permissions, so those are structural.

**Renames.** The rename refreshes the description only while it still holds the seeded default verbatim; anything else is text somebody chose, and a rename is not a reason to overwrite it. Non-owner app groups already behaved this way — the rename loop passes them `description=None`, which `ModifyGroupDetails` leaves untouched. Owner groups now follow the same rule once edited.

The alternative was to never touch it, which is more predictable but leaves a stale app name sitting in text nobody wrote. This costs one equality check.

**App creation.** Absorbing a pre-existing group now seeds a description only when that group has none, preserving any text it already had, so an owner group is never left blank where an operator has `REQUIRE_DESCRIPTIONS` set.

**Two guards this change makes necessary.**

Owner groups are excluded from the rebind-authorization block, and the owner-group guard compares `app_id` against the value captured at load rather than the live attribute. That block mutates `group.app_id` in memory *before* the guard runs. Harmless while every owner-group edit was rejected — the 400 rolled it back — but once a description edit can commit, the mutation would commit with it, and `get_app_managers` selects owners by `(app_id, is_owner)`, so it would hand one app's owner permissions to another app's owner group.

A `plugin_data` change on an owner group is now rejected explicitly. It was silently discarded whenever it accompanied a tag change, and owner groups do participate in lifecycle plugins, so that was meaningful config loss rather than a cosmetic no-op.

**One behaviour change worth knowing.** With the field editable, `REQUIRE_DESCRIPTIONS` applies to owner groups exactly as it does to every other group: an empty description is blocked. There's no trap, because the user can now reach the field to fix it.
</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

- Backend **952 passed, 0 failed**; frontend **45 passed**; `make ruff`, `make ty`, `tsc --noEmit` all clean.
- Every behavioural claim is mutation-tested — the code was made wrong, the covering test confirmed to fail, then restored:
  - unconditional overwrite on rename → the "leaves an edited description alone" test fails
  - never touch on rename → the "refreshes an unedited description" test fails
  - drop **both** rebind defences → the structural-fields test fails
  - drop the `plugin_data` guard → the structural-fields test fails
  - don't apply the description edit → the editable test fails
  - seed unconditionally / never seed on absorption → the seeding test fails each way
  - re-disable the frontend field → three frontend tests fail
- The frontend test file now pins `requireDescriptions` via a partial mock instead of inheriting it from a developer's `.env`; verified the suite passes with `.env` moved aside.

**Note on a suite failure you may see locally.** `tests/test_spa.py::test_missing_asset_returns_404_not_the_spa_shell` fails whenever a real `build/` directory exists in the checkout. That's a pre-existing test-isolation bug, not this branch: it reproduces on pristine `main` with a `build/` present, and this branch touches neither `api/app.py` nor `tests/test_spa.py`. `build/` is gitignored and CI never runs the Vite build, so CI is unaffected. Filed separately.
</details>

# Guidance for Reviewers
Small enough to read as a single diff.

Key judgments worth a second opinion:
- The rename rule: refreshing the description only while it exactly matches the seeded default as opposed to e.g. find-and-replace the app name or clobber with new boilerplate
- Whether it's important to ensure boilerplate remains in the description. This approach replaces #637, which took the opposite tack, keeping the boilerplate as an enforced invariant, with validation, a shared reseat rule, overflow pre-flights, and a cross-language pin test. This PR does much the same job in about a tenth of the code.
