### PR TITLE
Give Emotion the CSP nonce so MUI's injected styles are not blocked

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -46,8 +46,9 @@ def _inject_csp_nonce(html: str, nonce: str) -> str:
     `script-src`/`style-src` authorize inline content by nonce (see
     `api.middleware.build_csp`), so every inline `<script>`/`<style>` the build
     emitted (e.g. Vite's module-preload polyfill) must carry the nonce, and
-    styled-components' runtime `<style>` injections are authorized by seeding
-    `window.__webpack_nonce__` before the app bundle runs. External same-origin
+    Emotion's runtime `<style>` injections are authorized by seeding
+    `window.__webpack_nonce__` before the app bundle runs, which the Emotion
+    cache in `src/index.tsx` reads. External same-origin
     bundles and `<link>` stylesheets need no nonce (they're covered by `'self'`
     / the font-host allowance), so this only touches inline tags.
     """

--- a/api/middleware.py
+++ b/api/middleware.py
@@ -43,9 +43,14 @@ def build_csp(nonce: str) -> str:
     `script-src`/`style-src` allow `'self'` plus a per-response nonce (see
     `SecurityHeadersMiddleware`, threaded into the served `index.html` by
     `api.app.serve_spa`): the nonce authorizes the inline bootstrap `<script>`
-    and styled-components' runtime `<style>` injections, while same-origin
+    and Emotion's runtime `<style>` injections, while same-origin
     bundles/stylesheets are covered by `'self'` and Google Fonts by its host
     allowance.
+
+    The frontend half of that contract is the Emotion cache built in
+    `src/index.tsx`, which reads the nonce off `window.__webpack_nonce__` and
+    stamps it on every element it inserts. Without it the browser rejects all
+    of MUI's styles and the app renders unstyled.
 
     Two classes of *benign* console warnings are expected under this policy and
     are intentionally not accommodated — silencing either would weaken the

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "access",
       "version": "1.0.0",
       "dependencies": {
+        "@emotion/cache": "^11.14.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mui/base": "^5.0.0-beta.28",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "@emotion/cache": "^11.14.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/base": "^5.0.0-beta.28",

--- a/src/cspNonce.test.tsx
+++ b/src/cspNonce.test.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import {describe, it, expect, afterEach} from 'vitest';
+import {render, cleanup} from '@testing-library/react';
+import createCache from '@emotion/cache';
+import {CacheProvider} from '@emotion/react';
+import Button from '@mui/material/Button';
+
+// The production `style-src` admits inline styles only by nonce, so every `<style>` element
+// MUI injects has to carry one or the browser drops it and the whole app renders unstyled.
+// Emotion only stamps the nonce when its cache was built with one, which is easy to lose in a
+// refactor of src/index.tsx and invisible to every other test, since jsdom enforces no CSP.
+//
+// This mirrors what src/index.tsx builds. Asserting on the real thing would mean importing the
+// entry point, which mounts the app and initialises Sentry as a side effect.
+const NONCE = 'test-nonce-value';
+
+afterEach(cleanup);
+
+describe('Emotion cache', () => {
+  it('stamps the CSP nonce on the style elements it injects', () => {
+    const cache = createCache({key: 'csp-test', nonce: NONCE});
+    render(
+      <CacheProvider value={cache}>
+        <Button variant="contained">Renew</Button>
+      </CacheProvider>,
+    );
+
+    const styles = document.querySelectorAll('style[data-emotion~="csp-test"]');
+    expect(styles.length).toBeGreaterThan(0);
+    styles.forEach((el) => expect(el.getAttribute('nonce')).toBe(NONCE));
+  });
+
+  it('omits the nonce when the shell did not publish one', () => {
+    const cache = createCache({key: 'csp-test-none', nonce: undefined});
+    render(
+      <CacheProvider value={cache}>
+        <Button variant="contained">Renew</Button>
+      </CacheProvider>,
+    );
+
+    const styles = document.querySelectorAll('style[data-emotion~="csp-test-none"]');
+    expect(styles.length).toBeGreaterThan(0);
+    styles.forEach((el) => expect(el.getAttribute('nonce')).toBeNull());
+  });
+});

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -12,3 +12,9 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+interface Window {
+  // The per-response CSP nonce, stamped into the SPA shell by `api.app.serve_spa`.
+  // Undefined under `vite dev`, which serves index.html without one.
+  __webpack_nonce__?: string;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,8 @@ import {createRoot} from 'react-dom/client';
 import {BrowserRouter} from 'react-router-dom';
 import {AdapterDayjs} from '@mui/x-date-pickers/AdapterDayjs';
 import {LocalizationProvider} from '@mui/x-date-pickers';
+import createCache from '@emotion/cache';
+import {CacheProvider} from '@emotion/react';
 import * as Sentry from '@sentry/react';
 
 import App from './App';
@@ -47,16 +49,27 @@ if (['production', 'staging'].includes(import.meta.env.MODE)) {
   });
 }
 
+// Every MUI component styles itself by injecting a `<style>` element at runtime, and the
+// production `style-src` admits inline styles only by nonce (see `build_csp` in
+// api/middleware.py). Emotion stamps the nonce on the elements it inserts, but only when the
+// cache is built with one, so this provider is what stands between the app and an entirely
+// unstyled page. `api.app.serve_spa` publishes the per-response nonce as
+// `window.__webpack_nonce__`; it is absent under `vite dev`, whose relaxed policy carries
+// 'unsafe-inline' instead.
+const emotionCache = createCache({key: 'css', nonce: window.__webpack_nonce__});
+
 createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <Sentry.ErrorBoundary fallback={<Error />} showDialog>
-      <BrowserRouter>
-        <QueryClientProvider client={queryClient}>
-          <LocalizationProvider dateAdapter={AdapterDayjs}>
-            <App />
-          </LocalizationProvider>
-        </QueryClientProvider>
-      </BrowserRouter>
-    </Sentry.ErrorBoundary>
+    <CacheProvider value={emotionCache}>
+      <Sentry.ErrorBoundary fallback={<Error />} showDialog>
+        <BrowserRouter>
+          <QueryClientProvider client={queryClient}>
+            <LocalizationProvider dateAdapter={AdapterDayjs}>
+              <App />
+            </LocalizationProvider>
+          </QueryClientProvider>
+        </BrowserRouter>
+      </Sentry.ErrorBoundary>
+    </CacheProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
The deployed app renders completely unstyled. Every `<style>` element MUI injects at runtime is rejected:

```
Applying inline style violates the following Content Security Policy directive
'style-src 'self' 'nonce-...' https://fonts.googleapis.com'.
```

`build_csp` admits inline styles only by nonce, and `serve_spa` publishes the per-response nonce as `window.__webpack_nonce__`. [styled-components read that global on its own](https://styled-components.com/docs/advanced#content-security-policy); Emotion does not. It stamps the nonce only on elements inserted through a cache that was [built with one](https://mui.com/material-ui/guides/content-security-policy/), so switching the style engine in #647 left every style unauthorized and the browser dropped all of them. Regression from that PR, not from the Data Grid work it was fixing.

Building the cache in the entry point and providing it through `CacheProvider` restores the contract. The nonce is absent under `vite dev`, whose relaxed policy carries `'unsafe-inline'` instead, so the cache simply omits it there and nothing changes for local development.

`src/cspNonce.test.tsx` covers both the present and absent cases. It mirrors the cache construction rather than importing the entry point, which would mount the app and initialise Sentry as a side effect. That is a real limitation worth naming: the test guards the mechanism, not the wiring in `src/index.tsx`.

**Verification.** jsdom enforces no CSP, so no unit test could have caught this and none can prove the fix. I served a production build behind a copy of the production policy, with the nonce injected exactly as `_inject_csp_nonce` does it. The build from `main` reproduced the unstyled page seen on the deployed environment, with the same `style-src` violations. With this change the page renders correctly, both Emotion style elements carry the document nonce, 293 rules apply, and there are no `style-src` violations.

Two docstrings that described the styled-components arrangement are updated to describe the current one, since they are the only place the nonce contract is written down.