### PR TITLE
Drop the dead @mui/styled-engine tsconfig path override

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,6 @@
       "./src/globals.d.ts"
     ],
     "paths": {
-      "@mui/styled-engine": ["./node_modules/@mui/styled-engine-sc"],
       // `moduleResolution: node` predates `exports` maps, and react-hook-form-mui only
       // publishes this subpath through one. Vite and Node resolve it natively.
       "react-hook-form-mui/date-pickers": ["./node_modules/react-hook-form-mui/dist/date-pickers.d.ts"]

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "paths": {
-      "@mui/styled-engine": ["./node_modules/@mui/styled-engine-sc"],
       "react-hook-form-mui/date-pickers": ["./node_modules/react-hook-form-mui/dist/date-pickers.d.ts"]
     }
   }


### PR DESCRIPTION
# Summary
Removes the `@mui/styled-engine` path override from `tsconfig.json` and `tsconfig.paths.json`, which points at `@mui/styled-engine-sc` -- a package #647 removes from `package.json`.
**Urgency**: low
**Expected review effort**: LOW

# Motivation
Found while reviewing #647. Once that PR lands, `@mui/styled-engine-sc` no longer exists in `node_modules`, so this override points at a nonexistent directory. It doesn't currently break `tsc` (`skipLibCheck: true` skips resolving it -- verified `tsc --noEmit` exits 0 either way), but it's dead config that will confuse the next reader or an editor's language server that resolves `paths` more eagerly than `tsc` does.

`@mui/styled-engine` is a real package on its own (a transitive dependency of `@mui/material`/`@mui/system`) that already depends on Emotion's packages by default, so no replacement mapping is needed -- normal `node_modules` resolution is correct once the override is gone.

# Description of Changes
- `tsconfig.json` / `tsconfig.paths.json`: drop the `@mui/styled-engine` entry from `paths`. The `react-hook-form-mui/date-pickers` entry alongside it is unrelated and untouched.

# Validation of Changes
- `npx tsc --noEmit` -- exits 0, no errors, before and after this change
- `npx vitest run` -- 47/47 tests pass
- `npx prettier --check tsconfig.json tsconfig.paths.json` -- clean
- `npm run build` (production mode) -- builds clean

# Guidance for Reviewers
This is based on #647, not `main` -- `@mui/styled-engine-sc` is still real and in use on `main` today, so this override is only dead once #647 merges. Land after #647, or rebase onto `main` if #647's approach changes.