### PR TITLE
Build the frontend once so uploaded source maps match the served bundle

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,8 +5,9 @@ name: Build Docker Image
 # to main (after merge) and needs registry credentials to push.
 #
 # Deliberately secret-free so it runs on forked-PR builds too:
-#   - PUSH_SENTRY_RELEASE stays "false", so the Dockerfile's `sentry` stage is
-#     never in the build graph and the SENTRY_* secret mounts are never reached.
+#   - The SENTRY_* secrets are not mounted, so the frontend build leaves those
+#     variables unset, vite.config.ts skips @sentry/vite-plugin, and no source
+#     maps are generated or uploaded.
 #   - ACCESS_CONFIG_OVERRIDE is not mounted, so the frontend builds against
 #     config/config.default.json — the same path an open-source `docker build`
 #     takes.

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -48,7 +48,6 @@ jobs:
             us-east1-docker.pkg.dev/discord-access-prd/access/access:latest
           build-args: |
             SENTRY_RELEASE=${{ github.sha }}
-            PUSH_SENTRY_RELEASE=true
             INSTALL_GOOGLE_GROUP_LIFECYCLE_PLUGIN=true
           secrets: |
             "SENTRY_ORG=${{ secrets.SENTRY_ORG }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,3 @@
-# Build Arg on whether to push the sentry release or not
-# Default is false as it requires mounting a .sentryclirc secret file
-ARG PUSH_SENTRY_RELEASE="false"
-
 # Build step #1: build the React front end
 FROM node:24-alpine AS build-step
 WORKDIR /app
@@ -19,36 +15,34 @@ RUN npm install
 RUN touch .env.production
 # Set Vite environment variables
 ENV VITE_API_SERVER_URL=""
-# Set Sentry plugin environment variables for production build
 ENV NODE_ENV=production
-# If a frontend config override (e.g. IdP deep-link URLs) is provided as a build
-# secret, write it where Vite's config loader picks it up; otherwise build against
-# config.default.json. The secret is absent for open-source builds, so plain
-# `docker build` still works.
+# The release the browser SDK reports on every event, and the release the uploaded source maps
+# are filed under. Empty for a plain `docker build`, which reports events with no release.
+ARG SENTRY_RELEASE=""
+ENV SENTRY_RELEASE=$SENTRY_RELEASE
+# One build produces both the assets that ship and the source maps that explain them. Uploading
+# from a second build would file maps against a bundle nobody serves: @sentry/vite-plugin injects
+# a debug id into every asset, which changes its content hash, so two builds of the same commit
+# disagree on the hashed filenames Sentry matches against.
+#
+# Every secret here is optional and none are available on forks, where the loop below leaves the
+# SENTRY_* variables unset, vite.config.ts skips the plugin, and this is an ordinary production
+# build with no source maps. Likewise ACCESS_CONFIG_OVERRIDE: without it the frontend builds
+# against config/config.default.json.
 RUN --mount=type=secret,id=ACCESS_CONFIG_OVERRIDE \
+  --mount=type=secret,id=SENTRY_AUTH_TOKEN \
+  --mount=type=secret,id=SENTRY_ORG \
+  --mount=type=secret,id=SENTRY_PROJECT \
   if [ -s /run/secrets/ACCESS_CONFIG_OVERRIDE ]; then \
     cp /run/secrets/ACCESS_CONFIG_OVERRIDE config/config.override.json; \
   fi; \
+  for secret in SENTRY_AUTH_TOKEN SENTRY_ORG SENTRY_PROJECT; do \
+    if [ -s "/run/secrets/$secret" ]; then export "$secret=$(cat "/run/secrets/$secret")"; fi; \
+  done; \
   ACCESS_CONFIG_FILE=$(test -f config/config.override.json && echo config.override.json) npm run build
 
-# Optional build step #2: upload source maps to Sentry
-FROM build-step AS sentry
-ARG SENTRY_RELEASE=""
-ENV SENTRY_RELEASE=$SENTRY_RELEASE
-# Use secret mount for SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_PROJECT
-RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN \
-  --mount=type=secret,id=SENTRY_ORG \
-  --mount=type=secret,id=SENTRY_PROJECT \
-  SENTRY_AUTH_TOKEN=$(cat /run/secrets/SENTRY_AUTH_TOKEN) \
-  SENTRY_ORG=$(cat /run/secrets/SENTRY_ORG) \
-  SENTRY_PROJECT=$(cat /run/secrets/SENTRY_PROJECT) \
-  ACCESS_CONFIG_FILE=$(test -f config/config.override.json && echo config.override.json) \
-  npm run build
-# Source maps are automatically uploaded and deleted by Vite Sentry plugin during build
-RUN touch sentry
-
-# Build step #3: build the API with the client as static files
-FROM python:3.13 AS false
+# Build step #2: build the API with the client as static files
+FROM python:3.13
 ARG SENTRY_RELEASE=""
 WORKDIR /app
 
@@ -118,14 +112,6 @@ RUN --mount=type=bind,source=examples/plugins,target=examples/plugins,rw \
     if [ "$INSTALL_HEALTH_CHECK_PLUGIN" = "true" ]; then install_plugin ./examples/plugins/health_check_plugin; else echo "Skipping health_check_plugin plugin"; fi; \
     if [ "$INSTALL_NOTIFICATIONS_PLUGIN" = "true" ]; then install_plugin ./examples/plugins/notifications; else echo "Skipping notifications plugin"; fi; \
     if [ "$INSTALL_SLACK_NOTIFICATIONS_PLUGIN" = "true" ]; then install_plugin ./examples/plugins/notifications_slack; else echo "Skipping notifications_slack plugin"; fi
