### PR TITLE
Label managed Google groups as Workspace security groups

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -5,8 +5,9 @@ name: Build Docker Image
 # to main (after merge) and needs registry credentials to push.
 #
 # Deliberately secret-free so it runs on forked-PR builds too:
-#   - PUSH_SENTRY_RELEASE stays "false", so the Dockerfile's `sentry` stage is
-#     never in the build graph and the SENTRY_* secret mounts are never reached.
+#   - The SENTRY_* secrets are not mounted, so the frontend build leaves those
+#     variables unset, vite.config.ts skips @sentry/vite-plugin, and no source
+#     maps are generated or uploaded.
 #   - ACCESS_CONFIG_OVERRIDE is not mounted, so the frontend builds against
 #     config/config.default.json — the same path an open-source `docker build`
 #     takes.

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -48,7 +48,6 @@ jobs:
             us-east1-docker.pkg.dev/discord-access-prd/access/access:latest
           build-args: |
             SENTRY_RELEASE=${{ github.sha }}
-            PUSH_SENTRY_RELEASE=true
             INSTALL_GOOGLE_GROUP_LIFECYCLE_PLUGIN=true
           secrets: |
             "SENTRY_ORG=${{ secrets.SENTRY_ORG }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,3 @@
-# Build Arg on whether to push the sentry release or not
-# Default is false as it requires mounting a .sentryclirc secret file
-ARG PUSH_SENTRY_RELEASE="false"
-
 # Build step #1: build the React front end
 FROM node:24-alpine AS build-step
 WORKDIR /app
@@ -19,36 +15,34 @@ RUN npm install
 RUN touch .env.production
 # Set Vite environment variables
 ENV VITE_API_SERVER_URL=""
-# Set Sentry plugin environment variables for production build
 ENV NODE_ENV=production
-# If a frontend config override (e.g. IdP deep-link URLs) is provided as a build
-# secret, write it where Vite's config loader picks it up; otherwise build against
-# config.default.json. The secret is absent for open-source builds, so plain
-# `docker build` still works.
+# The release the browser SDK reports on every event, and the release the uploaded source maps
+# are filed under. Empty for a plain `docker build`, which reports events with no release.
+ARG SENTRY_RELEASE=""
+ENV SENTRY_RELEASE=$SENTRY_RELEASE
+# One build produces both the assets that ship and the source maps that explain them. Uploading
+# from a second build would file maps against a bundle nobody serves: @sentry/vite-plugin injects
+# a debug id into every asset, which changes its content hash, so two builds of the same commit
+# disagree on the hashed filenames Sentry matches against.
+#
+# Every secret here is optional and none are available on forks, where the loop below leaves the
+# SENTRY_* variables unset, vite.config.ts skips the plugin, and this is an ordinary production
+# build with no source maps. Likewise ACCESS_CONFIG_OVERRIDE: without it the frontend builds
+# against config/config.default.json.
 RUN --mount=type=secret,id=ACCESS_CONFIG_OVERRIDE \
+  --mount=type=secret,id=SENTRY_AUTH_TOKEN \
+  --mount=type=secret,id=SENTRY_ORG \
+  --mount=type=secret,id=SENTRY_PROJECT \
   if [ -s /run/secrets/ACCESS_CONFIG_OVERRIDE ]; then \
     cp /run/secrets/ACCESS_CONFIG_OVERRIDE config/config.override.json; \
   fi; \
+  for secret in SENTRY_AUTH_TOKEN SENTRY_ORG SENTRY_PROJECT; do \
+    if [ -s "/run/secrets/$secret" ]; then export "$secret=$(cat "/run/secrets/$secret")"; fi; \
+  done; \
   ACCESS_CONFIG_FILE=$(test -f config/config.override.json && echo config.override.json) npm run build
 
-# Optional build step #2: upload source maps to Sentry
-FROM build-step AS sentry
-ARG SENTRY_RELEASE=""
-ENV SENTRY_RELEASE=$SENTRY_RELEASE
-# Use secret mount for SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_PROJECT
-RUN --mount=type=secret,id=SENTRY_AUTH_TOKEN \
-  --mount=type=secret,id=SENTRY_ORG \
-  --mount=type=secret,id=SENTRY_PROJECT \
-  SENTRY_AUTH_TOKEN=$(cat /run/secrets/SENTRY_AUTH_TOKEN) \
-  SENTRY_ORG=$(cat /run/secrets/SENTRY_ORG) \
-  SENTRY_PROJECT=$(cat /run/secrets/SENTRY_PROJECT) \
-  ACCESS_CONFIG_FILE=$(test -f config/config.override.json && echo config.override.json) \
-  npm run build
-# Source maps are automatically uploaded and deleted by Vite Sentry plugin during build
-RUN touch sentry
-
-# Build step #3: build the API with the client as static files
-FROM python:3.13 AS false
+# Build step #2: build the API with the client as static files
+FROM python:3.13
 ARG SENTRY_RELEASE=""
 WORKDIR /app
 
@@ -118,14 +112,6 @@ RUN --mount=type=bind,source=examples/plugins,target=examples/plugins,rw \
     if [ "$INSTALL_HEALTH_CHECK_PLUGIN" = "true" ]; then install_plugin ./examples/plugins/health_check_plugin; else echo "Skipping health_check_plugin plugin"; fi; \
     if [ "$INSTALL_NOTIFICATIONS_PLUGIN" = "true" ]; then install_plugin ./examples/plugins/notifications; else echo "Skipping notifications plugin"; fi; \
     if [ "$INSTALL_SLACK_NOTIFICATIONS_PLUGIN" = "true" ]; then install_plugin ./examples/plugins/notifications_slack; else echo "Skipping notifications_slack plugin"; fi
-
-# Build an image that includes the optional sentry release push build step
-FROM false AS true
-COPY --from=sentry /app/sentry ./sentry
-
-# Final build step: copy the API and the client from the previous steps
-# Choose whether to include the sentry release push build step or not
-FROM ${PUSH_SENTRY_RELEASE}
 
 ENV ENV=production
 ENV SENTRY_RELEASE=$SENTRY_RELEASE

--- a/api/models/app_group.py
+++ b/api/models/app_group.py
@@ -17,8 +17,13 @@ async def get_app_managers(app_id: str) -> List[OktaUser]:
 
     if ((await db.session.scalar(select(func.count()).select_from(owner_app_groups_stmt.subquery()))) or 0) > 0:
         owner_app_group_ids = [ag.id for ag in await db.session.scalars(owner_app_groups_stmt)]
