### PR TITLE
Answer for the tags an app group inherits when approving a request

### DIFF
--- a/src/pages/group_requests/Create.test.tsx
+++ b/src/pages/group_requests/Create.test.tsx
@@ -1,0 +1,91 @@
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {describe, expect, it, vi, beforeEach} from 'vitest';
+
+import {AppDetail, OktaUserDetail} from '../../api/apiSchemas';
+
+const APP_TAG = {id: 'sox-tag-00000000000', name: 'SOX', constraints: {owner_time_limit: 7776000}};
+
+// The app carries a tag of its own, which `CreateGroup` copies onto every group
+// created under it whether or not the requester picks it.
+const APP = {
+  id: 'zendesk-sandbox-0000',
+  name: 'HammerAndChiselZendeskSandbox',
+  active_app_tags: [{active_tag: APP_TAG}],
+} as unknown as AppDetail;
+
+const USER = {id: 'user-000000000000', email: 'dana@example.com'} as unknown as OktaUserDetail;
+
+const constraintsAskedFor = vi.fn();
+// The owner-side limit the app's tag imposes, as the reader would report it.
+const OWNER_LIMIT_SECONDS = 7776000;
+let reportLimit = true;
+
+vi.mock('react-router-dom', () => ({useNavigate: () => vi.fn()}));
+
+vi.mock('../../constraints', () => ({
+  timeLimitLabel: (seconds: number) => `${seconds / 86400} days`,
+  useConstraintsForTags: (ids: string[]) => {
+    constraintsAskedFor(ids);
+    return {
+      pending: false,
+      error: null,
+      blocked: false,
+      timeLimit: () => (reportLimit ? OWNER_LIMIT_SECONDS : null),
+      isReasonRequired: () => false,
+      isSelfAddDisallowed: () => false,
+      forGroup: () => ({timeLimit: () => null, isReasonRequired: () => false, isSelfAddDisallowed: () => false}),
+    };
+  },
+}));
+
+vi.mock('../../api/apiComponents', () => ({
+  useGroupRequestsCreate: () => ({mutate: vi.fn()}),
+  useApps: () => ({data: {items: [APP]}}),
+  useAppById: () => ({data: APP, isLoading: false}),
+  useTags: () => ({data: {items: []}}),
+}));
+
+import CreateRequest from './Create';
+
+beforeEach(() => {
+  constraintsAskedFor.mockClear();
+  reportLimit = true;
+});
+
+const lastConstraintQuery = (): string[] => constraintsAskedFor.mock.calls.at(-1)![0];
+
+async function openDialogAndPickApp() {
+  render(<CreateRequest currentUser={USER} open setOpen={() => {}} />);
+  await userEvent.click(await screen.findByRole('combobox', {name: 'Group Type'}));
+  await userEvent.click(await screen.findByRole('option', {name: 'App Group'}));
+  await userEvent.click(await screen.findByRole('combobox', {name: 'App'}));
+  await userEvent.click(await screen.findByRole('option', {name: APP.name}));
+}
+
+// A group created under an app carries that app's tags, so the durations this
+// form offers have to answer for them. Nothing rejects a request that exceeds
+// them -- `ApproveGroupRequest` shortens it on approval -- so a duration left on
+// offer is one the requester is told they asked for and does not get.
+describe('tags a requested app group would inherit', () => {
+  it('asks about them alongside the tags the requester picked', async () => {
+    await openDialogAndPickApp();
+    await waitFor(() => expect(lastConstraintQuery()).toContain(APP_TAG.id));
+  });
+
+  it('shows them as belonging to the app rather than as a choice', async () => {
+    await openDialogAndPickApp();
+    expect(await screen.findByText(`Also inherited from ${APP.name}:`)).toBeInTheDocument();
+    expect(screen.getByText(APP_TAG.name)).toBeInTheDocument();
+  });
+
+  it('stops offering a duration the inherited limit forbids', async () => {
+    await openDialogAndPickApp();
+    const select = await screen.findByRole('combobox', {name: 'Requested ownership length'});
+    await waitFor(() => expect(select).not.toHaveTextContent('Indefinite'));
+    await userEvent.click(select);
+    const offered = screen.getAllByRole('option').map((option) => option.textContent);
+    expect(offered).not.toContain('Indefinite');
+    expect(offered).toContain('90 Days');
+  });
+});