-
-# Build an image that includes the optional sentry release push build step
-FROM false AS true
-COPY --from=sentry /app/sentry ./sentry
-
-# Final build step: copy the API and the client from the previous steps
-# Choose whether to include the sentry release push build step or not
-FROM ${PUSH_SENTRY_RELEASE}
 
 ENV ENV=production
 ENV SENTRY_RELEASE=$SENTRY_RELEASE

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -4,7 +4,8 @@ declare const REQUIRE_DESCRIPTIONS: boolean;
 
 interface ImportMetaEnv {
   readonly VITE_API_SERVER_URL: string;
-  readonly VITE_SENTRY_RELEASE: string;
+  // Undefined unless the build sets `SENTRY_RELEASE`; see the `define` in vite.config.ts.
+  readonly VITE_SENTRY_RELEASE: string | undefined;
   readonly MODE: string;
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,13 @@ export default defineConfig(({mode}) => {
   // Process environment variables take precedence over .env files
   const env = {...loadEnv(mode, process.cwd(), ''), ...process.env};
 
+  // One value stamps both the release the browser SDK reports and the release the uploaded
+  // source maps are filed under, so a report and its maps can never name different builds.
+  // `SENTRY_RELEASE` is the name to set: it is what the Sentry CLI and the vite plugin already
+  // read, and Vite only surfaces `VITE_`-prefixed vars to the client on its own, so the value
+  // is handed across explicitly in `define` below.
+  const sentryRelease = env.SENTRY_RELEASE || env.VITE_SENTRY_RELEASE || '';
+
   return {
     plugins: [
       react(),
@@ -65,7 +72,7 @@ export default defineConfig(({mode}) => {
                 filesToDeleteAfterUpload: './build/**/*.map',
               },
               release: {
-                name: env.SENTRY_RELEASE,
+                name: sentryRelease,
               },
             }),
           ]
@@ -88,6 +95,9 @@ export default defineConfig(({mode}) => {
       ACCESS_CONFIG: accessConfig,
       APP_NAME: JSON.stringify(env.APP_NAME || 'Access'),
       REQUIRE_DESCRIPTIONS: env.REQUIRE_DESCRIPTIONS?.toLowerCase() === 'true',
+      // `undefined` rather than `""` when unset: Sentry treats an empty-string release as a
+      // real release name and files every event under it.
+      'import.meta.env.VITE_SENTRY_RELEASE': sentryRelease ? JSON.stringify(sentryRelease) : 'undefined',
     },
     server: {
       port: 3000,


### PR DESCRIPTION
Frontend errors in Sentry arrive unsymbolicated even though source maps upload on every push to `main`. Two independent causes, both fixed here.

**The frontend was built twice, and the wrong build shipped.** `build-step` had no `SENTRY_AUTH_TOKEN`, so it skipped [`@sentry/vite-plugin`](https://www.npmjs.com/package/@sentry/vite-plugin) and emitted no maps, and its output is what the runtime image copies. A second `sentry` stage rebuilt *with* the plugin, uploaded, and discarded the build except for a marker file. That can never work: the plugin injects a [debug id](https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/debug-ids/) into each asset, changing its content hash, so two builds of the same commit disagree on the hashed filenames Sentry matches against. For one release the uploaded bundle described `index-WCb1vY9P.js` while production served `index-Dbcp0vxA.js`, leaving neither debug-id nor release-plus-filename matching anything to work with.

Mounting the `SENTRY_*` secrets on the single existing build removes the mismatch by construction and lets the `sentry`, `false`, `true` and `${PUSH_SENTRY_RELEASE}` stage indirection go with it. That indirection existed only to keep the second stage out of the build graph when secrets were absent, which conditional mounts already handle.

**The browser SDK sent no release.** `Sentry.init` reads `import.meta.env.VITE_SENTRY_RELEASE`, but the build sets `SENTRY_RELEASE`, and [Vite only exposes `VITE_`-prefixed variables](https://vite.dev/guide/env-and-mode.html#env-files) to client code, so every event reported `release: null`. Rather than introduce a second variable to keep in sync with the one the plugin and the Sentry CLI already read, `vite.config.ts` derives a single value and feeds both the SDK and the plugin's release name from it. It resolves to `undefined` rather than `""` when unset, because Sentry treats an empty string as a real release name and would file every event under it.

Two things fall out of collapsing the stages. The runtime `ENV SENTRY_RELEASE` in the final image always expanded to nothing, because `FROM ${PUSH_SENTRY_RELEASE}` began a stage where the `ARG` was out of scope; nothing reads it today, so this was latent. And the release pipeline drops a full second `npm run build`.

**Forks and plain `docker build` are unaffected.** Every secret stays optional: when they are absent the variables are left unset, `vite.config.ts` skips the plugin, and the result is an ordinary production build with no source maps. `docker-build.yml` is the merge-requirement check that proves this path still builds, and its header has been updated since it explained secret-freeness in terms of the now-removed build arg.

This does not address the React error the investigation started from, which is a separate MUI X Data Grid issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
