### PR TITLE
fix: preserve errors for missing SPA assets

### DIFF
--- a/api/exception_handlers.py
+++ b/api/exception_handlers.py
@@ -44,6 +44,10 @@ def _is_api(request: Request) -> bool:
     return request.url.path.startswith("/api/") or request.url.path == "/api"
 
 
+def _is_spa_asset(request: Request) -> bool:
+    return request.url.path.startswith("/assets/") or request.url.path == "/assets"
+
+
 def _problem(
     *,
     status_code: int,
@@ -111,6 +115,12 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> JSONRe
     detail = exc.detail
     # Cloudflare and other 404s for non-/api/ paths should serve the SPA.
     if exc.status_code == 404 and not _is_api(request):
+        # The SPA route deliberately raises a non-cacheable 404 for missing
+        # content-hashed assets. Do not turn it back into a cacheable HTML 200.
+        if _is_spa_asset(request):
+            headers = dict(exc.headers or {})
+            headers.setdefault("Cache-Control", "no-store")
+            return _problem(status_code=404, detail="Not Found", headers=headers)
         if INDEX_HTML.exists():
             return HTMLResponse(INDEX_HTML.read_text(), status_code=200)
         return _problem(status_code=404, detail="Not Found", headers=exc.headers or None)
@@ -191,11 +201,12 @@ async def okta_transient_error_handler(request: Request, exc: OktaTransientError
 
 async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse | HTMLResponse:
     logger.exception("Unhandled exception", exc_info=exc)
-    if _is_api(request):
+    if _is_api(request) or _is_spa_asset(request):
         # Return a static body — `str(exc)` for SQLAlchemy errors leaks the
         # full SQL statement, table/column names, and bound parameters.
         # Diagnostics already go to the log pipeline via logger.exception.
-        return _problem(status_code=500, detail="Internal Server Error")
+        headers = {"Cache-Control": "no-store"} if _is_spa_asset(request) else None
+        return _problem(status_code=500, detail="Internal Server Error", headers=headers)
     if INDEX_HTML.exists():
         return HTMLResponse(INDEX_HTML.read_text(), status_code=200)
     return _problem(status_code=500, detail="Internal Server Error")

--- a/tests/test_spa.py
+++ b/tests/test_spa.py
@@ -21,8 +21,10 @@ from typing import AsyncIterator
 import httpx
 import pytest
 from fastapi import FastAPI
+from starlette.requests import Request
 
 from api import app as app_module
+from api import exception_handlers
 from api.app import _inject_csp_nonce, create_app
 from api.config import settings
 from api.extensions import Db
@@ -35,6 +37,7 @@ def stub_build_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     (build_dir / "index.html").write_text("<html><body>shell</body></html>")
     (build_dir / "assets" / "index-existing.js").write_text('console.log("hi");')
     monkeypatch.setattr(app_module, "BUILD_DIR", build_dir)
+    monkeypatch.setattr(exception_handlers, "INDEX_HTML", build_dir / "index.html")
     return build_dir
 
 
@@ -59,6 +62,30 @@ async def test_missing_asset_returns_404_not_the_spa_shell(spa_client: httpx.Asy
     assert resp.status_code == 404
     assert resp.headers["cache-control"] == "no-store"
     assert "shell" not in resp.text
+
+
+async def test_unhandled_asset_error_is_not_replaced_with_the_spa_shell(
+    stub_build_dir: Path,
+) -> None:
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/assets/index-broken.js",
+            "raw_path": b"/assets/index-broken.js",
+            "query_string": b"",
+            "headers": [],
+            "client": ("127.0.0.1", 1234),
+            "server": ("testserver", 80),
+        }
+    )
+
+    response = await exception_handlers.unhandled_exception_handler(request, RuntimeError("broken asset"))
+
+    assert response.status_code == 500
+    assert response.headers["cache-control"] == "no-store"
+    assert response.headers["content-type"] == "application/problem+json"
 
 
 async def test_unknown_route_falls_back_to_spa_shell_without_caching(spa_client: httpx.AsyncClient) -> None:


### PR DESCRIPTION
# Summary
Keep SPA asset errors as non-cacheable problem responses instead of replacing them with the application shell.

**Urgency**: 1 day
**Expected review effort**: LOW

# Motivation
The global exception fallback could replace a missing content-hashed asset response with an HTML 200 whenever a built frontend was present. A caching proxy could then retain that HTML response under the script URL.

# Description of Changes
- Exclude /assets requests from exception-driven SPA fallback.
- Preserve explicit error headers and default asset failures to Cache-Control: no-store.
- Model the packaged frontend in SPA tests so the regression is exercised.

# Validation of Changes
- make test-backend
- Ruff, formatting, and type checking pass.
- 951 tests pass.

# Guidance for Reviewers
Review the asset-path exception ordering and the production-shaped test fixture together.