--- a/src/pages/group_requests/Create.tsx
+++ b/src/pages/group_requests/Create.tsx
@@ -21,6 +21,7 @@ import Typography from '@mui/material/Typography';
 
 import {FormContainer, AutocompleteElement, SelectElement, TextFieldElement} from 'react-hook-form-mui';
 import {DatePickerElement} from 'react-hook-form-mui/date-pickers';
+import {useFormContext, useWatch} from 'react-hook-form';
 
 import {
   useGroupRequestsCreate,
@@ -36,11 +37,14 @@ import {
   AppDetail,
   AppGroupDetail,
   AppSummary,
+  AppTagMapDetail,
   OktaUserDetail,
   GroupDetail,
   GroupRequestDetail,
   TagDetail,
+  TagSummary,
 } from '../../api/apiSchemas';
+import {timeLimitLabel, useConstraintsForTags} from '../../constraints';
 import {isAccessAdmin, isAppOwnerGroupOwner} from '../../authorization';
 import accessConfig, {requireDescriptions} from '../../config/accessConfig';
 
@@ -53,6 +57,53 @@ const GROUP_TYPE_ID_TO_LABELS: Record<string, string> = {
 } as const;
 
 const GROUP_TYPE_OPTIONS = Object.entries(GROUP_TYPE_ID_TO_LABELS).map(([id, label]) => ({id, label}));
+
+// Offers only the durations the tags in force allow, and moves the field off
+// one they do not. A request the constraints forbid is not refused on submit --
+// `ApproveGroupRequest` shortens it on approval instead -- so a duration left
+// on offer here is one the requester is told they asked for and does not get.
+function OwnershipLengthField({
+  timeLimit,
+  blocked,
+  onChange,
+}: {
+  timeLimit: number | null;
+  blocked: boolean;
+  onChange: (value: string) => void;
+}) {
+  const {control, setValue} = useFormContext();
+  const selected = useWatch({control, name: 'ownershipUntil'});
+
+  const [options, defaultId] = React.useMemo<[Array<{id: string; label: string}>, string]>(() => {
+    // While the answer is unknown the limit reads as null. Holding the narrower
+    // list rather than re-offering the full one keeps a duration the tags forbid
+    // from being briefly clickable.
+    if (timeLimit == null) {
+      return blocked ? [[], accessConfig.DEFAULT_ACCESS_TIME] : [UNTIL_OPTIONS, accessConfig.DEFAULT_ACCESS_TIME];
+    }
+    const [lastId, filtered] = filterUntilLabels(timeLimit);
+    return [filtered, lastId];
+  }, [timeLimit, blocked]);
+
+  React.useEffect(() => {
+    if (timeLimit == null) return;
+    if (!options.some((option) => option.id === selected)) {
+      setValue('ownershipUntil', defaultId);
+      onChange(defaultId);
+    }
+  }, [timeLimit, options, defaultId, selected, setValue, onChange]);
+
+  return (
+    <SelectElement
+      fullWidth
+      label="Requested ownership length"
+      name="ownershipUntil"
+      options={options}
+      onChange={(value) => onChange(value)}
+      required
+    />
+  );
+}
 
 const APP_GROUP_PREFIX = 'App-';
 const APP_NAME_APP_GROUP_SEPARATOR = '-';
@@ -69,6 +120,19 @@ const UNTIL_ID_TO_LABELS: Record<string, string> = {
 } as const;
 
 const UNTIL_OPTIONS = Object.entries(UNTIL_ID_TO_LABELS).map(([id, label]) => ({id, label}));
+
+const UNTIL_NUMERIC_ID_TO_LABELS: Record<string, string> = Object.fromEntries(
+  Object.entries(UNTIL_ID_TO_LABELS).filter(([key]) => !isNaN(Number(key))),
+);
+
+// The durations still on offer under `timeLimit`, and the longest of them.
+// Indefinite is not among them, and neither is any duration over the limit;
+// Custom stays, since its own picker is bounded separately.
+function filterUntilLabels(timeLimit: number): [string, Array<{id: string; label: string}>] {
+  const withinLimit = Object.entries(UNTIL_NUMERIC_ID_TO_LABELS).filter(([key]) => Number(key) <= timeLimit);
+  const labels = [...withinLimit, ['custom', 'Custom']].map(([id, label]) => ({id, label}));
+  return [withinLimit.at(-1)?.[0] ?? 'custom', labels];
+}
 
 interface CreateGroupRequestForm {
   type: 'okta_group' | 'app_group' | 'role_group';
@@ -161,6 +225,27 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
     {enabled: effectiveAppId != null},
   );
   const requestPluginId = pluginIdForApp(effectiveAppDetail);
+
+  // The tags `CreateGroup` will copy from the app onto the group, on top of the
+  // ones chosen here. `effectiveAppId` already covers both ways a request lands
+  // under an app, so a name typed with an "App-...-" prefix inherits them too.
+  // Tags chosen directly are left out: the Tags field is showing them, and the
+  // constraint reader deduplicates.
+  const inheritedAppTags = React.useMemo<TagSummary[]>(() => {
+    const chosen = new Set(selectedTags.map((tag) => tag.id));
+    const appTagMaps: AppTagMapDetail[] = effectiveAppDetail?.active_app_tags ?? [];
+    return appTagMaps
+      .map((mapping) => mapping.active_tag)
+      .filter((tag): tag is TagSummary => tag != null && !chosen.has(tag.id));
+  }, [effectiveAppDetail, selectedTags]);
+
+  // The group does not exist yet, so its constraints come from the tags it
+  // would be created with rather than from an id.
+  const constraints = useConstraintsForTags([
+    ...selectedTags.map((tag) => tag.id),
+    ...inheritedAppTags.map((tag) => tag.id),
+  ]);
+  const ownershipTimeLimit = constraints.timeLimit(true);
 
   const {data: tagSearchData} = useTags({
     queryParams: {page: 1, size: 10, q: tagSearchInput},
@@ -344,17 +429,33 @@ function CreateRequestContainer(props: CreateRequestContainerProps) {
             }
             renderInput={(params) => <TextField {...params} label="Tags" placeholder="Tags" />}
           />
+          {/* Shown outside the Tags field because these are not the requester's
+              to choose or remove: the group picks them up from its app. */}
+          {inheritedAppTags.length > 0 && (
+            <Box sx={{marginTop: '8px'}}>
+              <Typography variant="caption" color="text.secondary">
+                Also inherited from {effectiveAppDetail?.name}:
+              </Typography>
+              <Box sx={{display: 'flex', flexWrap: 'wrap', gap: '4px', marginTop: '4px'}}>
+                {inheritedAppTags.map((tag) => (
+                  <Chip key={tag.id} size="small" variant="outlined" label={tag.name} />
+                ))}
+              </Box>
+            </Box>
+          )}
         </FormControl>
         <FormControl margin="normal" fullWidth>
-          <Grid container alignItems="center" spacing={2}>
+          {ownershipTimeLimit != null && (
+            <Typography variant="subtitle2" color="text.accent" sx={{marginBottom: '12px'}}>
+              {'Ownership is limited to ' + timeLimitLabel(ownershipTimeLimit) + ' by a tag constraint.'}
+            </Typography>
+          )}
+          <Grid container alignItems="flex-start" spacing={2}>
             <Grid item xs={6}>
-              <SelectElement
-                fullWidth
-                label="Requested ownership length"
-                name="ownershipUntil"
-                options={UNTIL_OPTIONS}
-                onChange={(value) => setOwnershipUntil(value)}
-                required
+              <OwnershipLengthField
+                timeLimit={ownershipTimeLimit}
+                blocked={constraints.blocked}
+                onChange={setOwnershipUntil}
               />
             </Grid>
             <Grid item xs={6}>

--- a/src/pages/group_requests/Read.test.tsx
+++ b/src/pages/group_requests/Read.test.tsx
@@ -209,7 +209,7 @@ describe('tags an app group inherits from its app', () => {
   it('shows them as belonging to the app rather than as a choice', async () => {
     renderPage();
 
-    expect(await screen.findByText(`Also inherited from ${APP.name}`)).toBeInTheDocument();
+    expect(await screen.findByText(`Also inherited from ${APP.name}:`)).toBeInTheDocument();
     expect(screen.getByText(APP_TAG.name)).toBeInTheDocument();
   });
 
@@ -241,6 +241,6 @@ describe('tags an app group inherits from its app', () => {
     await userEvent.click(await screen.findByRole('option', {name: 'Group'}));
 
     await waitFor(() => expect(lastConstraintQuery()).not.toContain(APP_TAG.id));
-    expect(screen.queryByText(`Also inherited from ${APP.name}`)).not.toBeInTheDocument();
+    expect(screen.queryByText(`Also inherited from ${APP.name}:`)).not.toBeInTheDocument();
   });
 });

--- a/src/pages/group_requests/Read.test.tsx
+++ b/src/pages/group_requests/Read.test.tsx
@@ -4,10 +4,20 @@ import userEvent from '@testing-library/user-event';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 
 import {AppDetail, GroupRequestDetail, OktaUserDetail} from '../../api/apiSchemas';
+import {ACCESS_APP_RESERVED_NAME} from '../../authorization';
 
 const resolveMutate = vi.fn();
 
-const APP = {id: 'zendesk-sandbox-0000', name: 'HammerAndChiselZendeskSandbox'} as unknown as AppDetail;
+const APP_TAG = {id: 'sox-tag-00000000000', name: 'SOX'};
+
+// The app carries a tag of its own. `CreateGroup` copies it onto every group
+// created under the app, so it binds the new group whether or not the approver
+// picks it.
+const APP = {
+  id: 'zendesk-sandbox-0000',
+  name: 'HammerAndChiselZendeskSandbox',
+  active_app_tags: [{active_tag: APP_TAG}],
+} as unknown as AppDetail;
 
 // A tag the request names. The tag *list* mock below returns nothing, so this
 // can only be resolved by asking for it by id.
@@ -53,12 +63,15 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
-vi.mock('../../authentication', () => ({useCurrentUser: () => APP_OWNER}));
+let currentUser: OktaUserDetail = APP_OWNER;
+vi.mock('../../authentication', () => ({useCurrentUser: () => currentUser}));
 
-// The page asks the constraints endpoint what the selected tags impose, which
-// needs a QueryClient this render does not provide. Stand in a resolved reader,
-// restricting nothing unless a test sets an owner-side limit.
+// The page asks the constraints endpoint what the tags impose, which needs a
+// QueryClient this render does not provide. Stand in a resolved reader that
+// restricts nothing unless a test sets an owner-side limit, and record the ids
+// it is asked about so the tests below can assert which tags it covers.
 let ownerTimeLimit: number | null = null;
+const constraintsAskedFor = vi.fn();
 vi.mock('../../constraints', () => {
   const reader = () => ({
     timeLimit: (isOwner: boolean) => (isOwner ? ownerTimeLimit : null),
@@ -67,13 +80,16 @@ vi.mock('../../constraints', () => {
   });
   return {
     timeLimitLabel: (seconds: number) => `${seconds / 86400} days`,
-    useConstraintsForTags: () => ({
-      pending: false,
-      error: null,
-      blocked: false,
-      ...reader(),
-      forGroup: reader,
-    }),
+    useConstraintsForTags: (ids: string[]) => {
+      constraintsAskedFor(ids);
+      return {
+        pending: false,
+        error: null,
+        blocked: false,
+        ...reader(),
+        forGroup: reader,
+      };
+    },
   };
 });
 
@@ -103,8 +119,13 @@ const renderPage = () =>
 
 beforeEach(() => {
   resolveMutate.mockClear();
+  constraintsAskedFor.mockClear();
+  currentUser = APP_OWNER;
   ownerTimeLimit = null;
 });
+
+// The last id set the page asked about, which is what it will act on.
+const lastConstraintQuery = (): string[] => constraintsAskedFor.mock.calls.at(-1)![0];
 
 describe('an app owner approving an app group request', () => {
   // The Type select is locked for a non-admin approver. `submit` derives the resolved
@@ -169,5 +190,57 @@ describe('an ownership duration the tag forbids', () => {
     const select = screen.getByRole('combobox', {name: /Ownership Ending At/});
     await waitFor(() => expect(select).toHaveTextContent('90 Days'));
     expect(select).not.toHaveTextContent('Indefinite');
+  });
+});
+
+// A group created under an app carries that app's tags on top of the ones the
+// approver picks, so the approval form has to answer for both: the durations it
+// offers come from the constraints it asked about, and `ApproveGroupRequest`
+// shortens the granted ownership against the tags the group actually ends up
+// with.
+describe('tags an app group inherits from its app', () => {
+  it('asks about them alongside the tags the approver picked', async () => {
+    renderPage();
+
+    await screen.findByRole('button', {name: /Approve/});
+    await waitFor(() => expect(lastConstraintQuery()).toContain(APP_TAG.id));
+  });
+
+  it('shows them as belonging to the app rather than as a choice', async () => {
+    renderPage();
+
+    expect(await screen.findByText(`Also inherited from ${APP.name}`)).toBeInTheDocument();
+    expect(screen.getByText(APP_TAG.name)).toBeInTheDocument();
+  });
+
+  it('leaves them out of the resolved tags, which the app supplies on its own', async () => {
+    renderPage();
+
+    const approve = await screen.findByRole('button', {name: /Approve/});
+    await userEvent.click(approve);
+
+    await waitFor(() => expect(resolveMutate).toHaveBeenCalledTimes(1));
+    // Submitting them would write a second tag map with no link to the app, so
+    // the tag would stay on the group after being removed from the app.
+    expect(resolveMutate.mock.calls[0][0].body.resolved_group_tags).not.toContain(APP_TAG.id);
+  });
+
+  it('stops asking about them once the type is no longer an app group', async () => {
+    // Only an Access admin can change the type; an app owner's select is read-only.
+    currentUser = {
+      ...APP_OWNER,
+      active_group_memberships: [
+        {active_group: {type: 'app_group', is_owner: true, app: {name: ACCESS_APP_RESERVED_NAME}}},
+      ],
+    } as unknown as OktaUserDetail;
+    renderPage();
+
+    await waitFor(() => expect(lastConstraintQuery()).toContain(APP_TAG.id));
+
+    await userEvent.click(await screen.findByRole('combobox', {name: 'Type'}));
+    await userEvent.click(await screen.findByRole('option', {name: 'Group'}));
+
+    await waitFor(() => expect(lastConstraintQuery()).not.toContain(APP_TAG.id));
+    expect(screen.queryByText(`Also inherited from ${APP.name}`)).not.toBeInTheDocument();
   });
 });

--- a/src/pages/group_requests/Read.tsx
+++ b/src/pages/group_requests/Read.tsx
@@ -953,7 +953,10 @@ export default function ReadGroupRequest() {
                                     }}
                                   />
                                 </FormControl>
-                                <Grid container columnSpacing={2} rowSpacing={0} alignItems="center">
+                                {/* Top-aligned, not centred: the Tags column grows when the
+                                    app contributes tags of its own, and centring would drop the
+                                    duration field below the field beside it. */}
+                                <Grid container columnSpacing={2} rowSpacing={0} alignItems="flex-start">
                                   {ownershipTimeLimit != null && (
                                     <Grid item xs={12}>
                                       <Typography variant="subtitle2" color="text.accent" sx={{pt: 1}}>

--- a/src/pages/group_requests/Read.tsx
+++ b/src/pages/group_requests/Read.tsx
@@ -56,8 +56,10 @@ import {
   GroupRequestDetail,
   OktaUserGroupMemberDetail,
   ResolveGroupRequestBody,
+  AppTagMapDetail,
   TagDetail,
   TagListItem,
+  TagSummary,
 } from '../../api/apiSchemas';
 import {useCurrentUser} from '../../authentication';
 import {isAccessAdmin, isAppOwnerGroupOwner} from '../../authorization';
@@ -222,15 +224,11 @@ export default function ReadGroupRequest() {
   const [appName, setAppName] = React.useState('');
   const [appSearchInput, setAppSearchInput] = React.useState('');
   const [selectedTags, setSelectedTags] = React.useState<TagListItem[]>([]);
+  // The app the approver has settled on, which is the requested one until they
+  // change it. Tracked by id because the group inherits that app's tags.
+  const [resolvedAppId, setResolvedAppId] = React.useState<string | null>(null);
   const [tagSearchInput, setTagSearchInput] = React.useState('');
   const [ownershipUntil, setOwnershipUntil] = React.useState<string | null>(null);
-
-  // The group being tagged does not exist yet, so there is no id to resolve
-  // constraints against — only the tags the approver has picked. That is what
-  // the endpoint's tag mode is for, and it keeps the coalescing on the server
-  // here too.
-  const tagConstraints = useConstraintsForTags(selectedTags.map((tag) => tag.id));
-  const ownershipTimeLimit = tagConstraints.timeLimit(true);
 
   const {data, isError, isLoading} = useGroupRequestById({
     pathParams: {groupRequestId: id ?? ''},
@@ -268,9 +266,46 @@ export default function ReadGroupRequest() {
   React.useEffect(() => {
     if (!appSeeded && requestedAppData?.name) {
       setAppName(requestedAppData.name);
+      setResolvedAppId(requestedAppData.id ?? null);
       setAppSeeded(true);
     }
   }, [requestedAppData, appSeeded]);
+
+  // Reloaded for the resolved app, which is the requested one until the
+  // approver picks another; the app search results carry no tags of their own.
+  // React Query serves the requested app from cache while the two agree.
+  const {data: resolvedAppData} = useAppById(
+    {pathParams: {appId: resolvedAppId ?? ''}},
+    {enabled: resolvedAppId != null && groupType === 'app_group'},
+  );
+
+  // The tags `CreateGroup` will copy from the app onto the new group. Only an
+  // app group inherits them, so a type the approver has switched away from
+  // `app_group` contributes none. Tags already chosen directly are left out:
+  // the Tags field is showing them, and the constraint reader deduplicates.
+  const inheritedAppTags = React.useMemo<TagSummary[]>(() => {
+    if (groupType !== 'app_group') return [];
+    const chosen = new Set(selectedTags.map((tag) => tag.id));
+    const appTagMaps: AppTagMapDetail[] = resolvedAppData?.active_app_tags ?? [];
+    return appTagMaps
+      .map((mapping) => mapping.active_tag)
+      .filter((tag): tag is TagSummary => tag != null && !chosen.has(tag.id));
+  }, [groupType, resolvedAppData, selectedTags]);
+
+  // The group being tagged does not exist yet, so there is no id to resolve
+  // constraints against — only the tags it will be created with. That is what
+  // the endpoint's tag mode is for, and it keeps the coalescing on the server
+  // here too.
+  //
+  // An app group carries the app's tags on top of the chosen ones, so both go
+  // in: asking about the chosen tags alone reports weaker constraints than
+  // creation applies, and the approver is offered durations that
+  // `ApproveGroupRequest` then quietly shortens.
+  const tagConstraints = useConstraintsForTags([
+    ...selectedTags.map((tag) => tag.id),
+    ...inheritedAppTags.map((tag) => tag.id),
+  ]);
+  const ownershipTimeLimit = tagConstraints.timeLimit(true);
 
   const isAppOwner = React.useMemo<boolean>(() => {
     if (admin || ownRequest || requestedGroupType !== 'app_group' || !requestedAppId) {
@@ -809,6 +844,7 @@ export default function ReadGroupRequest() {
                                         onChange={(value) => {
                                           setGroupType(value);
                                           setAppName('');
+                                          setResolvedAppId(null);
                                         }}
                                         required
                                         // `readOnly`, not `disabled`: react-hook-form omits a
@@ -835,8 +871,10 @@ export default function ReadGroupRequest() {
                                               option.id == value?.id,
                                             onInputChange: (_event: React.SyntheticEvent, newInputValue: string) =>
                                               setAppSearchInput(newInputValue),
-                                            onChange: (_event: React.SyntheticEvent, value: AppDetail | null) =>
-                                              setAppName(value?.name ?? ''),
+                                            onChange: (_event: React.SyntheticEvent, value: AppDetail | null) => {
+                                              setAppName(value?.name ?? '');
+                                              setResolvedAppId(value?.id ?? null);
+                                            },
                                             // `readOnly`, not `disabled`: react-hook-form clears a disabled field's value, and
                                             // rhf-mui forwards `autocompleteProps.disabled` into `useController`, so disabling
                                             // this would drop the app from the submitted form.
@@ -950,6 +988,23 @@ export default function ReadGroupRequest() {
                                           <TextField {...params} label="Tags" placeholder="Tags" />
                                         )}
                                       />
+                                      {/* Shown outside the Tags field because these are not
+                                          the approver's to choose or remove, and because only
+                                          the chosen ones are submitted: the group picks these
+                                          up from the app, and submitting them here would
+                                          write a second, direct tag that outlives the app's. */}
+                                      {inheritedAppTags.length > 0 && (
+                                        <Box sx={{marginTop: '8px'}}>
+                                          <Typography variant="caption" color="text.secondary">
+                                            Also inherited from {appName}
+                                          </Typography>
+                                          <Box sx={{display: 'flex', flexWrap: 'wrap', gap: '4px', marginTop: '4px'}}>
+                                            {inheritedAppTags.map((tag) => (
+                                              <Chip key={tag.id} size="small" variant="outlined" label={tag.name} />
+                                            ))}
+                                          </Box>
+                                        </Box>
+                                      )}
                                     </FormControl>
                                   </Grid>
                                 </Grid>

--- a/src/pages/group_requests/Read.tsx
+++ b/src/pages/group_requests/Read.tsx
@@ -999,7 +999,7 @@ export default function ReadGroupRequest() {
                                       {inheritedAppTags.length > 0 && (
                                         <Box sx={{marginTop: '8px'}}>
                                           <Typography variant="caption" color="text.secondary">
-                                            Also inherited from {appName}
+                                            Also inherited from {appName}:
                                           </Typography>
                                           <Box sx={{display: 'flex', flexWrap: 'wrap', gap: '4px', marginTop: '4px'}}>
                                             {inheritedAppTags.map((tag) => (


### PR DESCRIPTION
# Summary

The group request forms offered ownership durations without accounting for the tags a group inherits from its app. Both the approval form and the create form now ask about the chosen tags and the app's together, and show the inherited tags so the person deciding can see what will bind the group.

**Urgency**: LOW - this is a low-priority bugfix at the top of the stack and doesn't need to land with the rest
**Expected review effort**: LOW

# Motivation

`CreateGroup` copies an app's active tags onto every group created under it, on top of the tags chosen for that group. The approval form's preview covered only the chosen ones, so where the app supplied the tighter constraint the form offered ownership durations the tag forbids. `ApproveGroupRequest` resolves `resolved_ownership_ending_at` against the tags the group is actually created with, so the grant was then shortened with nothing said to the approver.

The create form was worse: it consulted no constraints at all, so it offered every duration including Indefinite regardless of any tag, chosen or inherited. Nothing rejects such a request -- the same resolution shortens it on approval -- so a requester was told they asked for indefinite ownership and quietly given less.

Raised by @matthew-bass in review of #620.

# UI Diff

## Approval form: before

The app's SOX tag caps owner time at 90 days, but the form knows nothing about it: Indefinite is offered and selected, and approving silently grants 90 days.

<img width="838" height="678" alt="image" src="https://github.com/user-attachments/assets/7f0159c5-d1ea-4806-9fee-980a823a0d0a" />

## Approval form: after

The limit is stated, the field holds the longest duration still allowed, and the inherited tag is listed under the ones chosen for the group.

<img width="838" height="768" alt="image" src="https://github.com/user-attachments/assets/b3bfb627-43a6-4117-9d11-aa9cf9519783" />

## Create form: before

The requester picks the app and a tag of their own, and is still offered every duration. Indefinite is selectable, and nothing hints that the app contributes a 90-day cap.

<img width="1200" height="1682" alt="image" src="https://github.com/user-attachments/assets/66db1296-f701-4e9e-bb18-8c14c0da51aa" />

## Create form: after

The same request, now answering for both sets of tags: the cap is stated, Indefinite is gone from the list, and the app's tag is named below the chosen one.

<img width="1200" height="1870" alt="image" src="https://github.com/user-attachments/assets/8e4c0c9f-df8a-4c13-bb1a-61e0a242cbc7" />

<details>
<summary><h1>Description of Changes</h1></summary>

The page already tracked the resolved app's *name*, for the group name preview. It now tracks the id too, and reloads that app to read its tags; React Query serves the requested app from cache while the approver has not changed it.

The inherited tags are rendered below the Tags field rather than inside it, and are kept out of `resolved_group_tags`. That separation is load-bearing: `CreateGroup` adds a direct tag map for every submitted tag and does not deduplicate against the ones it derived from the app, so submitting an inherited tag would write a second mapping with no link back to the app. The tag would then stay on the group after being removed from the app.

Both the preview and the display follow the *resolved* type and app, not the requested ones, since an approver can change either. A type switched away from `app_group` inherits nothing.

The second commit fixes what the first exposed. The Ownership Ending At field is seeded from the request and defaults to Indefinite, which a limit removes from the option list along with every duration over it. The correction only moved a numeric value that exceeded the limit, so Indefinite stayed put: the Select had no matching option and rendered blank, and the submit still said indefinite. It now moves off any value the list no longer offers. That was reachable before this PR whenever a *chosen* tag carried an owner limit; answering for the app's tags is what made it surface here.

The last commit brings the create form to the same footing. It already tracked the app a request would land under -- including the one detected from an `App-...-` name typed on a plain group -- and already fetched that app's detail for its lifecycle plugin, so the tags were on hand. It now narrows the offered durations and moves the field off one the limit forbids, exactly as the approval form does.
</details>

<details>
<summary><h1>Validation of Changes</h1></summary>

- Five tests in `src/pages/group_requests/Read.test.tsx` for the approval form: the inherited tags reaching the constraints query, their display, their exclusion from the submitted tags, the type gate dropping them, and the ownership field moving off Indefinite.
- Three in `src/pages/group_requests/Create.test.tsx` for the create form: the query, the display, and the narrowed duration list.
- Each was checked against the unfixed code, so none passes for the wrong reason -- reverting the union, removing the display, restoring the old numeric-only correction, and ignoring the limit when building the option list each fail the test that covers them. The submitted-tags test is the exception, asserting an absence and so passing either way by design.
- Verified against a local instance seeded with an app carrying a SOX tag and a pending app group request naming a different tag. All four screenshots are that instance.
- Full frontend suite: 139 passing.
</details>