+        # A user can hold two concurrent active OktaUserGroupMember owner rows
+        # for the same app-owner group at once (a direct grant plus one via a
+        # role mapping, per the access-grant-precedence rules) -- distinct()
+        # so such a user is returned once, not once per row.
         result = await db.session.scalars(
             select(OktaUser)
+            .distinct()
             .join(OktaUser.all_group_memberships_and_ownerships)
             .where(OktaUserGroupMember.group_id.in_(owner_app_group_ids))
             .where(OktaUserGroupMember.is_owner.is_(True))
@@ -55,8 +60,11 @@ async def get_access_owners() -> List[OktaUser]:
 
     if ((await db.session.scalar(select(func.count()).select_from(owner_app_groups_stmt.subquery()))) or 0) > 0:
         owner_app_group_ids = [ag.id for ag in await db.session.scalars(owner_app_groups_stmt)]
+        # See the distinct() note in get_app_managers above -- same concurrent
+        # direct-plus-role-grant case applies to members of this group.
         result = await db.session.scalars(
             select(OktaUser)
+            .distinct()
             .join(OktaUser.all_group_memberships_and_ownerships)
             .where(OktaUserGroupMember.group_id.in_(owner_app_group_ids))
             .where(OktaUserGroupMember.is_owner.is_(False))

--- a/api/models/okta_group.py
+++ b/api/models/okta_group.py
@@ -7,8 +7,13 @@ from api.models.core_models import OktaUser, OktaUserGroupMember
 
 
 async def get_group_managers(group_id: str) -> List[OktaUser]:
+    # A user can hold two concurrent active OktaUserGroupMember owner rows for
+    # the same group at once (a direct grant plus one via a role mapping,
+    # per the access-grant-precedence rules) -- distinct() so such a user is
+    # returned once, not once per row.
     result = await db.session.scalars(
         select(OktaUser)
+        .distinct()
         .join(OktaUserGroupMember, OktaUser.id == OktaUserGroupMember.user_id)
         .where(OktaUserGroupMember.group_id == group_id)
         .where(OktaUserGroupMember.is_owner.is_(True))

--- a/examples/plugins/app_group_lifecycle_google/README.md
+++ b/examples/plugins/app_group_lifecycle_google/README.md
@@ -76,9 +76,10 @@ operation.
 
 **Google enforces [membership
 requirements](https://docs.cloud.google.com/identity/docs/how-to/update-group-to-security-group).** A
-security group may contain only users, service accounts, and other security groups in your own
-domain, and only a Workspace Super Admin or Groups Admin may apply the label (the **Group
-Administrator** role under [Calling the Google API](#calling-the-google-api) covers the latter). The
+security group may contain users and service accounts with Google accounts from any domain, plus
+other security groups from your own, and only a Workspace Super Admin or Groups Admin may apply the
+label (the **Group Administrator** role under [Calling the Google API](#calling-the-google-api)
+covers the latter). The
 plugin pre-checks none of that: Google rejects the label outright when it does not hold, and the
 plugin records the rejection as a sync error naming the requirement. That error is deliberately loud
 (it fails the `sync-app-groups` run) because Access is otherwise showing a security group it does

--- a/examples/plugins/app_group_lifecycle_google/README.md
+++ b/examples/plugins/app_group_lifecycle_google/README.md
@@ -6,8 +6,8 @@ This plugin automatically creates, modifies, and deletes Google Groups correspon
 
 When an Access group is created or deleted or its plugin configuration is modified, the plugin:
 
-1. On create, creates an Okta group push mapping with a new target group named after the email prefix. Okta creates the downstream Google Group *and* links it in one step, so the plugin never has to wait for Okta to import a group created directly in Google (which requires a manual trigger). It then updates that Google Group's display name and description from Access.
-2. On modify, updates the corresponding Google Group's properties (display name, description) in the configured Google Workspace domain. The email is immutable.
+1. On create, creates an Okta group push mapping with a new target group named after the email prefix. Okta creates the downstream Google Group *and* links it in one step, so the plugin never has to wait for Okta to import a group created directly in Google (which requires a manual trigger). It then updates that Google Group's display name, description, and security label from Access.
+2. On modify, updates the corresponding Google Group's properties (display name, description, security label) in the configured Google Workspace domain. The email is immutable.
 3. On delete, removes the Okta group push mapping and the Google Group.
 
 Membership is kept in sync automatically by Okta group push. A Google Group linked out-of-band is adopted rather than recreated; if Okta hasn't yet pushed a newly-created group to Google, the group is marked pending and finalized on a later reconcile. Groups are also periodically reconciled to ensure eventual alignment to the source of truth in Access.
@@ -26,6 +26,7 @@ Membership is kept in sync automatically by Okta group push. A Google Group link
 |-----|------|----------|-------------|
 | `enabled` | boolean | yes | Enable or disable this plugin for the app. |
 | `email_pattern` | text | no | Optional regex applied to the group email prefix to validate it before creating the Google Group. |
+| `require_security_groups` | boolean | no | Label every one of this app's Google Groups as a [Workspace security group](https://knowledge.workspace.google.com/admin/groups/control-access-to-sensitive-data-with-security-groups), whatever the individual groups are set to. Defaults to off. |
 
 ### Group-Level Configuration
 
@@ -33,6 +34,7 @@ Membership is kept in sync automatically by Okta group push. A Google Group link
 |-----|------|----------|-------------|
 | `email` | text | yes | The local-part (prefix) of the Google Group email address. The full address is `{email}@{GOOGLE_WORKSPACE_DOMAIN}`. Immutable after the group is created (the Cloud Identity `groupKey` cannot be changed). |
 | `display_name` | text | yes | The display name for the Google Group. |
+| `security_group` | boolean | no | Label this Google Group as a [Google Workspace security group](https://knowledge.workspace.google.com/admin/groups/control-access-to-sensitive-data-with-security-groups) so it can grant access to sensitive data. Defaults to off, or to on when the app sets `require_security_groups`. |
 
 ### Group-Level Status
 
@@ -40,11 +42,51 @@ Membership is kept in sync automatically by Okta group push. A Google Group link
 |-----|-------------|
 | `push_mapping_id` | The Okta group push mapping ID linking the Okta group to the Google Group. |
 | `google_group_id` | The Google Group resource ID. |
-| `sync_status` | One of `synced`, `pending`, or `error`. |
+| `sync_status` | One of `synced`, `pending`, `skipped`, or `error`. |
 | `sync_error` | Error message if `sync_status` is `error`; otherwise empty. |
 | `last_synced_at` | Timestamp of the last successful sync. |
 
 There are no app-level status properties.
+
+## Security groups
+
+Setting a group's `security_group` configuration adds the
+[`cloudidentity.googleapis.com/groups.security` label](https://docs.cloud.google.com/identity/docs/groups#group_labels)
+to the linked Google Group, which is what makes it a [Workspace security
+group](https://knowledge.workspace.google.com/admin/groups/control-access-to-sensitive-data-with-security-groups):
+a group that may be named in policies granting access to sensitive data.
+
+An app whose groups all gate sensitive data can mandate it instead, with the app-level
+`require_security_groups`. The app setting and the group setting are OR'd rather than one
+overriding the other, so the app can only raise the requirement: a mandate covers the app's
+existing groups without their stored configuration having to be rewritten one by one, and it
+rejects a group trying to opt out. Because nothing in the plugin interface fires on an app
+configuration change, a newly-set mandate reaches already-created groups on their next reconcile:
+the periodic `sync-app-groups` run, or the group's next update.
+
+Two properties of the label shape how the plugin handles it:
+
+**It is one-way.** [Google does not convert a security group back to an ordinary
+group](https://docs.cloud.google.com/identity/docs/how-to/update-group-to-security-group), so the
+configuration is a floor rather than a switch. The plugin raises the label and never attempts a
+downgrade; clearing the setting on a group that is already labeled has no effect in Google, and the
+next reconcile restores the setting so the UI keeps agreeing with Google. The setting is still
+mutable, because promoting an existing group to a security group is a legitimate (and supported)
+operation.
+
+**Google enforces [membership
+requirements](https://docs.cloud.google.com/identity/docs/how-to/update-group-to-security-group).** A
+security group may contain only users, service accounts, and other security groups in your own
+domain, and only a Workspace Super Admin or Groups Admin may apply the label (the **Group
+Administrator** role under [Calling the Google API](#calling-the-google-api) covers the latter). The
+plugin pre-checks none of that: Google rejects the label outright when it does not hold, and the
+plugin records the rejection as a sync error naming the requirement. That error is deliberately loud
+(it fails the `sync-app-groups` run) because Access is otherwise showing a security group it does
+not actually have.
+
+Because a new group is created through Okta group push rather than the Groups API, the Google Group
+exists as an ordinary group for the moment between Okta creating it and the plugin's reconcile
+labeling it.
 
 ## Environment Variables
 

--- a/examples/plugins/app_group_lifecycle_google/plugin.py
+++ b/examples/plugins/app_group_lifecycle_google/plugin.py
@@ -293,7 +293,8 @@ class GoogleGroupManagerPlugin:
             "Label the linked Google group as a Workspace security group so it can grant access to "
             "sensitive data. Google does not convert a security group back to an ordinary group, so "
             "clearing this later has no effect and it is restored on the next sync. A security group "
-            "may contain only users, service accounts, and other security groups in this domain."
+            "may contain users and service accounts with Google accounts from any domain, plus other "
+            "security groups from this one."
         )
         if app_requires_security_groups:
             security_group_help = (
@@ -1025,10 +1026,10 @@ class GoogleGroupManagerPlugin:
 
         Google Workspace treats the label as one-way: a security group cannot be converted back to
         an ordinary Google Group. So the configuration is a floor, not a two-way switch -- Access
-        raises the label and never tries to lower it. A group Google already reports as a security
-        group has its Access-side configuration corrected to match, so the checkbox keeps telling
-        the truth about what Google will enforce, rather than sitting unchecked next to a group
-        that is a security group regardless.
+        raises the label and never tries to lower it. Once the group carries the label, this group's
+        own setting is written to match, so the checkbox keeps telling the truth about what Google
+        will enforce rather than sitting unchecked next to a group that is a security group
+        regardless.
 
         Args:
             ctx: The plugin capability context.
@@ -1041,10 +1042,15 @@ class GoogleGroupManagerPlugin:
         """
         labels = google_group.get("labels") or {}
         already_labeled = GOOGLE_GROUP_LABEL_SECURITY in labels
-        configured = self._get_configured_security_group(ctx, group)
+        # The group's own setting, read separately from the effective value below: whether to label
+        # is the OR of group and app, but the value that has to stay converged with Google is this
+        # one. Keying the writes on the effective value would leave a mandated group's stored False
+        # untouched forever, and the config form submits that stale False straight back into the
+        # validation error for opting out of the mandate.
+        opted_in_by_group = bool(ctx.get_config(group, CONFIG_SECURITY_GROUP, False))
 
         if already_labeled:
-            if not configured:
+            if not opted_in_by_group:
                 logger.info(
                     f"The Google group for {group.name} is already a security group, which Google cannot "
                     f"undo; restoring its '{CONFIG_SECURITY_GROUP}' configuration to match."
@@ -1052,7 +1058,7 @@ class GoogleGroupManagerPlugin:
                 ctx.set_config(group, CONFIG_SECURITY_GROUP, True)
             return None
 
-        if not configured:
+        if not self._get_configured_security_group(ctx, group):
             return None
 
         logger.info(f"Labeling the Google group for {group.name} as a Workspace security group...")
@@ -1074,11 +1080,18 @@ class GoogleGroupManagerPlugin:
             reason = (e.reason or "").strip() or str(e)
             return (
                 f"Google refused to label the linked Google group as a security group: {reason}. A security "
-                "group may contain only users, service accounts, and other security groups in "
-                f"{self._domain}, and only a Workspace Super Admin or Groups Admin may apply the label. "
-                f"Remove any other members from the group, or clear its '{CONFIG_SECURITY_GROUP}' "
-                "configuration to stop trying."
+                "group may contain users and service accounts with Google accounts, in any domain, plus "
+                f"other security groups in {self._domain}, and only a Workspace Super Admin or Groups Admin "
+                "may apply the label. Correct the group's membership, or turn off whichever of this group's "
+                f"'{CONFIG_SECURITY_GROUP}' or its app's '{CONFIG_REQUIRE_SECURITY_GROUPS}' configuration is "
+                "asking for the label."
             )
+
+        # The group is a security group as of this patch, so record that on the group itself even
+        # when it was the app mandate that asked for it: same convergence as the restore above, at
+        # the moment it is established rather than a reconcile later.
+        if not opted_in_by_group:
+            ctx.set_config(group, CONFIG_SECURITY_GROUP, True)
         return None
 
     # ---- Lifecycle hooks ----

--- a/examples/plugins/app_group_lifecycle_google/plugin.py
+++ b/examples/plugins/app_group_lifecycle_google/plugin.py
@@ -40,9 +40,11 @@ ENV_DOMAIN = "GOOGLE_WORKSPACE_DOMAIN"
 # App config keys
 CONFIG_ENABLED = "enabled"
 CONFIG_EMAIL_PATTERN = "email_pattern"
+CONFIG_REQUIRE_SECURITY_GROUPS = "require_security_groups"
 # Group config keys
 CONFIG_EMAIL = "email"
 CONFIG_DISPLAY_NAME = "display_name"
+CONFIG_SECURITY_GROUP = "security_group"
 # Group status keys
 STATUS_PUSH_MAPPING_ID = "push_mapping_id"
 STATUS_GOOGLE_GROUP_ID = "google_group_id"
@@ -67,6 +69,14 @@ SYNC_SKIPPED = "skipped"
 
 OKTA_GOOGLE_GROUP_PROFILE_FIELD_EMAIL = "googleGroupEmail"
 
+# Cloud Identity group labels: https://docs.cloud.google.com/identity/docs/groups#group_labels
+# Every Google Group carries the discussion-forum label. A Google Workspace security group
+# (https://knowledge.workspace.google.com/admin/groups/control-access-to-sensitive-data-with-security-groups)
+# is that same group with the security label added alongside it, so it can be named in policies
+# that grant access to sensitive data.
+GOOGLE_GROUP_LABEL_DISCUSSION_FORUM = "cloudidentity.googleapis.com/groups.discussion_forum"
+GOOGLE_GROUP_LABEL_SECURITY = "cloudidentity.googleapis.com/groups.security"
+
 # Conservative subset of Google group local-part rules: lowercase alphanumerics
 # plus . _ - internally; must start and end alphanumeric.
 GOOGLE_LOCAL_PART_RE = re.compile(r"^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$")
@@ -90,6 +100,19 @@ class _RetryingHttpRequest(HttpRequest):
 
     def execute(self, http: Any = None, num_retries: int = GOOGLE_API_NUM_RETRIES) -> Any:
         return super().execute(http=http, num_retries=num_retries)
+
+
+def _app_requires_security_groups(app_config: dict[str, Any]) -> bool:
+    """Whether an app's configuration mandates security groups for all of its groups.
+
+    Args:
+        app_config: The app-level configuration for this plugin, as handed to the group config
+            schema and validation hooks. A non-dict reads as no mandate.
+
+    Returns:
+        True when every one of the app's Google groups is to carry the security label.
+    """
+    return bool(app_config.get(CONFIG_REQUIRE_SECURITY_GROUPS)) if isinstance(app_config, dict) else False
 
 
 def _is_group_absent_error(error: HttpError) -> bool:
@@ -169,6 +192,25 @@ class GoogleGroupManagerPlugin:
     def _get_configured_display_name(self, ctx: AppGroupLifecycleContext, group: AppGroup) -> str | None:
         return ctx.get_config(group, CONFIG_DISPLAY_NAME)
 
+    def _get_configured_security_group(self, ctx: AppGroupLifecycleContext, group: AppGroup) -> bool:
+        """Whether this group's Google group is to carry the Workspace security label.
+
+        The app-level mandate and the group's own setting are OR'd rather than one overriding the
+        other, matching what the label itself allows: an app can only raise the requirement, and
+        raising it covers the groups that predate the mandate without their stored configuration
+        having to be rewritten one by one.
+
+        Args:
+            ctx: The plugin capability context.
+            group: The group being reconciled.
+
+        Returns:
+            True when either the app mandates security groups or this group opted in.
+        """
+        if bool(ctx.get_config(group.app, CONFIG_REQUIRE_SECURITY_GROUPS, False)):
+            return True
+        return bool(ctx.get_config(group, CONFIG_SECURITY_GROUP, False))
+
     # ---- Metadata ----
 
     @hookimpl
@@ -204,6 +246,21 @@ class GoogleGroupManagerPlugin:
                 type="text",
                 required=False,
             ),
+            # Not immutable, and turning it back off is not an undo: it stops the plugin labeling
+            # anything further, while every group already labeled stays a security group, because
+            # Google does not convert one back. See _reconcile_security_label.
+            CONFIG_REQUIRE_SECURITY_GROUPS: AppGroupLifecyclePluginConfigProperty(
+                display_name="Require Security Groups?",
+                help_text=(
+                    "Label every one of this app's Google groups as a Workspace security group, "
+                    "including the ones that already exist. Individual groups can opt in on their "
+                    "own without this. Google does not convert a security group back to an "
+                    "ordinary group, so this cannot be undone for the groups it labels."
+                ),
+                type="boolean",
+                default_value=False,
+                required=False,
+            ),
         }
 
     @hookimpl
@@ -229,6 +286,21 @@ class GoogleGroupManagerPlugin:
                 {"regex": app_email_pattern, "message": f"Must match this app's email pattern: {app_email_pattern}"}
             )
 
+        # Under an app mandate the group-level setting is no longer the group's to make, so say so
+        # before the general explanation rather than leaving the owner to discover it on submit.
+        app_requires_security_groups = _app_requires_security_groups(app_config)
+        security_group_help = (
+            "Label the linked Google group as a Workspace security group so it can grant access to "
+            "sensitive data. Google does not convert a security group back to an ordinary group, so "
+            "clearing this later has no effect and it is restored on the next sync. A security group "
+            "may contain only users, service accounts, and other security groups in this domain."
+        )
+        if app_requires_security_groups:
+            security_group_help = (
+                "This app requires every one of its Google groups to be a Workspace security group, "
+                f"so this cannot be turned off here. {security_group_help}"
+            )
+
         return {
             CONFIG_EMAIL: AppGroupLifecyclePluginConfigProperty(
                 display_name="Google Group Email Prefix",
@@ -248,6 +320,21 @@ class GoogleGroupManagerPlugin:
                 help_text="The display name of the linked Google group",
                 type="text",
                 required=True,
+            ),
+            # Deliberately NOT immutable, unlike the email: Google supports promoting an existing
+            # Google Group to a security group, so an app group that turns out to gate sensitive
+            # data can be relabeled in place. The one-way half of that -- Google never converts a
+            # security group back -- is enforced in _reconcile_security_label, which restores this
+            # value rather than attempting a downgrade, because `immutable` would also block the
+            # legitimate promotion.
+            CONFIG_SECURITY_GROUP: AppGroupLifecyclePluginConfigProperty(
+                display_name="Google Workspace Security Group",
+                help_text=security_group_help,
+                type="boolean",
+                # Pre-checked under an app mandate, so the form submits what the app already
+                # enforces rather than an unchecked box the backend then rejects.
+                default_value=app_requires_security_groups,
+                required=False,
             ),
         }
 
@@ -307,6 +394,11 @@ class GoogleGroupManagerPlugin:
                     re.compile(pattern)
                 except re.error as e:
                     errors[CONFIG_EMAIL_PATTERN] = f"Invalid regex: {e}"
+
+        # Optional, and absent means no mandate; only a present non-boolean is an error.
+        require_security_groups = config.get(CONFIG_REQUIRE_SECURITY_GROUPS)
+        if require_security_groups is not None and not isinstance(require_security_groups, bool):
+            errors[CONFIG_REQUIRE_SECURITY_GROUPS] = f"The '{CONFIG_REQUIRE_SECURITY_GROUPS}' field must be a boolean"
         return errors
 
     @hookimpl
@@ -344,6 +436,19 @@ class GoogleGroupManagerPlugin:
             if pattern_error:
                 errors[CONFIG_EMAIL] = pattern_error
 
+        # Optional, and absent means "whatever the app says"; only a present non-boolean is an error.
+        security_group = config.get(CONFIG_SECURITY_GROUP)
+        if security_group is not None and not isinstance(security_group, bool):
+            errors[CONFIG_SECURITY_GROUP] = f"The '{CONFIG_SECURITY_GROUP}' field must be a boolean"
+        elif security_group is False and _app_requires_security_groups(app_config):
+            # Reported synchronously here, the way an email_pattern violation is, rather than left
+            # for reconcile to override silently. An *absent* value is left alone: a group predating
+            # the mandate must stay editable, and the mandate covers it regardless.
+            errors[CONFIG_SECURITY_GROUP] = (
+                "This app requires every one of its Google groups to be a Workspace security group, "
+                f"so '{CONFIG_SECURITY_GROUP}' cannot be turned off for this group."
+            )
+
         return errors
 
     # ---- Google API wrappers (Cloud Identity Groups API) ----
@@ -362,7 +467,12 @@ class GoogleGroupManagerPlugin:
         return await self._execute_request(self._groups_api.get(name=self._resource_name(google_group_id)))
 
     async def _patch_google_group(
-        self, google_group_id: str, *, display_name: str | None = None, description: str | None = None
+        self,
+        google_group_id: str,
+        *,
+        display_name: str | None = None,
+        description: str | None = None,
+        labels: dict[str, str] | None = None,
     ) -> None:
         """Patch a Google group's mutable properties.
 
@@ -370,15 +480,20 @@ class GoogleGroupManagerPlugin:
             google_group_id: The Cloud Identity group to patch.
             display_name: The display name to set, or None to leave it alone.
             description: The description to set, or None to leave it alone.
+            labels: The complete label map to set, or None to leave it alone. The API replaces the
+                map wholesale rather than merging into it, so a caller adding one label has to
+                re-send the labels the group already carries.
 
         groupKey (the email) is immutable in the Cloud Identity API, so it is not patchable here.
-        A call with neither field is a no-op.
+        A call with no fields is a no-op.
         """
         body: dict[str, Any] = {}
         if display_name is not None:
             body["displayName"] = display_name
         if description is not None:
             body["description"] = description
+        if labels is not None:
+            body["labels"] = labels
         if not body:
             return
         update_mask = ",".join(sorted(body))
@@ -804,8 +919,8 @@ class GoogleGroupManagerPlugin:
 
             # We hold a live Google group (cached, adopted, or freshly created) -> enforce Access's
             # properties onto it (or backfill from it during adoption). A group Okta just created is
-            # named after the email prefix and has no description, so this is what applies the real
-            # display name and description.
+            # named after the email prefix, has no description, and is an ordinary Google Group, so
+            # this is what applies the real display name, description, and security label.
             logger.debug(f"Reconciling group properties for {group.name}...")
             google_group = await self._get_google_group(claimed_google_group_id)
             reconcile_error = await self._adopt_or_enforce(ctx, group, claimed_google_group_id, google_group)
@@ -859,7 +974,9 @@ class GoogleGroupManagerPlugin:
         present values onto it.
 
         The email (groupKey) is immutable in the Cloud Identity API and host-blocked from changing,
-        so it is never patched here.
+        so it is never patched here. The security label is neither adopted nor enforced on the
+        adopt/enforce split -- it is one-way in Google, so it reconciles on its own terms; see
+        _reconcile_security_label, which runs after this method's metadata patch either way.
 
         Args:
             ctx: The plugin capability context.
@@ -897,6 +1014,70 @@ class GoogleGroupManagerPlugin:
             patch_description = access_description if google_description != access_description else None
             await self._patch_google_group(
                 google_group_id, display_name=patch_display_name, description=patch_description
+            )
+
+        return await self._reconcile_security_label(ctx, group, google_group_id, google_group)
+
+    async def _reconcile_security_label(
+        self, ctx: AppGroupLifecycleContext, group: AppGroup, google_group_id: str, google_group: dict[str, Any]
+    ) -> str | None:
+        """Bring the Google group's security label in line with this group's configuration.
+
+        Google Workspace treats the label as one-way: a security group cannot be converted back to
+        an ordinary Google Group. So the configuration is a floor, not a two-way switch -- Access
+        raises the label and never tries to lower it. A group Google already reports as a security
+        group has its Access-side configuration corrected to match, so the checkbox keeps telling
+        the truth about what Google will enforce, rather than sitting unchecked next to a group
+        that is a security group regardless.
+
+        Args:
+            ctx: The plugin capability context.
+            group: The Access group being reconciled.
+            google_group_id: The Cloud Identity group backing it.
+            google_group: That group's current state, as returned by the Groups API.
+
+        Returns:
+            An error message when Google refuses the label, else None.
+        """
+        labels = google_group.get("labels") or {}
+        already_labeled = GOOGLE_GROUP_LABEL_SECURITY in labels
+        configured = self._get_configured_security_group(ctx, group)
+
+        if already_labeled:
+            if not configured:
+                logger.info(
+                    f"The Google group for {group.name} is already a security group, which Google cannot "
+                    f"undo; restoring its '{CONFIG_SECURITY_GROUP}' configuration to match."
+                )
+                ctx.set_config(group, CONFIG_SECURITY_GROUP, True)
+            return None
+
+        if not configured:
+            return None
+
+        logger.info(f"Labeling the Google group for {group.name} as a Workspace security group...")
+        try:
+            # The patch replaces the label map rather than merging into it, so every label the
+            # group already carries is re-sent. discussion_forum is named explicitly as well
+            # because a group without it is not a Google Group at all, and dropping it here would
+            # be how that happens.
+            await self._patch_google_group(
+                google_group_id,
+                labels={**labels, GOOGLE_GROUP_LABEL_DISCUSSION_FORUM: "", GOOGLE_GROUP_LABEL_SECURITY: ""},
+            )
+        except HttpError as e:
+            # Google rejects the label outright when the group's membership or the caller's role
+            # does not permit it, and will keep rejecting it until one of those changes, so this is
+            # reported rather than deferred. It is an error, not a skip: Access is advertising a
+            # security group it has not actually got, which is worth failing the batch sync over
+            # even though the group's owner (not an admin) is usually the one who can fix it.
+            reason = (e.reason or "").strip() or str(e)
+            return (
+                f"Google refused to label the linked Google group as a security group: {reason}. A security "
+                "group may contain only users, service accounts, and other security groups in "
+                f"{self._domain}, and only a Workspace Super Admin or Groups Admin may apply the label. "
+                f"Remove any other members from the group, or clear its '{CONFIG_SECURITY_GROUP}' "
+                "configuration to stop trying."
             )
         return None
 

--- a/examples/plugins/app_group_lifecycle_google/test_plugin.py
+++ b/examples/plugins/app_group_lifecycle_google/test_plugin.py
@@ -39,11 +39,12 @@ sys.modules["googleapiclient.http"] = mock_googleapiclient_http
 
 
 class _FakeHttpError(Exception):
-    """Stand-in for googleapiclient.errors.HttpError carrying an HTTP status."""
+    """Stand-in for googleapiclient.errors.HttpError carrying an HTTP status and reason."""
 
-    def __init__(self, status: int) -> None:
+    def __init__(self, status: int, reason: str = "") -> None:
         super().__init__(f"HTTP {status}")
         self.resp = Mock(status=status)
+        self.reason = reason
 
 
 _errors_module = MagicMock()
@@ -58,7 +59,11 @@ from plugin import (  # noqa: E402
     CONFIG_DISPLAY_NAME,
     CONFIG_EMAIL,
     CONFIG_ENABLED,
+    CONFIG_REQUIRE_SECURITY_GROUPS,
+    CONFIG_SECURITY_GROUP,
     GOOGLE_API_NUM_RETRIES,
+    GOOGLE_GROUP_LABEL_DISCUSSION_FORUM,
+    GOOGLE_GROUP_LABEL_SECURITY,
     PLUGIN_ID,
     STATUS_GOOGLE_GROUP_ID,
     STATUS_PUSH_MAPPING_ID,
@@ -69,6 +74,7 @@ from plugin import (  # noqa: E402
     SYNC_SKIPPED,
     SYNC_SYNCED,
     GoogleGroupManagerPlugin,
+    GoogleGroupSyncError,
     _RetryingHttpRequest,
 )
 
@@ -110,16 +116,22 @@ def test_metadata(plugin_instance: GoogleGroupManagerPlugin) -> None:
 def test_app_config_properties_shape(plugin_instance: GoogleGroupManagerPlugin) -> None:
     props = plugin_instance.get_plugin_app_config_properties(PLUGIN_ID)
     assert props is not None
-    assert set(props) == {"enabled", "email_pattern"}
+    assert set(props) == {"enabled", "email_pattern", "require_security_groups"}
     assert props["enabled"].required is True
+    assert props["require_security_groups"].required is False
+    assert props["require_security_groups"].type == "boolean"
+    assert props["require_security_groups"].default_value is False
 
 
 def test_group_config_properties_shape(plugin_instance: GoogleGroupManagerPlugin) -> None:
     props = plugin_instance.get_plugin_group_config_properties(PLUGIN_ID, {})
     assert props is not None
-    assert set(props) == {"email", "display_name"}
+    assert set(props) == {"email", "display_name", "security_group"}
     assert props["email"].required is True
     assert props["display_name"].required is True
+    assert props["security_group"].required is False
+    assert props["security_group"].type == "boolean"
+    assert props["security_group"].default_value is False
 
 
 def test_group_config_email_property_carries_domain_suffix(plugin_instance: GoogleGroupManagerPlugin) -> None:
@@ -194,6 +206,16 @@ def test_validate_app_config_requires_enabled(plugin_instance: GoogleGroupManage
     assert "enabled" in errors
 
 
+@pytest.mark.parametrize("value,ok", [(True, True), (False, True), ("yes", False), (1, False)])
+def test_validate_app_config_require_security_groups_must_be_boolean(
+    plugin_instance: GoogleGroupManagerPlugin, value: Any, ok: bool
+) -> None:
+    errors = plugin_instance.validate_plugin_app_config(
+        {CONFIG_ENABLED: True, CONFIG_REQUIRE_SECURITY_GROUPS: value}, PLUGIN_ID
+    )
+    assert (errors == {}) is ok
+
+
 def test_validate_group_config_valid(plugin_instance: GoogleGroupManagerPlugin) -> None:
     errors = plugin_instance.validate_plugin_group_config(
         {"email": "platform-security", "display_name": "Platform Security"}, {}, PLUGIN_ID
@@ -215,6 +237,58 @@ def test_validate_group_config_errors(
 ) -> None:
     errors = plugin_instance.validate_plugin_group_config(config, {}, PLUGIN_ID)
     assert bad_key in errors
+
+
+@pytest.mark.parametrize("value,ok", [(True, True), (False, True), ("yes", False), (1, False)])
+def test_validate_group_config_security_group_must_be_boolean(
+    plugin_instance: GoogleGroupManagerPlugin, value: Any, ok: bool
+) -> None:
+    errors = plugin_instance.validate_plugin_group_config(
+        {"email": "sec", "display_name": "Sec", CONFIG_SECURITY_GROUP: value}, {}, PLUGIN_ID
+    )
+    assert (errors == {}) is ok
+
+
+def test_validate_group_config_rejects_opting_out_of_an_app_mandate(
+    plugin_instance: GoogleGroupManagerPlugin,
+) -> None:
+    app_config = {CONFIG_ENABLED: True, CONFIG_REQUIRE_SECURITY_GROUPS: True}
+    base = {CONFIG_EMAIL: "sec", CONFIG_DISPLAY_NAME: "Sec"}
+
+    # Turning it off against the app's mandate is rejected here rather than silently overridden
+    # by reconcile.
+    errors = plugin_instance.validate_plugin_group_config({**base, CONFIG_SECURITY_GROUP: False}, app_config, PLUGIN_ID)
+    assert CONFIG_SECURITY_GROUP in errors
+
+    assert (
+        plugin_instance.validate_plugin_group_config({**base, CONFIG_SECURITY_GROUP: True}, app_config, PLUGIN_ID) == {}
+    )
+    # An absent value is left alone: a group predating the mandate stays editable, and the mandate
+    # covers it anyway.
+    assert plugin_instance.validate_plugin_group_config(base, app_config, PLUGIN_ID) == {}
+    # Without the mandate, opting out is the group's call.
+    assert (
+        plugin_instance.validate_plugin_group_config(
+            {**base, CONFIG_SECURITY_GROUP: False}, {CONFIG_ENABLED: True}, PLUGIN_ID
+        )
+        == {}
+    )
+
+
+def test_group_config_security_group_property_reflects_an_app_mandate(
+    plugin_instance: GoogleGroupManagerPlugin,
+) -> None:
+    props = plugin_instance.get_plugin_group_config_properties(PLUGIN_ID, {})
+    assert props is not None
+    assert props[CONFIG_SECURITY_GROUP].default_value is False
+    assert "requires every one" not in (props[CONFIG_SECURITY_GROUP].help_text or "")
+
+    # Under a mandate the box is pre-checked, so the form submits what the app already enforces
+    # instead of an unchecked value the backend then rejects.
+    props = plugin_instance.get_plugin_group_config_properties(PLUGIN_ID, {CONFIG_REQUIRE_SECURITY_GROUPS: True})
+    assert props is not None
+    assert props[CONFIG_SECURITY_GROUP].default_value is True
+    assert "requires every one" in (props[CONFIG_SECURITY_GROUP].help_text or "")
 
 
 def test_validate_group_config_ignores_other_plugin(plugin_instance: GoogleGroupManagerPlugin) -> None:
@@ -362,6 +436,39 @@ def test_configured_accessors_read_group_config(
     assert plugin_instance._get_configured_display_name(ctx_mock, group) is None
 
 
+@pytest.mark.parametrize(
+    "app_requires,group_opted_in,expected",
+    [
+        (False, None, False),
+        (False, False, False),
+        (False, True, True),
+        (True, None, True),
+        # The mandate covers a group whose stored configuration predates it, so an app can be
+        # tightened without rewriting every group's config.
+        (True, False, True),
+        (True, True, True),
+    ],
+)
+def test_security_group_accessor_ors_the_app_mandate_with_the_group_setting(
+    plugin_instance: GoogleGroupManagerPlugin,
+    mocker: MockerFixture,
+    ctx_mock: MagicMock,
+    app_requires: bool,
+    group_opted_in: bool | None,
+    expected: bool,
+) -> None:
+    group_config: dict[str, Any] = {}
+    if group_opted_in is not None:
+        group_config[CONFIG_SECURITY_GROUP] = group_opted_in
+    group = _group(
+        mocker,
+        app_config={CONFIG_ENABLED: True, CONFIG_REQUIRE_SECURITY_GROUPS: app_requires},
+        group_config=group_config,
+    )
+
+    assert plugin_instance._get_configured_security_group(ctx_mock, group) is expected
+
+
 async def test_get_google_group_calls_get_by_resource_name(
     plugin_instance: GoogleGroupManagerPlugin, mock_groups_api: MagicMock
 ) -> None:
@@ -398,6 +505,18 @@ async def test_patch_google_group_sets_update_mask(
     assert kwargs["name"] == "groups/ggid-1"
     assert kwargs["body"] == {"displayName": "New", "description": "d"}
     assert kwargs["updateMask"] == "description,displayName"
+
+
+async def test_patch_google_group_sets_labels_update_mask(
+    plugin_instance: GoogleGroupManagerPlugin, mock_groups_api: MagicMock
+) -> None:
+    labels = {GOOGLE_GROUP_LABEL_DISCUSSION_FORUM: "", GOOGLE_GROUP_LABEL_SECURITY: ""}
+
+    await plugin_instance._patch_google_group("ggid-1", labels=labels)
+
+    kwargs = mock_groups_api.patch.call_args.kwargs
+    assert kwargs["body"] == {"labels": labels}
+    assert kwargs["updateMask"] == "labels"
 
 
 async def test_patch_google_group_noop_when_no_fields(
@@ -504,6 +623,9 @@ def test_email_config_property_is_immutable(plugin_instance: GoogleGroupManagerP
     assert props is not None
     assert props["email"].immutable is True
     assert props["display_name"].immutable is False
+    # Google supports promoting an existing group to a security group, so this stays editable; the
+    # one-way half is handled by restoring the value, not by blocking the edit.
+    assert props["security_group"].immutable is False
 
 
 @pytest.fixture
@@ -667,6 +789,192 @@ async def test_reconcile_clears_description_on_existing_group(
     assert patch.call_args.kwargs["description"] == ""
     assert group.description == ""
     ctx_mock.set_group_description.assert_not_awaited()
+
+
+# ---- Security label ----
+#
+# A Workspace security group is an ordinary Google Group carrying an extra label, and Google will
+# not take that label back off. These cover both directions of that asymmetry: Access raises the
+# label, and where Google is already ahead, Access adopts rather than attempting a downgrade.
+
+
+def _security_group_fixtures(
+    mocker: MockerFixture,
+    *,
+    configured: bool | None,
+    labels: dict[str, str] | None,
+    app_requires: bool = False,
+):
+    """A linked, already-converged group plus the live Google group it is linked to.
+
+    Args:
+        mocker: The pytest-mock fixture.
+        configured: The group's ``security_group`` configuration, or None to leave it unset.
+        labels: The live Google group's label map, or None for a group with no labels field.
+        app_requires: Whether the owning app mandates security groups.
+
+    Returns:
+        The Access group and the Groups API payload for its Google group. Display name and
+        description already match, so the only patch a reconcile has any reason to make is the
+        label one.
+    """
+    group_config: dict[str, Any] = {CONFIG_EMAIL: "sec", CONFIG_DISPLAY_NAME: "Sec"}
+    if configured is not None:
+        group_config[CONFIG_SECURITY_GROUP] = configured
+    group = _group(
+        mocker,
+        app_config={CONFIG_ENABLED: True, CONFIG_REQUIRE_SECURITY_GROUPS: app_requires},
+        group_config=group_config,
+        status={STATUS_GOOGLE_GROUP_ID: "ggid-1", STATUS_PUSH_MAPPING_ID: "map-1"},
+        description="Sec",
+    )
+    live: dict[str, Any] = {
+        "name": "groups/ggid-1",
+        "groupKey": {"id": "sec@test-company.com"},
+        "displayName": "Sec",
+        "description": "Sec",
+    }
+    if labels is not None:
+        live["labels"] = labels
+    return group, live
+
+
+def _label_patches(patch: MagicMock) -> list[dict[str, str]]:
+    """The label maps a reconcile actually sent, ignoring its metadata patch."""
+    return [c.kwargs["labels"] for c in patch.call_args_list if c.kwargs.get("labels") is not None]
+
+
+async def test_reconcile_labels_a_configured_group_as_a_security_group(
+    plugin_instance: GoogleGroupManagerPlugin, mocker: MockerFixture, ctx_mock: MagicMock
+) -> None:
+    # The patch replaces the label map rather than merging into it, so an unrelated label the group
+    # already carries has to survive the write.
+    group, live = _security_group_fixtures(
+        mocker, configured=True, labels={GOOGLE_GROUP_LABEL_DISCUSSION_FORUM: "", "example.com/team": "platform"}
+    )
+    mocker.patch.object(plugin_instance, "_get_google_group", return_value=live)
+    patch = mocker.patch.object(plugin_instance, "_patch_google_group")
+
+    await plugin_instance._reconcile(ctx_mock, group)
+
+    assert _label_patches(patch) == [
+        {
+            GOOGLE_GROUP_LABEL_DISCUSSION_FORUM: "",
+            "example.com/team": "platform",
+            GOOGLE_GROUP_LABEL_SECURITY: "",
+        }
+    ]
+    assert group.plugin_data[PLUGIN_ID]["status"][STATUS_SYNC_STATUS] == SYNC_SYNCED
+
+
+async def test_reconcile_sends_the_discussion_forum_label_on_a_group_reporting_none(
+    plugin_instance: GoogleGroupManagerPlugin, mocker: MockerFixture, ctx_mock: MagicMock
+) -> None:
+    # Dropping discussion_forum from the map is how a Google Group stops being one, so it is named
+    # explicitly rather than relied on to be present in what the API returned.
+    group, live = _security_group_fixtures(mocker, configured=True, labels=None)
+    mocker.patch.object(plugin_instance, "_get_google_group", return_value=live)
+    patch = mocker.patch.object(plugin_instance, "_patch_google_group")
+
+    await plugin_instance._reconcile(ctx_mock, group)
+
+    assert _label_patches(patch) == [{GOOGLE_GROUP_LABEL_DISCUSSION_FORUM: "", GOOGLE_GROUP_LABEL_SECURITY: ""}]
+
+
+async def test_reconcile_leaves_an_already_labeled_group_alone(
+    plugin_instance: GoogleGroupManagerPlugin, mocker: MockerFixture, ctx_mock: MagicMock
+) -> None:
+    group, live = _security_group_fixtures(
+        mocker,
+        configured=True,
+        labels={GOOGLE_GROUP_LABEL_DISCUSSION_FORUM: "", GOOGLE_GROUP_LABEL_SECURITY: ""},
+    )
+    mocker.patch.object(plugin_instance, "_get_google_group", return_value=live)
+    patch = mocker.patch.object(plugin_instance, "_patch_google_group")
+
+    await plugin_instance._reconcile(ctx_mock, group)
+
+    assert _label_patches(patch) == []
+
+
+async def test_reconcile_does_not_label_a_group_that_did_not_ask_for_it(
+    plugin_instance: GoogleGroupManagerPlugin, mocker: MockerFixture, ctx_mock: MagicMock
+) -> None:
+    # Absent configuration means an ordinary Google Group, not "whatever Google has": labelling one
+    # by default would be irreversible.
+    group, live = _security_group_fixtures(mocker, configured=None, labels={GOOGLE_GROUP_LABEL_DISCUSSION_FORUM: ""})
+    mocker.patch.object(plugin_instance, "_get_google_group", return_value=live)
+    patch = mocker.patch.object(plugin_instance, "_patch_google_group")
+
+    await plugin_instance._reconcile(ctx_mock, group)
+
+    assert _label_patches(patch) == []
+    assert CONFIG_SECURITY_GROUP not in group.plugin_data[PLUGIN_ID]["configuration"]
+
+
+@pytest.mark.parametrize("stored", [None, False, True])
+async def test_reconcile_labels_every_group_of_an_app_that_mandates_security_groups(
+    plugin_instance: GoogleGroupManagerPlugin, mocker: MockerFixture, ctx_mock: MagicMock, stored: bool | None
+) -> None:
+    # The mandate is a floor, so it reaches groups that predate it -- including one whose stored
+    # configuration still says False, which is what a group carries after the app is tightened.
+    group, live = _security_group_fixtures(
+        mocker, configured=stored, labels={GOOGLE_GROUP_LABEL_DISCUSSION_FORUM: ""}, app_requires=True
+    )
+    mocker.patch.object(plugin_instance, "_get_google_group", return_value=live)
+    patch = mocker.patch.object(plugin_instance, "_patch_google_group")
+
+    await plugin_instance._reconcile(ctx_mock, group)
+
+    assert _label_patches(patch) == [{GOOGLE_GROUP_LABEL_DISCUSSION_FORUM: "", GOOGLE_GROUP_LABEL_SECURITY: ""}]
+    assert group.plugin_data[PLUGIN_ID]["status"][STATUS_SYNC_STATUS] == SYNC_SYNCED
+
+
+async def test_reconcile_restores_the_configuration_of_a_group_google_already_labeled(
+    plugin_instance: GoogleGroupManagerPlugin, mocker: MockerFixture, ctx_mock: MagicMock
+) -> None:
+    # Google never converts a security group back, so an unchecked box next to a group that is one
+    # anyway is a lie. Access adopts Google's answer instead of trying (and failing) to downgrade.
+    group, live = _security_group_fixtures(
+        mocker,
+        configured=False,
+        labels={GOOGLE_GROUP_LABEL_DISCUSSION_FORUM: "", GOOGLE_GROUP_LABEL_SECURITY: ""},
+    )
+    mocker.patch.object(plugin_instance, "_get_google_group", return_value=live)
+    patch = mocker.patch.object(plugin_instance, "_patch_google_group")
+
+    await plugin_instance._reconcile(ctx_mock, group)
+
+    assert _label_patches(patch) == []
+    assert group.plugin_data[PLUGIN_ID]["configuration"][CONFIG_SECURITY_GROUP] is True
+    # Adopting reality is not a failure: the group is exactly what Access now says it is.
+    assert group.plugin_data[PLUGIN_ID]["status"][STATUS_SYNC_STATUS] == SYNC_SYNCED
+
+
+async def test_reconcile_errors_when_google_refuses_the_security_label(
+    plugin_instance: GoogleGroupManagerPlugin, mocker: MockerFixture, ctx_mock: MagicMock
+) -> None:
+    # Google rejects the label while the group holds members it does not allow, and will keep
+    # rejecting it. Access is advertising a security group it has not got, so the batch sync fails
+    # rather than reporting the group as synced.
+    group, live = _security_group_fixtures(mocker, configured=True, labels={GOOGLE_GROUP_LABEL_DISCUSSION_FORUM: ""})
+    mocker.patch.object(plugin_instance, "_get_google_group", return_value=live)
+
+    async def refuse_labels(_google_group_id: str, **kwargs: Any) -> None:
+        # Keyed on the argument rather than on call order, so it refuses the label write and only
+        # the label write however the metadata patch around it changes.
+        if kwargs.get("labels") is not None:
+            raise _FakeHttpError(400, "Group contains members that are not allowed")
+
+    mocker.patch.object(plugin_instance, "_patch_google_group", side_effect=refuse_labels)
+
+    with pytest.raises(GoogleGroupSyncError):
+        await plugin_instance.sync_group(ctx_mock, group, PLUGIN_ID)
+
+    status = group.plugin_data[PLUGIN_ID]["status"]
+    assert status[STATUS_SYNC_STATUS] == SYNC_ERROR
+    assert "Group contains members that are not allowed" in status[STATUS_SYNC_ERROR]
+    assert CONFIG_SECURITY_GROUP in status[STATUS_SYNC_ERROR]  # names the configuration to clear
 
 
 async def test_reconcile_adopts_missing_config_from_live_group(

--- a/examples/plugins/app_group_lifecycle_google/test_plugin.py
+++ b/examples/plugins/app_group_lifecycle_google/test_plugin.py
@@ -928,6 +928,30 @@ async def test_reconcile_labels_every_group_of_an_app_that_mandates_security_gro
 
     assert _label_patches(patch) == [{GOOGLE_GROUP_LABEL_DISCUSSION_FORUM: "", GOOGLE_GROUP_LABEL_SECURITY: ""}]
     assert group.plugin_data[PLUGIN_ID]["status"][STATUS_SYNC_STATUS] == SYNC_SYNCED
+    # The group's own setting is converged too, not just the effective one. Leaving a stale False
+    # there would have the config form submit it straight back into the opt-out validation error.
+    assert group.plugin_data[PLUGIN_ID]["configuration"][CONFIG_SECURITY_GROUP] is True
+
+
+@pytest.mark.parametrize("stored", [None, False])
+async def test_reconcile_converges_a_mandated_group_that_google_already_labeled(
+    plugin_instance: GoogleGroupManagerPlugin, mocker: MockerFixture, ctx_mock: MagicMock, stored: bool | None
+) -> None:
+    # The restore keys on the group's own setting, not the effective one: under a mandate the
+    # effective value is already True, so keying on it would leave the stale stored value forever.
+    group, live = _security_group_fixtures(
+        mocker,
+        configured=stored,
+        labels={GOOGLE_GROUP_LABEL_DISCUSSION_FORUM: "", GOOGLE_GROUP_LABEL_SECURITY: ""},
+        app_requires=True,
+    )
+    mocker.patch.object(plugin_instance, "_get_google_group", return_value=live)
+    patch = mocker.patch.object(plugin_instance, "_patch_google_group")
+
+    await plugin_instance._reconcile(ctx_mock, group)
+
+    assert _label_patches(patch) == []  # nothing to do in Google
+    assert group.plugin_data[PLUGIN_ID]["configuration"][CONFIG_SECURITY_GROUP] is True
 
 
 async def test_reconcile_restores_the_configuration_of_a_group_google_already_labeled(
@@ -974,7 +998,10 @@ async def test_reconcile_errors_when_google_refuses_the_security_label(
     status = group.plugin_data[PLUGIN_ID]["status"]
     assert status[STATUS_SYNC_STATUS] == SYNC_ERROR
     assert "Group contains members that are not allowed" in status[STATUS_SYNC_ERROR]
-    assert CONFIG_SECURITY_GROUP in status[STATUS_SYNC_ERROR]  # names the configuration to clear
+    # Names both settings that can be asking for the label: clearing only the group's does nothing
+    # while the app mandates it, so remediation advice naming just that one would be wrong.
+    assert CONFIG_SECURITY_GROUP in status[STATUS_SYNC_ERROR]
+    assert CONFIG_REQUIRE_SECURITY_GROUPS in status[STATUS_SYNC_ERROR]
 
 
 async def test_reconcile_adopts_missing_config_from_live_group(

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,12 @@
       "name": "access",
       "version": "1.0.0",
       "dependencies": {
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.1",
         "@mui/base": "^5.0.0-beta.28",
         "@mui/icons-material": "^6.5.0",
         "@mui/lab": "^6.0.1-beta.36",
         "@mui/material": "^6.5.0",
-        "@mui/styled-engine-sc": "^6.4.9",
         "@mui/x-data-grid": "^7.29.13",
         "@mui/x-date-pickers": "^7.29.4",
         "@sentry/react": "^8.34.0",
@@ -25,8 +26,7 @@
         "react-hook-form": "^7.51.2",
         "react-hook-form-mui": "^7.6.2",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "^7.18.2",
-        "styled-components": "^6.1.13"
+        "react-router-dom": "^7.18.2"
       },
       "devDependencies": {
         "@openapi-codegen/cli": "^3.1.0",
@@ -38,7 +38,6 @@
         "@types/node": "^24.2.0",
         "@types/react": "^18.2.74",
         "@types/react-dom": "^18.2.24",
-        "@types/styled-components": "^5.1.26",
         "@vitejs/plugin-react": "^6.1.0",
         "@vitest/ui": "^4.1.8",
         "husky": "^8.0.3",
@@ -79,7 +78,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
@@ -135,7 +133,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
       "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.7",
@@ -179,7 +176,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
       "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -189,7 +185,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
       "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.29.7",
@@ -221,7 +216,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -231,7 +225,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -265,7 +258,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.7"
@@ -298,7 +290,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
       "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -313,7 +304,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
       "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -332,7 +322,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -480,6 +469,31 @@
         "node": ">=18"
       }
     },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
     "node_modules/@emotion/cache": {
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
@@ -514,6 +528,30 @@
       "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
       "license": "MIT"
     },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@emotion/serialize": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
@@ -533,11 +571,43 @@
       "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
       "license": "MIT"
     },
+    "node_modules/@emotion/styled": {
+      "version": "11.14.1",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
+      "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@emotion/unitless": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
       "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
       "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@emotion/utils": {
       "version": "1.4.2",
@@ -600,7 +670,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -622,7 +691,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -631,14 +699,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.29",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
       "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -867,29 +933,6 @@
         "@emotion/styled": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@mui/styled-engine-sc": {
-      "version": "6.4.9",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine-sc/-/styled-engine-sc-6.4.9.tgz",
-      "integrity": "sha512-ua4dCpn023Z1wUJ1GShFvBojmwhGPsOo3q4ywxb0QuUBdOyHX0T1SwwOfXU9uCwahnrvaJGX55zEHwSENPDohg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@types/hoist-non-react-statics": "^3.3.6",
-        "csstype": "^3.1.3",
-        "hoist-non-react-statics": "^3.3.2",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "styled-components": "^6.0.0"
       }
     },
     "node_modules/@mui/system": {
@@ -2357,18 +2400,6 @@
         "@types/unist": "*"
       }
     },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
-      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
-      "license": "MIT",
-      "dependencies": {
-        "hoist-non-react-statics": "^3.3.0"
-      },
-      "peerDependencies": {
-        "@types/react": "*"
-      }
-    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -2401,6 +2432,12 @@
         "undici-types": "~7.10.0"
       }
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -2432,17 +2469,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*"
-      }
-    },
-    "node_modules/@types/styled-components": {
-      "version": "5.1.26",
-      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.26.tgz",
-      "integrity": "sha512-KuKJ9Z6xb93uJiIyxo/+ksS7yLjS1KzG6iv5i78dhVg/X3u5t1H7juRWqVmodIdz6wGVaIApo1u01kmFRdJHVw==",
-      "dev": true,
-      "dependencies": {
-        "@types/hoist-non-react-statics": "*",
-        "@types/react": "*",
-        "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/unist": {
@@ -2750,6 +2776,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -2918,13 +2959,13 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/camelize": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
-      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/caniuse-lite": {
@@ -3281,6 +3322,31 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3292,26 +3358,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/css-color-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/css-to-react-native": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
-      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "camelize": "^1.0.0",
-        "css-color-keywords": "^1.0.0",
-        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css.escape": {
@@ -3617,6 +3663,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -3631,7 +3686,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -3690,6 +3744,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/estree-util-is-identifier-name": {
@@ -3770,6 +3836,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -3855,7 +3927,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4104,10 +4175,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -4282,6 +4353,22 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -4347,6 +4434,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
     "node_modules/is-bigint": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
@@ -4393,6 +4486,21 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -4722,7 +4830,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -4736,6 +4843,12 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -5033,6 +5146,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
     },
     "node_modules/lint-staged": {
       "version": "15.2.10",
@@ -6692,6 +6811,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -6716,6 +6847,24 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -6778,6 +6927,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -6805,6 +6960,15 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -6816,7 +6980,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -6882,12 +7045,6 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
-    },
-    "node_modules/postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "license": "MIT"
     },
     "node_modules/prettier": {
       "version": "3.2.5",
@@ -7221,12 +7378,42 @@
       "integrity": "sha512-XGoLeRAVzUTcJ1qkxPQhDJyIZ5d6zzZD9nT7AEZOaaU9UbWclhycElmhO+VD5bFeLuzhPBaOV2oXC8uG35ZSpg==",
       "license": "MIT"
     },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/responselike": {
       "version": "3.0.0",
@@ -7573,6 +7760,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7688,48 +7884,6 @@
         "inline-style-parser": "0.2.4"
       }
     },
-    "node_modules/styled-components": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.5.3.tgz",
-      "integrity": "sha512-vAX79sfpmUerP9fsTTxoTrBDE0RuO4ahjInyWYoohNgqrdg63Ms4q6FJ/o2Fyity82NU3cujOT8Ewl9TThBdwg==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/is-prop-valid": "1.4.0",
-        "css-to-react-native": "3.2.0",
-        "csstype": "3.2.3",
-        "stylis": "4.3.6"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/styled-components"
-      },
-      "peerDependencies": {
-        "css-to-react-native": ">= 3.2.0",
-        "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0",
-        "react-native": ">= 0.68.0"
-      },
-      "peerDependenciesMeta": {
-        "css-to-react-native": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/styled-components/node_modules/stylis": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
-      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
-      "license": "MIT"
-    },
     "node_modules/stylis": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
@@ -7746,6 +7900,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/swagger2openapi": {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "private": true,
   "type": "module",
   "dependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
     "@mui/base": "^5.0.0-beta.28",
     "@mui/icons-material": "^6.5.0",
     "@mui/lab": "^6.0.1-beta.36",
     "@mui/material": "^6.5.0",
-    "@mui/styled-engine-sc": "^6.4.9",
     "@mui/x-data-grid": "^7.29.13",
     "@mui/x-date-pickers": "^7.29.4",
     "@sentry/react": "^8.34.0",
@@ -21,8 +22,7 @@
     "react-hook-form": "^7.51.2",
     "react-hook-form-mui": "^7.6.2",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.18.2",
-    "styled-components": "^6.1.13"
+    "react-router-dom": "^7.18.2"
   },
   "scripts": {
     "tsc": "./node_modules/.bin/tsc",
@@ -65,7 +65,6 @@
     "@types/node": "^24.2.0",
     "@types/react": "^18.2.74",
     "@types/react-dom": "^18.2.24",
-    "@types/styled-components": "^5.1.26",
     "@vitejs/plugin-react": "^6.1.0",
     "@vitest/ui": "^4.1.8",
     "husky": "^8.0.3",

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -4,7 +4,8 @@ declare const REQUIRE_DESCRIPTIONS: boolean;
 
 interface ImportMetaEnv {
   readonly VITE_API_SERVER_URL: string;
-  readonly VITE_SENTRY_RELEASE: string;
+  // Undefined unless the build sets `SENTRY_RELEASE`; see the `define` in vite.config.ts.
+  readonly VITE_SENTRY_RELEASE: string | undefined;
   readonly MODE: string;
 }
 

--- a/src/pages/groups/CreateUpdate.loop.test.tsx
+++ b/src/pages/groups/CreateUpdate.loop.test.tsx
@@ -1,0 +1,138 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+
+import {AppDetail, OktaUserDetail} from '../../api/apiSchemas';
+import CreateUpdateGroup from './CreateUpdate';
+
+vi.mock('react-router-dom', () => ({useNavigate: () => vi.fn()}));
+
+const ACCESS_OWNER_GROUP = {
+  id: 'access-owners-000000',
+  type: 'app_group',
+  name: 'App-Access-Owners',
+  is_owner: true,
+  app: {id: 'access-app-0000000000', name: 'Access'},
+};
+
+// The Access admin tier is membership in the Access app's owner group.
+const ACCESS_ADMIN = {
+  id: 'admin-00000000000000',
+  email: 'admin@example.com',
+  active_group_memberships: [{active_group: ACCESS_OWNER_GROUP}],
+  active_group_ownerships: [],
+} as unknown as OktaUserDetail;
+
+const APP_NAME = 'HammerAndChiselZendeskSandbox';
+
+// The app the dialog is opened from, as the app page holds it: an AppDetail, a
+// different object from the summary GET /api/apps returns for the same app.
+const APP = {
+  id: 'zendesk-sandbox-0000',
+  name: APP_NAME,
+  description: 'Zendesk sandbox',
+  plugin_data: {},
+  active_app_tags: [],
+} as unknown as AppDetail;
+
+const APP_SUMMARY = {id: APP.id, name: APP.name, description: APP.description};
+
+/** Apps that crowd out the target app on the first page of an empty search. */
+const OTHER_APPS = [
+  'Airtable',
+  'Asana',
+  'Datadog',
+  'Figma',
+  'Github',
+  'Jira',
+  'Linear',
+  'Notion',
+  'Sentry',
+  'Slack',
+].map((name, i) => ({id: `other-app-${i}`, name, description: name}));
+
+let appQueries: string[] = [];
+
+/**
+ * Serves GET /api/apps from `page`, answering on a later tick and honouring the
+ * abort signal. Both matter: a real round-trip leaves the query with no data
+ * while it is in flight, and React Query cancels a request whose key is
+ * superseded, so a cancelled key never populates the cache.
+ */
+const stubApps = (page: (q: string) => unknown[]) => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: string, init?: RequestInit) => {
+      const url = new URL(input, 'http://localhost');
+      const q = url.searchParams.get('q') ?? '';
+      const items = url.pathname === '/api/apps' ? (appQueries.push(q), page(q)) : [];
+      const body = JSON.stringify({items, total: items.length, page: 1, size: 10, pages: 1});
+
+      return new Promise<Response>((resolve, reject) => {
+        const timer = setTimeout(
+          () => resolve(new Response(body, {headers: {'Content-Type': 'application/json'}})),
+          10,
+        );
+        init?.signal?.addEventListener('abort', () => {
+          clearTimeout(timer);
+          reject(Object.assign(new Error('aborted'), {name: 'AbortError'}));
+        });
+      });
+    }),
+  );
+};
+
+const searchByName = (q: string) =>
+  [APP_SUMMARY, ...OTHER_APPS].filter((app) => app.name.toLowerCase().includes(q.toLowerCase()));
+
+beforeEach(() => {
+  appQueries = [];
+  // The runaway needs the app present for some searches and absent for others,
+  // which is what an ordinary search does as the query changes.
+  stubApps(searchByName);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const openDialog = async () => {
+  const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
+  render(
+    <QueryClientProvider client={queryClient}>
+      <CreateUpdateGroup currentUser={ACCESS_ADMIN} defaultGroupType="app_group" app={APP} />
+    </QueryClientProvider>,
+  );
+  await userEvent.click(screen.getByRole('button', {name: 'Create App Group'}));
+  return screen.getByRole('combobox', {name: /App/});
+};
+
+describe('the App field of the Create App Group dialog', () => {
+  // The field's input feeds the /api/apps search that supplies its own options, so
+  // anything that re-derives the displayed value from those options makes the two
+  // chase each other: the search in flight has no options yet, so the value reads as
+  // empty, which resets the input, which starts another search. That spun thousands
+  // of requests a second and exhausted the backend's ports.
+  it('settles after a bounded number of app searches', async () => {
+    await openDialog();
+
+    // Give any feedback loop room to run away before counting.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    expect(appQueries.length).toBeLessThanOrEqual(2);
+  });
+
+  // The dialog is opened from an app page, so the app is already known and the field
+  // is locked to it. What the field shows has to come from the form value, not from
+  // whichever apps the current search happens to return -- an app past the first page
+  // of results is absent from every search the field runs on its own, and the user is
+  // left staring at an empty required "App" dropdown.
+  it('shows the app it is locked to even when the search does not return it', async () => {
+    stubApps(() => OTHER_APPS);
+
+    const appField = await openDialog();
+
+    await waitFor(() => expect(appField).toHaveValue(APP_NAME));
+  });
+});

--- a/src/pages/groups/CreateUpdate.tsx
+++ b/src/pages/groups/CreateUpdate.tsx
@@ -262,6 +262,13 @@ function GroupDialog(props: GroupDialogProps) {
                 name="app"
                 options={appSearchOptions}
                 required
+                // Show the app the form actually holds. Left to itself, rhf-mui displays
+                // whichever entry of `options` matches the form value, and `options` here is
+                // the result of a search this field's own input drives: an app past the first
+                // page of results matches nothing and the field renders blank, and a search in
+                // flight has no options at all, so the value reads as empty, the input resets,
+                // and the reset starts another search -- a loop that outran the backend.
+                transform={{input: (app) => app ?? null}}
                 autocompleteProps={{
                   // `readOnly`, not `disabled`: react-hook-form clears a disabled field's value, and
                   // rhf-mui forwards `autocompleteProps.disabled` into `useController`, so disabling

--- a/src/styleEngine.test.tsx
+++ b/src/styleEngine.test.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import {describe, it} from 'vitest';
+import {render, act} from '@testing-library/react';
+import {styled} from '@mui/material/styles';
+
+// MUI X calls React hooks from inside a styled() interpolation: GridRootStyles reads
+// useGridPrivateApiContext() and useGridSelector() to decide a border radius. That is only
+// safe under an engine that re-evaluates interpolations on every render, which Emotion does
+// and styled-components does not -- it memoizes the interpolation result and serves it
+// whenever theme, stylesheet and props are unchanged, so the hooks inside vanish on the
+// second render and React throws "Rendered fewer hooks than expected" (minified error #300).
+// It surfaced as every Bulk Review dialog crashing the moment the grid re-rendered.
+//
+// This is the one property of the style engine the app depends on for correctness, and
+// nothing else in the test suite would notice it changing, so pin it here rather than
+// leaving a comment in vite.config.ts that a future alias could quietly contradict.
+const Ctx = React.createContext(0);
+
+const StyledWithHooks = styled('div')(() => {
+  React.useContext(Ctx);
+  React.useRef(null);
+  React.useState(0);
+  return {color: 'red'};
+});
+
+function Harness({onRender}: {onRender: (rerender: () => void) => void}) {
+  const [, setTick] = React.useState(0);
+  onRender(() => setTick((n) => n + 1));
+  // Props are referentially identical across renders, which is what lets a memoizing
+  // engine skip the interpolation.
+  return <StyledWithHooks className="stable">child</StyledWithHooks>;
+}
+
+describe('MUI style engine', () => {
+  it('re-evaluates styled() interpolations, so they may call hooks', () => {
+    let rerender = () => {};
+    render(<Harness onRender={(fn) => (rerender = fn)} />);
+    act(() => rerender());
+  });
+});

--- a/tests/test_group_owner_lookups_dedup.py
+++ b/tests/test_group_owner_lookups_dedup.py
@@ -1,0 +1,109 @@
+"""A user can hold two concurrent active OktaUserGroupMember owner rows for the
+same group at once -- a direct grant plus one via a role mapping, per the
+access-grant-precedence rules -- and those rows are never collapsed into one.
+The approver lookups used to notify a single access request must still return
+such a user once, not once per row, or the notification plugin sends one DM
+per list entry for what is really one owner.
+"""
+
+from sqlalchemy import select
+
+from api.models import App, AppGroup, OktaUser, RoleGroup
+from api.models.app_group import get_access_owners, get_app_managers
+from api.models.okta_group import get_group_managers
+from tests.factories import (
+    AppFactory,
+    AppGroupFactory,
+    OktaGroupFactory,
+    OktaUserGroupMemberFactory,
+    RoleGroupFactory,
+    RoleGroupMapFactory,
+)
+
+
+async def _double_owner(group_id: str, owner: OktaUser, role: RoleGroup) -> None:
+    """Grant `owner` ownership of `group_id` both directly and via `role`."""
+    role_group_map = await RoleGroupMapFactory.create_async(
+        role_group_id=role.id,
+        group_id=group_id,
+        is_owner=True,
+    )
+    await OktaUserGroupMemberFactory.create_async(
+        user_id=owner.id,
+        group_id=group_id,
+        is_owner=True,
+        role_group_map_id=role_group_map.id,
+    )
+    await OktaUserGroupMemberFactory.create_async(
+        user_id=owner.id,
+        group_id=group_id,
+        is_owner=True,
+        role_group_map_id=None,
+    )
+
+
+async def test_get_group_managers_dedupes_direct_and_role_ownership(db, user: OktaUser) -> None:
+    db.session.add(user)
+    await db.session.commit()
+
+    group = await OktaGroupFactory.create_async()
+    role = await RoleGroupFactory.create_async()
+    await _double_owner(group.id, user, role)
+
+    managers = await get_group_managers(group.id)
+
+    assert [m.id for m in managers] == [user.id]
+
+
+async def test_get_app_managers_dedupes_direct_and_role_ownership(db, user: OktaUser) -> None:
+    db.session.add(user)
+    await db.session.commit()
+
+    app = await AppFactory.create_async()
+    owner_group = await AppGroupFactory.create_async(app_id=app.id, is_owner=True)
+    role = await RoleGroupFactory.create_async()
+    await _double_owner(owner_group.id, user, role)
+
+    managers = await get_app_managers(app.id)
+
+    assert [m.id for m in managers] == [user.id]
+
+
+async def test_get_access_owners_dedupes_direct_and_role_membership(db, user: OktaUser) -> None:
+    db.session.add(user)
+    await db.session.commit()
+
+    # The `db` fixture already seeds the bootstrap Access app + its owner
+    # group; reuse it rather than creating a second app with the reserved name.
+    access_app = (await db.session.scalars(select(App).where(App.name == App.ACCESS_APP_RESERVED_NAME))).one()
+    owner_group = (
+        await db.session.scalars(
+            select(AppGroup).where(AppGroup.app_id == access_app.id).where(AppGroup.is_owner.is_(True))
+        )
+    ).one()
+    role = await RoleGroupFactory.create_async()
+    role_group_map = await RoleGroupMapFactory.create_async(
+        role_group_id=role.id,
+        group_id=owner_group.id,
+        is_owner=False,
+    )
+    await OktaUserGroupMemberFactory.create_async(
+        user_id=user.id,
+        group_id=owner_group.id,
+        is_owner=False,
+        role_group_map_id=role_group_map.id,
+    )
+    await OktaUserGroupMemberFactory.create_async(
+        user_id=user.id,
+        group_id=owner_group.id,
+        is_owner=False,
+        role_group_map_id=None,
+    )
+
+    owners = await get_access_owners()
+    owner_ids = [o.id for o in owners]
+
+    # The bootstrap admin (seeded by the `db` fixture) is also a member of
+    # this group, so `user` is one of (at least) two owners -- the point is
+    # that `user` appears exactly once despite its two active membership rows.
+    assert owner_ids.count(user.id) == 1

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,6 @@
       "./src/globals.d.ts"
     ],
     "paths": {
-      "@mui/styled-engine": ["./node_modules/@mui/styled-engine-sc"],
       // `moduleResolution: node` predates `exports` maps, and react-hook-form-mui only
       // publishes this subpath through one. Vite and Node resolve it natively.
       "react-hook-form-mui/date-pickers": ["./node_modules/react-hook-form-mui/dist/date-pickers.d.ts"]

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "paths": {
-      "@mui/styled-engine": ["./node_modules/@mui/styled-engine-sc"],
       "react-hook-form-mui/date-pickers": ["./node_modules/react-hook-form-mui/dist/date-pickers.d.ts"]
     }
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -71,19 +71,6 @@ export default defineConfig(({mode}) => {
           ]
         : []),
     ],
-    resolve: {
-      alias: {
-        '@mui/styled-engine': '@mui/styled-engine-sc',
-      },
-      // Test-only field order. Vitest resolves bare dependencies through Node, which
-      // picks MUI's CJS `main` (`node/index.js`); that build `require`s
-      // '@mui/styled-engine' itself, bypassing the alias above and demanding
-      // @emotion/styled, which this app does not install (it renders through
-      // styled-components). Preferring `module` keeps MUI on its ESM build so the
-      // alias applies and component tests can render real MUI instead of mocking it.
-      // The app build keeps Vite's default order.
-      ...(mode === 'test' ? {mainFields: ['module', 'browser', 'main']} : {}),
-    },
     define: {
       ACCESS_CONFIG: accessConfig,
       APP_NAME: JSON.stringify(env.APP_NAME || 'Access'),
@@ -115,8 +102,9 @@ export default defineConfig(({mode}) => {
       // *this* checkout's node_modules, reporting failures that belong to some
       // other branch. Every frontend test lives under src/.
       include: ['src/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
-      // Inline MUI and react-hook-form-mui so Vite transforms them (and applies the
-      // styled-engine alias) rather than handing them to Node's CJS loader.
+      // Inline MUI and react-hook-form-mui so Vite transforms them rather than handing
+      // them to Node's CJS loader, which resolves their `main` build and skips the
+      // config's resolution and transform rules.
       server: {deps: {inline: [/@mui/, /react-hook-form-mui/]}},
     },
   };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,6 +31,13 @@ export default defineConfig(({mode}) => {
   // Process environment variables take precedence over .env files
   const env = {...loadEnv(mode, process.cwd(), ''), ...process.env};
 
+  // One value stamps both the release the browser SDK reports and the release the uploaded
+  // source maps are filed under, so a report and its maps can never name different builds.
+  // `SENTRY_RELEASE` is the name to set: it is what the Sentry CLI and the vite plugin already
+  // read, and Vite only surfaces `VITE_`-prefixed vars to the client on its own, so the value
+  // is handed across explicitly in `define` below.
+  const sentryRelease = env.SENTRY_RELEASE || env.VITE_SENTRY_RELEASE || '';
+
   return {
     plugins: [
       react(),
@@ -65,7 +72,7 @@ export default defineConfig(({mode}) => {
                 filesToDeleteAfterUpload: './build/**/*.map',
               },
               release: {
-                name: env.SENTRY_RELEASE,
+                name: sentryRelease,
               },
             }),
           ]
@@ -75,6 +82,9 @@ export default defineConfig(({mode}) => {
       ACCESS_CONFIG: accessConfig,
       APP_NAME: JSON.stringify(env.APP_NAME || 'Access'),
       REQUIRE_DESCRIPTIONS: env.REQUIRE_DESCRIPTIONS?.toLowerCase() === 'true',
+      // `undefined` rather than `""` when unset: Sentry treats an empty-string release as a
+      // real release name and files every event under it.
+      'import.meta.env.VITE_SENTRY_RELEASE': sentryRelease ? JSON.stringify(sentryRelease) : 'undefined',
     },
     server: {
       port: 3000,


### PR DESCRIPTION
[Google Workspace security groups](https://knowledge.workspace.google.com/admin/groups/control-access-to-sensitive-data-with-security-groups) are the groups you are allowed to name in a policy that grants access to sensitive data. An operator running app groups through the example Google plugin has to go label them by hand in the
Admin console, and keep doing it for every new group. That is the kind of manual step the plugin
exists to remove, and skipping it means an app group that looks like it gates sensitive data cannot
actually be used to.

A security group is an ordinary Google Group carrying an [extra label](https://docs.cloud.google.com/identity/docs/groups#group_labels), so this adds a `security_group` group configuration and a `require_security_groups` app mandate, both reconciled by patching that label onto the linked group. The [plugin README](https://github.com/discord/access/blob/pcollins/google-groups-lifecycle-plugin-c00710/examples/plugins/app_group_lifecycle_google/README.md#security-groups) documents the behaviour.

## Two properties of the label drove the design

**It is one-way.** [Google never converts a security group back](https://docs.cloud.google.com/identity/docs/how-to/update-group-to-security-group),
so the configuration is a floor rather than a switch. Access raises the label and never attempts a
downgrade, and a group Google already reports as a security group has its configuration *restored*
to match, so the checkbox keeps agreeing with what Google will enforce instead of sitting unchecked
next to a group that is one regardless. This is also why the property is not declared `immutable`:
promoting an existing group is a legitimate operation Google supports, and `immutable` would block
it to prevent an un-set that is already a no-op.

The app mandate ORs with the group setting for the same reason: an app can only raise the
requirement. That lets a mandate cover groups predating it without rewriting each one's stored
config, and group validation rejects an explicit opt-out while it is set. Since nothing in the
plugin interface fires on an app configuration change, a newly-set mandate reaches existing groups
on their next `sync-app-groups` sweep or group update.

**Google enforces [membership requirements](https://docs.cloud.google.com/identity/docs/how-to/update-group-to-security-group),**
and rejects the label outright when they do not hold. That is recorded as a sync *error*, not a
skip, which is deliberately the louder of the plugin's two tiers: Access is otherwise displaying a
security group it has not actually got, so the divergence should fail the `sync-app-groups` run
even though the group's owner, not an admin, is usually who resolves it. Worth a reviewer's opinion
if you would rather it route quietly to owners instead.

## Reviewer notes

The label patch is a separate Groups API call from the display-name/description one, so a refusal
is attributable and does not block metadata converging. The patch replaces the label map rather
than merging into it, hence re-sending the group's existing labels alongside
`groups.discussion_forum` (dropping that one is how a group stops being a Google Group).

No frontend change: the generic plugin config form already renders `boolean` properties as a
checkbox and resolves `default_value`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)